### PR TITLE
Upgrade rand to 0.10, rand_distr to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +351,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -537,6 +557,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -937,7 +958,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "proptest",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rand_distr",
  "rayon",
  "regex",
@@ -1354,6 +1375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,13 +1424,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.5.1"
+name = "rand_core"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -1645,7 +1683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/miniextendr-api/Cargo.toml
+++ b/miniextendr-api/Cargo.toml
@@ -112,8 +112,8 @@ refcount-fast-hash = ["dep:ahash"]
 linkme = { workspace = true }
 miniextendr-macros = { workspace = true }
 rayon = { version = "1.11.0", optional = true }
-rand = { version = "0.9.2", optional = true }
-rand_distr = { version = "0.5.1", optional = true }
+rand = { version = "0.10.0", optional = true }
+rand_distr = { version = "0.6.0", optional = true }
 either = { version = "1.15.0", optional = true }
 ndarray = { version = "0.17.1", optional = true }
 nalgebra = { version = "0.34.1", optional = true }

--- a/miniextendr-api/src/optionals.rs
+++ b/miniextendr-api/src/optionals.rs
@@ -61,7 +61,7 @@ pub use rayon_bridge::{RParallelExtend, RParallelIterator};
 /// Integration with the `rand` crate for R's RNG.
 ///
 /// Provides:
-/// - [`RRng`][rand_impl::RRng] - Wraps R's RNG, implements `rand::RngCore`
+/// - [`RRng`][rand_impl::RRng] - Wraps R's RNG, implements `rand::Rng`
 /// - [`RDistributions`][rand_impl::RDistributions] - Direct access to R's native distributions
 /// - [`RRngOps`][rand_impl::RRngOps] - Adapter trait for exposing custom RNGs to R
 ///

--- a/miniextendr-api/src/optionals/rand_impl.rs
+++ b/miniextendr-api/src/optionals/rand_impl.rs
@@ -1,7 +1,7 @@
 //! Integration with the `rand` crate for R's RNG.
 //!
 //! This module provides [`RRng`], a wrapper around R's random number generator
-//! that implements the `rand` crate's [`RngCore`] trait. This allows using R's
+//! that implements the `rand` crate's [`Rng`] trait. This allows using R's
 //! RNG with any `rand`-compatible code.
 //!
 //! # Features
@@ -17,7 +17,7 @@
 //!
 //! ```ignore
 //! use miniextendr_api::rand_impl::RRng;
-//! use rand::Rng;
+//! use rand::RngExt;
 //!
 //! #[miniextendr(rng)]
 //! fn random_gaussian(n: i32) -> Vec<f64> {
@@ -63,7 +63,7 @@
 //!
 //! 1. **Batch generation**: Generate all needed random numbers in one call, then
 //!    process them on the worker thread
-//! 2. **Use Rust RNG**: For non-reproducibility-critical work, use `rand::thread_rng()`
+//! 2. **Use Rust RNG**: For non-reproducibility-critical work, use `rand::rng()`
 //!    which doesn't require R thread access
 //!
 //! ```ignore
@@ -77,9 +77,11 @@
 //! }
 //! ```
 
-use rand::RngCore;
+use std::convert::Infallible;
 
-/// A wrapper around R's random number generator that implements [`RngCore`].
+use rand::TryRng;
+
+/// A wrapper around R's random number generator that implements [`rand::Rng`].
 ///
 /// This allows using R's RNG with any `rand`-compatible code, ensuring
 /// reproducibility when seeds are set via `set.seed()` in R.
@@ -94,7 +96,7 @@ use rand::RngCore;
 ///
 /// ```ignore
 /// use miniextendr_api::rand_impl::RRng;
-/// use rand::Rng;
+/// use rand::RngExt;
 ///
 /// #[miniextendr(rng)]
 /// fn random_sample(n: i32) -> Vec<f64> {
@@ -122,47 +124,51 @@ impl RRng {
     }
 }
 
-impl RngCore for RRng {
+/// Implement `TryRng` with `Error = Infallible` so the blanket impl provides `Rng`.
+impl TryRng for RRng {
+    type Error = Infallible;
+
     /// Generate a random u32 using R's RNG.
     ///
     /// Uses `unif_rand()` to generate a value in [0, 1) and scales to u32 range.
     #[inline]
-    fn next_u32(&mut self) -> u32 {
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
         // R's unif_rand() returns a value in [0, 1)
         // Scale to full u32 range
         let u = unsafe { crate::ffi::unif_rand() };
         // u * 2^32, but we need to be careful with floating point
         // Using the standard conversion: floor(u * (MAX + 1))
-        (u * (u32::MAX as f64 + 1.0)) as u32
+        Ok((u * (u32::MAX as f64 + 1.0)) as u32)
     }
 
     /// Generate a random u64 using R's RNG.
     ///
     /// Combines two u32 values to create a full u64.
     #[inline]
-    fn next_u64(&mut self) -> u64 {
-        // Combine two u32 values
-        let high = self.next_u32() as u64;
-        let low = self.next_u32() as u64;
-        (high << 32) | low
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+        // Combine two u32 values — call try_next_u32 (infallible) directly
+        let high = self.try_next_u32()? as u64;
+        let low = self.try_next_u32()? as u64;
+        Ok((high << 32) | low)
     }
 
     /// Fill a byte slice with random data from R's RNG.
     #[inline]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
         // Fill using u64 values for efficiency
         let mut chunks = dest.chunks_exact_mut(8);
         for chunk in chunks.by_ref() {
-            let val = self.next_u64();
+            let val = self.try_next_u64()?;
             chunk.copy_from_slice(&val.to_le_bytes());
         }
         // Handle remainder
         let remainder = chunks.into_remainder();
         if !remainder.is_empty() {
-            let val = self.next_u64();
+            let val = self.try_next_u64()?;
             let bytes = val.to_le_bytes();
             remainder.copy_from_slice(&bytes[..remainder.len()]);
         }
+        Ok(())
     }
 }
 
@@ -243,7 +249,7 @@ impl RDistributions for RRng {
 
 // region: Adapter Traits for Exposing RNGs to R
 
-/// Adapter trait for exposing any [`rand::Rng`] to R.
+/// Adapter trait for exposing any [`rand::RngExt`] to R.
 ///
 /// This trait provides R-friendly methods for random number generation.
 /// It has a blanket implementation for all types implementing `Rng`,
@@ -278,7 +284,7 @@ impl RDistributions for RRng {
 ///
 /// impl RRngOps for MyRng {
 ///     fn random_f64(&self) -> f64 {
-///         use rand::Rng;
+///         use rand::RngExt;
 ///         self.0.borrow_mut().random()
 ///     }
 ///     // ... implement other methods using self.0.borrow_mut()
@@ -299,7 +305,7 @@ impl RDistributions for RRng {
 /// # Design Note
 ///
 /// Like `RIterator`, this trait does NOT have a blanket impl because
-/// `rand::Rng` methods require `&mut self`, but R's ExternalPtr pattern
+/// `rand::RngExt` methods require `&mut self`, but R's ExternalPtr pattern
 /// provides `&self`. Users must implement manually using interior mutability.
 pub trait RRngOps {
     /// Generate a random f64 in [0, 1).
@@ -359,7 +365,7 @@ pub trait RRngOps {
     }
 }
 
-// Note: No blanket impl because Rng methods require &mut self,
+// Note: No blanket impl because RngExt methods require &mut self,
 // but ExternalPtr methods receive &self. Users must use interior mutability.
 
 /// Adapter trait for exposing probability distributions to R.

--- a/tests/model_project/src/rust/Cargo.toml
+++ b/tests/model_project/src/rust/Cargo.toml
@@ -18,8 +18,8 @@ connections = ["miniextendr-api/connections"]
 
 [dependencies]
 miniextendr-api = { path = "../../vendor/miniextendr-api" }
-rand = "0.9"
-rand_distr = "0.5"
+rand = "0.10"
+rand_distr = "0.6"
 rayon = "1.10"
 itertools = "0.14"
 


### PR DESCRIPTION
## Summary

Upgrades rand 0.9 → 0.10 and rand_distr 0.5 → 0.6.

### Key API change

rand 0.10 renamed `RngCore` to `Rng` and requires `TryRng<Error = Infallible>` as supertrait. The `RRng` adapter (R's RNG exposed as a Rust RNG) now implements `TryRng` instead of `RngCore`, with a blanket impl providing `Rng`.

### Files changed

- `miniextendr-api/Cargo.toml` — version bumps
- `miniextendr-api/src/optionals/rand_impl.rs` — `RngCore` → `TryRng` impl
- `miniextendr-api/src/optionals.rs` — doc comment update
- `tests/model_project/src/rust/Cargo.toml` — version bumps
- `Cargo.lock` — updated

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)
