### PR TITLE
Align rpkg/configure.ac with template structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.r == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -235,6 +237,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -402,6 +406,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         run: |
@@ -502,6 +508,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -635,6 +643,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -700,6 +710,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -766,6 +778,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -831,6 +845,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install just
         uses: taiki-e/install-action@just

--- a/justfile
+++ b/justfile
@@ -319,27 +319,26 @@ expand *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo expand --lib --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo expand --lib --manifest-path="$root/rpkg/src/rust/Cargo.toml" --config "patch.crates-io.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.crates-io.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.crates-io.miniextendr-macros-core.path=\"$root/miniextendr-macros-core\"" --config "patch.crates-io.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
 
-# Run ./configure for dev mode (BUILD_CONTEXT=dev-monorepo)
+# Run ./configure for dev mode
 #
 # In dev mode, this:
 # 1. Generates build configuration files (Makevars, cargo config, etc.)
-# 2. Cleans up stale vendor artifacts (vendor/, vendor.tar.xz)
-# 3. Does NOT vendor — cargo resolves deps via [patch] in Cargo.toml
+# 2. Syncs vendor/ from the monorepo via vendor-crates.R
+#    (same path end-user scaffolded packages use)
 #
 # For CRAN release prep, use `just vendor` then `just configure-cran`.
 configure:
     cd rpkg && \
     if command -v autoconf >/dev/null 2>&1; then autoconf; else echo "autoconf not found; using existing configure"; fi && \
-    bash ./configure
+    NOT_CRAN=true MINIEXTENDR_LOCAL="$(cd .. && pwd)" bash ./configure
 
-# Configure in CRAN/offline mode (BUILD_CONTEXT=prepare-cran)
+# Configure in CRAN/offline mode
 #
-# Uses PREPARE_CRAN=true for explicit release-prep intent.
 # Run `just vendor` first to create inst/vendor.tar.xz.
 configure-cran:
     cd rpkg && \
     if command -v autoconf >/dev/null 2>&1; then autoconf; else echo "autoconf not found; using existing configure"; fi && \
-    PREPARE_CRAN=true bash ./configure
+    NOT_CRAN=false bash ./configure
 
 # Vendor dependencies for CRAN release preparation.
 # Uses the package-local vendoring script that configure and generated packages

--- a/minirextendr/R/vendor.R
+++ b/minirextendr/R/vendor.R
@@ -354,6 +354,27 @@ vendor_miniextendr_local <- function(local_path, dest) {
   writeLines(local_path, fs::path(dest, ".vendor-source"))
 
   cli::cli_alert_success("miniextendr crates vendored from local path to {.path {dest}}")
+
+  # If vendor-crates.R is available, rebuild vendor/ with cargo-package resolution.
+  # This replaces the regex-patched copies with properly resolved crates.
+  vendor_script <- file.path(dirname(dest), "tools", "vendor-crates.R")
+  if (file.exists(vendor_script)) {
+    pkg_root <- dirname(dest)
+    tryCatch({
+      result <- system2("Rscript", c(vendor_script, "sync",
+        "--path", pkg_root, "--source-root", local_path),
+        stdout = TRUE, stderr = TRUE)
+      status <- attr(result, "status")
+      if (is.null(status) || status == 0L) {
+        cli::cli_alert_success("Rebuilt vendor/ with cargo-package resolution")
+      } else {
+        cli::cli_alert_warning("vendor-crates.R sync exited with status {status}, using patched copies")
+      }
+    }, error = function(e) {
+      cli::cli_alert_warning("vendor-crates.R sync failed, using patched copies: {conditionMessage(e)}")
+    })
+  }
+
   invisible(TRUE)
 }
 
@@ -527,6 +548,13 @@ strip_toml_sections <- function(lines, headers) {
 
   # Check if a line matches any target header (exact match after trim)
   is_target <- trimmed %in% headers
+  # Also match table subsections: [dev-dependencies.X] for header [dev-dependencies]
+  for (h in headers) {
+    if (!startsWith(h, "[[") && endsWith(h, "]")) {
+      prefix <- paste0(substr(h, 1, nchar(h) - 1), ".")
+      is_target <- is_target | startsWith(trimmed, prefix)
+    }
+  }
 
   # Check if a line starts any TOML section (single or double bracket)
   is_any_header <- grepl("^\\[", trimmed)

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -52,17 +52,6 @@ miniextendr_configure <- function(path = ".") {
     ))
   }
 
-  # Auto-sync vendor/ from local monorepo (dev mode only)
-  not_cran <- Sys.getenv("NOT_CRAN", unset = "")
-  if (identical(not_cran, "true") || identical(not_cran, "TRUE") || identical(not_cran, "1")) {
-    tryCatch(
-      vendor_sync(),
-      error = function(e) {
-        cli::cli_alert_warning("vendor_sync failed: {conditionMessage(e)}")
-      }
-    )
-  }
-
   # Ensure configure is executable
   perms <- fs::file_info(configure_path)$permissions
   if (!grepl("x", as.character(perms))) {

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -81,54 +81,14 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  clean:
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-13 21:21:42
+--- a/monorepo/rpkg/configure.ac	2026-03-15 07:53:06
 +++ b/monorepo/rpkg/configure.ac	2026-03-13 12:03:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
  
  dnl Use tools/ directory for auxiliary build files (config.guess, config.sub)
-@@ -30,18 +30,8 @@
- fi
- 
--dnl ---- Build context inputs ----
--dnl PREPARE_CRAN: explicit release-prep signal (highest precedence)
--: ${PREPARE_CRAN:=false}
--case "$PREPARE_CRAN" in
--  true|TRUE|1) PREPARE_CRAN=true ;;
--  *)           PREPARE_CRAN=false ;;
--esac
--
--dnl NOT_CRAN: legacy compatibility signal
--dnl Detect if explicitly set BEFORE defaulting, so auto-detection works
--NOT_CRAN_EXPLICIT=false
--if test "${NOT_CRAN+set}" = "set"; then
--  NOT_CRAN_EXPLICIT=true
--fi
-+dnl NOT_CRAN handling:
-+dnl - CRAN builds: NOT_CRAN is unset or empty → default to false (offline mode)
-+dnl - Dev builds: set NOT_CRAN=true in environment to enable network/vendoring
-+dnl Normalize to "true" or "false" for consistent checks
- : ${NOT_CRAN:=false}
- case "$NOT_CRAN" in
-@@ -49,27 +39,42 @@
-   *)           NOT_CRAN=false ;;
- esac
-+export NOT_CRAN
- 
--dnl BUILD_CONTEXT, cargo flags, and NOT_CRAN derivation are set after
--dnl canonical paths are computed (needs monorepo detection).
-+dnl Set cargo offline/locked flags based on NOT_CRAN
-+dnl - NOT_CRAN=true (dev): no --offline, no --locked (cargo updates lockfile for patches)
-+dnl - NOT_CRAN=false (CRAN): use --offline, omit --locked (checksums cleared)
-+if test "$NOT_CRAN" = "true"; then
-+  CARGO_OFFLINE_FLAG=""
-+else
-+  CARGO_OFFLINE_FLAG="--offline"
-+fi
-+AC_SUBST([CARGO_OFFLINE_FLAG])
-+AC_SUBST([NOT_CRAN])
- 
+@@ -54,31 +54,27 @@
  dnl Set cargo features flag
  dnl
 -dnl rpkg is a demo package that demonstrates ALL miniextendr features.
@@ -145,20 +105,27 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -dnl Enable all features by default for this demo package
 -dnl Users can override by setting MINIEXTENDR_FEATURES explicitly (even to empty string)
 -if test -z "${MINIEXTENDR_FEATURES+x}"; then
--  dnl MINIEXTENDR_FEATURES not set - enable all optional features
--  MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+-  dnl MINIEXTENDR_FEATURES not set — auto-detect via R script if available,
+-  dnl falling back to the full feature set for this demo package
 +dnl Default: no extra features enabled
 +dnl Users can set {{{features_var}}} to enable specific features
 +if test -z "${{{{features_var}}}+x}"; then
 +  dnl {{{features_var}}} not set - auto-detect via R script if available
-+  if test -f "${srcdir}/tools/detect-features.R"; then
+   if test -f "${srcdir}/tools/detect-features.R"; then
+-    MINIEXTENDR_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
+-    if test -n "$MINIEXTENDR_FEATURES"; then
+-      AC_MSG_NOTICE([Auto-detected features: $MINIEXTENDR_FEATURES])
 +    {{{features_var}}}=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
 +    if test -n "${{{features_var}}}"; then
 +      AC_MSG_NOTICE([Auto-detected features: ${{{features_var}}}])
-+    fi
+     fi
 +  else
 +    {{{features_var}}}=""
-+  fi
+   fi
+-  dnl If auto-detection returned nothing, enable all features
+-  if test -z "$MINIEXTENDR_FEATURES"; then
+-    MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+-  fi
  fi
  
 -if test -n "$MINIEXTENDR_FEATURES"; then
@@ -167,119 +134,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -94,84 +99,4 @@
- AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
- 
--dnl Miniextendr crate source paths (in monorepo)
--MINIEXTENDR_API_SRC="$root_miniextendr_repo/miniextendr-api"
--MINIEXTENDR_MACROS_SRC="$root_miniextendr_repo/miniextendr-macros"
--MINIEXTENDR_MACROS_CORE_SRC="$root_miniextendr_repo/miniextendr-macros-core"
--MINIEXTENDR_LINT_SRC="$root_miniextendr_repo/miniextendr-lint"
--MINIEXTENDR_ENGINE_SRC="$root_miniextendr_repo/miniextendr-engine"
--
--dnl ---- Build context resolution ----
--dnl Resolve one of: dev-monorepo, dev-detached, vendored-install, prepare-cran
--dnl
--dnl Truth table:
--dnl   PREPARE_CRAN=true                              → prepare-cran
--dnl   NOT_CRAN explicit=true  + monorepo present     → dev-monorepo
--dnl   NOT_CRAN explicit=true  + monorepo absent      → dev-detached
--dnl   NOT_CRAN explicit=false + any                  → vendored-install
--dnl   auto-detect: monorepo present                  → dev-monorepo
--dnl   auto-detect: vendor hint present               → vendored-install
--dnl   auto-detect: neither                           → dev-detached
--
--HAS_MONOREPO=false
--if test -d "$root_miniextendr_repo/miniextendr-api"; then
--  HAS_MONOREPO=true
--fi
--
--HAS_VENDOR_HINT=false
--if test -d "$abs_top_srcdir/vendor" && test -n "$(ls -A "$abs_top_srcdir/vendor" 2>/dev/null)"; then
--  HAS_VENDOR_HINT=true
--elif test -f "$abs_top_srcdir/inst/vendor.tar.xz"; then
--  HAS_VENDOR_HINT=true
--fi
--
--if test "$PREPARE_CRAN" = "true"; then
--  BUILD_CONTEXT="prepare-cran"
--elif test "$NOT_CRAN_EXPLICIT" = "true"; then
--  if test "$NOT_CRAN" = "true"; then
--    if test "$HAS_MONOREPO" = "true"; then
--      BUILD_CONTEXT="dev-monorepo"
--    else
--      BUILD_CONTEXT="dev-detached"
--    fi
--  else
--    BUILD_CONTEXT="vendored-install"
--  fi
--else
--  dnl Neither PREPARE_CRAN nor NOT_CRAN explicitly set — auto-detect
--  if test "$HAS_MONOREPO" = "true"; then
--    BUILD_CONTEXT="dev-monorepo"
--  elif test "$HAS_VENDOR_HINT" = "true"; then
--    BUILD_CONTEXT="vendored-install"
--  else
--    BUILD_CONTEXT="dev-detached"
--  fi
--fi
--AC_SUBST([BUILD_CONTEXT])
--
--dnl Derive NOT_CRAN from BUILD_CONTEXT for backward compatibility
--case "$BUILD_CONTEXT" in
--  dev-monorepo|dev-detached)
--    NOT_CRAN=true
--    ;;
--  vendored-install|prepare-cran)
--    NOT_CRAN=false
--    ;;
--esac
--export NOT_CRAN
--AC_SUBST([NOT_CRAN])
--
--dnl Set cargo offline/locked flags based on BUILD_CONTEXT
--dnl Dev contexts: no --offline (cargo uses network or [patch] paths)
--dnl Release contexts: --offline (all deps must be vendored)
--case "$BUILD_CONTEXT" in
--  dev-monorepo|dev-detached)
--    CARGO_OFFLINE_FLAG=""
--    ;;
--  vendored-install|prepare-cran)
--    CARGO_OFFLINE_FLAG="--offline"
--    ;;
--esac
--AC_SUBST([CARGO_OFFLINE_FLAG])
--
- dnl ---- tool discovery ----
- AC_PATH_TOOL([CARGO],[cargo],[no])
-@@ -190,15 +115,12 @@
- dnl MSYS2 paths like /d/a/foo become D:/d/a/foo when interpreted by Cargo,
- dnl so we convert them to proper Windows paths (D:/a/foo) with cygpath -m.
--root_miniextendr_repo_cargo="$root_miniextendr_repo"
- abs_rpkg_src_cargo="$abs_rpkg_src"
- case "$host_os" in
-   *msys*|*cygwin*|*mingw*)
-     if test "x$CYGPATH" != "xno"; then
--      root_miniextendr_repo_cargo="$($CYGPATH -m "$root_miniextendr_repo")"
-       abs_rpkg_src_cargo="$($CYGPATH -m "$abs_rpkg_src")"
-     fi
-     ;;
- esac
--AC_SUBST([ROOT_MINIEXTENDR_REPO_CARGO], ["$root_miniextendr_repo_cargo"])
- AC_SUBST([ABS_RPKG_SRC_CARGO], ["$abs_rpkg_src_cargo"])
- 
-@@ -300,9 +222,6 @@
- 
- dnl ---- user feedback ----
--AC_MSG_NOTICE([BUILD_CONTEXT         = $BUILD_CONTEXT])
--AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
--AS_IF([test "$PREPARE_CRAN" = "true"],
--      [AC_MSG_NOTICE([PREPARE_CRAN          = $PREPARE_CRAN])])
- AC_MSG_NOTICE([R_HOME                = $R_HOME])
-+AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
- AC_MSG_NOTICE([CARGO_TARGET_DIR      = $CARGO_TARGET_DIR])
- AC_MSG_NOTICE([CARGO_PROFILE         = $CARGO_PROFILE])
-@@ -314,6 +233,6 @@
+@@ -237,6 +233,6 @@
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
  AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
@@ -288,7 +143,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -330,14 +249,4 @@
+@@ -253,14 +249,4 @@
  AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
  
 -dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
@@ -303,379 +158,108 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -
  dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
-@@ -370,8 +279,7 @@
+@@ -293,5 +279,5 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Note: Cargo.toml now uses git dependencies with [patch."https://..."] for local dev.
+-dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
--dnl In dev mode, we remove the cargo config so cargo uses normal resolution with
--dnl the [patch] section in Cargo.toml.
-+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
- 
- dnl ---- output files ----
-@@ -382,45 +290,27 @@
+ dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+@@ -304,9 +290,9 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
 +  src/{{package}}-win.def:src/win.def.in
  ])
  
--dnl 1) Configure cargo config and [patch] section based on BUILD_CONTEXT
-+dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
+ dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
+-dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
 +dnl    In dev mode, Cargo.toml uses git deps directly
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-   RPKG_CFG="src/rust/.cargo/config.toml"
- 
--  case "$BUILD_CONTEXT" in
--    dev-monorepo)
--      dnl Remove cargo config — use [patch] paths to monorepo
--      if test -f "$RPKG_CFG"; then
--        rm "$RPKG_CFG"
--        echo "configure: removed cargo config (dev-monorepo — using [patch] paths)"
--      fi
--      ;;
--    dev-detached)
--      dnl Remove cargo config — use git/network deps directly
--      if test -f "$RPKG_CFG"; then
--        rm "$RPKG_CFG"
--        echo "configure: removed cargo config (dev-detached — using git deps)"
--      fi
--      dnl Strip [patch] section — paths reference monorepo which isn't available
--      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: stripped @<:@patch@:>@ section (dev-detached — monorepo not available)"
--      fi
--      ;;
--    vendored-install|prepare-cran)
--      dnl Keep cargo config for vendored source resolution
--      echo "configure: keeping cargo config ($BUILD_CONTEXT)"
--      ;;
--  esac
-+  if test "$NOT_CRAN" = "true"; then
-+    dnl In dev mode, remove the generated cargo config so cargo uses normal resolution
-+    if test -f "$RPKG_CFG"; then
-+      rm "$RPKG_CFG"
+@@ -317,5 +303,5 @@
+     if test -f "$RPKG_CFG"; then
+       rm "$RPKG_CFG"
+-      echo "configure: removed cargo config (dev mode)"
 +      echo "configure: removed cargo config (dev mode - using git deps)"
-+    fi
-+  fi
- ],
--[BUILD_CONTEXT="$BUILD_CONTEXT" SED="$SED"])
-+[NOT_CRAN="$NOT_CRAN"])
- 
- dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
- dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor
- 
--dnl 1) Ensure Cargo.lock is compatible with the installed cargo version.
-+dnl 2) Ensure Cargo.lock is compatible with the installed cargo version.
- dnl    Older cargo releases (e.g. 1.75) cannot read lockfile version 4.
- AC_CONFIG_COMMANDS([cargo-lockfile-compat],
-@@ -440,26 +330,25 @@
-     if test "$CARGO_MAJOR" -lt 1 || \
-        (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
--      dnl In release contexts, ensure vendor sources exist before regenerating lockfile.
--      case "$BUILD_CONTEXT" in
--        vendored-install|prepare-cran)
--          if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
--            if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
--              echo "configure: $BUILD_CONTEXT - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
--              (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
--              if test $? -ne 0; then
--                echo "configure: error: failed to unpack vendor.tar.xz" >&2
--                exit 1
--              fi
--              if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
--                $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
--              fi
--            else
--              echo "configure: error: $BUILD_CONTEXT requires vendored sources to regenerate Cargo.lock" >&2
--              echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
-+      dnl In CRAN/offline mode, ensure vendor sources exist before regenerating lockfile.
-+      if test "$NOT_CRAN" != "true"; then
-+        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+          if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-+            echo "configure: CRAN build - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
-+            (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-+            if test $? -ne 0; then
-+              echo "configure: error: failed to unpack vendor.tar.xz" >&2
-               exit 1
-             fi
-+            dnl Strip checksums from Cargo.lock (vendored crates have empty checksums)
-+            if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+              $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-+            fi
-+          else
-+            echo "configure: error: CRAN/offline build requires vendored sources to regenerate Cargo.lock" >&2
-+            echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
-+            exit 1
-           fi
--          ;;
--      esac
-+        fi
-+      fi
-       echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
-       rm -f "$LOCKFILE_PATH"
-@@ -473,180 +362,93 @@
+     fi
    fi
- ],
--[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
-+[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+@@ -379,5 +365,5 @@
  
--dnl 2) Handle vendor directory based on BUILD_CONTEXT
-+dnl 3) Ensure vendor/ exists for offline builds
+ dnl 3) Ensure vendor/ exists for offline builds
+-dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
-+dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
-+dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
- AC_CONFIG_COMMANDS([cargo-vendor],
- [
--  case "$BUILD_CONTEXT" in
--    dev-monorepo)
--      dnl Clean stale vendor artifacts, use [patch] paths
--      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
--        rm -rf "$VENDOR_OUT"
--        echo "configure: removed vendor directory (dev-monorepo)"
-+  if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+    if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-+      echo "configure: unpacking inst/vendor.tar.xz"
-+      (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-+      if test $? -ne 0; then
-+        echo "configure: error: failed to unpack vendor.tar.xz" >&2
-+        exit 1
+ dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
+ dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
+@@ -424,5 +410,4 @@
        fi
--      rm -f "$VENDOR_OUT/.vendor.lock.cksum"
+     elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+-      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
+       echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+       "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+@@ -449,62 +434,4 @@
+       echo "configure: error: CRAN build requires vendored sources." >&2
+       echo "configure:        Run 'just vendor' before CRAN submission." >&2
+-      exit 1
+-    fi
 -
--      dnl Reverse vendored-install Cargo.toml rewrites if present
--      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
--        dnl 1) Rewrite vendor path deps back to git deps
--        for _crate in miniextendr-api miniextendr-lint; do
--          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-    dnl Rewrite git deps to vendor/ path deps for offline builds.
+-    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
+-    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
+-    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
+-    for _crate in miniextendr-api miniextendr-lint; do
+-      _vendor_dir=""
+-      if test -d "$VENDOR_OUT/$_crate"; then
+-        _vendor_dir="$VENDOR_OUT/$_crate"
+-      else
+-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
 -        done
--
--        dnl 2) Strip [patch.crates-io] section and trailing blank lines
--        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
--          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        fi
--        dnl Remove trailing blank lines left after section deletion
--        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--
--        dnl 3) Add [patch."https://..."] with monorepo-relative paths
--        printf '@<:@patch."https://github.com/CGMossa/miniextendr"@:>@\n' >> src/rust/Cargo.toml
--        for _crate in miniextendr-api miniextendr-macros miniextendr-macros-core miniextendr-lint; do
--          printf '%s = { path = "../../../%s" }\n' "$_crate" "$_crate" >> src/rust/Cargo.toml
--        done
--
--        echo "configure: restored Cargo.toml from vendored to monorepo state"
-+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-       fi
-+    fi
-+  fi
- 
--      echo "configure: dev-monorepo — using [patch] paths"
--      ;;
--    dev-detached)
--      dnl Clean stale vendor artifacts, use git/network deps
--      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
--        rm -rf "$VENDOR_OUT"
--        echo "configure: removed vendor directory (dev-detached)"
-+  if test "$NOT_CRAN" = "true"; then
-+    if test "$FORCE_VENDOR" = "1"; then
-+      echo "configure: FORCE_VENDOR — running cargo vendor"
-+      mkdir -p "$VENDOR_OUT"
-+      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-+      if test $? -ne 0; then
-+        echo "configure: error: cargo vendor failed" >&2
-+        exit 1
-       fi
--
--      dnl Reverse vendored-install Cargo.toml rewrites if present
--      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
--        dnl 1) Rewrite vendor path deps back to git deps
--        for _crate in miniextendr-api miniextendr-lint; do
--          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        done
--
--        dnl 2) Strip [patch.crates-io] section and trailing blank lines
--        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
--          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        fi
--        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--
--        echo "configure: restored Cargo.toml from vendored to git state"
 -      fi
--
--      echo "configure: dev-detached — using git/network deps"
--      ;;
--    vendored-install|prepare-cran)
--      dnl Ensure vendor/ exists: unpack tarball or vendor from network
--      if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
--        if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
--          echo "configure: unpacking inst/vendor.tar.xz"
--          (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
--          if test $? -ne 0; then
--            echo "configure: error: failed to unpack vendor.tar.xz" >&2
--            exit 1
--          fi
--          if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
--            $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
--          fi
--        elif test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
--          dnl No tarball — try vendor-crates.R to populate vendor/
--          echo "configure: no inst/vendor.tar.xz — calling tools/vendor-crates.R sync"
--          "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
--            sync --path "$abs_rpkg_dir" 2>&1 || {
--            echo "configure: error: vendor-crates.R sync failed" >&2
--            exit 1
--          }
--        else
--          echo "configure: error: $BUILD_CONTEXT requires vendored sources." >&2
--          echo "configure:        Provide inst/vendor.tar.xz or tools/vendor-crates.R." >&2
--          exit 1
--        fi
+-      if test -n "$_vendor_dir"; then
+-        _dirname="$(basename "$_vendor_dir")"
+-        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
+-          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
 -      fi
+-    done
 -
--      dnl Vendor exists — rewrite deps for vendored build
--      echo "configure: $BUILD_CONTEXT — vendor ready"
+-    dnl Strip [patch] section (monorepo paths not available in tarball)
+-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
+-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-      echo "configure: stripped @<:@patch@:>@ section"
+-    fi
 -
--      dnl Rewrite git deps to path deps
--      dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
--      dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
--      for _crate in miniextendr-api miniextendr-lint; do
--        _vendor_dir=""
--        if test -d "$VENDOR_OUT/$_crate"; then
--          _vendor_dir="$VENDOR_OUT/$_crate"
--        else
--          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-+      for _crate_dir in "$VENDOR_OUT"/*/; do
-+        if test -d "$_crate_dir"; then
-+          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-+                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-+          for _dotfile in "$_crate_dir"/.*; do
-+            case "$(basename "$_dotfile")" in
-+              .|..|.cargo-checksum.json) ;;
-+              *) rm -rf "$_dotfile" ;;
-+            esac
-           done
-+          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
-         fi
--        if test -n "$_vendor_dir"; then
--          _dirname="$(basename "$_vendor_dir")"
--          "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--          echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
--        fi
-       done
--
--      dnl Strip [patch] section (monorepo paths not available)
--      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: stripped [patch] section"
-+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-       fi
--
--      dnl Add [patch.crates-io] for transitive miniextendr deps
--      _patch_lines=""
--      for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
--        _vendor_dir=""
--        if test -d "$VENDOR_OUT/$_crate"; then
--          _vendor_dir="$VENDOR_OUT/$_crate"
--        else
--          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--          done
--        fi
--        if test -n "$_vendor_dir"; then
--          _dirname="$(basename "$_vendor_dir")"
--          _patch_lines="$_patch_lines
+-    dnl Add [patch.crates-io] for transitive miniextendr deps
+-    _patch_lines=""
+-    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
+-      _vendor_dir=""
+-      if test -d "$VENDOR_OUT/$_crate"; then
+-        _vendor_dir="$VENDOR_OUT/$_crate"
+-      else
+-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+-        done
+-      fi
+-      if test -n "$_vendor_dir"; then
+-        _dirname="$(basename "$_vendor_dir")"
+-        _patch_lines="$_patch_lines
 -$_crate = { path = \"../../vendor/$_dirname\" }"
--        fi
--      done
--      if test -n "$_patch_lines"; then
--        printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
--        echo "configure: added [patch.crates-io] for transitive deps"
-+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-+      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-+      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-+        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-+        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-+      }
-+    elif test -f "$VENDOR_OUT/.vendor-source"; then
-+      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-+      if test -d "$_recorded"; then
-+        echo "configure: syncing vendor/ from recorded source: $_recorded"
-+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-+          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-+          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-+        }
-+      else
-+        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
-       fi
--
--      dnl Regenerate Cargo.lock from vendored sources
--      rm -f src/rust/Cargo.lock
--      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--      if test $? -ne 0; then
--        echo "configure: error: failed to generate lockfile from vendored sources" >&2
--        exit 1
 -      fi
--      echo "configure: regenerated Cargo.lock for $BUILD_CONTEXT"
--      ;;
--  esac
-+    else
-+      echo "configure: dev mode — using vendor/ from scaffolding"
-+    fi
-+  else
-+    dnl CRAN/offline mode: vendor/ must exist
-+    if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+      echo "configure: error: CRAN build requires vendored sources." >&2
-+      echo "configure:        Run 'just vendor' before CRAN submission." >&2
-+      exit 1
-+    fi
-+    echo "configure: CRAN build — vendor ready"
-+  fi
- ],
--[CARGO_CMD="$CARGO_CMD" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
-+[NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
- 
--dnl 2b) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
-+dnl 4) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
- AC_CONFIG_COMMANDS([post-vendor],
- [
-   dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
-   if test ! -f "src/rust/Cargo.lock"; then
--    case "$BUILD_CONTEXT" in
--      dev-monorepo|dev-detached)
--        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
--        ;;
--      vendored-install|prepare-cran)
--        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--        ;;
--    esac
-+    if test "$NOT_CRAN" = "true"; then
-+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
-+    else
-+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-+    fi
-   fi
- 
-@@ -660,5 +462,5 @@
-   dnl Dev mode does not use --locked, so cargo resolves source locations at build time.
- ],
--[ABS_RPKG_SRC="$abs_rpkg_src" BUILD_CONTEXT="$BUILD_CONTEXT" CARGO_CMD="$CARGO_CMD"])
-+[ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
- 
- AC_OUTPUT
+-    done
+-    if test -n "$_patch_lines"; then
+-      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
+-      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
+-    fi
+-
+-    dnl Regenerate Cargo.lock from vendored sources
+-    rm -f src/rust/Cargo.lock
+-    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+-    if test $? -ne 0; then
+-      echo "configure: error: failed to generate lockfile from vendored sources" >&2
+       exit 1
+     fi
 diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
 --- a/rpkg/Makevars.in	2026-03-13 19:23:15
 +++ b/rpkg/Makevars.in	2026-03-12 07:03:30
@@ -759,54 +343,14 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  clean:
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-13 21:21:42
+--- a/rpkg/configure.ac	2026-03-15 07:53:06
 +++ b/rpkg/configure.ac	2026-03-13 12:03:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
  
  dnl Use tools/ directory for auxiliary build files (config.guess, config.sub)
-@@ -30,18 +30,8 @@
- fi
- 
--dnl ---- Build context inputs ----
--dnl PREPARE_CRAN: explicit release-prep signal (highest precedence)
--: ${PREPARE_CRAN:=false}
--case "$PREPARE_CRAN" in
--  true|TRUE|1) PREPARE_CRAN=true ;;
--  *)           PREPARE_CRAN=false ;;
--esac
--
--dnl NOT_CRAN: legacy compatibility signal
--dnl Detect if explicitly set BEFORE defaulting, so auto-detection works
--NOT_CRAN_EXPLICIT=false
--if test "${NOT_CRAN+set}" = "set"; then
--  NOT_CRAN_EXPLICIT=true
--fi
-+dnl NOT_CRAN handling:
-+dnl - CRAN builds: NOT_CRAN is unset or empty → default to false (offline mode)
-+dnl - Dev builds: set NOT_CRAN=true in environment to enable network/vendoring
-+dnl Normalize to "true" or "false" for consistent checks
- : ${NOT_CRAN:=false}
- case "$NOT_CRAN" in
-@@ -49,27 +39,42 @@
-   *)           NOT_CRAN=false ;;
- esac
-+export NOT_CRAN
- 
--dnl BUILD_CONTEXT, cargo flags, and NOT_CRAN derivation are set after
--dnl canonical paths are computed (needs monorepo detection).
-+dnl Set cargo offline/locked flags based on NOT_CRAN
-+dnl - NOT_CRAN=true (dev): no --offline, no --locked (cargo updates lockfile for patches)
-+dnl - NOT_CRAN=false (CRAN): use --offline, omit --locked (checksums cleared)
-+if test "$NOT_CRAN" = "true"; then
-+  CARGO_OFFLINE_FLAG=""
-+else
-+  CARGO_OFFLINE_FLAG="--offline"
-+fi
-+AC_SUBST([CARGO_OFFLINE_FLAG])
-+AC_SUBST([NOT_CRAN])
- 
+@@ -54,31 +54,27 @@
  dnl Set cargo features flag
  dnl
 -dnl rpkg is a demo package that demonstrates ALL miniextendr features.
@@ -823,20 +367,27 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -dnl Enable all features by default for this demo package
 -dnl Users can override by setting MINIEXTENDR_FEATURES explicitly (even to empty string)
 -if test -z "${MINIEXTENDR_FEATURES+x}"; then
--  dnl MINIEXTENDR_FEATURES not set - enable all optional features
--  MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+-  dnl MINIEXTENDR_FEATURES not set — auto-detect via R script if available,
+-  dnl falling back to the full feature set for this demo package
 +dnl Default: no extra features enabled
 +dnl Users can set {{{features_var}}} to enable specific features
 +if test -z "${{{{features_var}}}+x}"; then
 +  dnl {{{features_var}}} not set - auto-detect via R script if available
-+  if test -f "${srcdir}/tools/detect-features.R"; then
+   if test -f "${srcdir}/tools/detect-features.R"; then
+-    MINIEXTENDR_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
+-    if test -n "$MINIEXTENDR_FEATURES"; then
+-      AC_MSG_NOTICE([Auto-detected features: $MINIEXTENDR_FEATURES])
 +    {{{features_var}}}=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
 +    if test -n "${{{features_var}}}"; then
 +      AC_MSG_NOTICE([Auto-detected features: ${{{features_var}}}])
-+    fi
+     fi
 +  else
 +    {{{features_var}}}=""
-+  fi
+   fi
+-  dnl If auto-detection returned nothing, enable all features
+-  if test -z "$MINIEXTENDR_FEATURES"; then
+-    MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+-  fi
  fi
  
 -if test -n "$MINIEXTENDR_FEATURES"; then
@@ -845,119 +396,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -94,84 +99,4 @@
- AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
- 
--dnl Miniextendr crate source paths (in monorepo)
--MINIEXTENDR_API_SRC="$root_miniextendr_repo/miniextendr-api"
--MINIEXTENDR_MACROS_SRC="$root_miniextendr_repo/miniextendr-macros"
--MINIEXTENDR_MACROS_CORE_SRC="$root_miniextendr_repo/miniextendr-macros-core"
--MINIEXTENDR_LINT_SRC="$root_miniextendr_repo/miniextendr-lint"
--MINIEXTENDR_ENGINE_SRC="$root_miniextendr_repo/miniextendr-engine"
--
--dnl ---- Build context resolution ----
--dnl Resolve one of: dev-monorepo, dev-detached, vendored-install, prepare-cran
--dnl
--dnl Truth table:
--dnl   PREPARE_CRAN=true                              → prepare-cran
--dnl   NOT_CRAN explicit=true  + monorepo present     → dev-monorepo
--dnl   NOT_CRAN explicit=true  + monorepo absent      → dev-detached
--dnl   NOT_CRAN explicit=false + any                  → vendored-install
--dnl   auto-detect: monorepo present                  → dev-monorepo
--dnl   auto-detect: vendor hint present               → vendored-install
--dnl   auto-detect: neither                           → dev-detached
--
--HAS_MONOREPO=false
--if test -d "$root_miniextendr_repo/miniextendr-api"; then
--  HAS_MONOREPO=true
--fi
--
--HAS_VENDOR_HINT=false
--if test -d "$abs_top_srcdir/vendor" && test -n "$(ls -A "$abs_top_srcdir/vendor" 2>/dev/null)"; then
--  HAS_VENDOR_HINT=true
--elif test -f "$abs_top_srcdir/inst/vendor.tar.xz"; then
--  HAS_VENDOR_HINT=true
--fi
--
--if test "$PREPARE_CRAN" = "true"; then
--  BUILD_CONTEXT="prepare-cran"
--elif test "$NOT_CRAN_EXPLICIT" = "true"; then
--  if test "$NOT_CRAN" = "true"; then
--    if test "$HAS_MONOREPO" = "true"; then
--      BUILD_CONTEXT="dev-monorepo"
--    else
--      BUILD_CONTEXT="dev-detached"
--    fi
--  else
--    BUILD_CONTEXT="vendored-install"
--  fi
--else
--  dnl Neither PREPARE_CRAN nor NOT_CRAN explicitly set — auto-detect
--  if test "$HAS_MONOREPO" = "true"; then
--    BUILD_CONTEXT="dev-monorepo"
--  elif test "$HAS_VENDOR_HINT" = "true"; then
--    BUILD_CONTEXT="vendored-install"
--  else
--    BUILD_CONTEXT="dev-detached"
--  fi
--fi
--AC_SUBST([BUILD_CONTEXT])
--
--dnl Derive NOT_CRAN from BUILD_CONTEXT for backward compatibility
--case "$BUILD_CONTEXT" in
--  dev-monorepo|dev-detached)
--    NOT_CRAN=true
--    ;;
--  vendored-install|prepare-cran)
--    NOT_CRAN=false
--    ;;
--esac
--export NOT_CRAN
--AC_SUBST([NOT_CRAN])
--
--dnl Set cargo offline/locked flags based on BUILD_CONTEXT
--dnl Dev contexts: no --offline (cargo uses network or [patch] paths)
--dnl Release contexts: --offline (all deps must be vendored)
--case "$BUILD_CONTEXT" in
--  dev-monorepo|dev-detached)
--    CARGO_OFFLINE_FLAG=""
--    ;;
--  vendored-install|prepare-cran)
--    CARGO_OFFLINE_FLAG="--offline"
--    ;;
--esac
--AC_SUBST([CARGO_OFFLINE_FLAG])
--
- dnl ---- tool discovery ----
- AC_PATH_TOOL([CARGO],[cargo],[no])
-@@ -190,15 +115,12 @@
- dnl MSYS2 paths like /d/a/foo become D:/d/a/foo when interpreted by Cargo,
- dnl so we convert them to proper Windows paths (D:/a/foo) with cygpath -m.
--root_miniextendr_repo_cargo="$root_miniextendr_repo"
- abs_rpkg_src_cargo="$abs_rpkg_src"
- case "$host_os" in
-   *msys*|*cygwin*|*mingw*)
-     if test "x$CYGPATH" != "xno"; then
--      root_miniextendr_repo_cargo="$($CYGPATH -m "$root_miniextendr_repo")"
-       abs_rpkg_src_cargo="$($CYGPATH -m "$abs_rpkg_src")"
-     fi
-     ;;
- esac
--AC_SUBST([ROOT_MINIEXTENDR_REPO_CARGO], ["$root_miniextendr_repo_cargo"])
- AC_SUBST([ABS_RPKG_SRC_CARGO], ["$abs_rpkg_src_cargo"])
- 
-@@ -300,9 +222,6 @@
- 
- dnl ---- user feedback ----
--AC_MSG_NOTICE([BUILD_CONTEXT         = $BUILD_CONTEXT])
--AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
--AS_IF([test "$PREPARE_CRAN" = "true"],
--      [AC_MSG_NOTICE([PREPARE_CRAN          = $PREPARE_CRAN])])
- AC_MSG_NOTICE([R_HOME                = $R_HOME])
-+AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
- AC_MSG_NOTICE([CARGO_TARGET_DIR      = $CARGO_TARGET_DIR])
- AC_MSG_NOTICE([CARGO_PROFILE         = $CARGO_PROFILE])
-@@ -314,6 +233,6 @@
+@@ -237,6 +233,6 @@
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
  AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
@@ -966,7 +405,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -330,14 +249,4 @@
+@@ -253,14 +249,4 @@
  AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
  
 -dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
@@ -981,377 +420,99 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -
  dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
-@@ -370,8 +279,7 @@
+@@ -293,5 +279,5 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Note: Cargo.toml now uses git dependencies with [patch."https://..."] for local dev.
+-dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
--dnl In dev mode, we remove the cargo config so cargo uses normal resolution with
--dnl the [patch] section in Cargo.toml.
-+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
- 
- dnl ---- output files ----
-@@ -382,45 +290,27 @@
+ dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+@@ -304,9 +290,9 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
 +  src/{{package}}-win.def:src/win.def.in
  ])
  
--dnl 1) Configure cargo config and [patch] section based on BUILD_CONTEXT
-+dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
+ dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
+-dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
 +dnl    In dev mode, Cargo.toml uses git deps directly
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-   RPKG_CFG="src/rust/.cargo/config.toml"
- 
--  case "$BUILD_CONTEXT" in
--    dev-monorepo)
--      dnl Remove cargo config — use [patch] paths to monorepo
--      if test -f "$RPKG_CFG"; then
--        rm "$RPKG_CFG"
--        echo "configure: removed cargo config (dev-monorepo — using [patch] paths)"
--      fi
--      ;;
--    dev-detached)
--      dnl Remove cargo config — use git/network deps directly
--      if test -f "$RPKG_CFG"; then
--        rm "$RPKG_CFG"
--        echo "configure: removed cargo config (dev-detached — using git deps)"
--      fi
--      dnl Strip [patch] section — paths reference monorepo which isn't available
--      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: stripped @<:@patch@:>@ section (dev-detached — monorepo not available)"
--      fi
--      ;;
--    vendored-install|prepare-cran)
--      dnl Keep cargo config for vendored source resolution
--      echo "configure: keeping cargo config ($BUILD_CONTEXT)"
--      ;;
--  esac
-+  if test "$NOT_CRAN" = "true"; then
-+    dnl In dev mode, remove the generated cargo config so cargo uses normal resolution
-+    if test -f "$RPKG_CFG"; then
-+      rm "$RPKG_CFG"
+@@ -317,5 +303,5 @@
+     if test -f "$RPKG_CFG"; then
+       rm "$RPKG_CFG"
+-      echo "configure: removed cargo config (dev mode)"
 +      echo "configure: removed cargo config (dev mode - using git deps)"
-+    fi
-+  fi
- ],
--[BUILD_CONTEXT="$BUILD_CONTEXT" SED="$SED"])
-+[NOT_CRAN="$NOT_CRAN"])
- 
- dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
- dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor
- 
--dnl 1) Ensure Cargo.lock is compatible with the installed cargo version.
-+dnl 2) Ensure Cargo.lock is compatible with the installed cargo version.
- dnl    Older cargo releases (e.g. 1.75) cannot read lockfile version 4.
- AC_CONFIG_COMMANDS([cargo-lockfile-compat],
-@@ -440,26 +330,25 @@
-     if test "$CARGO_MAJOR" -lt 1 || \
-        (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
--      dnl In release contexts, ensure vendor sources exist before regenerating lockfile.
--      case "$BUILD_CONTEXT" in
--        vendored-install|prepare-cran)
--          if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
--            if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
--              echo "configure: $BUILD_CONTEXT - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
--              (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
--              if test $? -ne 0; then
--                echo "configure: error: failed to unpack vendor.tar.xz" >&2
--                exit 1
--              fi
--              if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
--                $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
--              fi
--            else
--              echo "configure: error: $BUILD_CONTEXT requires vendored sources to regenerate Cargo.lock" >&2
--              echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
-+      dnl In CRAN/offline mode, ensure vendor sources exist before regenerating lockfile.
-+      if test "$NOT_CRAN" != "true"; then
-+        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+          if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-+            echo "configure: CRAN build - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
-+            (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-+            if test $? -ne 0; then
-+              echo "configure: error: failed to unpack vendor.tar.xz" >&2
-               exit 1
-             fi
-+            dnl Strip checksums from Cargo.lock (vendored crates have empty checksums)
-+            if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+              $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-+            fi
-+          else
-+            echo "configure: error: CRAN/offline build requires vendored sources to regenerate Cargo.lock" >&2
-+            echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
-+            exit 1
-           fi
--          ;;
--      esac
-+        fi
-+      fi
-       echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
-       rm -f "$LOCKFILE_PATH"
-@@ -473,180 +362,94 @@
+     fi
    fi
- ],
--[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
-+[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+@@ -379,5 +365,5 @@
  
--dnl 2) Handle vendor directory based on BUILD_CONTEXT
-+dnl 3) Ensure vendor/ exists for offline builds
+ dnl 3) Ensure vendor/ exists for offline builds
+-dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
-+dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
-+dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
- AC_CONFIG_COMMANDS([cargo-vendor],
- [
--  case "$BUILD_CONTEXT" in
--    dev-monorepo)
--      dnl Clean stale vendor artifacts, use [patch] paths
--      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
--        rm -rf "$VENDOR_OUT"
--        echo "configure: removed vendor directory (dev-monorepo)"
-+  if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+    if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-+      echo "configure: unpacking inst/vendor.tar.xz"
-+      (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-+      if test $? -ne 0; then
-+        echo "configure: error: failed to unpack vendor.tar.xz" >&2
-+        exit 1
-       fi
--      rm -f "$VENDOR_OUT/.vendor.lock.cksum"
+ dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
+ dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
+@@ -449,62 +435,4 @@
+       echo "configure: error: CRAN build requires vendored sources." >&2
+       echo "configure:        Run 'just vendor' before CRAN submission." >&2
+-      exit 1
+-    fi
 -
--      dnl Reverse vendored-install Cargo.toml rewrites if present
--      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
--        dnl 1) Rewrite vendor path deps back to git deps
--        for _crate in miniextendr-api miniextendr-lint; do
--          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-    dnl Rewrite git deps to vendor/ path deps for offline builds.
+-    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
+-    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
+-    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
+-    for _crate in miniextendr-api miniextendr-lint; do
+-      _vendor_dir=""
+-      if test -d "$VENDOR_OUT/$_crate"; then
+-        _vendor_dir="$VENDOR_OUT/$_crate"
+-      else
+-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
 -        done
--
--        dnl 2) Strip [patch.crates-io] section and trailing blank lines
--        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
--          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        fi
--        dnl Remove trailing blank lines left after section deletion
--        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--
--        dnl 3) Add [patch."https://..."] with monorepo-relative paths
--        printf '@<:@patch."https://github.com/CGMossa/miniextendr"@:>@\n' >> src/rust/Cargo.toml
--        for _crate in miniextendr-api miniextendr-macros miniextendr-macros-core miniextendr-lint; do
--          printf '%s = { path = "../../../%s" }\n' "$_crate" "$_crate" >> src/rust/Cargo.toml
--        done
--
--        echo "configure: restored Cargo.toml from vendored to monorepo state"
-+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-       fi
-+    fi
-+  fi
- 
--      echo "configure: dev-monorepo — using [patch] paths"
--      ;;
--    dev-detached)
--      dnl Clean stale vendor artifacts, use git/network deps
--      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
--        rm -rf "$VENDOR_OUT"
--        echo "configure: removed vendor directory (dev-detached)"
-+  if test "$NOT_CRAN" = "true"; then
-+    if test "$FORCE_VENDOR" = "1"; then
-+      echo "configure: FORCE_VENDOR — running cargo vendor"
-+      mkdir -p "$VENDOR_OUT"
-+      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-+      if test $? -ne 0; then
-+        echo "configure: error: cargo vendor failed" >&2
-+        exit 1
-       fi
--
--      dnl Reverse vendored-install Cargo.toml rewrites if present
--      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
--        dnl 1) Rewrite vendor path deps back to git deps
--        for _crate in miniextendr-api miniextendr-lint; do
--          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        done
--
--        dnl 2) Strip [patch.crates-io] section and trailing blank lines
--        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
--          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        fi
--        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--
--        echo "configure: restored Cargo.toml from vendored to git state"
 -      fi
--
--      echo "configure: dev-detached — using git/network deps"
--      ;;
--    vendored-install|prepare-cran)
--      dnl Ensure vendor/ exists: unpack tarball or vendor from network
--      if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
--        if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
--          echo "configure: unpacking inst/vendor.tar.xz"
--          (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
--          if test $? -ne 0; then
--            echo "configure: error: failed to unpack vendor.tar.xz" >&2
--            exit 1
--          fi
--          if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
--            $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
--          fi
--        elif test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
--          dnl No tarball — try vendor-crates.R to populate vendor/
--          echo "configure: no inst/vendor.tar.xz — calling tools/vendor-crates.R sync"
--          "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
--            sync --path "$abs_rpkg_dir" 2>&1 || {
--            echo "configure: error: vendor-crates.R sync failed" >&2
--            exit 1
--          }
--        else
--          echo "configure: error: $BUILD_CONTEXT requires vendored sources." >&2
--          echo "configure:        Provide inst/vendor.tar.xz or tools/vendor-crates.R." >&2
--          exit 1
--        fi
+-      if test -n "$_vendor_dir"; then
+-        _dirname="$(basename "$_vendor_dir")"
+-        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
+-          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
 -      fi
+-    done
 -
--      dnl Vendor exists — rewrite deps for vendored build
--      echo "configure: $BUILD_CONTEXT — vendor ready"
+-    dnl Strip [patch] section (monorepo paths not available in tarball)
+-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
+-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-      echo "configure: stripped @<:@patch@:>@ section"
+-    fi
 -
--      dnl Rewrite git deps to path deps
--      dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
--      dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
--      for _crate in miniextendr-api miniextendr-lint; do
--        _vendor_dir=""
--        if test -d "$VENDOR_OUT/$_crate"; then
--          _vendor_dir="$VENDOR_OUT/$_crate"
--        else
--          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-+      for _crate_dir in "$VENDOR_OUT"/*/; do
-+        if test -d "$_crate_dir"; then
-+          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-+                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-+          for _dotfile in "$_crate_dir"/.*; do
-+            case "$(basename "$_dotfile")" in
-+              .|..|.cargo-checksum.json) ;;
-+              *) rm -rf "$_dotfile" ;;
-+            esac
-           done
-+          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
-         fi
--        if test -n "$_vendor_dir"; then
--          _dirname="$(basename "$_vendor_dir")"
--          "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
--            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--          echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
--        fi
-       done
--
--      dnl Strip [patch] section (monorepo paths not available)
--      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: stripped [patch] section"
-+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-       fi
--
--      dnl Add [patch.crates-io] for transitive miniextendr deps
--      _patch_lines=""
--      for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
--        _vendor_dir=""
--        if test -d "$VENDOR_OUT/$_crate"; then
--          _vendor_dir="$VENDOR_OUT/$_crate"
--        else
--          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--          done
--        fi
--        if test -n "$_vendor_dir"; then
--          _dirname="$(basename "$_vendor_dir")"
--          _patch_lines="$_patch_lines
+-    dnl Add [patch.crates-io] for transitive miniextendr deps
+-    _patch_lines=""
+-    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
+-      _vendor_dir=""
+-      if test -d "$VENDOR_OUT/$_crate"; then
+-        _vendor_dir="$VENDOR_OUT/$_crate"
+-      else
+-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+-        done
+-      fi
+-      if test -n "$_vendor_dir"; then
+-        _dirname="$(basename "$_vendor_dir")"
+-        _patch_lines="$_patch_lines
 -$_crate = { path = \"../../vendor/$_dirname\" }"
--        fi
--      done
--      if test -n "$_patch_lines"; then
--        printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
--        echo "configure: added [patch.crates-io] for transitive deps"
-+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-+      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
-+      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-+      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-+        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-+        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-+      }
-+    elif test -f "$VENDOR_OUT/.vendor-source"; then
-+      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-+      if test -d "$_recorded"; then
-+        echo "configure: syncing vendor/ from recorded source: $_recorded"
-+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-+          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-+          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-+        }
-+      else
-+        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
-       fi
--
--      dnl Regenerate Cargo.lock from vendored sources
--      rm -f src/rust/Cargo.lock
--      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--      if test $? -ne 0; then
--        echo "configure: error: failed to generate lockfile from vendored sources" >&2
--        exit 1
 -      fi
--      echo "configure: regenerated Cargo.lock for $BUILD_CONTEXT"
--      ;;
--  esac
-+    else
-+      echo "configure: dev mode — using vendor/ from scaffolding"
-+    fi
-+  else
-+    dnl CRAN/offline mode: vendor/ must exist
-+    if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-+      echo "configure: error: CRAN build requires vendored sources." >&2
-+      echo "configure:        Run 'just vendor' before CRAN submission." >&2
-+      exit 1
-+    fi
-+    echo "configure: CRAN build — vendor ready"
-+  fi
- ],
--[CARGO_CMD="$CARGO_CMD" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
-+[NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
- 
--dnl 2b) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
-+dnl 4) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
- AC_CONFIG_COMMANDS([post-vendor],
- [
-   dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
-   if test ! -f "src/rust/Cargo.lock"; then
--    case "$BUILD_CONTEXT" in
--      dev-monorepo|dev-detached)
--        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
--        ;;
--      vendored-install|prepare-cran)
--        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--        ;;
--    esac
-+    if test "$NOT_CRAN" = "true"; then
-+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
-+    else
-+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-+    fi
-   fi
- 
-@@ -660,5 +463,5 @@
-   dnl Dev mode does not use --locked, so cargo resolves source locations at build time.
- ],
--[ABS_RPKG_SRC="$abs_rpkg_src" BUILD_CONTEXT="$BUILD_CONTEXT" CARGO_CMD="$CARGO_CMD"])
-+[ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
- 
- AC_OUTPUT
+-    done
+-    if test -n "$_patch_lines"; then
+-      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
+-      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
+-    fi
+-
+-    dnl Regenerate Cargo.lock from vendored sources
+-    rm -f src/rust/Cargo.lock
+-    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+-    if test $? -ne 0; then
+-      echo "configure: error: failed to generate lockfile from vendored sources" >&2
+       exit 1
+     fi

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -81,7 +81,7 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  clean:
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-15 07:53:06
+--- a/monorepo/rpkg/configure.ac	2026-03-15 08:27:19
 +++ b/monorepo/rpkg/configure.ac	2026-03-13 12:03:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
@@ -158,14 +158,18 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -
  dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
-@@ -293,5 +279,5 @@
+@@ -293,8 +279,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
+-dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
+-dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
- dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
-@@ -304,9 +290,9 @@
+-dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
++dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+ 
+ dnl ---- output files ----
+@@ -305,9 +290,9 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -177,27 +181,27 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl    In dev mode, Cargo.toml uses git deps directly
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -317,5 +303,5 @@
+@@ -318,5 +303,5 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
 +      echo "configure: removed cargo config (dev mode - using git deps)"
      fi
    fi
-@@ -379,5 +365,5 @@
+@@ -380,5 +365,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -424,5 +410,4 @@
+@@ -425,5 +410,4 @@
        fi
      elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
 -      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
        echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-@@ -449,62 +434,4 @@
+@@ -450,62 +434,4 @@
        echo "configure: error: CRAN build requires vendored sources." >&2
        echo "configure:        Run 'just vendor' before CRAN submission." >&2
 -      exit 1
@@ -343,7 +347,7 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  clean:
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-15 07:53:06
+--- a/rpkg/configure.ac	2026-03-15 08:27:19
 +++ b/rpkg/configure.ac	2026-03-13 12:03:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
@@ -420,14 +424,18 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -
  dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
-@@ -293,5 +279,5 @@
+@@ -293,8 +279,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
+-dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
+-dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
- dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
-@@ -304,9 +290,9 @@
+-dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
++dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+ 
+ dnl ---- output files ----
+@@ -305,9 +290,9 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -439,21 +447,21 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl    In dev mode, Cargo.toml uses git deps directly
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -317,5 +303,5 @@
+@@ -318,5 +303,5 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
 +      echo "configure: removed cargo config (dev mode - using git deps)"
      fi
    fi
-@@ -379,5 +365,5 @@
+@@ -380,5 +365,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -449,62 +435,4 @@
+@@ -450,62 +435,4 @@
        echo "configure: error: CRAN build requires vendored sources." >&2
        echo "configure:        Run 'just vendor' before CRAN submission." >&2
 -      exit 1

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -625,19 +625,17 @@ CARGO_TARGET_DIR
 CARGO_CMD
 RUST_TOOLCHAIN
 ABS_RPKG_SRC_CARGO
-ROOT_MINIEXTENDR_REPO_CARGO
 CYGPATH
 SED
 RUSTC
 CARGO
-CARGO_OFFLINE_FLAG
-NOT_CRAN
-BUILD_CONTEXT
 ROOT_MINIEXTENDR_REPO
 ABS_RPKG_SRCDIR
 ABS_TOP_SRCDIR
 CARGO_FEATURES_FLAG
 MINIEXTENDR_FEATURES
+NOT_CRAN
+CARGO_OFFLINE_FLAG
 host_os
 host_vendor
 host_cpu
@@ -1974,27 +1972,34 @@ if test ! -d "$R_HOME"; then
   as_fn_error $? "R_HOME directory does not exist: $R_HOME" "$LINENO" 5
 fi
 
-: ${PREPARE_CRAN:=false}
-case "$PREPARE_CRAN" in
-  true|TRUE|1) PREPARE_CRAN=true ;;
-  *)           PREPARE_CRAN=false ;;
-esac
-
-NOT_CRAN_EXPLICIT=false
-if test "${NOT_CRAN+set}" = "set"; then
-  NOT_CRAN_EXPLICIT=true
-fi
 : ${NOT_CRAN:=false}
 case "$NOT_CRAN" in
   true|TRUE|1) NOT_CRAN=true ;;
   *)           NOT_CRAN=false ;;
 esac
+export NOT_CRAN
+
+if test "$NOT_CRAN" = "true"; then
+  CARGO_OFFLINE_FLAG=""
+else
+  CARGO_OFFLINE_FLAG="--offline"
+fi
+
 
 
 
 
 if test -z "${MINIEXTENDR_FEATURES+x}"; then
+      if test -f "${srcdir}/tools/detect-features.R"; then
+    MINIEXTENDR_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
+    if test -n "$MINIEXTENDR_FEATURES"; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Auto-detected features: $MINIEXTENDR_FEATURES" >&5
+printf "%s\n" "$as_me: Auto-detected features: $MINIEXTENDR_FEATURES" >&6;}
+    fi
+  fi
+    if test -z "$MINIEXTENDR_FEATURES"; then
     MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+  fi
 fi
 
 if test -n "$MINIEXTENDR_FEATURES"; then
@@ -2016,69 +2021,6 @@ RUST_SRC_DIR="$abs_rpkg_src/rust"
 
 root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
 ROOT_MINIEXTENDR_REPO="$root_miniextendr_repo"
-
-
-MINIEXTENDR_API_SRC="$root_miniextendr_repo/miniextendr-api"
-MINIEXTENDR_MACROS_SRC="$root_miniextendr_repo/miniextendr-macros"
-MINIEXTENDR_MACROS_CORE_SRC="$root_miniextendr_repo/miniextendr-macros-core"
-MINIEXTENDR_LINT_SRC="$root_miniextendr_repo/miniextendr-lint"
-MINIEXTENDR_ENGINE_SRC="$root_miniextendr_repo/miniextendr-engine"
-
-
-HAS_MONOREPO=false
-if test -d "$root_miniextendr_repo/miniextendr-api"; then
-  HAS_MONOREPO=true
-fi
-
-HAS_VENDOR_HINT=false
-if test -d "$abs_top_srcdir/vendor" && test -n "$(ls -A "$abs_top_srcdir/vendor" 2>/dev/null)"; then
-  HAS_VENDOR_HINT=true
-elif test -f "$abs_top_srcdir/inst/vendor.tar.xz"; then
-  HAS_VENDOR_HINT=true
-fi
-
-if test "$PREPARE_CRAN" = "true"; then
-  BUILD_CONTEXT="prepare-cran"
-elif test "$NOT_CRAN_EXPLICIT" = "true"; then
-  if test "$NOT_CRAN" = "true"; then
-    if test "$HAS_MONOREPO" = "true"; then
-      BUILD_CONTEXT="dev-monorepo"
-    else
-      BUILD_CONTEXT="dev-detached"
-    fi
-  else
-    BUILD_CONTEXT="vendored-install"
-  fi
-else
-    if test "$HAS_MONOREPO" = "true"; then
-    BUILD_CONTEXT="dev-monorepo"
-  elif test "$HAS_VENDOR_HINT" = "true"; then
-    BUILD_CONTEXT="vendored-install"
-  else
-    BUILD_CONTEXT="dev-detached"
-  fi
-fi
-
-
-case "$BUILD_CONTEXT" in
-  dev-monorepo|dev-detached)
-    NOT_CRAN=true
-    ;;
-  vendored-install|prepare-cran)
-    NOT_CRAN=false
-    ;;
-esac
-export NOT_CRAN
-
-
-case "$BUILD_CONTEXT" in
-  dev-monorepo|dev-detached)
-    CARGO_OFFLINE_FLAG=""
-    ;;
-  vendored-install|prepare-cran)
-    CARGO_OFFLINE_FLAG="--offline"
-    ;;
-esac
 
 
 if test -n "$ac_tool_prefix"; then
@@ -2412,18 +2354,14 @@ fi
 
 
 
-root_miniextendr_repo_cargo="$root_miniextendr_repo"
 abs_rpkg_src_cargo="$abs_rpkg_src"
 case "$host_os" in
   *msys*|*cygwin*|*mingw*)
     if test "x$CYGPATH" != "xno"; then
-      root_miniextendr_repo_cargo="$($CYGPATH -m "$root_miniextendr_repo")"
       abs_rpkg_src_cargo="$($CYGPATH -m "$abs_rpkg_src")"
     fi
     ;;
 esac
-ROOT_MINIEXTENDR_REPO_CARGO="$root_miniextendr_repo_cargo"
-
 ABS_RPKG_SRC_CARGO="$abs_rpkg_src_cargo"
 
 
@@ -2507,17 +2445,10 @@ else
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: BUILD_CONTEXT         = $BUILD_CONTEXT" >&5
-printf "%s\n" "$as_me: BUILD_CONTEXT         = $BUILD_CONTEXT" >&6;}
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: NOT_CRAN              = $NOT_CRAN" >&5
-printf "%s\n" "$as_me: NOT_CRAN              = $NOT_CRAN" >&6;}
-if test "$PREPARE_CRAN" = "true"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: PREPARE_CRAN          = $PREPARE_CRAN" >&5
-printf "%s\n" "$as_me: PREPARE_CRAN          = $PREPARE_CRAN" >&6;}
-fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: R_HOME                = $R_HOME" >&5
 printf "%s\n" "$as_me: R_HOME                = $R_HOME" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: NOT_CRAN              = $NOT_CRAN" >&5
+printf "%s\n" "$as_me: NOT_CRAN              = $NOT_CRAN" >&6;}
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: CARGO_TARGET_DIR      = $CARGO_TARGET_DIR" >&5
 printf "%s\n" "$as_me: CARGO_TARGET_DIR      = $CARGO_TARGET_DIR" >&6;}
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: CARGO_PROFILE         = $CARGO_PROFILE" >&5
@@ -3304,10 +3235,10 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 #
 # INIT-COMMANDS
 #
-BUILD_CONTEXT="$BUILD_CONTEXT" SED="$SED"
-CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
-CARGO_CMD="$CARGO_CMD" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
-ABS_RPKG_SRC="$abs_rpkg_src" BUILD_CONTEXT="$BUILD_CONTEXT" CARGO_CMD="$CARGO_CMD"
+NOT_CRAN="$NOT_CRAN"
+CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
+NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
+ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"
 
 _ACEOF
 
@@ -3745,28 +3676,12 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
     "dev-cargo-config":C)
   RPKG_CFG="src/rust/.cargo/config.toml"
 
-  case "$BUILD_CONTEXT" in
-    dev-monorepo)
-            if test -f "$RPKG_CFG"; then
-        rm "$RPKG_CFG"
-        echo "configure: removed cargo config (dev-monorepo — using patch paths)"
-      fi
-      ;;
-    dev-detached)
-            if test -f "$RPKG_CFG"; then
-        rm "$RPKG_CFG"
-        echo "configure: removed cargo config (dev-detached — using git deps)"
-      fi
-            if grep -q '^\[patch\.' src/rust/Cargo.toml 2>/dev/null; then
-        "$SED" '/^\[patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: stripped [patch] section (dev-detached — monorepo not available)"
-      fi
-      ;;
-    vendored-install|prepare-cran)
-            echo "configure: keeping cargo config ($BUILD_CONTEXT)"
-      ;;
-  esac
+  if test "$NOT_CRAN" = "true"; then
+        if test -f "$RPKG_CFG"; then
+      rm "$RPKG_CFG"
+      echo "configure: removed cargo config (dev mode)"
+    fi
+  fi
  ;;
     "cargo-lockfile-compat":C)
   LOCKFILE_PATH="src/rust/Cargo.lock"
@@ -3783,27 +3698,25 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
   if test -n "$LOCKFILE_VERSION" && test "$LOCKFILE_VERSION" -ge 4; then
     if test "$CARGO_MAJOR" -lt 1 || \
        (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
-            case "$BUILD_CONTEXT" in
-        vendored-install|prepare-cran)
-          if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-            if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-              echo "configure: $BUILD_CONTEXT - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
-              (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-              if test $? -ne 0; then
-                echo "configure: error: failed to unpack vendor.tar.xz" >&2
-                exit 1
-              fi
-              if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-                $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-              fi
-            else
-              echo "configure: error: $BUILD_CONTEXT requires vendored sources to regenerate Cargo.lock" >&2
-              echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
+            if test "$NOT_CRAN" != "true"; then
+        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+          if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
+            echo "configure: CRAN build - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
+            (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
+            if test $? -ne 0; then
+              echo "configure: error: failed to unpack vendor.tar.xz" >&2
               exit 1
             fi
+                        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+              $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+            fi
+          else
+            echo "configure: error: CRAN/offline build requires vendored sources to regenerate Cargo.lock" >&2
+            echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
+            exit 1
           fi
-          ;;
-      esac
+        fi
+      fi
       echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
       rm -f "$LOCKFILE_PATH"
       $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
@@ -3816,153 +3729,132 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
   fi
  ;;
     "cargo-vendor":C)
-  case "$BUILD_CONTEXT" in
-    dev-monorepo)
-            if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
-        rm -rf "$VENDOR_OUT"
-        echo "configure: removed vendor directory (dev-monorepo)"
-      fi
-      rm -f "$VENDOR_OUT/.vendor.lock.cksum"
-
-            if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
-                for _crate in miniextendr-api miniextendr-lint; do
-          "$SED" "s|$_crate = { path = \"../../vendor/$_crate[^\"]*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        done
-
-                if grep -q '^\[patch\.crates-io\]' src/rust/Cargo.toml 2>/dev/null; then
-          "$SED" '/^\[patch\.crates-io\]/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        fi
-                "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-
-                printf '[patch."https://github.com/CGMossa/miniextendr"]\n' >> src/rust/Cargo.toml
-        for _crate in miniextendr-api miniextendr-macros miniextendr-macros-core miniextendr-lint; do
-          printf '%s = { path = "../../../%s" }\n' "$_crate" "$_crate" >> src/rust/Cargo.toml
-        done
-
-        echo "configure: restored Cargo.toml from vendored to monorepo state"
-      fi
-
-      echo "configure: dev-monorepo — using patch paths"
-      ;;
-    dev-detached)
-            if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
-        rm -rf "$VENDOR_OUT"
-        echo "configure: removed vendor directory (dev-detached)"
-      fi
-
-            if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
-                for _crate in miniextendr-api miniextendr-lint; do
-          "$SED" "s|$_crate = { path = \"../../vendor/$_crate[^\"]*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        done
-
-                if grep -q '^\[patch\.crates-io\]' src/rust/Cargo.toml 2>/dev/null; then
-          "$SED" '/^\[patch\.crates-io\]/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        fi
-        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-
-        echo "configure: restored Cargo.toml from vendored to git state"
-      fi
-
-      echo "configure: dev-detached — using git/network deps"
-      ;;
-    vendored-install|prepare-cran)
-            if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-        if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-          echo "configure: unpacking inst/vendor.tar.xz"
-          (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-          if test $? -ne 0; then
-            echo "configure: error: failed to unpack vendor.tar.xz" >&2
-            exit 1
-          fi
-          if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-            $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-          fi
-        elif test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
-                    echo "configure: no inst/vendor.tar.xz — calling tools/vendor-crates.R sync"
-          "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-            sync --path "$abs_rpkg_dir" 2>&1 || {
-            echo "configure: error: vendor-crates.R sync failed" >&2
-            exit 1
-          }
-        else
-          echo "configure: error: $BUILD_CONTEXT requires vendored sources." >&2
-          echo "configure:        Provide inst/vendor.tar.xz or tools/vendor-crates.R." >&2
-          exit 1
-        fi
-      fi
-
-            echo "configure: $BUILD_CONTEXT — vendor ready"
-
-                        for _crate in miniextendr-api miniextendr-lint; do
-        _vendor_dir=""
-        if test -d "$VENDOR_OUT/$_crate"; then
-          _vendor_dir="$VENDOR_OUT/$_crate"
-        else
-          for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
-            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-          done
-        fi
-        if test -n "$_vendor_dir"; then
-          _dirname="$(basename "$_vendor_dir")"
-          "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-          echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
-        fi
-      done
-
-            if grep -q '^\[patch\.' src/rust/Cargo.toml 2>/dev/null; then
-        "$SED" '/^\[patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: stripped patch section"
-      fi
-
-            _patch_lines=""
-      for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
-        _vendor_dir=""
-        if test -d "$VENDOR_OUT/$_crate"; then
-          _vendor_dir="$VENDOR_OUT/$_crate"
-        else
-          for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
-            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-          done
-        fi
-        if test -n "$_vendor_dir"; then
-          _dirname="$(basename "$_vendor_dir")"
-          _patch_lines="$_patch_lines
-$_crate = { path = \"../../vendor/$_dirname\" }"
-        fi
-      done
-      if test -n "$_patch_lines"; then
-        printf '\n[patch.crates-io]%s\n' "$_patch_lines" >> src/rust/Cargo.toml
-        echo "configure: added patch.crates-io for transitive deps"
-      fi
-
-            rm -f src/rust/Cargo.lock
-      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+  if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+    if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
+      echo "configure: unpacking inst/vendor.tar.xz"
+      (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
       if test $? -ne 0; then
-        echo "configure: error: failed to generate lockfile from vendored sources" >&2
+        echo "configure: error: failed to unpack vendor.tar.xz" >&2
         exit 1
       fi
-      echo "configure: regenerated Cargo.lock for $BUILD_CONTEXT"
-      ;;
-  esac
+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+      fi
+    fi
+  fi
+
+  if test "$NOT_CRAN" = "true"; then
+    if test "$FORCE_VENDOR" = "1"; then
+      echo "configure: FORCE_VENDOR — running cargo vendor"
+      mkdir -p "$VENDOR_OUT"
+      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
+      if test $? -ne 0; then
+        echo "configure: error: cargo vendor failed" >&2
+        exit 1
+      fi
+      for _crate_dir in "$VENDOR_OUT"/*/; do
+        if test -d "$_crate_dir"; then
+          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
+                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
+          for _dotfile in "$_crate_dir"/.*; do
+            case "$(basename "$_dotfile")" in
+              .|..|.cargo-checksum.json) ;;
+              *) rm -rf "$_dotfile" ;;
+            esac
+          done
+          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+        fi
+      done
+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+      fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+            echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+      }
+    elif test -f "$VENDOR_OUT/.vendor-source"; then
+      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+      if test -d "$_recorded"; then
+        echo "configure: syncing vendor/ from recorded source: $_recorded"
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
+          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+        }
+      else
+        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+      fi
+    else
+      echo "configure: dev mode — using vendor/ from scaffolding"
+    fi
+  else
+        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      echo "configure: error: CRAN build requires vendored sources." >&2
+      echo "configure:        Run 'just vendor' before CRAN submission." >&2
+      exit 1
+    fi
+
+                    for _crate in miniextendr-api miniextendr-lint; do
+      _vendor_dir=""
+      if test -d "$VENDOR_OUT/$_crate"; then
+        _vendor_dir="$VENDOR_OUT/$_crate"
+      else
+        for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
+          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+        done
+      fi
+      if test -n "$_vendor_dir"; then
+        _dirname="$(basename "$_vendor_dir")"
+        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
+          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
+      fi
+    done
+
+        if grep -q '^\[patch\.' src/rust/Cargo.toml 2>/dev/null; then
+      "$SED" '/^\[patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+      echo "configure: stripped [patch] section"
+    fi
+
+        _patch_lines=""
+    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
+      _vendor_dir=""
+      if test -d "$VENDOR_OUT/$_crate"; then
+        _vendor_dir="$VENDOR_OUT/$_crate"
+      else
+        for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
+          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+        done
+      fi
+      if test -n "$_vendor_dir"; then
+        _dirname="$(basename "$_vendor_dir")"
+        _patch_lines="$_patch_lines
+$_crate = { path = \"../../vendor/$_dirname\" }"
+      fi
+    done
+    if test -n "$_patch_lines"; then
+      printf '\n[patch.crates-io]%s\n' "$_patch_lines" >> src/rust/Cargo.toml
+      echo "configure: added [patch.crates-io] for transitive deps"
+    fi
+
+        rm -f src/rust/Cargo.lock
+    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+    if test $? -ne 0; then
+      echo "configure: error: failed to generate lockfile from vendored sources" >&2
+      exit 1
+    fi
+    echo "configure: CRAN build — vendor ready"
+  fi
  ;;
     "post-vendor":C)
     if test ! -f "src/rust/Cargo.lock"; then
-    case "$BUILD_CONTEXT" in
-      dev-monorepo|dev-detached)
-        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
-        ;;
-      vendored-install|prepare-cran)
-        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-        ;;
-    esac
+    if test "$NOT_CRAN" = "true"; then
+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
+    else
+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+    fi
   fi
 
         touch "$ABS_RPKG_SRC/rust/Cargo.toml"

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -29,28 +29,27 @@ if test ! -d "$R_HOME"; then
   AC_MSG_ERROR([R_HOME directory does not exist: $R_HOME])
 fi
 
-dnl ---- Build context inputs ----
-dnl PREPARE_CRAN: explicit release-prep signal (highest precedence)
-: ${PREPARE_CRAN:=false}
-case "$PREPARE_CRAN" in
-  true|TRUE|1) PREPARE_CRAN=true ;;
-  *)           PREPARE_CRAN=false ;;
-esac
-
-dnl NOT_CRAN: legacy compatibility signal
-dnl Detect if explicitly set BEFORE defaulting, so auto-detection works
-NOT_CRAN_EXPLICIT=false
-if test "${NOT_CRAN+set}" = "set"; then
-  NOT_CRAN_EXPLICIT=true
-fi
+dnl NOT_CRAN handling:
+dnl - CRAN builds: NOT_CRAN is unset or empty → default to false (offline mode)
+dnl - Dev builds: set NOT_CRAN=true in environment to enable network/vendoring
+dnl Normalize to "true" or "false" for consistent checks
 : ${NOT_CRAN:=false}
 case "$NOT_CRAN" in
   true|TRUE|1) NOT_CRAN=true ;;
   *)           NOT_CRAN=false ;;
 esac
+export NOT_CRAN
 
-dnl BUILD_CONTEXT, cargo flags, and NOT_CRAN derivation are set after
-dnl canonical paths are computed (needs monorepo detection).
+dnl Set cargo offline/locked flags based on NOT_CRAN
+dnl - NOT_CRAN=true (dev): no --offline, no --locked (cargo updates lockfile for patches)
+dnl - NOT_CRAN=false (CRAN): use --offline, omit --locked (checksums cleared)
+if test "$NOT_CRAN" = "true"; then
+  CARGO_OFFLINE_FLAG=""
+else
+  CARGO_OFFLINE_FLAG="--offline"
+fi
+AC_SUBST([CARGO_OFFLINE_FLAG])
+AC_SUBST([NOT_CRAN])
 
 dnl Set cargo features flag
 dnl
@@ -65,8 +64,18 @@ AC_ARG_VAR([MINIEXTENDR_FEATURES], [Comma-separated cargo features to enable (e.
 dnl Enable all features by default for this demo package
 dnl Users can override by setting MINIEXTENDR_FEATURES explicitly (even to empty string)
 if test -z "${MINIEXTENDR_FEATURES+x}"; then
-  dnl MINIEXTENDR_FEATURES not set - enable all optional features
-  MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+  dnl MINIEXTENDR_FEATURES not set — auto-detect via R script if available,
+  dnl falling back to the full feature set for this demo package
+  if test -f "${srcdir}/tools/detect-features.R"; then
+    MINIEXTENDR_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
+    if test -n "$MINIEXTENDR_FEATURES"; then
+      AC_MSG_NOTICE([Auto-detected features: $MINIEXTENDR_FEATURES])
+    fi
+  fi
+  dnl If auto-detection returned nothing, enable all features
+  if test -z "$MINIEXTENDR_FEATURES"; then
+    MINIEXTENDR_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh"
+  fi
 fi
 
 if test -n "$MINIEXTENDR_FEATURES"; then
@@ -93,86 +102,6 @@ dnl Canonical path two levels above src (rpkg/src → miniextendr)
 root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
 AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
 
-dnl Miniextendr crate source paths (in monorepo)
-MINIEXTENDR_API_SRC="$root_miniextendr_repo/miniextendr-api"
-MINIEXTENDR_MACROS_SRC="$root_miniextendr_repo/miniextendr-macros"
-MINIEXTENDR_MACROS_CORE_SRC="$root_miniextendr_repo/miniextendr-macros-core"
-MINIEXTENDR_LINT_SRC="$root_miniextendr_repo/miniextendr-lint"
-MINIEXTENDR_ENGINE_SRC="$root_miniextendr_repo/miniextendr-engine"
-
-dnl ---- Build context resolution ----
-dnl Resolve one of: dev-monorepo, dev-detached, vendored-install, prepare-cran
-dnl
-dnl Truth table:
-dnl   PREPARE_CRAN=true                              → prepare-cran
-dnl   NOT_CRAN explicit=true  + monorepo present     → dev-monorepo
-dnl   NOT_CRAN explicit=true  + monorepo absent      → dev-detached
-dnl   NOT_CRAN explicit=false + any                  → vendored-install
-dnl   auto-detect: monorepo present                  → dev-monorepo
-dnl   auto-detect: vendor hint present               → vendored-install
-dnl   auto-detect: neither                           → dev-detached
-
-HAS_MONOREPO=false
-if test -d "$root_miniextendr_repo/miniextendr-api"; then
-  HAS_MONOREPO=true
-fi
-
-HAS_VENDOR_HINT=false
-if test -d "$abs_top_srcdir/vendor" && test -n "$(ls -A "$abs_top_srcdir/vendor" 2>/dev/null)"; then
-  HAS_VENDOR_HINT=true
-elif test -f "$abs_top_srcdir/inst/vendor.tar.xz"; then
-  HAS_VENDOR_HINT=true
-fi
-
-if test "$PREPARE_CRAN" = "true"; then
-  BUILD_CONTEXT="prepare-cran"
-elif test "$NOT_CRAN_EXPLICIT" = "true"; then
-  if test "$NOT_CRAN" = "true"; then
-    if test "$HAS_MONOREPO" = "true"; then
-      BUILD_CONTEXT="dev-monorepo"
-    else
-      BUILD_CONTEXT="dev-detached"
-    fi
-  else
-    BUILD_CONTEXT="vendored-install"
-  fi
-else
-  dnl Neither PREPARE_CRAN nor NOT_CRAN explicitly set — auto-detect
-  if test "$HAS_MONOREPO" = "true"; then
-    BUILD_CONTEXT="dev-monorepo"
-  elif test "$HAS_VENDOR_HINT" = "true"; then
-    BUILD_CONTEXT="vendored-install"
-  else
-    BUILD_CONTEXT="dev-detached"
-  fi
-fi
-AC_SUBST([BUILD_CONTEXT])
-
-dnl Derive NOT_CRAN from BUILD_CONTEXT for backward compatibility
-case "$BUILD_CONTEXT" in
-  dev-monorepo|dev-detached)
-    NOT_CRAN=true
-    ;;
-  vendored-install|prepare-cran)
-    NOT_CRAN=false
-    ;;
-esac
-export NOT_CRAN
-AC_SUBST([NOT_CRAN])
-
-dnl Set cargo offline/locked flags based on BUILD_CONTEXT
-dnl Dev contexts: no --offline (cargo uses network or [patch] paths)
-dnl Release contexts: --offline (all deps must be vendored)
-case "$BUILD_CONTEXT" in
-  dev-monorepo|dev-detached)
-    CARGO_OFFLINE_FLAG=""
-    ;;
-  vendored-install|prepare-cran)
-    CARGO_OFFLINE_FLAG="--offline"
-    ;;
-esac
-AC_SUBST([CARGO_OFFLINE_FLAG])
-
 dnl ---- tool discovery ----
 AC_PATH_TOOL([CARGO],[cargo],[no])
 AC_PATH_TOOL([RUSTC],[rustc],[no])
@@ -189,17 +118,14 @@ AC_SUBST([CYGPATH])
 dnl Use native paths for Cargo on Windows/MSYS to avoid path mangling.
 dnl MSYS2 paths like /d/a/foo become D:/d/a/foo when interpreted by Cargo,
 dnl so we convert them to proper Windows paths (D:/a/foo) with cygpath -m.
-root_miniextendr_repo_cargo="$root_miniextendr_repo"
 abs_rpkg_src_cargo="$abs_rpkg_src"
 case "$host_os" in
   *msys*|*cygwin*|*mingw*)
     if test "x$CYGPATH" != "xno"; then
-      root_miniextendr_repo_cargo="$($CYGPATH -m "$root_miniextendr_repo")"
       abs_rpkg_src_cargo="$($CYGPATH -m "$abs_rpkg_src")"
     fi
     ;;
 esac
-AC_SUBST([ROOT_MINIEXTENDR_REPO_CARGO], ["$root_miniextendr_repo_cargo"])
 AC_SUBST([ABS_RPKG_SRC_CARGO], ["$abs_rpkg_src_cargo"])
 
 dnl Report rustc version (required by CRAN for Rust packages)
@@ -299,11 +225,8 @@ fi
 AC_SUBST([CARGO_LIBDIR])
 
 dnl ---- user feedback ----
-AC_MSG_NOTICE([BUILD_CONTEXT         = $BUILD_CONTEXT])
-AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
-AS_IF([test "$PREPARE_CRAN" = "true"],
-      [AC_MSG_NOTICE([PREPARE_CRAN          = $PREPARE_CRAN])])
 AC_MSG_NOTICE([R_HOME                = $R_HOME])
+AC_MSG_NOTICE([NOT_CRAN              = $NOT_CRAN])
 AC_MSG_NOTICE([CARGO_TARGET_DIR      = $CARGO_TARGET_DIR])
 AC_MSG_NOTICE([CARGO_PROFILE         = $CARGO_PROFILE])
 AC_MSG_NOTICE([ENV_RUSTFLAGS         = $ENV_RUSTFLAGS])
@@ -369,10 +292,9 @@ esac
 VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
 AC_SUBST([VENDOR_OUT_CARGO])
 
-dnl Note: Cargo.toml now uses git dependencies with [patch."https://..."] for local dev.
+dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
 dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
-dnl In dev mode, we remove the cargo config so cargo uses normal resolution with
-dnl the [patch] section in Cargo.toml.
+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
 
 dnl ---- output files ----
 dnl Create .cargo directory (it's a hidden dir not included in tarball)
@@ -384,44 +306,26 @@ AC_CONFIG_FILES([
   src/miniextendr-win.def:src/win.def.in
 ])
 
-dnl 1) Configure cargo config and [patch] section based on BUILD_CONTEXT
+dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
+dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
 AC_CONFIG_COMMANDS([dev-cargo-config],
 [
   RPKG_CFG="src/rust/.cargo/config.toml"
 
-  case "$BUILD_CONTEXT" in
-    dev-monorepo)
-      dnl Remove cargo config — use [patch] paths to monorepo
-      if test -f "$RPKG_CFG"; then
-        rm "$RPKG_CFG"
-        echo "configure: removed cargo config (dev-monorepo — using [patch] paths)"
-      fi
-      ;;
-    dev-detached)
-      dnl Remove cargo config — use git/network deps directly
-      if test -f "$RPKG_CFG"; then
-        rm "$RPKG_CFG"
-        echo "configure: removed cargo config (dev-detached — using git deps)"
-      fi
-      dnl Strip [patch] section — paths reference monorepo which isn't available
-      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: stripped @<:@patch@:>@ section (dev-detached — monorepo not available)"
-      fi
-      ;;
-    vendored-install|prepare-cran)
-      dnl Keep cargo config for vendored source resolution
-      echo "configure: keeping cargo config ($BUILD_CONTEXT)"
-      ;;
-  esac
+  if test "$NOT_CRAN" = "true"; then
+    dnl In dev mode, remove the generated cargo config so cargo uses normal resolution
+    if test -f "$RPKG_CFG"; then
+      rm "$RPKG_CFG"
+      echo "configure: removed cargo config (dev mode)"
+    fi
+  fi
 ],
-[BUILD_CONTEXT="$BUILD_CONTEXT" SED="$SED"])
+[NOT_CRAN="$NOT_CRAN"])
 
 dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
 dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor
 
-dnl 1) Ensure Cargo.lock is compatible with the installed cargo version.
+dnl 2) Ensure Cargo.lock is compatible with the installed cargo version.
 dnl    Older cargo releases (e.g. 1.75) cannot read lockfile version 4.
 AC_CONFIG_COMMANDS([cargo-lockfile-compat],
 [
@@ -439,28 +343,27 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
   if test -n "$LOCKFILE_VERSION" && test "$LOCKFILE_VERSION" -ge 4; then
     if test "$CARGO_MAJOR" -lt 1 || \
        (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
-      dnl In release contexts, ensure vendor sources exist before regenerating lockfile.
-      case "$BUILD_CONTEXT" in
-        vendored-install|prepare-cran)
-          if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-            if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-              echo "configure: $BUILD_CONTEXT - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
-              (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-              if test $? -ne 0; then
-                echo "configure: error: failed to unpack vendor.tar.xz" >&2
-                exit 1
-              fi
-              if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-                $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-              fi
-            else
-              echo "configure: error: $BUILD_CONTEXT requires vendored sources to regenerate Cargo.lock" >&2
-              echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
+      dnl In CRAN/offline mode, ensure vendor sources exist before regenerating lockfile.
+      if test "$NOT_CRAN" != "true"; then
+        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+          if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
+            echo "configure: CRAN build - unpacking inst/vendor.tar.xz (for lockfile regeneration)" >&2
+            (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
+            if test $? -ne 0; then
+              echo "configure: error: failed to unpack vendor.tar.xz" >&2
               exit 1
             fi
+            dnl Strip checksums from Cargo.lock (vendored crates have empty checksums)
+            if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+              $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+            fi
+          else
+            echo "configure: error: CRAN/offline build requires vendored sources to regenerate Cargo.lock" >&2
+            echo "configure:        Expected inst/vendor.tar.xz or a populated vendor/ directory." >&2
+            exit 1
           fi
-          ;;
-      esac
+        fi
+      fi
       echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
       rm -f "$LOCKFILE_PATH"
       $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
@@ -472,182 +375,154 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
     fi
   fi
 ],
-[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+[CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
 
-dnl 2) Handle vendor directory based on BUILD_CONTEXT
+dnl 3) Ensure vendor/ exists for offline builds
+dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
+dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
+dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
 AC_CONFIG_COMMANDS([cargo-vendor],
 [
-  case "$BUILD_CONTEXT" in
-    dev-monorepo)
-      dnl Clean stale vendor artifacts, use [patch] paths
-      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
-        rm -rf "$VENDOR_OUT"
-        echo "configure: removed vendor directory (dev-monorepo)"
-      fi
-      rm -f "$VENDOR_OUT/.vendor.lock.cksum"
-
-      dnl Reverse vendored-install Cargo.toml rewrites if present
-      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
-        dnl 1) Rewrite vendor path deps back to git deps
-        for _crate in miniextendr-api miniextendr-lint; do
-          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        done
-
-        dnl 2) Strip [patch.crates-io] section and trailing blank lines
-        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
-          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        fi
-        dnl Remove trailing blank lines left after section deletion
-        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-
-        dnl 3) Add [patch."https://..."] with monorepo-relative paths
-        printf '@<:@patch."https://github.com/CGMossa/miniextendr"@:>@\n' >> src/rust/Cargo.toml
-        for _crate in miniextendr-api miniextendr-macros miniextendr-macros-core miniextendr-lint; do
-          printf '%s = { path = "../../../%s" }\n' "$_crate" "$_crate" >> src/rust/Cargo.toml
-        done
-
-        echo "configure: restored Cargo.toml from vendored to monorepo state"
-      fi
-
-      echo "configure: dev-monorepo — using [patch] paths"
-      ;;
-    dev-detached)
-      dnl Clean stale vendor artifacts, use git/network deps
-      if test -d "$VENDOR_OUT" && test -n "$(ls -A "$VENDOR_OUT" 2>/dev/null)"; then
-        rm -rf "$VENDOR_OUT"
-        echo "configure: removed vendor directory (dev-detached)"
-      fi
-
-      dnl Reverse vendored-install Cargo.toml rewrites if present
-      if grep -q 'path = "../../vendor/' src/rust/Cargo.toml 2>/dev/null; then
-        dnl 1) Rewrite vendor path deps back to git deps
-        for _crate in miniextendr-api miniextendr-lint; do
-          "$SED" "s|$_crate = { path = \"../../vendor/$_crate@<:@^\"@:>@*\" }|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        done
-
-        dnl 2) Strip [patch.crates-io] section and trailing blank lines
-        if grep -q '^\@<:@patch\.crates-io\@:>@' src/rust/Cargo.toml 2>/dev/null; then
-          "$SED" '/^\@<:@patch\.crates-io\@:>@/,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-            && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        fi
-        "$SED" -e :a -e '/^$/{$d' -e N -e ba -e '}' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-
-        echo "configure: restored Cargo.toml from vendored to git state"
-      fi
-
-      echo "configure: dev-detached — using git/network deps"
-      ;;
-    vendored-install|prepare-cran)
-      dnl Ensure vendor/ exists: unpack tarball or vendor from network
-      if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-        if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
-          echo "configure: unpacking inst/vendor.tar.xz"
-          (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
-          if test $? -ne 0; then
-            echo "configure: error: failed to unpack vendor.tar.xz" >&2
-            exit 1
-          fi
-          if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-            $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-          fi
-        elif test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
-          dnl No tarball — try vendor-crates.R to populate vendor/
-          echo "configure: no inst/vendor.tar.xz — calling tools/vendor-crates.R sync"
-          "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-            sync --path "$abs_rpkg_dir" 2>&1 || {
-            echo "configure: error: vendor-crates.R sync failed" >&2
-            exit 1
-          }
-        else
-          echo "configure: error: $BUILD_CONTEXT requires vendored sources." >&2
-          echo "configure:        Provide inst/vendor.tar.xz or tools/vendor-crates.R." >&2
-          exit 1
-        fi
-      fi
-
-      dnl Vendor exists — rewrite deps for vendored build
-      echo "configure: $BUILD_CONTEXT — vendor ready"
-
-      dnl Rewrite git deps to path deps
-      dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
-      dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
-      for _crate in miniextendr-api miniextendr-lint; do
-        _vendor_dir=""
-        if test -d "$VENDOR_OUT/$_crate"; then
-          _vendor_dir="$VENDOR_OUT/$_crate"
-        else
-          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
-            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-          done
-        fi
-        if test -n "$_vendor_dir"; then
-          _dirname="$(basename "$_vendor_dir")"
-          "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
-            src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-          echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
-        fi
-      done
-
-      dnl Strip [patch] section (monorepo paths not available)
-      if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-        "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-          && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: stripped [patch] section"
-      fi
-
-      dnl Add [patch.crates-io] for transitive miniextendr deps
-      _patch_lines=""
-      for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
-        _vendor_dir=""
-        if test -d "$VENDOR_OUT/$_crate"; then
-          _vendor_dir="$VENDOR_OUT/$_crate"
-        else
-          for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
-            if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-          done
-        fi
-        if test -n "$_vendor_dir"; then
-          _dirname="$(basename "$_vendor_dir")"
-          _patch_lines="$_patch_lines
-$_crate = { path = \"../../vendor/$_dirname\" }"
-        fi
-      done
-      if test -n "$_patch_lines"; then
-        printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
-        echo "configure: added [patch.crates-io] for transitive deps"
-      fi
-
-      dnl Regenerate Cargo.lock from vendored sources
-      rm -f src/rust/Cargo.lock
-      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+  if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+    if test -f "$abs_rpkg_dir/inst/vendor.tar.xz"; then
+      echo "configure: unpacking inst/vendor.tar.xz"
+      (cd "$abs_rpkg_dir" && tar -xJf "$abs_rpkg_dir/inst/vendor.tar.xz")
       if test $? -ne 0; then
-        echo "configure: error: failed to generate lockfile from vendored sources" >&2
+        echo "configure: error: failed to unpack vendor.tar.xz" >&2
         exit 1
       fi
-      echo "configure: regenerated Cargo.lock for $BUILD_CONTEXT"
-      ;;
-  esac
-],
-[CARGO_CMD="$CARGO_CMD" BUILD_CONTEXT="$BUILD_CONTEXT" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+      fi
+    fi
+  fi
 
-dnl 2b) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
+  if test "$NOT_CRAN" = "true"; then
+    if test "$FORCE_VENDOR" = "1"; then
+      echo "configure: FORCE_VENDOR — running cargo vendor"
+      mkdir -p "$VENDOR_OUT"
+      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
+      if test $? -ne 0; then
+        echo "configure: error: cargo vendor failed" >&2
+        exit 1
+      fi
+      for _crate_dir in "$VENDOR_OUT"/*/; do
+        if test -d "$_crate_dir"; then
+          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
+                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
+          for _dotfile in "$_crate_dir"/.*; do
+            case "$(basename "$_dotfile")" in
+              .|..|.cargo-checksum.json) ;;
+              *) rm -rf "$_dotfile" ;;
+            esac
+          done
+          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+        fi
+      done
+      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+      fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
+      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+      }
+    elif test -f "$VENDOR_OUT/.vendor-source"; then
+      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+      if test -d "$_recorded"; then
+        echo "configure: syncing vendor/ from recorded source: $_recorded"
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
+          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+        }
+      else
+        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+      fi
+    else
+      echo "configure: dev mode — using vendor/ from scaffolding"
+    fi
+  else
+    dnl CRAN/offline mode: vendor/ must exist
+    if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      echo "configure: error: CRAN build requires vendored sources." >&2
+      echo "configure:        Run 'just vendor' before CRAN submission." >&2
+      exit 1
+    fi
+
+    dnl Rewrite git deps to vendor/ path deps for offline builds.
+    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
+    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
+    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
+    for _crate in miniextendr-api miniextendr-lint; do
+      _vendor_dir=""
+      if test -d "$VENDOR_OUT/$_crate"; then
+        _vendor_dir="$VENDOR_OUT/$_crate"
+      else
+        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+        done
+      fi
+      if test -n "$_vendor_dir"; then
+        _dirname="$(basename "$_vendor_dir")"
+        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
+          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
+      fi
+    done
+
+    dnl Strip [patch] section (monorepo paths not available in tarball)
+    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
+      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+      echo "configure: stripped @<:@patch@:>@ section"
+    fi
+
+    dnl Add [patch.crates-io] for transitive miniextendr deps
+    _patch_lines=""
+    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
+      _vendor_dir=""
+      if test -d "$VENDOR_OUT/$_crate"; then
+        _vendor_dir="$VENDOR_OUT/$_crate"
+      else
+        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
+          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
+        done
+      fi
+      if test -n "$_vendor_dir"; then
+        _dirname="$(basename "$_vendor_dir")"
+        _patch_lines="$_patch_lines
+$_crate = { path = \"../../vendor/$_dirname\" }"
+      fi
+    done
+    if test -n "$_patch_lines"; then
+      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
+      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
+    fi
+
+    dnl Regenerate Cargo.lock from vendored sources
+    rm -f src/rust/Cargo.lock
+    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+    if test $? -ne 0; then
+      echo "configure: error: failed to generate lockfile from vendored sources" >&2
+      exit 1
+    fi
+    echo "configure: CRAN build — vendor ready"
+  fi
+],
+[NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+
+dnl 4) Post-vendor tasks: ensure Cargo.lock exists, touch Cargo.toml to force rebuild
 AC_CONFIG_COMMANDS([post-vendor],
 [
   dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
   if test ! -f "src/rust/Cargo.lock"; then
-    case "$BUILD_CONTEXT" in
-      dev-monorepo|dev-detached)
-        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
-        ;;
-      vendored-install|prepare-cran)
-        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-        ;;
-    esac
+    if test "$NOT_CRAN" = "true"; then
+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml
+    else
+      $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
+    fi
   fi
 
   dnl Touch Cargo.toml to ensure make rebuilds the staticlib.
@@ -659,6 +534,6 @@ AC_CONFIG_COMMANDS([post-vendor],
   dnl Note: Cargo.lock updates for patched sources are handled by cargo build itself.
   dnl Dev mode does not use --locked, so cargo resolves source locations at build time.
 ],
-[ABS_RPKG_SRC="$abs_rpkg_src" BUILD_CONTEXT="$BUILD_CONTEXT" CARGO_CMD="$CARGO_CMD"])
+[ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
 
 AC_OUTPUT

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -292,9 +292,10 @@ esac
 VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
 AC_SUBST([VENDOR_OUT_CARGO])
 
-dnl Cargo.toml uses path dependencies to vendor/ for both dev and CRAN builds.
+dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
+dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
-dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
 
 dnl ---- output files ----
 dnl Create .cargo directory (it's a hidden dir not included in tarball)

--- a/rpkg/inst/vendor.tar.xz
+++ b/rpkg/inst/vendor.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8883cdc5161401211cef151db9e61f89a7af86fb7c0eb6ef5029063d438c759
-size 10756128
+oid sha256:884bfd690f51f8728127b3d5c86e4751ca5f7033ee0d4bdcad0b0a416513ef43
+size 10757324


### PR DESCRIPTION
## Summary
- Replace the 4-state BUILD_CONTEXT machine with the template's NOT_CRAN binary switch + vendor-crates.R delegation
- `just configure` now sets `MINIEXTENDR_LOCAL` → vendor-crates.R sync (same path end-user packages use)
- CI on rpkg now tests the real end-user vendoring flow
- CRAN tarball path retains rpkg-specific git→path dep rewriting (~50 lines)
- Net: -1073 lines, templates.patch shrinks significantly

## What changed
- **rpkg/configure.ac**: Deleted BUILD_CONTEXT state machine, PREPARE_CRAN, monorepo detection, reverse-rewrite logic. Replaced with template's NOT_CRAN + vendor-crates.R pattern.
- **justfile**: `configure` recipe passes `MINIEXTENDR_LOCAL` and `NOT_CRAN=true`; `configure-cran` uses `NOT_CRAN=false`
- **patches/templates.patch**: Shrunk (less divergence between rpkg and templates)

## Test plan
- [x] `just configure` populates vendor/ from monorepo via vendor-crates.R sync
- [x] `just rcmdinstall` builds and installs successfully
- [x] CRAN tarball path: `just vendor && R CMD build && NOT_CRAN=false R CMD check` passes (Status: 1 NOTE)
- [ ] CI passes on all platforms

Generated with [Claude Code](https://claude.com/claude-code)
