### PR TITLE
Auto-create vendor.tar.xz in configure, respect caller's NOT_CRAN

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -472,4 +472,20 @@ AC_CONFIG_COMMANDS([post-vendor],
 ],
 [ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
 
+dnl 5) Create vendor.tar.xz from vendor/ if it doesn't exist yet
+dnl    This ensures R CMD build produces a tarball with vendored sources
+dnl    without requiring a manual `just vendor` step.
+AC_CONFIG_COMMANDS([vendor-tarball],
+[
+  _tarball="$abs_rpkg_dir/inst/vendor.tar.xz"
+  if test ! -f "$_tarball"; then
+    if test -d "$VENDOR_OUT" && test -n "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      mkdir -p "$abs_rpkg_dir/inst"
+      tar $TAR_FORCE_LOCAL -cJf "$_tarball" -C "$abs_rpkg_dir" vendor
+      echo "configure: created inst/vendor.tar.xz"
+    fi
+  fi
+],
+[abs_rpkg_dir="$abs_top_srcdir" VENDOR_OUT="$VENDOR_OUT" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+
 AC_OUTPUT

--- a/minirextendr/inst/templates/rpkg/bootstrap.R
+++ b/minirextendr/inst/templates/rpkg/bootstrap.R
@@ -1,8 +1,13 @@
 # bootstrap.R - Run before package build (Config/build/bootstrap: TRUE)
-# Sets NOT_CRAN=true so configure runs in dev mode during devtools workflows.
+# Respect caller's NOT_CRAN if explicitly set; default to true (dev mode).
+# bootstrap.R only runs during R CMD build (Config/build/bootstrap: TRUE),
+# never on CRAN install, so defaulting to true is safe.
 # PREPARE_CRAN=false prevents accidental inheritance of release-prep mode.
 
-env <- c(NOT_CRAN = "true", PREPARE_CRAN = "false")
+not_cran <- Sys.getenv("NOT_CRAN", unset = "")
+if (!nzchar(not_cran)) not_cran <- "true"
+
+env <- c(NOT_CRAN = not_cran, PREPARE_CRAN = "false")
 env_strings <- paste0(names(env), "=", env)
 
 if (.Platform$OS.type == "windows") {

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -473,4 +473,20 @@ AC_CONFIG_COMMANDS([post-vendor],
 ],
 [ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
 
+dnl 5) Create vendor.tar.xz from vendor/ if it doesn't exist yet
+dnl    This ensures R CMD build produces a tarball with vendored sources
+dnl    without requiring a manual `just vendor` step.
+AC_CONFIG_COMMANDS([vendor-tarball],
+[
+  _tarball="$abs_rpkg_dir/inst/vendor.tar.xz"
+  if test ! -f "$_tarball"; then
+    if test -d "$VENDOR_OUT" && test -n "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      mkdir -p "$abs_rpkg_dir/inst"
+      tar $TAR_FORCE_LOCAL -cJf "$_tarball" -C "$abs_rpkg_dir" vendor
+      echo "configure: created inst/vendor.tar.xz"
+    fi
+  fi
+],
+[abs_rpkg_dir="$abs_top_srcdir" VENDOR_OUT="$VENDOR_OUT" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+
 AC_OUTPUT

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-15 09:09:12
-+++ b/monorepo/rpkg/configure.ac	2026-03-15 09:21:40
+--- a/monorepo/rpkg/configure.ac	2026-03-15 09:57:06
++++ b/monorepo/rpkg/configure.ac	2026-03-15 09:57:10
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -196,8 +196,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
        exit 1
      fi
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-15 09:09:12
-+++ b/rpkg/configure.ac	2026-03-15 09:21:31
+--- a/rpkg/configure.ac	2026-03-15 09:57:06
++++ b/rpkg/configure.ac	2026-03-15 09:57:08
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])

--- a/rpkg/bootstrap.R
+++ b/rpkg/bootstrap.R
@@ -1,8 +1,13 @@
 # bootstrap.R - Run before package build (Config/build/bootstrap: TRUE)
-# Sets NOT_CRAN=true so configure runs in dev mode during devtools workflows.
+# Respect caller's NOT_CRAN if explicitly set; default to true (dev mode).
+# bootstrap.R only runs during R CMD build (Config/build/bootstrap: TRUE),
+# never on CRAN install, so defaulting to true is safe.
 # PREPARE_CRAN=false prevents accidental inheritance of release-prep mode.
 
-env <- c(NOT_CRAN = "true", PREPARE_CRAN = "false")
+not_cran <- Sys.getenv("NOT_CRAN", unset = "")
+if (!nzchar(not_cran)) not_cran <- "true"
+
+env <- c(NOT_CRAN = not_cran, PREPARE_CRAN = "false")
 env_strings <- paste0(names(env), "=", env)
 
 if (.Platform$OS.type == "windows") {

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2535,6 +2535,9 @@ ac_config_commands="$ac_config_commands cargo-vendor"
 ac_config_commands="$ac_config_commands post-vendor"
 
 
+ac_config_commands="$ac_config_commands vendor-tarball"
+
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure
@@ -3239,6 +3242,7 @@ NOT_CRAN="$NOT_CRAN"
 CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"
+abs_rpkg_dir="$abs_top_srcdir" VENDOR_OUT="$VENDOR_OUT" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 
 _ACEOF
 
@@ -3255,6 +3259,7 @@ do
     "cargo-lockfile-compat") CONFIG_COMMANDS="$CONFIG_COMMANDS cargo-lockfile-compat" ;;
     "cargo-vendor") CONFIG_COMMANDS="$CONFIG_COMMANDS cargo-vendor" ;;
     "post-vendor") CONFIG_COMMANDS="$CONFIG_COMMANDS post-vendor" ;;
+    "vendor-tarball") CONFIG_COMMANDS="$CONFIG_COMMANDS vendor-tarball" ;;
 
   *) as_fn_error $? "invalid argument: '$ac_config_target'" "$LINENO" 5;;
   esac
@@ -3861,6 +3866,16 @@ $_crate = { path = \"../../vendor/$_dirname\" }"
   echo "configure: touched $ABS_RPKG_SRC/rust/Cargo.toml to force rebuild" >&2
 
      ;;
+    "vendor-tarball":C)
+  _tarball="$abs_rpkg_dir/inst/vendor.tar.xz"
+  if test ! -f "$_tarball"; then
+    if test -d "$VENDOR_OUT" && test -n "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      mkdir -p "$abs_rpkg_dir/inst"
+      tar $TAR_FORCE_LOCAL -cJf "$_tarball" -C "$abs_rpkg_dir" vendor
+      echo "configure: created inst/vendor.tar.xz"
+    fi
+  fi
+ ;;
 
   esac
 done # for ac_tag

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -537,4 +537,20 @@ AC_CONFIG_COMMANDS([post-vendor],
 ],
 [ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"])
 
+dnl 5) Create vendor.tar.xz from vendor/ if it doesn't exist yet
+dnl    This ensures R CMD build produces a tarball with vendored sources
+dnl    without requiring a manual `just vendor` step.
+AC_CONFIG_COMMANDS([vendor-tarball],
+[
+  _tarball="$abs_rpkg_dir/inst/vendor.tar.xz"
+  if test ! -f "$_tarball"; then
+    if test -d "$VENDOR_OUT" && test -n "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      mkdir -p "$abs_rpkg_dir/inst"
+      tar $TAR_FORCE_LOCAL -cJf "$_tarball" -C "$abs_rpkg_dir" vendor
+      echo "configure: created inst/vendor.tar.xz"
+    fi
+  fi
+],
+[abs_rpkg_dir="$abs_top_srcdir" VENDOR_OUT="$VENDOR_OUT" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
+
 AC_OUTPUT


### PR DESCRIPTION
## Summary
- Add `vendor-tarball` step to configure that auto-compresses `vendor/` into `inst/vendor.tar.xz` when the tarball doesn't exist yet — eliminates manual `just vendor` before CRAN builds
- `bootstrap.R` now respects caller's `NOT_CRAN` (defaults to `true` when unset, safe since bootstrap only runs during `R CMD build`)
- Same changes applied to both template `configure.ac` files and rpkg template `bootstrap.R`

## Test plan
- [x] `just configure` creates `inst/vendor.tar.xz` automatically
- [x] `just templates-check` passes
- [x] `just minirextendr-test` — all 390 tests pass
- [ ] E2E: scaffold fresh package → `R CMD build` → `NOT_CRAN=false R CMD check` → passes

Generated with [Claude Code](https://claude.com/claude-code)
