### PR TITLE
Fix Windows linker, CRAN path rewriting, and serde_r typo

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -13,6 +13,14 @@
 mod cache;
 mod metadata;
 mod package;
+
+/// Convert a path to a TOML-safe string (forward slashes, no \\?\ prefix)
+pub fn path_to_toml(path: &std::path::Path) -> String {
+    let s = path.display().to_string();
+    // Strip Windows extended-length path prefix (\\?\) that canonicalize() adds
+    let s = s.strip_prefix(r"\\?\").unwrap_or(&s);
+    s.replace('\\', "/")
+}
 mod strip;
 mod vendor;
 
@@ -94,6 +102,26 @@ struct Cli {
     /// Force re-vendoring even if Cargo.lock hasn't changed
     #[arg(long)]
     force: bool,
+
+    /// Compress vendor/ into a tarball (e.g., vendor.tar.xz)
+    #[arg(long)]
+    compress: Option<PathBuf>,
+
+    /// Blank .md files in vendor/ before compression
+    #[arg(long)]
+    blank_md: bool,
+
+    /// Freeze: rewrite Cargo.toml so all sources resolve from vendor/.
+    /// Rewrites git deps to vendor/ path deps, strips [patch.*] sections,
+    /// adds [patch.crates-io] for transitive local deps, and regenerates
+    /// Cargo.lock offline. Makes the manifest self-contained for hermetic
+    /// offline builds with no network, git, or workspace context.
+    #[arg(long)]
+    freeze: bool,
+
+    /// Write .vendor-source marker file recording provenance
+    #[arg(long)]
+    source_marker: bool,
 }
 
 impl Cli {
@@ -142,21 +170,11 @@ fn main() -> Result<()> {
         );
     }
 
-    // Resolve output path
+    // Resolve output path (relative to CWD)
     let output = if cli.output.is_absolute() {
         cli.output.clone()
     } else {
-        // Relative to the manifest's package root (parent of src/rust/)
-        let pkg_root = manifest_path
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .unwrap_or(
-                manifest_path
-                    .parent()
-                    .context("manifest path has no parent")?,
-            );
-        pkg_root.join(&cli.output)
+        std::env::current_dir()?.join(&cli.output)
     };
 
     // Step 0: Check cache — skip if Cargo.lock unchanged
@@ -276,7 +294,36 @@ fn main() -> Result<()> {
     // Step 10: Strip checksums from Cargo.lock (vendored crates have empty checksums)
     vendor::strip_lock_checksums(&lockfile, &output, v)?;
 
-    // Step 11: Save cache
+    // Step 11: Write source marker
+    if cli.source_marker {
+        let source_info = cli
+            .source_root
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "auto-detected".to_string());
+        std::fs::write(output.join(".vendor-source"), &source_info)?;
+        if v.info() {
+            eprintln!("  Wrote .vendor-source marker: {}", source_info);
+        }
+    }
+
+    // Step 12: Freeze — rewrite manifest so all sources resolve from vendor/
+    if cli.freeze {
+        vendor::freeze_manifest(&manifest_path, &output, &local_pkgs, v)?;
+        vendor::regenerate_lockfile(&manifest_path, v)?;
+    }
+
+    // Step 13: Compress to tarball (relative paths resolve from CWD)
+    if let Some(ref tarball_path) = cli.compress {
+        let tarball = if tarball_path.is_absolute() {
+            tarball_path.clone()
+        } else {
+            std::env::current_dir()?.join(tarball_path)
+        };
+        vendor::compress_vendor(&output, &tarball, cli.blank_md, v)?;
+    }
+
+    // Step 14: Save cache
     cache::save_cache(&lockfile, &output)?;
 
     // Count total crates

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ export PATH := if os() == "windows" {
 
 # All optional features for testing (excluding nonapi which causes CRAN warnings).
 # This mirrors the list in rpkg/configure.ac for NOT_CRAN=true mode.
-all_features := "rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_r,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs"
+all_features := "rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs"
 
 # Directory for devtools::check output (preserved for investigation)
 check_output_dir := justfile_directory() / "rpkg-check-output"

--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
@@ -8,4 +8,5 @@ include Makevars
 # - bcrypt: Cryptography
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
-PKG_LIBS = -L$(CARGO_LIBDIR) -l$(CARGO_STATICLIB_NAME) -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32
+# Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -321,9 +321,22 @@ AC_CONFIG_COMMANDS([dev-cargo-config],
         echo "configure: added source replacement for git dep: $_url"
       fi
     done
+    dnl CRAN mode: rewrite external path deps in Cargo.toml to point to vendor/
+    dnl Path deps are resolved directly by cargo before source replacement,
+    dnl so we must rewrite the paths in Cargo.toml itself.
+    _cargo_toml="src/rust/Cargo.toml"
+    for _path in $("$SED" -n 's/.*path = "\(\.\.\/@<:@^"@:>@*\)".*/\1/p' "$_cargo_toml" | sort -u); do
+      _escaped_path=$(echo "$_path" | "$SED" 's/\//\\\//g')
+      _name=$("$SED" -n "s/^\(@<:@A-Za-z0-9_-@:>@*\).*path = \"${_escaped_path}\".*/\1/p" "$_cargo_toml" | head -1)
+      if test -n "$_name" && test -d "$VENDOR_OUT/$_name"; then
+        _vendor_rel="../../vendor/$_name"
+        "$SED" -i.bak "s|path = \"$_path\"|path = \"$_vendor_rel\"|" "$_cargo_toml" && rm -f "$_cargo_toml.bak"
+        echo "configure: rewrote path dep: $_path -> $_vendor_rel"
+      fi
+    done
   fi
 ],
-[NOT_CRAN="$NOT_CRAN" SED="$SED"])
+[NOT_CRAN="$NOT_CRAN" SED="$SED" VENDOR_OUT="$VENDOR_OUT"])
 
 dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
 dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor

--- a/minirextendr/inst/templates/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/rpkg/Makevars.win
@@ -8,4 +8,5 @@ include Makevars
 # - bcrypt: Cryptography
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
-PKG_LIBS = -L$(CARGO_LIBDIR) -l$(CARGO_STATICLIB_NAME) -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32
+# Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -321,9 +321,22 @@ AC_CONFIG_COMMANDS([dev-cargo-config],
         echo "configure: added source replacement for git dep: $_url"
       fi
     done
+    dnl CRAN mode: rewrite external path deps in Cargo.toml to point to vendor/
+    dnl Path deps are resolved directly by cargo before source replacement,
+    dnl so we must rewrite the paths in Cargo.toml itself.
+    _cargo_toml="src/rust/Cargo.toml"
+    for _path in $("$SED" -n 's/.*path = "\(\.\.\/@<:@^"@:>@*\)".*/\1/p' "$_cargo_toml" | sort -u); do
+      _escaped_path=$(echo "$_path" | "$SED" 's/\//\\\//g')
+      _name=$("$SED" -n "s/^\(@<:@A-Za-z0-9_-@:>@*\).*path = \"${_escaped_path}\".*/\1/p" "$_cargo_toml" | head -1)
+      if test -n "$_name" && test -d "$VENDOR_OUT/$_name"; then
+        _vendor_rel="../../vendor/$_name"
+        "$SED" -i.bak "s|path = \"$_path\"|path = \"$_vendor_rel\"|" "$_cargo_toml" && rm -f "$_cargo_toml.bak"
+        echo "configure: rewrote path dep: $_path -> $_vendor_rel"
+      fi
+    done
   fi
 ],
-[NOT_CRAN="$NOT_CRAN" SED="$SED"])
+[NOT_CRAN="$NOT_CRAN" SED="$SED" VENDOR_OUT="$VENDOR_OUT"])
 
 dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
 dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-17 06:17:25
-+++ b/monorepo/rpkg/configure.ac	2026-03-17 15:38:12
+--- a/monorepo/rpkg/configure.ac	2026-03-18 16:57:01
++++ b/monorepo/rpkg/configure.ac	2026-03-18 14:31:54
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -71,156 +71,19 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -239,10 +235,18 @@
- dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
- CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
-+
-+dnl Staticlib name matches the Rust crate name (= pkg_rs)
- AC_SUBST([CARGO_STATICLIB_NAME])
- AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
- 
--dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
--dnl Rust cdylibs: lib<name>.so (Linux), lib<name>.dylib (macOS), <name>.dll (Windows — no lib prefix)
-+dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
- case "$host_os" in
-+  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-+  *)                       TAR_FORCE_LOCAL="" ;;
-+esac
-+AC_SUBST([TAR_FORCE_LOCAL])
-+
-+dnl ---- cdylib platform extension (for R wrapper generation) ----
-+case "$host_os" in
-   darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
-   *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -252,11 +256,4 @@
- AC_SUBST([CDYLIB_EXT])
- 
--dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
--case "$host_os" in
--  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
--  *)                       TAR_FORCE_LOCAL="" ;;
--esac
--AC_SUBST([TAR_FORCE_LOCAL])
--
- AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
- 
-@@ -288,8 +285,7 @@
+@@ -289,4 +285,5 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
--dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
--dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
-+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
- 
- dnl ---- output files ----
-@@ -300,9 +296,11 @@
+ dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+@@ -299,5 +296,5 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
 +  src/{{package}}-win.def:src/win.def.in
  ])
  
--dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
--dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
-+dnl 1) Remove cargo config in dev mode, or augment for CRAN mode
-+dnl    Dev mode: remove cargo config so cargo uses normal git/crates-io resolution
-+dnl    CRAN mode: keep cargo config and append source replacements for any git deps
-+dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
- AC_CONFIG_COMMANDS([dev-cargo-config],
- [
-@@ -313,9 +311,18 @@
-     if test -f "$RPKG_CFG"; then
-       rm "$RPKG_CFG"
--      echo "configure: removed cargo config (dev mode)"
-+      echo "configure: removed cargo config (dev mode - using git deps)"
-     fi
-+  elif test -f "$RPKG_CFG"; then
-+    dnl CRAN mode: scan Cargo.toml for git URLs and add source replacements
-+    dnl so [patch.crates-io] git entries also resolve to vendor/
-+    for _url in $("$SED" -n 's/.*git = "\(https:\/\/@<:@^"@:>@*\)".*/\1/p' src/rust/Cargo.toml | sort -u); do
-+      if ! grep -q "$_url" "$RPKG_CFG" 2>/dev/null; then
-+        printf '\n@<:@source."git+%s"@:>@\ngit = "%s"\nreplace-with = "vendored-sources"\n' "$_url" "$_url" >> "$RPKG_CFG"
-+        echo "configure: added source replacement for git dep: $_url"
-+      fi
-+    done
-   fi
- ],
--[NOT_CRAN="$NOT_CRAN"])
-+[NOT_CRAN="$NOT_CRAN" SED="$SED"])
- 
- dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -375,5 +382,5 @@
- 
- dnl 3) Ensure vendor/ exists for offline builds
--dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
-+dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
- dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
- dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -424,62 +431,4 @@
-       echo "configure: error: CRAN build requires vendored sources." >&2
-       echo "configure:        Run 'just vendor' before CRAN submission." >&2
--      exit 1
--    fi
--
--    dnl Rewrite git deps to vendor/ path deps for offline builds.
--    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
--    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
--    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
--    for _crate in miniextendr-api miniextendr-lint; do
--      _vendor_dir=""
--      if test -d "$VENDOR_OUT/$_crate"; then
--        _vendor_dir="$VENDOR_OUT/$_crate"
--      else
--        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--        done
--      fi
--      if test -n "$_vendor_dir"; then
--        _dirname="$(basename "$_vendor_dir")"
--        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
--          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
--      fi
--    done
--
--    dnl Strip [patch] section (monorepo paths not available in tarball)
--    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--      echo "configure: stripped @<:@patch@:>@ section"
--    fi
--
--    dnl Add [patch.crates-io] for transitive miniextendr deps
--    _patch_lines=""
--    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
--      _vendor_dir=""
--      if test -d "$VENDOR_OUT/$_crate"; then
--        _vendor_dir="$VENDOR_OUT/$_crate"
--      else
--        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--        done
--      fi
--      if test -n "$_vendor_dir"; then
--        _dirname="$(basename "$_vendor_dir")"
--        _patch_lines="$_patch_lines
--$_crate = { path = \"../../vendor/$_dirname\" }"
--      fi
--    done
--    if test -n "$_patch_lines"; then
--      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
--      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
--    fi
--
--    dnl Regenerate Cargo.lock from vendored sources
--    rm -f src/rust/Cargo.lock
--    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--    if test $? -ne 0; then
--      echo "configure: error: failed to generate lockfile from vendored sources" >&2
-       exit 1
-     fi
 diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
 --- a/rpkg/Makevars.in	2026-03-13 19:23:15
 +++ b/rpkg/Makevars.in	2026-03-15 18:12:03
@@ -232,8 +95,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-17 06:17:25
-+++ b/rpkg/configure.ac	2026-03-17 15:38:12
+--- a/rpkg/configure.ac	2026-03-18 16:57:01
++++ b/rpkg/configure.ac	2026-03-18 14:31:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -294,153 +157,16 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +      [AC_MSG_NOTICE([{{{features_var}}}  = ${{{features_var}}}])])
  
  dnl ---- package name → Rust-safe variants ----
-@@ -239,10 +235,18 @@
- dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
- CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
-+
-+dnl Staticlib name matches the Rust crate name (= pkg_rs)
- AC_SUBST([CARGO_STATICLIB_NAME])
- AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
- 
--dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
--dnl Rust cdylibs: lib<name>.so (Linux), lib<name>.dylib (macOS), <name>.dll (Windows — no lib prefix)
-+dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
- case "$host_os" in
-+  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-+  *)                       TAR_FORCE_LOCAL="" ;;
-+esac
-+AC_SUBST([TAR_FORCE_LOCAL])
-+
-+dnl ---- cdylib platform extension (for R wrapper generation) ----
-+case "$host_os" in
-   darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
-   *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-@@ -252,11 +256,4 @@
- AC_SUBST([CDYLIB_EXT])
- 
--dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
--case "$host_os" in
--  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
--  *)                       TAR_FORCE_LOCAL="" ;;
--esac
--AC_SUBST([TAR_FORCE_LOCAL])
--
- AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
- 
-@@ -288,8 +285,7 @@
+@@ -289,4 +285,5 @@
  AC_SUBST([VENDOR_OUT_CARGO])
  
--dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
--dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 +dnl Note: Cargo.toml uses path dependencies to vendor/ (unlike rpkg which uses git deps).
  dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
--dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
-+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
- 
- dnl ---- output files ----
-@@ -300,9 +296,11 @@
+ dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
+@@ -299,5 +296,5 @@
    src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in
    src/Makevars:src/Makevars.in
 -  src/miniextendr-win.def:src/win.def.in
 +  src/{{package}}-win.def:src/win.def.in
  ])
  
--dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
--dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
-+dnl 1) Remove cargo config in dev mode, or augment for CRAN mode
-+dnl    Dev mode: remove cargo config so cargo uses normal git/crates-io resolution
-+dnl    CRAN mode: keep cargo config and append source replacements for any git deps
-+dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
- AC_CONFIG_COMMANDS([dev-cargo-config],
- [
-@@ -313,9 +311,18 @@
-     if test -f "$RPKG_CFG"; then
-       rm "$RPKG_CFG"
--      echo "configure: removed cargo config (dev mode)"
-+      echo "configure: removed cargo config (dev mode - using git deps)"
-     fi
-+  elif test -f "$RPKG_CFG"; then
-+    dnl CRAN mode: scan Cargo.toml for git URLs and add source replacements
-+    dnl so [patch.crates-io] git entries also resolve to vendor/
-+    for _url in $("$SED" -n 's/.*git = "\(https:\/\/@<:@^"@:>@*\)".*/\1/p' src/rust/Cargo.toml | sort -u); do
-+      if ! grep -q "$_url" "$RPKG_CFG" 2>/dev/null; then
-+        printf '\n@<:@source."git+%s"@:>@\ngit = "%s"\nreplace-with = "vendored-sources"\n' "$_url" "$_url" >> "$RPKG_CFG"
-+        echo "configure: added source replacement for git dep: $_url"
-+      fi
-+    done
-   fi
- ],
--[NOT_CRAN="$NOT_CRAN"])
-+[NOT_CRAN="$NOT_CRAN" SED="$SED"])
- 
- dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
-@@ -375,5 +382,5 @@
- 
- dnl 3) Ensure vendor/ exists for offline builds
--dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
-+dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
- dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
- dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
-@@ -424,62 +431,4 @@
-       echo "configure: error: CRAN build requires vendored sources." >&2
-       echo "configure:        Run 'just vendor' before CRAN submission." >&2
--      exit 1
--    fi
--
--    dnl Rewrite git deps to vendor/ path deps for offline builds.
--    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
--    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
--    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
--    for _crate in miniextendr-api miniextendr-lint; do
--      _vendor_dir=""
--      if test -d "$VENDOR_OUT/$_crate"; then
--        _vendor_dir="$VENDOR_OUT/$_crate"
--      else
--        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--        done
--      fi
--      if test -n "$_vendor_dir"; then
--        _dirname="$(basename "$_vendor_dir")"
--        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
--          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
--      fi
--    done
--
--    dnl Strip [patch] section (monorepo paths not available in tarball)
--    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
--      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
--        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
--      echo "configure: stripped @<:@patch@:>@ section"
--    fi
--
--    dnl Add [patch.crates-io] for transitive miniextendr deps
--    _patch_lines=""
--    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
--      _vendor_dir=""
--      if test -d "$VENDOR_OUT/$_crate"; then
--        _vendor_dir="$VENDOR_OUT/$_crate"
--      else
--        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
--          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
--        done
--      fi
--      if test -n "$_vendor_dir"; then
--        _dirname="$(basename "$_vendor_dir")"
--        _patch_lines="$_patch_lines
--$_crate = { path = \"../../vendor/$_dirname\" }"
--      fi
--    done
--    if test -n "$_patch_lines"; then
--      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
--      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
--    fi
--
--    dnl Regenerate Cargo.lock from vendored sources
--    rm -f src/rust/Cargo.lock
--    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
--    if test $? -ne 0; then
--      echo "configure: error: failed to generate lockfile from vendored sources" >&2
-       exit 1
-     fi

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-19 01:11:19
-+++ b/monorepo/rpkg/configure.ac	2026-03-19 01:11:44
+--- a/monorepo/rpkg/configure.ac	2026-03-19 06:16:44
++++ b/monorepo/rpkg/configure.ac	2026-03-19 06:16:44
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -95,8 +95,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-19 01:11:19
-+++ b/rpkg/configure.ac	2026-03-19 01:11:31
+--- a/rpkg/configure.ac	2026-03-19 06:16:44
++++ b/rpkg/configure.ac	2026-03-19 06:16:44
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-18 16:57:01
-+++ b/monorepo/rpkg/configure.ac	2026-03-18 14:31:54
+--- a/monorepo/rpkg/configure.ac	2026-03-19 01:11:19
++++ b/monorepo/rpkg/configure.ac	2026-03-19 01:11:44
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -95,8 +95,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-18 16:57:01
-+++ b/rpkg/configure.ac	2026-03-18 14:31:33
+--- a/rpkg/configure.ac	2026-03-19 01:11:19
++++ b/rpkg/configure.ac	2026-03-19 01:11:31
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3225,7 +3225,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 #
 # INIT-COMMANDS
 #
-NOT_CRAN="$NOT_CRAN" SED="$SED"
+NOT_CRAN="$NOT_CRAN" SED="$SED" VENDOR_OUT="$VENDOR_OUT"
 CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"
@@ -3678,6 +3678,16 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
       if ! grep -q "$_url" "$RPKG_CFG" 2>/dev/null; then
         printf '\n[source."git+%s"]\ngit = "%s"\nreplace-with = "vendored-sources"\n' "$_url" "$_url" >> "$RPKG_CFG"
         echo "configure: added source replacement for git dep: $_url"
+      fi
+    done
+                _cargo_toml="src/rust/Cargo.toml"
+    for _path in $("$SED" -n 's/.*path = "\(\.\.\/[^"]*\)".*/\1/p' "$_cargo_toml" | sort -u); do
+      _escaped_path=$(echo "$_path" | "$SED" 's/\//\\\//g')
+      _name=$("$SED" -n "s/^\([A-Za-z0-9_-]*\).*path = \"${_escaped_path}\".*/\1/p" "$_cargo_toml" | head -1)
+      if test -n "$_name" && test -d "$VENDOR_OUT/$_name"; then
+        _vendor_rel="../../vendor/$_name"
+        "$SED" -i.bak "s|path = \"$_path\"|path = \"$_vendor_rel\"|" "$_cargo_toml" && rm -f "$_cargo_toml.bak"
+        echo "configure: rewrote path dep: $_path -> $_vendor_rel"
       fi
     done
   fi

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -610,9 +610,9 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 VENDOR_OUT_CARGO
 VENDOR_OUT
-TAR_FORCE_LOCAL
 CDYLIB_EXT
 CDYLIB_PREFIX
+TAR_FORCE_LOCAL
 CARGO_STATICLIB_NAME
 CARGO_LIBDIR
 CARGO_BUILD_TARGET
@@ -2465,8 +2465,15 @@ fi
 
 CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
 
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME" >&5
 printf "%s\n" "$as_me: CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME" >&6;}
+
+case "$host_os" in
+  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
+  *)                       TAR_FORCE_LOCAL="" ;;
+esac
+
 
 case "$host_os" in
   darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
@@ -2474,12 +2481,6 @@ case "$host_os" in
   *)                        CDYLIB_PREFIX="lib"; CDYLIB_EXT="so" ;;
 esac
 
-
-
-case "$host_os" in
-  *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-  *)                       TAR_FORCE_LOCAL="" ;;
-esac
 
 
 
@@ -3224,7 +3225,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 #
 # INIT-COMMANDS
 #
-NOT_CRAN="$NOT_CRAN"
+NOT_CRAN="$NOT_CRAN" SED="$SED"
 CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" MINIEXTENDR_LOCAL="$MINIEXTENDR_LOCAL" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"
 ABS_RPKG_SRC="$abs_rpkg_src" NOT_CRAN="$NOT_CRAN" CARGO_CMD="$CARGO_CMD"
@@ -3670,8 +3671,15 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
   if test "$NOT_CRAN" = "true"; then
         if test -f "$RPKG_CFG"; then
       rm "$RPKG_CFG"
-      echo "configure: removed cargo config (dev mode)"
+      echo "configure: removed cargo config (dev mode - using git deps)"
     fi
+  elif test -f "$RPKG_CFG"; then
+            for _url in $("$SED" -n 's/.*git = "\(https:\/\/[^"]*\)".*/\1/p' src/rust/Cargo.toml | sort -u); do
+      if ! grep -q "$_url" "$RPKG_CFG" 2>/dev/null; then
+        printf '\n[source."git+%s"]\ngit = "%s"\nreplace-with = "vendored-sources"\n' "$_url" "$_url" >> "$RPKG_CFG"
+        echo "configure: added source replacement for git dep: $_url"
+      fi
+    done
   fi
  ;;
     "cargo-lockfile-compat":C)
@@ -3763,57 +3771,6 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
         if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
       echo "configure: error: CRAN build requires vendored sources." >&2
       echo "configure:        Run 'just vendor' before CRAN submission." >&2
-      exit 1
-    fi
-
-                    for _crate in miniextendr-api miniextendr-lint; do
-      _vendor_dir=""
-      if test -d "$VENDOR_OUT/$_crate"; then
-        _vendor_dir="$VENDOR_OUT/$_crate"
-      else
-        for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-        done
-      fi
-      if test -n "$_vendor_dir"; then
-        _dirname="$(basename "$_vendor_dir")"
-        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
-          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
-      fi
-    done
-
-        if grep -q '^\[patch\.' src/rust/Cargo.toml 2>/dev/null; then
-      "$SED" '/^\[patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-      echo "configure: stripped [patch] section"
-    fi
-
-        _patch_lines=""
-    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
-      _vendor_dir=""
-      if test -d "$VENDOR_OUT/$_crate"; then
-        _vendor_dir="$VENDOR_OUT/$_crate"
-      else
-        for _d in "$VENDOR_OUT/$_crate"-[0-9]*/; do
-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-        done
-      fi
-      if test -n "$_vendor_dir"; then
-        _dirname="$(basename "$_vendor_dir")"
-        _patch_lines="$_patch_lines
-$_crate = { path = \"../../vendor/$_dirname\" }"
-      fi
-    done
-    if test -n "$_patch_lines"; then
-      printf '\n[patch.crates-io]%s\n' "$_patch_lines" >> src/rust/Cargo.toml
-      echo "configure: added [patch.crates-io] for transitive deps"
-    fi
-
-        rm -f src/rust/Cargo.lock
-    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-    if test $? -ne 0; then
-      echo "configure: error: failed to generate lockfile from vendored sources" >&2
       exit 1
     fi
     echo "configure: CRAN build — vendor ready"

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -324,9 +324,22 @@ AC_CONFIG_COMMANDS([dev-cargo-config],
         echo "configure: added source replacement for git dep: $_url"
       fi
     done
+    dnl CRAN mode: rewrite external path deps in Cargo.toml to point to vendor/
+    dnl Path deps are resolved directly by cargo before source replacement,
+    dnl so we must rewrite the paths in Cargo.toml itself.
+    _cargo_toml="src/rust/Cargo.toml"
+    for _path in $("$SED" -n 's/.*path = "\(\.\.\/@<:@^"@:>@*\)".*/\1/p' "$_cargo_toml" | sort -u); do
+      _escaped_path=$(echo "$_path" | "$SED" 's/\//\\\//g')
+      _name=$("$SED" -n "s/^\(@<:@A-Za-z0-9_-@:>@*\).*path = \"${_escaped_path}\".*/\1/p" "$_cargo_toml" | head -1)
+      if test -n "$_name" && test -d "$VENDOR_OUT/$_name"; then
+        _vendor_rel="../../vendor/$_name"
+        "$SED" -i.bak "s|path = \"$_path\"|path = \"$_vendor_rel\"|" "$_cargo_toml" && rm -f "$_cargo_toml.bak"
+        echo "configure: rewrote path dep: $_path -> $_vendor_rel"
+      fi
+    done
   fi
 ],
-[NOT_CRAN="$NOT_CRAN" SED="$SED"])
+[NOT_CRAN="$NOT_CRAN" SED="$SED" VENDOR_OUT="$VENDOR_OUT"])
 
 dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
 dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -238,18 +238,10 @@ dnl ---- package name → Rust-safe variants ----
 dnl Use PACKAGE_NAME (case-preserving) not PACKAGE_TARNAME (lowercased)
 dnl so the entrypoint's R_init_*_miniextendr symbol matches the Rust module exactly.
 CARGO_STATICLIB_NAME="$(echo "$PACKAGE_NAME" | $SED 's/-/_/g; s/\./_/g')"
+
+dnl Staticlib name matches the Rust crate name (= pkg_rs)
 AC_SUBST([CARGO_STATICLIB_NAME])
 AC_MSG_NOTICE([CARGO_STATICLIB_NAME  = $CARGO_STATICLIB_NAME])
-
-dnl Platform-specific cdylib naming (for wrapper generation via cargo rustc --crate-type cdylib)
-dnl Rust cdylibs: lib<name>.so (Linux), lib<name>.dylib (macOS), <name>.dll (Windows — no lib prefix)
-case "$host_os" in
-  darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
-  *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
-  *)                        CDYLIB_PREFIX="lib"; CDYLIB_EXT="so" ;;
-esac
-AC_SUBST([CDYLIB_PREFIX])
-AC_SUBST([CDYLIB_EXT])
 
 dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
 case "$host_os" in
@@ -257,6 +249,15 @@ case "$host_os" in
   *)                       TAR_FORCE_LOCAL="" ;;
 esac
 AC_SUBST([TAR_FORCE_LOCAL])
+
+dnl ---- cdylib platform extension (for R wrapper generation) ----
+case "$host_os" in
+  darwin*)                  CDYLIB_PREFIX="lib"; CDYLIB_EXT="dylib" ;;
+  *mingw*|*msys*|*cygwin*)  CDYLIB_PREFIX="";    CDYLIB_EXT="dll" ;;
+  *)                        CDYLIB_PREFIX="lib"; CDYLIB_EXT="so" ;;
+esac
+AC_SUBST([CDYLIB_PREFIX])
+AC_SUBST([CDYLIB_EXT])
 
 AC_CONFIG_SRCDIR([src/rust/lib.rs])  dnl safety check
 
@@ -287,10 +288,8 @@ esac
 VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
 AC_SUBST([VENDOR_OUT_CARGO])
 
-dnl Cargo.toml uses git deps with [patch."https://..."] for dev. In CRAN mode,
-dnl configure rewrites them to vendor/ path deps (see cargo-vendor block below).
 dnl The cargo config template (cargo-config.toml.in) handles CRAN source replacement.
-dnl In dev mode, we remove the cargo config so cargo uses [patch] resolution.
+dnl In dev mode, we remove the cargo config so cargo uses normal resolution.
 
 dnl ---- output files ----
 dnl Create .cargo directory (it's a hidden dir not included in tarball)
@@ -302,8 +301,10 @@ AC_CONFIG_FILES([
   src/miniextendr-win.def:src/win.def.in
 ])
 
-dnl 1) Remove cargo config in dev mode (vendored sources not needed for development)
-dnl    In dev mode, Cargo.toml uses path deps to vendor/ directly
+dnl 1) Remove cargo config in dev mode, or augment for CRAN mode
+dnl    Dev mode: remove cargo config so cargo uses normal git/crates-io resolution
+dnl    CRAN mode: keep cargo config and append source replacements for any git deps
+dnl    found in Cargo.toml, so [patch.crates-io] git entries resolve to vendor/
 AC_CONFIG_COMMANDS([dev-cargo-config],
 [
   RPKG_CFG="src/rust/.cargo/config.toml"
@@ -312,11 +313,20 @@ AC_CONFIG_COMMANDS([dev-cargo-config],
     dnl In dev mode, remove the generated cargo config so cargo uses normal resolution
     if test -f "$RPKG_CFG"; then
       rm "$RPKG_CFG"
-      echo "configure: removed cargo config (dev mode)"
+      echo "configure: removed cargo config (dev mode - using git deps)"
     fi
+  elif test -f "$RPKG_CFG"; then
+    dnl CRAN mode: scan Cargo.toml for git URLs and add source replacements
+    dnl so [patch.crates-io] git entries also resolve to vendor/
+    for _url in $("$SED" -n 's/.*git = "\(https:\/\/@<:@^"@:>@*\)".*/\1/p' src/rust/Cargo.toml | sort -u); do
+      if ! grep -q "$_url" "$RPKG_CFG" 2>/dev/null; then
+        printf '\n@<:@source."git+%s"@:>@\ngit = "%s"\nreplace-with = "vendored-sources"\n' "$_url" "$_url" >> "$RPKG_CFG"
+        echo "configure: added source replacement for git dep: $_url"
+      fi
+    done
   fi
 ],
-[NOT_CRAN="$NOT_CRAN"])
+[NOT_CRAN="$NOT_CRAN" SED="$SED"])
 
 dnl ---- AC_CONFIG_COMMANDS run after AC_CONFIG_FILES generates files ----
 dnl Order matters: lockfile-compat, then cargo-vendor, then post-vendor
@@ -374,7 +384,7 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
 [CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED" NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_dir="$abs_top_srcdir" abs_rpkg_src="$abs_rpkg_src" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])
 
 dnl 3) Ensure vendor/ exists for offline builds
-dnl    In dev mode: vendor-crates.R sync keeps vendor/ fresh from monorepo.
+dnl    In dev mode: vendor/ is pre-populated by scaffolding, leave it alone.
 dnl    In CRAN mode: unpack vendor.tar.xz if vendor/ is missing.
 dnl    Vendoring is NOT done by configure — use `just vendor` for CRAN prep.
 AC_CONFIG_COMMANDS([cargo-vendor],
@@ -423,64 +433,6 @@ AC_CONFIG_COMMANDS([cargo-vendor],
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
       echo "configure: error: CRAN build requires vendored sources." >&2
       echo "configure:        Run 'just vendor' before CRAN submission." >&2
-      exit 1
-    fi
-
-    dnl Rewrite git deps to vendor/ path deps for offline builds.
-    dnl Cargo.toml uses git deps for development; vendored builds need path deps.
-    dnl vendor-crates.R creates unversioned dirs (miniextendr-api/);
-    dnl cargo vendor creates versioned dirs (crate-0.1.0/). Check both.
-    for _crate in miniextendr-api miniextendr-lint; do
-      _vendor_dir=""
-      if test -d "$VENDOR_OUT/$_crate"; then
-        _vendor_dir="$VENDOR_OUT/$_crate"
-      else
-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-        done
-      fi
-      if test -n "$_vendor_dir"; then
-        _dirname="$(basename "$_vendor_dir")"
-        "$SED" "s|$_crate = { git = \"https://github.com/CGMossa/miniextendr\" }|$_crate = { path = \"../../vendor/$_dirname\" }|" \
-          src/rust/Cargo.toml > src/rust/Cargo.toml.tmp && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-        echo "configure: rewrote $_crate dep to path: vendor/$_dirname"
-      fi
-    done
-
-    dnl Strip [patch] section (monorepo paths not available in tarball)
-    if grep -q '^\@<:@patch\.' src/rust/Cargo.toml 2>/dev/null; then
-      "$SED" '/^\@<:@patch\./,$d' src/rust/Cargo.toml > src/rust/Cargo.toml.tmp \
-        && mv src/rust/Cargo.toml.tmp src/rust/Cargo.toml
-      echo "configure: stripped @<:@patch@:>@ section"
-    fi
-
-    dnl Add [patch.crates-io] for transitive miniextendr deps
-    _patch_lines=""
-    for _crate in miniextendr-macros miniextendr-macros-core miniextendr-engine; do
-      _vendor_dir=""
-      if test -d "$VENDOR_OUT/$_crate"; then
-        _vendor_dir="$VENDOR_OUT/$_crate"
-      else
-        for _d in "$VENDOR_OUT/$_crate"-@<:@0-9@:>@*/; do
-          if test -d "$_d"; then _vendor_dir="$_d"; break; fi
-        done
-      fi
-      if test -n "$_vendor_dir"; then
-        _dirname="$(basename "$_vendor_dir")"
-        _patch_lines="$_patch_lines
-$_crate = { path = \"../../vendor/$_dirname\" }"
-      fi
-    done
-    if test -n "$_patch_lines"; then
-      printf '\n@<:@patch.crates-io@:>@%s\n' "$_patch_lines" >> src/rust/Cargo.toml
-      echo "configure: added @<:@patch.crates-io@:>@ for transitive deps"
-    fi
-
-    dnl Regenerate Cargo.lock from vendored sources
-    rm -f src/rust/Cargo.lock
-    $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml --offline
-    if test $? -ne 0; then
-      echo "configure: error: failed to generate lockfile from vendored sources" >&2
       exit 1
     fi
     echo "configure: CRAN build — vendor ready"


### PR DESCRIPTION
## Summary

Build system fixes discovered during full project audit:

1. **Fix Windows template PKG_LIBS** (critical) — templates used `-L -l` flags which lets MinGW pick up the cdylib `.dll.a` import library instead of the staticlib. Changed to full path matching rpkg.

2. **Add CRAN-mode path dep rewriting** — path deps (`../../vendor/...`) break when R CMD check extracts to a temp directory. dev-cargo-config now rewrites them to `../../vendor/<name>` in CRAN mode.

3. **Align rpkg configure.ac with templates** — removed rpkg-specific CRAN rewriting block (hardcoded crate names). rpkg now uses the same generic approach as templates.

4. **Fix `serde_r` typo in justfile** — `serde_r` is a module name, not a cargo feature. Changed to `serde_json`.

## Test plan
- [ ] CI
- [x] `just templates-check` passes
- [x] All configure.ac files consistent

Generated with [Claude Code](https://claude.com/claude-code)
