### PR TITLE
Fix Windows template PKG_LIBS and serde_r typo

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ export PATH := if os() == "windows" {
 
 # All optional features for testing (excluding nonapi which causes CRAN warnings).
 # This mirrors the list in rpkg/configure.ac for NOT_CRAN=true mode.
-all_features := "rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_r,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs"
+all_features := "rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs"
 
 # Directory for devtools::check output (preserved for investigation)
 check_output_dir := justfile_directory() / "rpkg-check-output"

--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
@@ -8,4 +8,5 @@ include Makevars
 # - bcrypt: Cryptography
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
-PKG_LIBS = -L$(CARGO_LIBDIR) -l$(CARGO_STATICLIB_NAME) -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32
+# Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/minirextendr/inst/templates/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/rpkg/Makevars.win
@@ -8,4 +8,5 @@ include Makevars
 # - bcrypt: Cryptography
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
-PKG_LIBS = -L$(CARGO_LIBDIR) -l$(CARGO_STATICLIB_NAME) -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32
+# Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -9,8 +9,8 @@ diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-03-19 06:04:26
-+++ b/monorepo/rpkg/configure.ac	2026-03-19 06:05:10
+--- a/monorepo/rpkg/configure.ac	2026-03-19 10:45:49
++++ b/monorepo/rpkg/configure.ac	2026-03-19 10:45:49
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])
@@ -95,8 +95,8 @@ diff -ruN -U2 a/rpkg/Makevars.in b/rpkg/Makevars.in
  
  # cdylib for R wrapper generation (platform-specific extension)
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-03-19 06:04:26
-+++ b/rpkg/configure.ac	2026-03-19 06:05:10
+--- a/rpkg/configure.ac	2026-03-19 10:45:49
++++ b/rpkg/configure.ac	2026-03-19 10:45:49
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [1.0])
 +AC_INIT([{{package}}], [1.0])


### PR DESCRIPTION
## Summary

Two fixes from the project audit:

1. **Windows Makevars.win PKG_LIBS** (critical) — templates used `-L -l` flags which lets MinGW pick up the cdylib `.dll.a` import library instead of the staticlib. Changed to full path matching rpkg.

2. **`serde_r` typo in justfile** — `serde_r` is a module name, not a cargo feature. Changed to `serde_json`.

## Test plan
- [x] `just templates-check` passes
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)
