### PR TITLE
Fix vendor mechanism bugs and remove dead code

### DIFF
--- a/minirextendr/inst/templates/monorepo/justfile
+++ b/minirextendr/inst/templates/monorepo/justfile
@@ -14,6 +14,8 @@
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+export NOT_CRAN := "true"
+
 # R package subdirectory
 rpkg := "{{{rpkg_name}}}"
 
@@ -59,16 +61,18 @@ clean:
 # 2. Sets up cargo config for vendored sources (CRAN mode only)
 # Note: vendor/ has miniextendr crates from scaffolding. Run 'just vendor' for full CRAN prep.
 configure:
-    cd {{rpkg}} && NOT_CRAN=true ./configure
+    cd {{rpkg}} && \
+    if command -v autoconf >/dev/null 2>&1; then autoconf; else echo "autoconf not found; using existing configure"; fi && \
+    bash ./configure
 
 # Configure in CRAN mode (for testing CRAN submission)
 # Uses vendored sources in offline mode
 configure-cran:
-    cd {{rpkg}} && ./configure
+    cd {{rpkg}} && NOT_CRAN=false bash ./configure
 
 # Build and install R package with R CMD INSTALL
 install *args: configure
-    cd {{rpkg}} && NOT_CRAN=true R CMD INSTALL {{args}} .
+    cd {{rpkg}} && R CMD INSTALL {{args}} .
 
 # Run R package tests with devtools
 rtest FILTER="": configure
@@ -109,7 +113,7 @@ rcheck-cran: configure-cran
 
 # Run devtools::check
 devtools-check: configure
-    NOT_CRAN=true Rscript -e 'devtools::check("{{rpkg}}", error_on = "error")'
+    Rscript -e 'devtools::check("{{rpkg}}", error_on = "error")'
 
 # ============================================================================
 # Development workflow shortcuts

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -269,6 +269,12 @@ AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
 dnl Note: R CMD build already tracks .rs files for rebuild detection via pkgbuild,
 dnl so we don't need to enumerate RUST_SOURCES for Make dependencies.
 
+dnl Normalize FORCE_VENDOR (accept 1/true/TRUE/yes)
+case "$FORCE_VENDOR" in
+  1|true|TRUE|yes) FORCE_VENDOR=1 ;;
+  *)               FORCE_VENDOR="" ;;
+esac
+
 dnl ---- vendoring (at package root, outside src/) ----
 dnl IMPORTANT: vendor directory MUST be outside src/ to avoid pkgbuild scanning
 dnl thousands of .rs files in vendor/ during needs_compile() checks (same reasoning
@@ -405,48 +411,28 @@ AC_CONFIG_COMMANDS([cargo-vendor],
 
   if test "$NOT_CRAN" = "true"; then
     if test "$FORCE_VENDOR" = "1"; then
-      echo "configure: FORCE_VENDOR — running cargo vendor"
-      mkdir -p "$VENDOR_OUT"
-      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-      if test $? -ne 0; then
-        echo "configure: error: cargo vendor failed" >&2
-        exit 1
-      fi
-      for _crate_dir in "$VENDOR_OUT"/*/; do
-        if test -d "$_crate_dir"; then
-          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-          for _dotfile in "$_crate_dir"/.*; do
-            case "$(basename "$_dotfile")" in
-              .|..|.cargo-checksum.json) ;;
-              *) rm -rf "$_dotfile" ;;
-            esac
-          done
-          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+      echo "configure: FORCE_VENDOR — running vendor-crates.R pack"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        _vendor_src=""
+        if test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+          _vendor_src="--source-root $MINIEXTENDR_LOCAL"
+        elif test -f "$VENDOR_OUT/.vendor-source"; then
+          _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+          if test -d "$_recorded"; then
+            _vendor_src="--source-root $_recorded"
+          fi
         fi
-      done
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
-    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-      }
-    elif test -f "$VENDOR_OUT/.vendor-source"; then
-      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-      if test -d "$_recorded"; then
-        echo "configure: syncing vendor/ from recorded source: $_recorded"
         "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+          pack --path "$abs_rpkg_dir" $_vendor_src 2>&1 || {
+          echo "configure: error: vendor-crates.R pack failed" >&2
+          exit 1
         }
       else
-        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
       fi
     else
-      echo "configure: dev mode — using vendor/ from scaffolding"
+      echo "configure: dev mode — using existing vendor/"
     fi
   else
     dnl CRAN/offline mode: vendor/ must exist
@@ -454,13 +440,6 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: error: CRAN build requires vendored sources." >&2
       echo "configure:        Run 'just vendor' before CRAN submission." >&2
       exit 1
-    fi
-    dnl Strip [patch] section — git sources don't work offline;
-    dnl vendored-sources replacement in .cargo/config.toml handles resolution
-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-      echo "configure: stripped @<:@patch@:>@ section for offline build"
     fi
     echo "configure: CRAN build — vendor ready"
   fi

--- a/minirextendr/inst/templates/monorepo/tools/vendor-crates.R
+++ b/minirextendr/inst/templates/monorepo/tools/vendor-crates.R
@@ -117,6 +117,9 @@ parse_tree_packages <- function(lines) {
     path <- NA_character_
     if (grepl(" \\([^()]*[/\\\\][^()]*\\)$", line)) {
       path <- sub("^.* \\(([^()]*[/\\\\][^()]*)\\)$", "\\1", line)
+      if (grepl("^https?://", path) || grepl("^git[+@]", path)) {
+        path <- NA_character_
+      }
     }
 
     data.frame(

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -269,6 +269,12 @@ AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
 dnl Note: R CMD build already tracks .rs files for rebuild detection via pkgbuild,
 dnl so we don't need to enumerate RUST_SOURCES for Make dependencies.
 
+dnl Normalize FORCE_VENDOR (accept 1/true/TRUE/yes)
+case "$FORCE_VENDOR" in
+  1|true|TRUE|yes) FORCE_VENDOR=1 ;;
+  *)               FORCE_VENDOR="" ;;
+esac
+
 dnl ---- vendoring (at package root, outside src/) ----
 dnl IMPORTANT: vendor directory MUST be outside src/ to avoid pkgbuild scanning
 dnl thousands of .rs files in vendor/ during needs_compile() checks (same reasoning
@@ -405,49 +411,28 @@ AC_CONFIG_COMMANDS([cargo-vendor],
 
   if test "$NOT_CRAN" = "true"; then
     if test "$FORCE_VENDOR" = "1"; then
-      echo "configure: FORCE_VENDOR — running cargo vendor"
-      mkdir -p "$VENDOR_OUT"
-      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-      if test $? -ne 0; then
-        echo "configure: error: cargo vendor failed" >&2
-        exit 1
-      fi
-      for _crate_dir in "$VENDOR_OUT"/*/; do
-        if test -d "$_crate_dir"; then
-          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-          for _dotfile in "$_crate_dir"/.*; do
-            case "$(basename "$_dotfile")" in
-              .|..|.cargo-checksum.json) ;;
-              *) rm -rf "$_dotfile" ;;
-            esac
-          done
-          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+      echo "configure: FORCE_VENDOR — running vendor-crates.R pack"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        _vendor_src=""
+        if test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+          _vendor_src="--source-root $MINIEXTENDR_LOCAL"
+        elif test -f "$VENDOR_OUT/.vendor-source"; then
+          _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+          if test -d "$_recorded"; then
+            _vendor_src="--source-root $_recorded"
+          fi
         fi
-      done
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
-    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
-      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-      }
-    elif test -f "$VENDOR_OUT/.vendor-source"; then
-      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-      if test -d "$_recorded"; then
-        echo "configure: syncing vendor/ from recorded source: $_recorded"
         "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+          pack --path "$abs_rpkg_dir" $_vendor_src 2>&1 || {
+          echo "configure: error: vendor-crates.R pack failed" >&2
+          exit 1
         }
       else
-        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
       fi
     else
-      echo "configure: dev mode — using vendor/ from scaffolding"
+      echo "configure: dev mode — using existing vendor/"
     fi
   else
     dnl CRAN/offline mode: vendor/ must exist
@@ -455,13 +440,6 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: error: CRAN build requires vendored sources." >&2
       echo "configure:        Run 'just vendor' before CRAN submission." >&2
       exit 1
-    fi
-    dnl Strip [patch] section — git sources don't work offline;
-    dnl vendored-sources replacement in .cargo/config.toml handles resolution
-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-      echo "configure: stripped @<:@patch@:>@ section for offline build"
     fi
     echo "configure: CRAN build — vendor ready"
   fi

--- a/minirextendr/inst/templates/rpkg/tools/vendor-crates.R
+++ b/minirextendr/inst/templates/rpkg/tools/vendor-crates.R
@@ -117,6 +117,9 @@ parse_tree_packages <- function(lines) {
     path <- NA_character_
     if (grepl(" \\([^()]*[/\\\\][^()]*\\)$", line)) {
       path <- sub("^.* \\(([^()]*[/\\\\][^()]*)\\)$", "\\1", line)
+      if (grepl("^https?://", path) || grepl("^git[+@]", path)) {
+        path <- NA_character_
+      }
     }
 
     data.frame(

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
 --- a/monorepo/rpkg/Makevars.in	2026-03-13 19:23:15
-+++ b/monorepo/rpkg/Makevars.in	2026-03-15 16:37:16
++++ b/monorepo/rpkg/Makevars.in	2026-03-15 18:12:03
 @@ -26,5 +26,5 @@
  
  CARGO_TOML = $(ABS_RPKG_SRCDIR)/rust/Cargo.toml
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-15 11:24:37
-+++ b/monorepo/rpkg/configure.ac	2026-03-15 16:37:16
+--- a/monorepo/rpkg/configure.ac	2026-03-16 19:21:23
++++ b/monorepo/rpkg/configure.ac	2026-03-16 19:23:53
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -62,7 +62,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -237,6 +233,6 @@
+@@ -237,17 +233,29 @@
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
  AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
@@ -71,7 +71,17 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -253,7 +249,13 @@
+ dnl Use PACKAGE_NAME (case-preserving) not PACKAGE_TARNAME (lowercased)
+ dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
+-CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
++pkg_rs="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
++AC_SUBST([PACKAGE_TARNAME_RS], [$pkg_rs])
++pkg_rs_upper=`printf '%s' "$pkg_rs" | tr 'a-z' 'A-Z'`
++AC_SUBST([PACKAGE_TARNAME_RS_UPPERCASE], [$pkg_rs_upper])
++
++dnl Staticlib name matches the Rust crate name (= pkg_rs)
++CARGO_STATICLIB_NAME="$pkg_rs"
+ AC_SUBST([CARGO_STATICLIB_NAME])
  AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
  
 -dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
@@ -87,7 +97,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +case "$host_os" in
    darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
    *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -263,11 +265,4 @@
+@@ -257,11 +265,4 @@
  AC_SUBST([CDYLIB_EXT])
  
 -dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
@@ -99,7 +109,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -
  AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
  
-@@ -293,8 +288,7 @@
+@@ -293,8 +294,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
 -dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
@@ -110,7 +120,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
  
  dnl ---- output files ----
-@@ -305,9 +299,11 @@
+@@ -305,9 +305,11 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -125,7 +135,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -318,9 +314,18 @@
+@@ -318,9 +320,18 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
@@ -146,22 +156,18 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +[NOT_CRAN="$NOT_CRAN" SED="$SED"])
  
  dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -380,5 +385,5 @@
+@@ -380,5 +391,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -425,5 +430,4 @@
-       fi
-     elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
--      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
-       echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-       "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-@@ -452,61 +456,10 @@
-       exit 1
-     fi
+@@ -429,62 +440,4 @@
+       echo "configure: error: CRAN build requires vendored sources." >&2
+       echo "configure:        Run 'just vendor' before CRAN submission." >&2
+-      exit 1
+-    fi
 -
 -    dnl Rewrite git deps to vendor/ path deps for offline builds.
 -    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
@@ -185,11 +191,9 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -    done
 -
 -    dnl Strip [patch] section (monorepo paths not available in tarball)
-+    dnl Strip [patch] section — git sources don't work offline;
-+    dnl vendored-sources replacement in .cargo/config.toml handles resolution
-     if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-       "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-         && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
+-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
 -      echo "configure: stripped @<:@patch@:>@ section"
 -    fi
 -
@@ -220,13 +224,11 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
 -    if test $? -ne 0; then
 -      echo "configure: error: failed to generate lockfile from vendored sources" >&2
--      exit 1
-+      echo "configure: stripped @<:@patch@:>@ section for offline build"
+       exit 1
      fi
-     echo "configure: CRAN build — vendor ready"
 diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
 --- a/rpkg/Makevars.in	2026-03-13 19:23:15
-+++ b/rpkg/Makevars.in	2026-03-15 16:37:16
++++ b/rpkg/Makevars.in	2026-03-15 18:12:03
 @@ -26,5 +26,5 @@
  
  CARGO_TOML = $(ABS_RPKG_SRCDIR)/rust/Cargo.toml
@@ -235,8 +237,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-15 11:24:37
-+++ b/rpkg/configure.ac	2026-03-15 16:37:16
+--- a/rpkg/configure.ac	2026-03-16 19:21:23
++++ b/rpkg/configure.ac	2026-03-16 19:22:50
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -288,7 +290,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -237,6 +233,6 @@
+@@ -237,17 +233,29 @@
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
  AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
@@ -297,7 +299,17 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -253,7 +249,13 @@
+ dnl Use PACKAGE_NAME (case-preserving) not PACKAGE_TARNAME (lowercased)
+ dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
+-CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
++pkg_rs="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
++AC_SUBST([PACKAGE_TARNAME_RS], [$pkg_rs])
++pkg_rs_upper=`printf '%s' "$pkg_rs" | tr 'a-z' 'A-Z'`
++AC_SUBST([PACKAGE_TARNAME_RS_UPPERCASE], [$pkg_rs_upper])
++
++dnl Staticlib name matches the Rust crate name (= pkg_rs)
++CARGO_STATICLIB_NAME="$pkg_rs"
+ AC_SUBST([CARGO_STATICLIB_NAME])
  AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
  
 -dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
@@ -313,7 +325,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +case "$host_os" in
    darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
    *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -263,11 +265,4 @@
+@@ -257,11 +265,4 @@
  AC_SUBST([CDYLIB_EXT])
  
 -dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
@@ -325,7 +337,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -
  AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
  
-@@ -293,8 +288,7 @@
+@@ -293,8 +294,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
 -dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
@@ -336,7 +348,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
  
  dnl ---- output files ----
-@@ -305,9 +299,11 @@
+@@ -305,9 +305,11 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -351,7 +363,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -318,9 +314,18 @@
+@@ -318,9 +320,18 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
@@ -372,16 +384,18 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +[NOT_CRAN="$NOT_CRAN" SED="$SED"])
  
  dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -380,5 +385,5 @@
+@@ -380,5 +391,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -452,61 +457,10 @@
-       exit 1
-     fi
+@@ -429,62 +440,4 @@
+       echo "configure: error: CRAN build requires vendored sources." >&2
+       echo "configure:        Run 'just vendor' before CRAN submission." >&2
+-      exit 1
+-    fi
 -
 -    dnl Rewrite git deps to vendor/ path deps for offline builds.
 -    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
@@ -405,11 +419,9 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -    done
 -
 -    dnl Strip [patch] section (monorepo paths not available in tarball)
-+    dnl Strip [patch] section — git sources don't work offline;
-+    dnl vendored-sources replacement in .cargo/config.toml handles resolution
-     if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-       "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-         && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
+-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
+-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
+-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
 -      echo "configure: stripped @<:@patch@:>@ section"
 -    fi
 -
@@ -440,7 +452,5 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
 -    if test $? -ne 0; then
 -      echo "configure: error: failed to generate lockfile from vendored sources" >&2
--      exit 1
-+      echo "configure: stripped @<:@patch@:>@ section for offline build"
+       exit 1
      fi
-     echo "configure: CRAN build — vendor ready"

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,7 +9,7 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-16 19:21:23
+--- a/monorepo/rpkg/configure.ac	2026-03-16 19:37:05
 +++ b/monorepo/rpkg/configure.ac	2026-03-16 19:23:53
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
@@ -62,11 +62,33 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -237,17 +233,29 @@
+@@ -101,4 +97,5 @@
+ dnl Canonical path two levels above src (rpkg/src → miniextendr)
+ root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
++AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
+ 
+ dnl ---- tool discovery ----
+@@ -111,5 +108,7 @@
+ AS_IF([test "x$SED" = "xno"], [AC_MSG_ERROR([`sed` not found])])
+ AC_SUBST([CARGO])
+-dnl RUSTC, SED, CYGPATH used only within configure.ac — no AC_SUBST needed
++AC_SUBST([RUSTC])
++AC_SUBST([SED])
++AC_SUBST([CYGPATH])
+ 
+ dnl Use native paths for Cargo on Windows/MSYS to avoid path mangling.
+@@ -149,4 +148,5 @@
+ dnl Convenience: cargo command that includes optional toolchain selector
+ CARGO_CMD="$CARGO $RUST_TOOLCHAIN"
++AC_SUBST([CARGO_CMD])
+ 
+ dnl ---- Cargo configuration ----
+@@ -232,17 +232,30 @@
+ AS_IF([test -n "$CARGO_BUILD_TARGET"],
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
- AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
 -      [AC_MSG_NOTICE([MINIEXTENDR_FEATURES  = $MINIEXTENDR_FEATURES])])
++AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 +AS_IF([test -n "${{{features_var}}}"],
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
@@ -97,7 +119,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +case "$host_os" in
    darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
    *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -257,11 +265,4 @@
+@@ -252,11 +265,4 @@
  AC_SUBST([CDYLIB_EXT])
  
 -dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
@@ -109,7 +131,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 -
  AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
  
-@@ -293,8 +294,7 @@
+@@ -288,8 +294,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
 -dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
@@ -120,7 +142,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
  
  dnl ---- output files ----
-@@ -305,9 +305,11 @@
+@@ -300,9 +305,11 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -135,7 +157,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -318,9 +320,18 @@
+@@ -313,9 +320,18 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
@@ -156,14 +178,14 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +[NOT_CRAN="$NOT_CRAN" SED="$SED"])
  
  dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -380,5 +391,5 @@
+@@ -375,5 +391,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -429,62 +440,4 @@
+@@ -424,62 +440,4 @@
        echo "configure: error: CRAN build requires vendored sources." >&2
        echo "configure:        Run 'just vendor' before CRAN submission." >&2
 -      exit 1
@@ -237,7 +259,7 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-16 19:21:23
+--- a/rpkg/configure.ac	2026-03-16 19:37:05
 +++ b/rpkg/configure.ac	2026-03-16 19:22:50
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
@@ -290,11 +312,33 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +  CARGO_FEATURES_FLAG="--features=${{{features_var}}}"
  else
    CARGO_FEATURES_FLAG=""
-@@ -237,17 +233,29 @@
+@@ -101,4 +97,5 @@
+ dnl Canonical path two levels above src (rpkg/src → miniextendr)
+ root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
++AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
+ 
+ dnl ---- tool discovery ----
+@@ -111,5 +108,7 @@
+ AS_IF([test "x$SED" = "xno"], [AC_MSG_ERROR([`sed` not found])])
+ AC_SUBST([CARGO])
+-dnl RUSTC, SED, CYGPATH used only within configure.ac — no AC_SUBST needed
++AC_SUBST([RUSTC])
++AC_SUBST([SED])
++AC_SUBST([CYGPATH])
+ 
+ dnl Use native paths for Cargo on Windows/MSYS to avoid path mangling.
+@@ -149,4 +148,5 @@
+ dnl Convenience: cargo command that includes optional toolchain selector
+ CARGO_CMD="$CARGO $RUST_TOOLCHAIN"
++AC_SUBST([CARGO_CMD])
+ 
+ dnl ---- Cargo configuration ----
+@@ -232,17 +232,30 @@
+ AS_IF([test -n "$CARGO_BUILD_TARGET"],
        [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
- AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 -AS_IF([test -n "$MINIEXTENDR_FEATURES"],
 -      [AC_MSG_NOTICE([MINIEXTENDR_FEATURES  = $MINIEXTENDR_FEATURES])])
++AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 +AS_IF([test -n "${{{features_var}}}"],
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
@@ -325,7 +369,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +case "$host_os" in
    darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
    *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -257,11 +265,4 @@
+@@ -252,11 +265,4 @@
  AC_SUBST([CDYLIB_EXT])
  
 -dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
@@ -337,7 +381,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 -
  AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
  
-@@ -293,8 +294,7 @@
+@@ -288,8 +294,7 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
 -dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
@@ -348,7 +392,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
  
  dnl ---- output files ----
-@@ -305,9 +305,11 @@
+@@ -300,9 +305,11 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
@@ -363,7 +407,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
  AC_CONFIG_COMMANDS([dev-cargo-config],
  [
-@@ -318,9 +320,18 @@
+@@ -313,9 +320,18 @@
      if test -f "$RPKG_CFG"; then
        rm "$RPKG_CFG"
 -      echo "configure: removed cargo config (dev mode)"
@@ -384,14 +428,14 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +[NOT_CRAN="$NOT_CRAN" SED="$SED"])
  
  dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -380,5 +391,5 @@
+@@ -375,5 +391,5 @@
  
  dnl 3) Ensure vendor/ exists for offline builds
 -dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
 +dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
  dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
  dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -429,62 +440,4 @@
+@@ -424,62 +440,4 @@
        echo "configure: error: CRAN build requires vendored sources." >&2
        echo "configure:        Run 'just vendor' before CRAN submission." >&2
 -      exit 1

--- a/rpkg/cleanup
+++ b/rpkg/cleanup
@@ -42,8 +42,6 @@ rm -f src/rust/.cargo/config.toml
 
 # Remove generated files (configure recreates them from .in templates)
 rm -f src/Makevars
-rm -f src/entrypoint.c
-rm -f src/mx_abi.c
 rm -f src/*-wrappers.R
 # Note: Cargo.toml is NOT removed - it's a source file, not generated
 

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -614,8 +614,6 @@ TAR_FORCE_LOCAL
 CDYLIB_EXT
 CDYLIB_PREFIX
 CARGO_STATICLIB_NAME
-PACKAGE_TARNAME_RS_UPPERCASE
-PACKAGE_TARNAME_RS
 CARGO_LIBDIR
 CARGO_BUILD_TARGET
 ENV_RUSTFLAGS
@@ -2475,14 +2473,7 @@ then :
 printf "%s\n" "$as_me: MINIEXTENDR_FEATURES  = $MINIEXTENDR_FEATURES" >&6;}
 fi
 
-pkg_rs="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
-PACKAGE_TARNAME_RS=$pkg_rs
-
-pkg_rs_upper=`printf '%s' "$pkg_rs" | tr 'a-z' 'A-Z'`
-PACKAGE_TARNAME_RS_UPPERCASE=$pkg_rs_upper
-
-
-CARGO_STATICLIB_NAME="$pkg_rs"
+CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME" >&5
 printf "%s\n" "$as_me: CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME" >&6;}
@@ -2502,6 +2493,11 @@ esac
 
 
 
+
+case "$FORCE_VENDOR" in
+  1|true|TRUE|yes) FORCE_VENDOR=1 ;;
+  *)               FORCE_VENDOR="" ;;
+esac
 
 VENDOR_OUT="$abs_top_srcdir/vendor"
 
@@ -3750,48 +3746,28 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
 
   if test "$NOT_CRAN" = "true"; then
     if test "$FORCE_VENDOR" = "1"; then
-      echo "configure: FORCE_VENDOR — running cargo vendor"
-      mkdir -p "$VENDOR_OUT"
-      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-      if test $? -ne 0; then
-        echo "configure: error: cargo vendor failed" >&2
-        exit 1
-      fi
-      for _crate_dir in "$VENDOR_OUT"/*/; do
-        if test -d "$_crate_dir"; then
-          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-          for _dotfile in "$_crate_dir"/.*; do
-            case "$(basename "$_dotfile")" in
-              .|..|.cargo-checksum.json) ;;
-              *) rm -rf "$_dotfile" ;;
-            esac
-          done
-          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+      echo "configure: FORCE_VENDOR — running vendor-crates.R pack"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        _vendor_src=""
+        if test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+          _vendor_src="--source-root $MINIEXTENDR_LOCAL"
+        elif test -f "$VENDOR_OUT/.vendor-source"; then
+          _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+          if test -d "$_recorded"; then
+            _vendor_src="--source-root $_recorded"
+          fi
         fi
-      done
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
-    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-            echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-      }
-    elif test -f "$VENDOR_OUT/.vendor-source"; then
-      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-      if test -d "$_recorded"; then
-        echo "configure: syncing vendor/ from recorded source: $_recorded"
         "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+          pack --path "$abs_rpkg_dir" $_vendor_src 2>&1 || {
+          echo "configure: error: vendor-crates.R pack failed" >&2
+          exit 1
         }
       else
-        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
       fi
     else
-      echo "configure: dev mode — using vendor/ from scaffolding"
+      echo "configure: dev mode — using existing vendor/"
     fi
   else
         if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -620,14 +620,12 @@ ENV_RUSTFLAGS
 CARGO_PROFILE
 CARGO_TARGET_DIR_CARGO
 CARGO_TARGET_DIR
-CARGO_CMD
 RUST_TOOLCHAIN
 ABS_RPKG_SRC_CARGO
 CYGPATH
 SED
 RUSTC
 CARGO
-ROOT_MINIEXTENDR_REPO
 ABS_RPKG_SRCDIR
 ABS_TOP_SRCDIR
 CARGO_FEATURES_FLAG
@@ -2018,8 +2016,6 @@ ABS_RPKG_SRCDIR="$abs_rpkg_src"
 RUST_SRC_DIR="$abs_rpkg_src/rust"
 
 root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
-ROOT_MINIEXTENDR_REPO="$root_miniextendr_repo"
-
 
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}cargo", so it can be a program name with args.
@@ -2349,9 +2345,6 @@ then :
 fi
 
 
-
-
-
 abs_rpkg_src_cargo="$abs_rpkg_src"
 case "$host_os" in
   *msys*|*cygwin*|*mingw*)
@@ -2382,7 +2375,6 @@ fi
 
 
 CARGO_CMD="$CARGO $RUST_TOOLCHAIN"
-
 
 
 : ${CARGO_TARGET_DIR="$abs_top_srcdir/rust-target"}
@@ -2465,8 +2457,6 @@ then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET" >&5
 printf "%s\n" "$as_me: CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET" >&6;}
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO" >&5
-printf "%s\n" "$as_me: ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO" >&6;}
 if test -n "$MINIEXTENDR_FEATURES"
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: MINIEXTENDR_FEATURES  = $MINIEXTENDR_FEATURES" >&5

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -242,13 +242,7 @@ AS_IF([test -n "$MINIEXTENDR_FEATURES"],
 dnl ---- package name → Rust-safe variants ----
 dnl Use PACKAGE_NAME (case-preserving) not PACKAGE_TARNAME (lowercased)
 dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
-pkg_rs="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
-AC_SUBST([PACKAGE_TARNAME_RS], [$pkg_rs])
-pkg_rs_upper=`printf '%s' "$pkg_rs" | tr 'a-z' 'A-Z'`
-AC_SUBST([PACKAGE_TARNAME_RS_UPPERCASE], [$pkg_rs_upper])
-
-dnl Staticlib name matches the Rust crate name (= pkg_rs)
-CARGO_STATICLIB_NAME="$pkg_rs"
+CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
 AC_SUBST([CARGO_STATICLIB_NAME])
 AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
 
@@ -273,6 +267,12 @@ AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
 
 dnl Note: R CMD build already tracks .rs files for rebuild detection via pkgbuild,
 dnl so we don't need to enumerate RUST_SOURCES for Make dependencies.
+
+dnl Normalize FORCE_VENDOR (accept 1/true/TRUE/yes)
+case "$FORCE_VENDOR" in
+  1|true|TRUE|yes) FORCE_VENDOR=1 ;;
+  *)               FORCE_VENDOR="" ;;
+esac
 
 dnl ---- vendoring (at package root, outside src/) ----
 dnl IMPORTANT: vendor directory MUST be outside src/ to avoid pkgbuild scanning
@@ -400,49 +400,28 @@ AC_CONFIG_COMMANDS([cargo-vendor],
 
   if test "$NOT_CRAN" = "true"; then
     if test "$FORCE_VENDOR" = "1"; then
-      echo "configure: FORCE_VENDOR — running cargo vendor"
-      mkdir -p "$VENDOR_OUT"
-      $CARGO_CMD vendor --manifest-path src/rust/Cargo.toml "$VENDOR_OUT"
-      if test $? -ne 0; then
-        echo "configure: error: cargo vendor failed" >&2
-        exit 1
-      fi
-      for _crate_dir in "$VENDOR_OUT"/*/; do
-        if test -d "$_crate_dir"; then
-          rm -rf "$_crate_dir/tests" "$_crate_dir/benches" "$_crate_dir/examples" \
-                 "$_crate_dir/.github" "$_crate_dir/docs" "$_crate_dir/ci"
-          for _dotfile in "$_crate_dir"/.*; do
-            case "$(basename "$_dotfile")" in
-              .|..|.cargo-checksum.json) ;;
-              *) rm -rf "$_dotfile" ;;
-            esac
-          done
-          echo '{"files":{}}' > "$_crate_dir/.cargo-checksum.json"
+      echo "configure: FORCE_VENDOR — running vendor-crates.R pack"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        _vendor_src=""
+        if test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+          _vendor_src="--source-root $MINIEXTENDR_LOCAL"
+        elif test -f "$VENDOR_OUT/.vendor-source"; then
+          _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
+          if test -d "$_recorded"; then
+            _vendor_src="--source-root $_recorded"
+          fi
         fi
-      done
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
-    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
-      dnl MINIEXTENDR_LOCAL set — delegate vendoring to the package-local script
-      echo "configure: syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
-      "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-        sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
-        echo "configure: warning: vendor sync failed, using existing vendor/" >&2
-      }
-    elif test -f "$VENDOR_OUT/.vendor-source"; then
-      _recorded="$(cat "$VENDOR_OUT/.vendor-source")"
-      if test -d "$_recorded"; then
-        echo "configure: syncing vendor/ from recorded source: $_recorded"
         "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
-          sync --path "$abs_rpkg_dir" --source-root "$_recorded" 2>&1 || {
-          echo "configure: warning: vendor sync failed, using existing vendor/" >&2
+          pack --path "$abs_rpkg_dir" $_vendor_src 2>&1 || {
+          echo "configure: error: vendor-crates.R pack failed" >&2
+          exit 1
         }
       else
-        echo "configure: dev mode — using vendor/ from scaffolding (recorded source not found)"
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
       fi
     else
-      echo "configure: dev mode — using vendor/ from scaffolding"
+      echo "configure: dev mode — using existing vendor/"
     fi
   else
     dnl CRAN/offline mode: vendor/ must exist

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -100,7 +100,6 @@ RUST_SRC_DIR="$abs_rpkg_src/rust"
 
 dnl Canonical path two levels above src (rpkg/src → miniextendr)
 root_miniextendr_repo="$(cd "$abs_rpkg_src/../.." && pwd)"
-AC_SUBST([ROOT_MINIEXTENDR_REPO], ["$root_miniextendr_repo"])
 
 dnl ---- tool discovery ----
 AC_PATH_TOOL([CARGO],[cargo],[no])
@@ -111,9 +110,7 @@ AS_IF([test "x$CARGO" = "xno"], [AC_MSG_ERROR([`cargo` not found])])
 AS_IF([test "x$RUSTC" = "xno"], [AC_MSG_ERROR([`rustc` not found])])
 AS_IF([test "x$SED" = "xno"], [AC_MSG_ERROR([`sed` not found])])
 AC_SUBST([CARGO])
-AC_SUBST([RUSTC])
-AC_SUBST([SED])
-AC_SUBST([CYGPATH])
+dnl RUSTC, SED, CYGPATH used only within configure.ac — no AC_SUBST needed
 
 dnl Use native paths for Cargo on Windows/MSYS to avoid path mangling.
 dnl MSYS2 paths like /d/a/foo become D:/d/a/foo when interpreted by Cargo,
@@ -151,7 +148,6 @@ AC_SUBST([RUST_TOOLCHAIN])
 
 dnl Convenience: cargo command that includes optional toolchain selector
 CARGO_CMD="$CARGO $RUST_TOOLCHAIN"
-AC_SUBST([CARGO_CMD])
 
 dnl ---- Cargo configuration ----
 dnl IMPORTANT: target directory MUST be outside src/ to avoid pkgbuild scanning
@@ -235,7 +231,6 @@ AS_IF([test -n "$RUST_TOOLCHAIN"],
       [AC_MSG_NOTICE([RUST_TOOLCHAIN        = $RUST_TOOLCHAIN])])
 AS_IF([test -n "$CARGO_BUILD_TARGET"],
       [AC_MSG_NOTICE([CARGO_BUILD_TARGET    = $CARGO_BUILD_TARGET])])
-AC_MSG_NOTICE([ROOT_MINIEXTENDR_REPO = $ROOT_MINIEXTENDR_REPO])
 AS_IF([test -n "$MINIEXTENDR_FEATURES"],
       [AC_MSG_NOTICE([MINIEXTENDR_FEATURES  = $MINIEXTENDR_FEATURES])])
 

--- a/rpkg/tools/vendor-crates.R
+++ b/rpkg/tools/vendor-crates.R
@@ -117,6 +117,10 @@ parse_tree_packages <- function(lines) {
     path <- NA_character_
     if (grepl(" \\([^()]*[/\\\\][^()]*\\)$", line)) {
       path <- sub("^.* \\(([^()]*[/\\\\][^()]*)\\)$", "\\1", line)
+      # Filter out git URLs (cargo tree shows them as paths too)
+      if (grepl("^https?://", path) || grepl("^git[+@]", path)) {
+        path <- NA_character_
+      }
     }
 
     data.frame(


### PR DESCRIPTION
## Summary
Addresses all 6 issues from `reviews/vendor-path-deps-and-dead-code.md`:

1. **`parse_tree_packages()` git URL bug** — filter URLs that were mistakenly treated as local paths
2. **FORCE_VENDOR uses `vendor-crates.R pack`** — replaces raw `cargo vendor` which can't handle path deps
3. **Remove destructive `[patch]` stripping** — PR #35's cargo config source replacement handles CRAN mode
4. **FORCE_VENDOR normalization** — accepts `1/true/TRUE/yes`, not just `"1"`
5. **Dead code removal** — `PACKAGE_TARNAME_RS` and `PACKAGE_TARNAME_RS_UPPERCASE` unused in rpkg
6. **Dev mode skips vendor sync** — no more auto-sync on every `./configure`, only `FORCE_VENDOR` triggers it

Net: -225 lines, +157 lines (68 lines removed).

## Test plan
- [ ] CI passes
- [ ] `just configure` works (dev mode, no vendor sync)
- [ ] `FORCE_VENDOR=true just configure` works (normalization)
- [ ] `just templates-check` passes

Generated with [Claude Code](https://claude.com/claude-code)
