### PR TITLE
Add Box<[T]> support for R ↔ Rust conversions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,27 @@ A Rust-R interoperability framework for building R packages with Rust backends.
 - **Windows paths in TOML**: Use forward slashes. `canonicalize()` adds `\\?\` prefix on Windows — strip it with `strip_prefix(r"\\?\")` before writing to TOML/config files.
 - **macOS tar xattrs**: Set `COPYFILE_DISABLE=1` when creating tarballs on macOS to prevent Apple xattr metadata that causes warnings on Linux/Windows GNU tar.
 
+## Adding a New Conversion Type (e.g., `Box<[T]>`)
+
+To add a new container type to the R ↔ Rust conversion system, modify these files:
+
+1. **`miniextendr-api/src/from_r.rs`** — `TryFromSexp` impls (R → Rust):
+   - Native types: `Box<[i32]>`, `Box<[f64]>`, `Box<[u8]>`, `Box<[RLogical]>`, `Box<[Rcomplex]>`
+   - NA-aware: `Box<[Option<i32>]>`, `Box<[Option<f64>]>`
+   - Bool: `Box<[bool]>`, `Box<[Option<bool>]>`
+   - String: `Box<[String]>`, `Box<[Option<String>]>`
+2. **`miniextendr-api/src/into_r.rs`** — `IntoR` impls (Rust → R):
+   - Native blanket: `Box<[T: RNativeType]>` (delegates to `&[T]`)
+   - Bool: `Box<[bool]>` (non-RNativeType, needs explicit impl)
+   - String: `Box<[String]>`
+3. **`miniextendr-api/src/coerce.rs`** — `Coerce<Box<[R]>> for Box<[T]>`
+4. **Serde docs** — `src/serde.rs`, `src/serde/de.rs`, `src/serde/traits.rs` (update type tables)
+5. **rpkg test fixtures** — `rpkg/src/rust/<type>_tests.rs` + `rpkg/tests/testthat/test-<type>.R`
+6. **Vendor sync** — run `vendor_miniextendr(path = "rpkg", local_path = ".")` to update rpkg's vendor/
+
+Note: `bool` is NOT `RNativeType` (R uses `i32` for logicals), so it needs separate impls.
+Note: The proc-macro (`#[miniextendr]`) handles `Box<[T]>` generically via `TryFromSexp`/`IntoR` — no macro changes needed.
+
 ## Capturing Command Output
 
 **Always redirect long-running R/Cargo command output to a log file**, then read the log. This ensures you see the full output (no truncation from `tail`) and can re-read sections as needed.

--- a/miniextendr-api/src/coerce.rs
+++ b/miniextendr-api/src/coerce.rs
@@ -1089,6 +1089,14 @@ impl<T: Coerce<R>, R> Coerce<Vec<R>> for Vec<T> {
     }
 }
 
+/// Infallible element-wise coercion for `Box<[T]>` → `Box<[R]>`.
+impl<T: Coerce<R>, R> Coerce<Box<[R]>> for Box<[T]> {
+    #[inline]
+    fn coerce(self) -> Box<[R]> {
+        Vec::from(self).into_iter().map(Coerce::coerce).collect()
+    }
+}
+
 /// Infallible element-wise coercion for VecDeque to VecDeque.
 impl<T: Coerce<R>, R> Coerce<std::collections::VecDeque<R>> for std::collections::VecDeque<T> {
     fn coerce(self) -> std::collections::VecDeque<R> {

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -2453,6 +2453,38 @@ macro_rules! impl_vec_option_try_from_sexp {
 impl_vec_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
 impl_vec_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
 
+/// Macro for NA-aware `R vector → Box<[Option<T>]>` conversions.
+macro_rules! impl_boxed_slice_option_try_from_sexp {
+    ($t:ty, $sexptype:ident, $dataptr:ident, $is_na:expr) => {
+        impl TryFromSexp for Box<[Option<$t>]> {
+            type Error = SexpError;
+
+            fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+                let actual = sexp.type_of();
+                if actual != SEXPTYPE::$sexptype {
+                    return Err(SexpTypeError {
+                        expected: SEXPTYPE::$sexptype,
+                        actual,
+                    }
+                    .into());
+                }
+
+                let len = sexp.len();
+                let ptr = unsafe { crate::ffi::$dataptr(sexp) };
+                let slice = unsafe { r_slice(ptr, len) };
+
+                Ok(slice
+                    .iter()
+                    .map(|&v| if $is_na(v) { None } else { Some(v) })
+                    .collect())
+            }
+        }
+    };
+}
+
+impl_boxed_slice_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
+impl_boxed_slice_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
+
 /// Convert R logical vector (LGLSXP) to `Vec<Option<bool>>` with NA support.
 impl TryFromSexp for Vec<Option<bool>> {
     type Error = SexpError;
@@ -2495,6 +2527,16 @@ impl TryFromSexp for Vec<Option<bool>> {
             .iter()
             .map(|&v| RLogical::from_i32(v).to_option_bool())
             .collect())
+    }
+}
+
+/// Convert R logical vector (LGLSXP) to `Box<[Option<bool>]>` with NA support.
+impl TryFromSexp for Box<[Option<bool>]> {
+    type Error = SexpError;
+
+    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        let vec: Vec<Option<bool>> = TryFromSexp::try_from_sexp(sexp)?;
+        Ok(vec.into_boxed_slice())
     }
 }
 
@@ -2662,6 +2704,16 @@ impl TryFromSexp for Vec<Option<String>> {
         }
 
         Ok(result)
+    }
+}
+
+/// Convert R character vector to `Box<[Option<String>]>` with NA support.
+impl TryFromSexp for Box<[Option<String>]> {
+    type Error = SexpError;
+
+    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        let vec: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
+        Ok(vec.into_boxed_slice())
     }
 }
 
@@ -2988,6 +3040,25 @@ impl_vec_try_from_sexp_native!(f64);
 impl_vec_try_from_sexp_native!(u8);
 impl_vec_try_from_sexp_native!(RLogical);
 impl_vec_try_from_sexp_native!(crate::ffi::Rcomplex);
+
+macro_rules! impl_boxed_slice_try_from_sexp_native {
+    ($t:ty) => {
+        impl TryFromSexp for Box<[$t]> {
+            type Error = SexpTypeError;
+
+            fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+                let slice: &[$t] = TryFromSexp::try_from_sexp(sexp)?;
+                Ok(slice.into())
+            }
+        }
+    };
+}
+
+impl_boxed_slice_try_from_sexp_native!(i32);
+impl_boxed_slice_try_from_sexp_native!(f64);
+impl_boxed_slice_try_from_sexp_native!(u8);
+impl_boxed_slice_try_from_sexp_native!(RLogical);
+impl_boxed_slice_try_from_sexp_native!(crate::ffi::Rcomplex);
 // endregion
 
 // region: Fixed-size array conversions
@@ -3172,6 +3243,18 @@ impl TryFromSexp for Vec<String> {
         }
 
         Ok(result)
+    }
+}
+
+/// Convert R character vector to `Box<[String]>`.
+///
+/// **Warning:** `NA_character_` values are converted to empty string `""`.
+impl TryFromSexp for Box<[String]> {
+    type Error = SexpError;
+
+    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        let vec: Vec<String> = TryFromSexp::try_from_sexp(sexp)?;
+        Ok(vec.into_boxed_slice())
     }
 }
 
@@ -3721,6 +3804,15 @@ impl TryFromSexp for Vec<bool> {
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
         Self::try_from_sexp(sexp)
+    }
+}
+
+impl TryFromSexp for Box<[bool]> {
+    type Error = SexpError;
+
+    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        let vec: Vec<bool> = TryFromSexp::try_from_sexp(sexp)?;
+        Ok(vec.into_boxed_slice())
     }
 }
 // endregion

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -886,6 +886,29 @@ where
     }
 }
 
+impl<T> IntoR for Box<[T]>
+where
+    T: crate::ffi::RNativeType,
+{
+    type Error = std::convert::Infallible;
+    #[inline]
+    fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(unsafe { vec_to_sexp(&self) })
+    }
+    #[inline]
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(unsafe { vec_to_sexp_unchecked(&self) })
+    }
+    #[inline]
+    fn into_sexp(self) -> crate::ffi::SEXP {
+        unsafe { vec_to_sexp(&self) }
+    }
+    #[inline]
+    unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
+        unsafe { vec_to_sexp_unchecked(&self) }
+    }
+}
+
 /// Convert a slice to an R vector (checked).
 #[inline]
 unsafe fn vec_to_sexp<T: crate::ffi::RNativeType>(slice: &[T]) -> crate::ffi::SEXP {
@@ -1823,6 +1846,23 @@ impl IntoR for &[String] {
     }
 }
 
+/// Convert `Box<[String]>` to R character vector (STRSXP).
+impl IntoR for Box<[String]> {
+    type Error = std::convert::Infallible;
+    fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(self.into_sexp())
+    }
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(unsafe { self.into_sexp_unchecked() })
+    }
+    fn into_sexp(self) -> crate::ffi::SEXP {
+        str_iter_to_strsxp(self.iter().map(|s| s.as_str()))
+    }
+    unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
+        unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_str())) }
+    }
+}
+
 /// Convert &[&str] to R character vector (STRSXP).
 impl IntoR for &[&str] {
     type Error = std::convert::Infallible;
@@ -2142,6 +2182,25 @@ impl IntoR for Vec<bool> {
     unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.into_iter().map(|v| v as i32)) }
+    }
+}
+
+/// Convert `Box<[bool]>` to R logical vector.
+impl IntoR for Box<[bool]> {
+    type Error = std::convert::Infallible;
+    fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(self.into_sexp())
+    }
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::ffi::SEXP, Self::Error> {
+        Ok(unsafe { self.into_sexp_unchecked() })
+    }
+    fn into_sexp(self) -> crate::ffi::SEXP {
+        let n = self.len();
+        logical_iter_to_lglsxp(n, self.iter().map(|&v| v as i32))
+    }
+    unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
+        let n = self.len();
+        unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&v| v as i32)) }
     }
 }
 

--- a/miniextendr-api/src/serde.rs
+++ b/miniextendr-api/src/serde.rs
@@ -40,7 +40,7 @@
 //! | `numeric(1)` | `f64` |
 //! | `character(1)` | `String` |
 //! | NA values | `Option<T>::None` |
-//! | atomic vectors | `Vec<primitive>` |
+//! | atomic vectors | `Vec<primitive>` or `Box<[primitive]>` |
 //! | lists | `Vec<T>` or struct |
 //! | named lists | struct or `HashMap<String, T>` |
 //! | NULL | `()` or `Option<T>::None` |

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -20,7 +20,7 @@ use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, MapAccess, Seq
 /// | `numeric(1)` | `f64` |
 /// | `character(1)` | `String` |
 /// | NA values | `Option<T>::None` |
-/// | atomic vectors | `Vec<primitive>` |
+/// | atomic vectors | `Vec<primitive>` or `Box<[primitive]>` |
 /// | lists | `Vec<T>` or struct |
 /// | named lists | struct or `HashMap<String, T>` |
 /// | NULL | `()` or `Option<T>::None` |

--- a/miniextendr-api/src/serde/traits.rs
+++ b/miniextendr-api/src/serde/traits.rs
@@ -90,7 +90,7 @@ impl<T: serde::Serialize> RSerializeNative for T {
 /// | `numeric(1)` | `f64` |
 /// | `character(1)` | `String` |
 /// | NA values | `Option<T>::None` |
-/// | atomic vectors | `Vec<primitive>` |
+/// | atomic vectors | `Vec<primitive>` or `Box<[primitive]>` |
 /// | lists | `Vec<T>` |
 /// | named lists | struct or `HashMap<String, T>` |
 /// | NULL | `()` or `Option<T>::None` |

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -422,6 +422,18 @@ AC_CONFIG_COMMANDS([cargo-vendor],
         echo "configure:        Install: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
         exit 1
       fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+      echo "configure: dev mode — syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+          echo "configure: error: vendor-crates.R sync failed" >&2
+          exit 1
+        }
+      else
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
+      fi
     else
       echo "configure: dev mode — using existing vendor/"
     fi

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -422,6 +422,18 @@ AC_CONFIG_COMMANDS([cargo-vendor],
         echo "configure:        Install: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
         exit 1
       fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+      echo "configure: dev mode — syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+          echo "configure: error: vendor-crates.R sync failed" >&2
+          exit 1
+        }
+      else
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
+      fi
     else
       echo "configure: dev mode — using existing vendor/"
     fi

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-19 10:45:49
-+++ b/monorepo/rpkg/configure.ac	2026-03-19 10:45:49
+--- a/monorepo/rpkg/configure.ac	2026-03-20 09:01:59
++++ b/monorepo/rpkg/configure.ac	2026-03-20 09:01:59
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -95,8 +95,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-19 10:45:49
-+++ b/rpkg/configure.ac	2026-03-19 10:45:49
+--- a/rpkg/configure.ac	2026-03-20 09:01:59
++++ b/rpkg/configure.ac	2026-03-20 09:01:59
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3764,6 +3764,18 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
         echo "configure:        Install: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
         exit 1
       fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+      echo "configure: dev mode — syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+          echo "configure: error: vendor-crates.R sync failed" >&2
+          exit 1
+        }
+      else
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
+      fi
     else
       echo "configure: dev mode — using existing vendor/"
     fi

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -425,6 +425,18 @@ AC_CONFIG_COMMANDS([cargo-vendor],
         echo "configure:        Install: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
         exit 1
       fi
+    elif test -n "$MINIEXTENDR_LOCAL" && test -d "$MINIEXTENDR_LOCAL"; then
+      echo "configure: dev mode — syncing vendor/ from MINIEXTENDR_LOCAL=$MINIEXTENDR_LOCAL"
+      if test -f "$abs_rpkg_dir/tools/vendor-crates.R"; then
+        "$R_HOME/bin/Rscript" "$abs_rpkg_dir/tools/vendor-crates.R" \
+          sync --path "$abs_rpkg_dir" --source-root "$MINIEXTENDR_LOCAL" 2>&1 || {
+          echo "configure: error: vendor-crates.R sync failed" >&2
+          exit 1
+        }
+      else
+        echo "configure: error: tools/vendor-crates.R not found" >&2
+        exit 1
+      fi
     else
       echo "configure: dev mode — using existing vendor/"
     fi

--- a/rpkg/src/rust/box_slice_tests.rs
+++ b/rpkg/src/rust/box_slice_tests.rs
@@ -1,0 +1,60 @@
+use miniextendr_api::miniextendr;
+
+// region: Box<[T]> roundtrip tests
+
+/// Box<[f64]> roundtrip: R numeric → Rust → R numeric
+#[miniextendr]
+pub fn box_slice_f64_roundtrip(x: Box<[f64]>) -> Box<[f64]> {
+    x
+}
+
+/// Box<[i32]> roundtrip: R integer → Rust → R integer
+#[miniextendr]
+pub fn box_slice_i32_roundtrip(x: Box<[i32]>) -> Box<[i32]> {
+    x
+}
+
+/// Box<[String]> roundtrip: R character → Rust → R character
+#[miniextendr]
+pub fn box_slice_string_roundtrip(x: Box<[String]>) -> Box<[String]> {
+    x
+}
+
+/// Box<[bool]> roundtrip: R logical → Rust → R logical
+#[miniextendr]
+pub fn box_slice_bool_roundtrip(x: Box<[bool]>) -> Box<[bool]> {
+    x
+}
+
+/// Box<[u8]> roundtrip: R raw → Rust → R raw
+#[miniextendr]
+pub fn box_slice_raw_roundtrip(x: Box<[u8]>) -> Box<[u8]> {
+    x
+}
+
+/// Transform: double each element using Box<[f64]>
+#[miniextendr]
+pub fn box_slice_double(x: Box<[f64]>) -> Box<[f64]> {
+    x.iter().map(|v| v * 2.0).collect()
+}
+
+/// Box<[Option<f64>]> with NA support
+#[miniextendr]
+pub fn box_slice_option_f64_roundtrip(x: Box<[Option<f64>]>) -> Vec<Option<f64>> {
+    // Return as Vec to verify Box→Vec conversion path
+    x.into_vec()
+}
+
+/// Box<[Option<i32>]> with NA support
+#[miniextendr]
+pub fn box_slice_option_i32_roundtrip(x: Box<[Option<i32>]>) -> Vec<Option<i32>> {
+    x.into_vec()
+}
+
+/// Box<[Option<String>]> with NA support
+#[miniextendr]
+pub fn box_slice_option_string_roundtrip(x: Box<[Option<String>]>) -> Vec<Option<String>> {
+    x.into_vec()
+}
+
+// endregion

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -115,6 +115,7 @@ mod bitvec_adapter_tests;
 mod borsh_adapter_tests;
 #[cfg(feature = "bytes")]
 mod bytes_adapter_tests;
+mod box_slice_tests;
 mod class_system_matrix;
 mod coerce_tests;
 #[cfg(feature = "connections")]

--- a/rpkg/tests/testthat/test-box-slice.R
+++ b/rpkg/tests/testthat/test-box-slice.R
@@ -1,0 +1,43 @@
+test_that("Box<[f64]> roundtrip works", {
+  expect_equal(box_slice_f64_roundtrip(c(1.5, 2.5, 3.5)), c(1.5, 2.5, 3.5))
+  expect_equal(box_slice_f64_roundtrip(numeric(0)), numeric(0))
+})
+
+test_that("Box<[i32]> roundtrip works", {
+  expect_equal(box_slice_i32_roundtrip(1:5), 1:5)
+  expect_equal(box_slice_i32_roundtrip(integer(0)), integer(0))
+})
+
+test_that("Box<[String]> roundtrip works", {
+  expect_equal(box_slice_string_roundtrip(c("a", "b", "c")), c("a", "b", "c"))
+  expect_equal(box_slice_string_roundtrip(character(0)), character(0))
+})
+
+test_that("Box<[bool]> roundtrip works", {
+  expect_equal(box_slice_bool_roundtrip(c(TRUE, FALSE, TRUE)), c(TRUE, FALSE, TRUE))
+  expect_equal(box_slice_bool_roundtrip(logical(0)), logical(0))
+})
+
+test_that("Box<[u8]> roundtrip works", {
+  expect_equal(box_slice_raw_roundtrip(as.raw(1:5)), as.raw(1:5))
+  expect_equal(box_slice_raw_roundtrip(raw(0)), raw(0))
+})
+
+test_that("Box<[f64]> transform works", {
+  expect_equal(box_slice_double(c(1, 2, 3)), c(2, 4, 6))
+})
+
+test_that("Box<[Option<f64>]> with NA works", {
+  result <- box_slice_option_f64_roundtrip(c(1.5, NA, 3.5))
+  expect_equal(result, c(1.5, NA, 3.5))
+})
+
+test_that("Box<[Option<i32>]> with NA works", {
+  result <- box_slice_option_i32_roundtrip(c(1L, NA, 3L))
+  expect_equal(result, c(1L, NA, 3L))
+})
+
+test_that("Box<[Option<String>]> with NA works", {
+  result <- box_slice_option_string_roundtrip(c("a", NA, "c"))
+  expect_equal(result, c("a", NA, "c"))
+})


### PR DESCRIPTION
## Summary

`Box<[T]>` is now supported as a parameter and return type in `#[miniextendr]` functions, alongside `Vec<T>`.

`Box<[T]>` is like `Vec<T>` but without the capacity field — it's an owned, fixed-size allocation. Appropriate when:
- You receive data from R and won't grow it
- You want to signal "this data is fixed-size" in your API
- You want to save 8 bytes per vector (no capacity field)

### New conversions

**TryFromSexp (R → Rust):**
- `Box<[i32]>`, `Box<[f64]>`, `Box<[u8]>`, `Box<[RLogical]>`, `Box<[Rcomplex]>`
- `Box<[Option<i32>]>`, `Box<[Option<f64>]>` (NA-aware)
- `Box<[bool]>`, `Box<[Option<bool>]>`
- `Box<[String]>`, `Box<[Option<String>]>`

**IntoR (Rust → R):**
- `Box<[T: RNativeType]>` — via Deref to `&[T]`
- `Box<[String]>`

### Usage

```rust
#[miniextendr]
pub fn double_values(data: Box<[f64]>) -> Box<[f64]> {
    data.iter().map(|x| x * 2.0).collect()
}
```

## Test plan
- [x] `cargo check -p miniextendr-api` compiles
- [x] `cargo clippy -p miniextendr-api -- -D warnings` clean
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)
