### PR TITLE
miniextendr_init!() auto-detects package name

### DIFF
--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -2667,20 +2667,11 @@ pub fn impl_typed_external(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// # Usage
 ///
 /// ```ignore
-/// miniextendr_init!(mypkg);
-/// ```
+/// // Auto-detects package name from CARGO_CRATE_NAME (recommended):
+/// miniextendr_api::miniextendr_init!();
 ///
-/// This expands to:
-///
-/// ```ignore
-/// #[unsafe(no_mangle)]
-/// pub unsafe extern "C-unwind" fn R_init_mypkg(
-///     dll: *mut ::miniextendr_api::ffi::DllInfo,
-/// ) {
-///     unsafe {
-///         ::miniextendr_api::init::package_init(dll, c"mypkg");
-///     }
-/// }
+/// // Or specify explicitly (for edge cases):
+/// miniextendr_api::miniextendr_init!(mypkg);
 /// ```
 ///
 /// The generated function calls [`miniextendr_api::init::package_init`] which
@@ -2688,7 +2679,18 @@ pub fn impl_typed_external(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// registration, routine registration, and symbol locking.
 #[proc_macro]
 pub fn miniextendr_init(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let pkg_name: syn::Ident = syn::parse_macro_input!(input as syn::Ident);
+    let pkg_name: syn::Ident = if input.is_empty() {
+        // Auto-detect from CARGO_CRATE_NAME (set by cargo during compilation)
+        let name = std::env::var("CARGO_CRATE_NAME").unwrap_or_else(|_| {
+            panic!(
+                "CARGO_CRATE_NAME not set. Either pass the package name explicitly: \
+                 miniextendr_init!(mypkg), or ensure you're building with cargo."
+            )
+        });
+        syn::Ident::new(&name, proc_macro2::Span::call_site())
+    } else {
+        syn::parse_macro_input!(input as syn::Ident)
+    };
     let fn_name = syn::Ident::new(&format!("R_init_{}", pkg_name), pkg_name.span());
 
     // Build a byte string literal with NUL terminator for the package name.

--- a/minirextendr/R/rust-source.R
+++ b/minirextendr/R/rust-source.R
@@ -395,7 +395,7 @@ scaffold_inline_package <- function(code, hash, features, pkg_name, pkg_rs,
   # ---- Rust source: lib.rs ----
   # Prepend miniextendr_init!() macro invocation (required for R_init_* entry point)
   lib_rs_content <- paste0(
-    "miniextendr_api::miniextendr_init!(", pkg_rs, ");\n\n",
+    "miniextendr_api::miniextendr_init!();\n\n",
     code, "\n"
   )
   writeLines(lib_rs_content, fs::path(pkg_dir, "src", "rust", "lib.rs"))

--- a/minirextendr/inst/templates/monorepo/rpkg/lib.rs
+++ b/minirextendr/inst/templates/monorepo/rpkg/lib.rs
@@ -1,6 +1,6 @@
 use miniextendr_api::miniextendr;
 
-miniextendr_api::miniextendr_init!({{package_rs}});
+miniextendr_api::miniextendr_init!();
 
 /// A simple function that adds two numbers
 ///

--- a/minirextendr/inst/templates/rpkg/lib.rs
+++ b/minirextendr/inst/templates/rpkg/lib.rs
@@ -1,6 +1,6 @@
 use miniextendr_api::miniextendr;
 
-miniextendr_api::miniextendr_init!({{package_rs}});
+miniextendr_api::miniextendr_init!();
 
 // ---- Adding new functions ----
 //

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -91,7 +91,7 @@ use miniextendr_api::miniextendr;
 
 // Package initialization — generates R_init_miniextendr() entry point.
 // Replaces the previous entrypoint.c with a pure-Rust implementation.
-miniextendr_api::miniextendr_init!(miniextendr);
+miniextendr_api::miniextendr_init!();
 
 // Re-export the serde crate from miniextendr-api so test modules can derive
 // Serialize/Deserialize without a direct serde dependency.

--- a/tests/cross-package/consumer.pkg/src/rust/lib.rs
+++ b/tests/cross-package/consumer.pkg/src/rust/lib.rs
@@ -8,7 +8,7 @@
 
 use miniextendr_api::{ExternalPtr, ffi::SEXP, miniextendr, trait_abi::ccall};
 
-miniextendr_api::miniextendr_init!(consumer_pkg);
+miniextendr_api::miniextendr_init!();
 
 // Import the shared Counter trait and its generated ABI types
 pub use shared_traits::{__counter_build_vtable, Counter, CounterVTable, CounterView, TAG_COUNTER};

--- a/tests/cross-package/producer.pkg/src/rust/lib.rs
+++ b/tests/cross-package/producer.pkg/src/rust/lib.rs
@@ -10,7 +10,7 @@
 
 use miniextendr_api::{ExternalPtr, ffi::SEXP, miniextendr, trait_abi::ccall};
 
-miniextendr_api::miniextendr_init!(producer_pkg);
+miniextendr_api::miniextendr_init!();
 
 // Import the shared Counter trait and its generated ABI types
 pub use shared_traits::{__counter_build_vtable, Counter, CounterVTable, CounterView, TAG_COUNTER};


### PR DESCRIPTION
## Summary

`miniextendr_init!()` no longer requires the package name as an argument. It reads `CARGO_CRATE_NAME` (set by cargo during compilation), which is the lib target name with hyphens→underscores — exactly what R expects for `R_init_<name>`.

```rust
// Before:
miniextendr_api::miniextendr_init!(mypkg);

// After:
miniextendr_api::miniextendr_init!();
```

The explicit form still works for edge cases where the crate name doesn't match the desired R init symbol.

### How it works

Cargo sets `CARGO_CRATE_NAME` to the `[lib] name` (or package name if no explicit lib name), with hyphens replaced by underscores. The proc macro reads this at expansion time via `std::env::var("CARGO_CRATE_NAME")`.

### Files changed

- `miniextendr-macros/src/lib.rs` — macro accepts empty input, falls back to env var
- `rpkg/src/rust/lib.rs` — `miniextendr_init!()` (was `miniextendr_init!(miniextendr)`)
- Both template `lib.rs` files — no more `{{package_rs}}` mustache substitution needed
- `minirextendr/R/rust-source.R` — `rust_source()` helper updated
- Cross-package test `lib.rs` files — updated

## Test plan
- [x] `cargo check --workspace` compiles
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)
