### PR TITLE
Error on Missing<T> with default value

### DIFF
--- a/miniextendr-macros/src/miniextendr_fn.rs
+++ b/miniextendr-macros/src/miniextendr_fn.rs
@@ -392,6 +392,18 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                         per_param_choices.insert(param_name.clone(), choices);
                     }
                     if let Some((default, span)) = default_with_span {
+                        if crate::r_wrapper_builder::is_missing_type(pat_type.ty.as_ref()) {
+                            return Err(syn::Error::new(
+                                span,
+                                format!(
+                                    "`Missing<T>` parameter `{}` cannot have a default value. \
+                                     `Missing<T>` detects omitted arguments via `missing()` in R, \
+                                     which is incompatible with default values in the R function signature. \
+                                     Use `Option<T>` with `#[miniextendr(default = \"...\")]` instead.",
+                                    param_name
+                                ),
+                            ));
+                        }
                         per_param_defaults.insert(param_name.clone(), default);
                         per_param_default_spans.insert(param_name, span);
                     }

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -1719,6 +1719,30 @@ impl ParsedMethod {
         // Get parameter defaults from method-level #[miniextendr(defaults(...))] attribute
         let param_defaults = method_attrs.defaults.clone();
 
+        // Validate: Missing<T> parameters must not have defaults
+        for arg in item.sig.inputs.iter() {
+            if let syn::FnArg::Typed(pt) = arg {
+                if let syn::Pat::Ident(pat_ident) = pt.pat.as_ref() {
+                    let name = pat_ident.ident.to_string();
+                    if crate::r_wrapper_builder::is_missing_type(pt.ty.as_ref())
+                        && param_defaults.contains_key(&name)
+                    {
+                        let span = method_attrs.defaults_span.unwrap_or(item.sig.ident.span());
+                        return Err(syn::Error::new(
+                            span,
+                            format!(
+                                "`Missing<T>` parameter `{}` cannot have a default value. \
+                                 `Missing<T>` detects omitted arguments via `missing()` in R, \
+                                 which is incompatible with default values in the R function signature. \
+                                 Use `Option<T>` with a default instead.",
+                                name
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
         // Validate: `self` by value (consuming) methods are not fully supported
         // They're either: constructor (returns Self), finalizer (marked or inferred), or error
         if env == ReceiverKind::Value {

--- a/miniextendr-macros/src/r_wrapper_builder.rs
+++ b/miniextendr-macros/src/r_wrapper_builder.rs
@@ -297,7 +297,7 @@ pub(crate) fn collect_param_idents(
 ///
 /// `Missing<T>` is the miniextendr wrapper for R's "missing argument" concept,
 /// allowing Rust functions to accept optional arguments that R callers can omit.
-fn is_missing_type(ty: &syn::Type) -> bool {
+pub(crate) fn is_missing_type(ty: &syn::Type) -> bool {
     match ty {
         syn::Type::Path(tp) => tp
             .path
@@ -343,9 +343,8 @@ pub fn collect_missing_params(
 /// signature clean (no `quote(expr=)` in formals) while still passing the
 /// `R_MissingArg` sentinel through to Rust when the caller omits the argument.
 ///
-/// Skips parameters that already have a user-specified default (from
-/// `#[miniextendr(default = "...")]`), since those appear in formals with that
-/// default and `missing()` would never be true for them.
+/// Note: `Missing<T>` + `default` is a compile error (checked in `miniextendr_fn.rs`
+/// and `miniextendr_impl.rs`), so the `user_defaults` filter is a safety net only.
 ///
 /// Returns a vector of R code lines, one per `Missing<T>` parameter.
 pub fn build_missing_prelude(


### PR DESCRIPTION
## Summary
- `Missing<T>` parameters now produce a compile error if combined with `#[miniextendr(default = "...")]`
- `Missing<T>` detects omitted arguments via `missing()` in R — a default value in the function signature makes the argument never truly "missing" from the caller's perspective
- Error message suggests using `Option<T>` with a default instead
- Checked in both standalone functions and impl methods

## Test plan
- [x] `just devtools-test` — 3186 tests pass, 0 failures
- [x] Existing `Missing<T>` usage (without defaults) unaffected
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)
