### PR TITLE
CI: fix Windows testing (rtools45, remove continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,14 +492,12 @@ jobs:
     name: R CMD check / Windows
     runs-on: windows-latest
     timeout-minutes: 90
-    continue-on-error: true  # Windows CI is flaky; don't block on it
     needs: changes
     if: needs.changes.outputs.r == 'true'
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       SCCACHE_GHA_ENABLED: "true"
-      # Windows GNU toolchain requires explicit target (msys != windows-gnu)
       CARGO_BUILD_TARGET: x86_64-pc-windows-gnu
 
     steps:
@@ -509,7 +507,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
-          rtools-version: "44"
+          rtools-version: "45"
           use-public-rspm: true
 
       - name: Setup R dependencies
@@ -541,52 +539,39 @@ jobs:
           shared-key: r-windows
           cache-on-failure: true
 
-      - name: Install just
-        uses: extractions/setup-just@v3
-
       - name: Configure Windows Rust environment
         shell: pwsh
         run: |
-          $rtools_home = "C:\rtools44"
+          $rtools_home = "C:\rtools45"
 
-          # Add Rtools to PATH
+          # Add Rtools to PATH for configure/vendor steps
           Add-Content -Path $env:GITHUB_PATH -Value "${rtools_home}\x86_64-w64-mingw32.static.posix\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "${rtools_home}\usr\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "$(Rscript.exe -e 'cat(normalizePath(R.home()))')\bin\x64"
 
-          # Create empty libgcc stubs for Rust linking
+          # Create empty libgcc stubs for Rust linking (Rust std expects these)
           New-Item -Path libgcc_mock -Type Directory -Force
           New-Item -Path libgcc_mock\libgcc_eh.a -Type File -Force
           New-Item -Path libgcc_mock\libgcc_s.a -Type File -Force
 
-          # Configure Cargo target for Windows GNU
-          # Note: patch.crates-io is handled by just configure
-          # Write UTF-8 without BOM which can cause parsing issues
+          # Configure Cargo for Windows GNU target
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = (Get-Location).Path -replace '\\','/'
           $config = "[target.x86_64-pc-windows-gnu]`nlinker = `"x86_64-w64-mingw32.static.posix-gcc.exe`"`n`n[env]`nLIBRARY_PATH = `"$pwd_slash/libgcc_mock`""
           [System.IO.File]::WriteAllText("$PWD\.cargo\config.toml", $config)
 
       - name: Configure and vendor
-        shell: C:\rtools44\usr\bin\bash.exe -e -o pipefail {0}
+        shell: C:\rtools45\usr\bin\bash.exe -e -o pipefail {0}
         run: |
-          # Add rtools and cargo to PATH (--login might reset PATH)
-          export PATH="/c/rtools44/usr/bin:/c/rtools44/x86_64-w64-mingw32.static.posix/bin:$PATH"
+          export PATH="/c/rtools45/usr/bin:/c/rtools45/x86_64-w64-mingw32.static.posix/bin:$PATH"
           if [ -n "${CARGO_HOME:-}" ]; then
             export PATH="$(cygpath -u "$CARGO_HOME")/bin:$PATH"
           fi
-          # Debug: show PATH and check for required tools
-          echo "PATH: $PATH"
-          echo "rsync: $(which rsync || echo 'not found')"
-          echo "sed: $(which sed || echo 'not found')"
-          echo "cargo: $(which cargo || echo 'not found')"
-          echo "rustc: $(which rustc || echo 'not found')"
           cd "$(cygpath -u "$GITHUB_WORKSPACE")/rpkg"
-          # Windows needs explicit target for GNU toolchain (msys != windows-gnu)
-          CARGO_BUILD_TARGET=x86_64-pc-windows-gnu ./configure
+          CARGO_BUILD_TARGET=x86_64-pc-windows-gnu bash ./configure
           cd "$(cygpath -u "$GITHUB_WORKSPACE")"
-          # Call Rscript directly instead of `just vendor` because just's
-          # shell resolution on Windows finds the WSL sh shim before rtools'.
+          # Call Rscript directly — just's shell resolution on Windows
+          # finds the WSL sh shim before rtools' bash.
           cd rpkg && Rscript tools/vendor-crates.R pack
 
       - name: R CMD check


### PR DESCRIPTION
## Summary
- Update Rtools 44 → 45 to match R 4.5
- Remove `continue-on-error: true` from Windows job so failures actually gate the CI
- Clean up stale debug echo lines and comments in configure step
- Use `bash ./configure` per project conventions

## Test plan
- [ ] Windows R CMD check passes (or fails visibly instead of being silently ignored)
- [ ] Linux and macOS jobs unaffected
- [ ] Change detection still gates jobs correctly

Generated with [Claude Code](https://claude.com/claude-code)
