### PR TITLE
fix: @title multiline warning, strip method tags from impl blocks

### DIFF
--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -231,7 +231,7 @@ fn generate_explicit_make_class(base_name: &str, ident: &syn::Ident) -> proc_mac
         let __cls = ::miniextendr_api::ffi::altrep::#make_fn(
             <#ident as ::miniextendr_api::altrep::AltrepClass>::CLASS_NAME.as_ptr(),
             ::miniextendr_api::AltrepPkgName::as_ptr(),
-            core::ptr::null_mut(),
+            ::miniextendr_api::altrep_dll_info(),
         );
         ::miniextendr_api::altrep::validate_altrep_class(
             __cls,

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -1973,7 +1973,9 @@ impl ParsedImpl {
             .filter(|attr| attr.path().is_ident("cfg"))
             .cloned()
             .collect();
-        let doc_tags = crate::roxygen::roxygen_tags_from_attrs(&item_impl.attrs);
+        let doc_tags = crate::roxygen::strip_method_tags(crate::roxygen::roxygen_tags_from_attrs(
+            &item_impl.attrs,
+        ));
 
         Ok(ParsedImpl {
             type_ident,

--- a/miniextendr-macros/src/miniextendr_impl/s3_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s3_class.rs
@@ -86,7 +86,7 @@ pub fn generate_s3_r_wrapper(parsed_impl: &ParsedImpl) -> String {
                 lines.push("#' @noRd".to_string());
             } else {
                 lines.push(format!("#' @title S3 generic for `{}`", generic_name));
-                lines.push(format!("#' S3 generic for `{}`", generic_name));
+                lines.push(format!("#' @description S3 generic for `{}`", generic_name));
                 lines.push(format!("#' @name {}", generic_name));
                 lines.push(format!("#' @rdname {}", class_name));
                 lines.push("#' @param x An object".to_string());

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_private_methods.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_private_methods.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1835
 expression: generate_r6_r_wrapper(&parsed)
 ---
 #' @title Secure R6 Class
@@ -11,6 +12,7 @@ expression: generate_r6_r_wrapper(&parsed)
 #' @export
 Secure <- R6::R6Class("Secure",
   public = list(
+    #' @description Create a new `Secure`.
     initialize = function(.ptr = NULL) {
       if (!is.null(.ptr)) {
         private$.ptr <- .ptr
@@ -25,6 +27,7 @@ Secure <- R6::R6Class("Secure",
         private$.ptr <- .val
       }
     },
+    #' @description Method `public_api`.
     public_api = function() {
       .val <- .Call(C_Secure__public_api, .call = match.call(), private$.ptr)
       if (inherits(.val, "rust_error_value") && isTRUE(attr(.val, "__rust_error__"))) {

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_with_options.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_with_options.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1822
 expression: generate_r6_r_wrapper(&parsed)
 ---
 #' @title Child R6 Class
@@ -11,6 +12,7 @@ expression: generate_r6_r_wrapper(&parsed)
 #' @export
 Child <- R6::R6Class("Child", inherit = ParentClass,
   public = list(
+    #' @description Create a new `Child`.
     initialize = function(.ptr = NULL) {
       if (!is.null(.ptr)) {
         private$.ptr <- .ptr
@@ -25,6 +27,7 @@ Child <- R6::R6Class("Child", inherit = ParentClass,
         private$.ptr <- .val
       }
     },
+    #' @description Method `greet`.
     greet = function() {
       .val <- .Call(C_Child__greet, .call = match.call(), private$.ptr)
       if (inherits(.val, "rust_error_value") && isTRUE(attr(.val, "__rust_error__"))) {

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s3_basic.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s3_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1849
 expression: generate_s3_r_wrapper(&parsed)
 ---
 #' @title Counter S3 Class
@@ -23,7 +24,7 @@ new_counter <- function(value) {
 }
 
 #' @title S3 generic for `get`
-#' S3 generic for `get`
+#' @description S3 generic for `get`
 #' @name get
 #' @rdname Counter
 #' @param x An object
@@ -53,7 +54,7 @@ get.Counter <- function(x, ...) {
 }
 
 #' @title S3 generic for `increment`
-#' S3 generic for `increment`
+#' @description S3 generic for `increment`
 #' @name increment
 #' @rdname Counter
 #' @param x An object

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_vctrs_rcrd.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_vctrs_rcrd.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1939
 expression: generate_vctrs_r_wrapper(&parsed)
 ---
 #' @title Rational vctrs S3 Class
@@ -48,7 +49,7 @@ vec_ptype2.Rational.Rational <- function(x, y, ...) x[0]
 vec_cast.Rational.Rational <- function(x, to, ...) x
 
 #' @title S3 generic for `numerator`
-#' S3 generic for `numerator`
+#' @description S3 generic for `numerator`
 #' @rdname Rational
 #' @name numerator
 #' @param x An object

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_vctrs_vctr.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_vctrs_vctr.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1918
 expression: generate_vctrs_r_wrapper(&parsed)
 ---
 #' @title Percent vctrs S3 Class
@@ -46,7 +47,7 @@ vec_ptype2.Percent.Percent <- function(x, y, ...) vctrs::new_vctr(double(), clas
 vec_cast.Percent.Percent <- function(x, to, ...) x
 
 #' @title S3 generic for `value`
-#' S3 generic for `value`
+#' @description S3 generic for `value`
 #' @rdname Percent
 #' @name value
 #' @param x An object
@@ -73,7 +74,7 @@ value.Percent <- function(x, ...) {
 }
 
 #' @title S3 generic for `scale`
-#' S3 generic for `scale`
+#' @description S3 generic for `scale`
 #' @rdname Percent
 #' @name scale
 #' @param x An object

--- a/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
@@ -214,7 +214,7 @@ pub fn generate_vctrs_r_wrapper(parsed_impl: &ParsedImpl) -> String {
         // vctrs protocol methods use existing generics from the vctrs package
         if !is_protocol && !ctx.has_generic_override() && !ctx.has_class_override() {
             lines.push(format!("#' @title S3 generic for `{}`", generic_name));
-            lines.push(format!("#' S3 generic for `{}`", generic_name));
+            lines.push(format!("#' @description S3 generic for `{}`", generic_name));
             lines.push(format!("#' @rdname {}", class_name));
             lines.push(format!("#' @name {}", generic_name));
             lines.push("#' @param x An object".to_string());

--- a/miniextendr-macros/src/miniextendr_impl_trait.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait.rs
@@ -269,7 +269,9 @@ pub fn expand_miniextendr_impl_trait(
 
     // TPIE: empty impl body → expand via macro_rules! helper from the trait definition
     if impl_item.items.is_empty() && !impl_attrs.blanket {
-        let doc_tags = crate::roxygen::roxygen_tags_from_attrs(&impl_item.attrs);
+        let doc_tags = crate::roxygen::strip_method_tags(crate::roxygen::roxygen_tags_from_attrs(
+            &impl_item.attrs,
+        ));
         let no_rd = crate::roxygen::has_roxygen_tag(&doc_tags, "noRd");
         return generate_tpie_invocation(
             &trait_path,

--- a/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
@@ -140,7 +140,9 @@ pub(super) fn generate_vtable_static(
         .collect();
 
     // Check if impl block has @noRd doc comment
-    let impl_doc_tags = crate::roxygen::roxygen_tags_from_attrs(&impl_item.attrs);
+    let impl_doc_tags = crate::roxygen::strip_method_tags(crate::roxygen::roxygen_tags_from_attrs(
+        &impl_item.attrs,
+    ));
     let class_has_no_rd = crate::roxygen::has_roxygen_tag(&impl_doc_tags, "noRd");
 
     // Generate R wrapper code string based on class system (only non-skipped methods)

--- a/miniextendr-macros/src/roxygen.rs
+++ b/miniextendr-macros/src/roxygen.rs
@@ -484,6 +484,25 @@ pub(crate) fn doc_conflict_warnings(
     proc_macro2::TokenStream::new()
 }
 
+/// Strip method-specific roxygen tags from impl-block-level doc tags.
+///
+/// Impl blocks can carry doc comments, but tags like `@param`, `@return`, `@returns`,
+/// and `@examples` are method-specific and meaningless at the impl-block level.
+/// This function removes those tags so they don't leak into class-level documentation.
+pub(crate) fn strip_method_tags(tags: Vec<String>) -> Vec<String> {
+    tags.into_iter()
+        .filter(|tag| {
+            let trimmed = tag.trim_start();
+            if let Some(rest) = trimmed.strip_prefix('@') {
+                let tag_name = rest.split_whitespace().next().unwrap_or("");
+                !matches!(tag_name, "param" | "return" | "returns" | "examples")
+            } else {
+                true
+            }
+        })
+        .collect()
+}
+
 /// Strip roxygen tag lines from doc attributes, keeping only regular documentation.
 ///
 /// Returns a new vector of attributes with roxygen lines removed from doc comments.


### PR DESCRIPTION
## Summary

- Fix `@title must be a single paragraph` roxygen2 warning by adding explicit `@description` after `@title` in S3/Vctrs generic docs (#64)
- Rename `strip_param_tags` → `strip_method_tags`, extend to also strip `@return`, `@returns`, `@examples` from impl-block-level docs (#65)
- Fix null DllInfo in explicit `base=` ALTREP class registration (#62)

## Test plan

- [x] 271 macro crate tests pass
- [x] Clippy clean
- [ ] CI

Closes #62, closes #64, closes #65

Generated with [Claude Code](https://claude.com/claude-code)
