### PR TITLE
Add macro validation for parameter attribute conflicts

### DIFF
--- a/miniextendr-macros/src/miniextendr_fn.rs
+++ b/miniextendr-macros/src/miniextendr_fn.rs
@@ -114,6 +114,156 @@ impl CoercionMapping {
     }
 }
 
+// endregion
+
+// region: Type inspection helpers
+
+/// Check if a type path ends with the given identifier (e.g., "Dots", "Missing").
+///
+/// Handles fully-qualified paths like `miniextendr_api::dots::Dots` as well as
+/// bare `Dots`.
+fn type_ends_with(ty: &syn::Type, name: &str) -> bool {
+    match ty {
+        syn::Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident == name)
+            .unwrap_or(false),
+        syn::Type::Reference(r) => type_ends_with(&r.elem, name),
+        _ => false,
+    }
+}
+
+/// Check if a type is `Dots` or `&Dots` (the variadic `...` parameter type).
+pub(crate) fn is_dots_type(ty: &syn::Type) -> bool {
+    type_ends_with(ty, "Dots")
+}
+
+/// Check if a type is `Missing<T>`.
+pub(crate) fn is_missing_type(ty: &syn::Type) -> bool {
+    type_ends_with(ty, "Missing")
+}
+
+/// Extract the inner type `T` from `Missing<T>`, if the type is `Missing<T>`.
+///
+/// Returns `None` if the type is not `Missing<T>` or has no generic argument.
+pub(crate) fn get_missing_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(tp) = ty else {
+        return None;
+    };
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "Missing" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+        Some(inner)
+    } else {
+        None
+    }
+}
+
+/// Validate a parameter's type for `Missing` and `Dots` conflicts.
+///
+/// Returns `Err` if:
+/// - `Missing<Missing<T>>` (nested Missing)
+/// - `Missing<Dots>` or `Missing<&Dots>`
+pub(crate) fn validate_param_type(ty: &syn::Type, span: proc_macro2::Span) -> syn::Result<()> {
+    if let Some(inner) = get_missing_inner_type(ty) {
+        if is_missing_type(inner) {
+            return Err(syn::Error::new(
+                span,
+                "Missing<T> cannot be nested; use Missing<T> with the inner type directly",
+            ));
+        }
+        if is_dots_type(inner) {
+            return Err(syn::Error::new(
+                span,
+                "Missing<T> cannot wrap Dots; variadic parameters (...) are always present when called",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate per-parameter attribute conflicts.
+///
+/// Returns `Err` if:
+/// - `coerce` + `match_arg` on the same parameter
+/// - `coerce` + `choices(...)` on the same parameter
+/// - `choices(...)` + explicit `default` on the same parameter
+/// - `default` on a `&Dots` parameter
+pub(crate) fn validate_per_param_attr_conflicts(
+    attr: &PerParamMiniextendrAttr,
+    param_name: &str,
+    is_dots: bool,
+    ty: Option<&syn::Type>,
+    span: proc_macro2::Span,
+) -> syn::Result<()> {
+    if attr.has_coerce && attr.has_match_arg {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "cannot combine coerce and match_arg on parameter `{}`; \
+                 coerce converts the R type while match_arg validates string values",
+                param_name
+            ),
+        ));
+    }
+    if attr.has_coerce && attr.choices.is_some() {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "cannot combine coerce and choices on parameter `{}`; \
+                 coerce converts the R type while choices validates string values",
+                param_name
+            ),
+        ));
+    }
+    if attr.choices.is_some() && attr.default_value.is_some() {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "cannot combine choices() and default on parameter `{}`; \
+                 choices auto-generates its default from the first choice value",
+                param_name
+            ),
+        ));
+    }
+    if is_dots && attr.default_value.is_some() {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "variadic (...) parameter `{}` cannot have a default value",
+                param_name
+            ),
+        ));
+    }
+    if let Some(ty) = ty
+        && is_missing_type(ty)
+        && attr.default_value.is_some()
+    {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "`Missing<T>` parameter `{}` cannot have a default value. \
+                 `Missing<T>` detects omitted arguments via `missing()` in R, \
+                 which is incompatible with default values in the R function signature. \
+                 Use `Option<T>` with `#[miniextendr(default = \"...\")]` instead.",
+                param_name
+            ),
+        ));
+    }
+    Ok(())
+}
+
+// endregion
+
+// region: Per-parameter attribute parsing
+
 /// Parsed per-parameter `#[miniextendr(...)]` attribute content.
 ///
 /// A single attribute can contain multiple items, e.g.
@@ -379,9 +529,14 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                     && parse_default_attr(attr).is_none()
             });
 
+            // Validate type-based constraints (Missing nesting, Missing<Dots>)
+            validate_param_type(pat_type.ty.as_ref(), pat_type.ty.span())?;
+
+            let param_name_for_validation: String;
             match pat_type.pat.as_ref() {
                 syn::Pat::Ident(pat_ident) => {
                     let param_name = pat_ident.ident.to_string();
+                    param_name_for_validation = param_name.clone();
                     if had_coerce_attr {
                         per_param_coerce.insert(param_name.clone());
                     }
@@ -391,19 +546,7 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                     if let Some(choices) = had_choices.clone() {
                         per_param_choices.insert(param_name.clone(), choices);
                     }
-                    if let Some((default, span)) = default_with_span {
-                        if crate::r_wrapper_builder::is_missing_type(pat_type.ty.as_ref()) {
-                            return Err(syn::Error::new(
-                                span,
-                                format!(
-                                    "`Missing<T>` parameter `{}` cannot have a default value. \
-                                     `Missing<T>` detects omitted arguments via `missing()` in R, \
-                                     which is incompatible with default values in the R function signature. \
-                                     Use `Option<T>` with `#[miniextendr(default = \"...\")]` instead.",
-                                    param_name
-                                ),
-                            ));
-                        }
+                    if let Some((default, span)) = default_with_span.clone() {
                         per_param_defaults.insert(param_name.clone(), default);
                         per_param_default_spans.insert(param_name, span);
                     }
@@ -419,6 +562,7 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                         ident: synthetic_ident,
                         subpat: None,
                     });
+                    param_name_for_validation = synthetic_name.clone();
                     if had_coerce_attr {
                         per_param_coerce.insert(synthetic_name.clone());
                     }
@@ -428,7 +572,7 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                     if let Some(choices) = had_choices.clone() {
                         per_param_choices.insert(synthetic_name.clone(), choices);
                     }
-                    if let Some((default, span)) = default_with_span {
+                    if let Some((default, span)) = default_with_span.clone() {
                         per_param_defaults.insert(synthetic_name.clone(), default);
                         per_param_default_spans.insert(synthetic_name, span);
                     }
@@ -446,16 +590,17 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                         subpat: None,
                     });
                     pattern_destructures.push((original_pat, synthetic_ident.clone()));
+                    param_name_for_validation = synthetic_name.clone();
                     if had_coerce_attr {
                         per_param_coerce.insert(synthetic_name.clone());
                     }
                     if had_match_arg_attr {
                         per_param_match_arg.insert(synthetic_name.clone());
                     }
-                    if let Some(choices) = had_choices {
+                    if let Some(choices) = had_choices.clone() {
                         per_param_choices.insert(synthetic_name.clone(), choices);
                     }
-                    if let Some((default, span)) = default_with_span {
+                    if let Some((default, span)) = default_with_span.clone() {
                         per_param_defaults.insert(synthetic_name.clone(), default);
                         per_param_default_spans.insert(synthetic_name, span);
                     }
@@ -467,6 +612,21 @@ impl syn::parse::Parse for MiniextendrFunctionParsed {
                     ));
                 }
             }
+
+            // Validate per-parameter attribute conflicts (coerce+match_arg, coerce+choices, etc.)
+            let per_param_combined = PerParamMiniextendrAttr {
+                has_coerce: had_coerce_attr,
+                has_match_arg: had_match_arg_attr,
+                default_value: default_with_span,
+                choices: had_choices,
+            };
+            validate_per_param_attr_conflicts(
+                &per_param_combined,
+                &param_name_for_validation,
+                is_dots_type(pat_type.ty.as_ref()),
+                Some(pat_type.ty.as_ref()),
+                pat_type.ty.span(),
+            )?;
         }
 
         // Insert destructuring let-bindings for pattern parameters at the start of the function body

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -1651,6 +1651,7 @@ impl ParsedMethod {
     ///
     /// Regular doc comments are auto-converted to `@description` for all class systems.
     pub fn from_impl_item(item: syn::ImplItemFn, _class_system: ClassSystem) -> syn::Result<Self> {
+        use syn::spanned::Spanned;
         let env = Self::detect_env(&item.sig);
         let mut method_attrs = Self::parse_method_attrs(&item.attrs)?;
 
@@ -1700,6 +1701,35 @@ impl ParsedMethod {
             ));
         }
 
+        // Validate type-based constraints on each parameter
+        for input in &item.sig.inputs {
+            let syn::FnArg::Typed(pat_type) = input else {
+                continue;
+            };
+            let syn::Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
+                continue;
+            };
+            let param_name = pat_ident.ident.to_string();
+
+            // Validate Missing nesting and Missing<Dots>
+            crate::miniextendr_fn::validate_param_type(pat_type.ty.as_ref(), pat_type.ty.span())?;
+
+            // Validate: no defaults on Dots-type parameters
+            if crate::miniextendr_fn::is_dots_type(pat_type.ty.as_ref())
+                && method_attrs.defaults.contains_key(&param_name)
+            {
+                return Err(syn::Error::new(
+                    method_attrs
+                        .defaults_span
+                        .unwrap_or_else(|| pat_ident.ident.span()),
+                    format!(
+                        "variadic (...) parameter `{}` cannot have a default value",
+                        param_name
+                    ),
+                ));
+            }
+        }
+
         // Extract lifecycle from #[deprecated] attribute if not already set via #[miniextendr(lifecycle = ...)]
         if method_attrs.lifecycle.is_none() {
             method_attrs.lifecycle = item
@@ -1721,24 +1751,24 @@ impl ParsedMethod {
 
         // Validate: Missing<T> parameters must not have defaults
         for arg in item.sig.inputs.iter() {
-            if let syn::FnArg::Typed(pt) = arg {
-                if let syn::Pat::Ident(pat_ident) = pt.pat.as_ref() {
-                    let name = pat_ident.ident.to_string();
-                    if crate::r_wrapper_builder::is_missing_type(pt.ty.as_ref())
-                        && param_defaults.contains_key(&name)
-                    {
-                        let span = method_attrs.defaults_span.unwrap_or(item.sig.ident.span());
-                        return Err(syn::Error::new(
-                            span,
-                            format!(
-                                "`Missing<T>` parameter `{}` cannot have a default value. \
-                                 `Missing<T>` detects omitted arguments via `missing()` in R, \
-                                 which is incompatible with default values in the R function signature. \
-                                 Use `Option<T>` with a default instead.",
-                                name
-                            ),
-                        ));
-                    }
+            if let syn::FnArg::Typed(pt) = arg
+                && let syn::Pat::Ident(pat_ident) = pt.pat.as_ref()
+            {
+                let name = pat_ident.ident.to_string();
+                if crate::r_wrapper_builder::is_missing_type(pt.ty.as_ref())
+                    && param_defaults.contains_key(&name)
+                {
+                    let span = method_attrs.defaults_span.unwrap_or(item.sig.ident.span());
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "`Missing<T>` parameter `{}` cannot have a default value. \
+                             `Missing<T>` detects omitted arguments via `missing()` in R, \
+                             which is incompatible with default values in the R function signature. \
+                             Use `Option<T>` with a default instead.",
+                            name
+                        ),
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds compile-time validation for six previously-undetected error conditions in `#[miniextendr]` parameter handling:
  - `coerce` + `match_arg` conflict on same parameter
  - `coerce` + `choices()` conflict on same parameter
  - `choices()` + explicit `default` conflict (choices auto-generates its default)
  - `default` on variadic (`...`) parameters
  - `Missing<Missing<T>>` nested types
  - `Missing<Dots>` or `Missing<&Dots>` wrapper types
- Applies to both standalone functions (per-param attrs) and impl methods (method-level `defaults(...)`)
- Shared helper functions in `miniextendr_fn.rs` (`validate_param_type`, `validate_per_param_attr_conflicts`, `is_dots_type`, etc.) reused from `miniextendr_impl.rs`

## Test plan

- [x] `cargo check --manifest-path miniextendr-macros/Cargo.toml` -- clean compilation
- [x] `cargo clippy --manifest-path miniextendr-macros/Cargo.toml` -- no warnings
- [x] `just configure && just rcmdinstall` -- rpkg builds with no false positives
- [x] `just test` -- all Rust tests pass (0 failures)
- [x] `just devtools-test` -- all 3186 R tests pass (FAIL 0 | WARN 0 | SKIP 11 | PASS 3186)

Generated with [Claude Code](https://claude.com/claude-code)
