### PR TITLE
fix: null DllInfo for explicit base= ALTREP, runtime class name collision detection

### DIFF
--- a/miniextendr-api/src/altrep.rs
+++ b/miniextendr-api/src/altrep.rs
@@ -13,6 +13,7 @@
 
 use crate::ffi::altrep::*;
 use std::ffi::CStr;
+use std::sync::Mutex;
 
 /// Base type for ALTREP vectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,10 +64,20 @@ pub trait RegisterAltrep {
 
 // region: Runtime dispatch helper for class creation
 
+/// Records every ALTREP class name registered during `package_init()`.
+///
+/// After all registrations complete, [`assert_altrep_class_uniqueness`] checks
+/// for duplicates. Using `Mutex` rather than `RefCell` because `validate_altrep_class`
+/// can be called from any context during init.
+static REGISTERED_CLASS_NAMES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
 /// Validate that an ALTREP class handle was successfully created.
 ///
 /// Panics with a descriptive message if the class handle is null, indicating
 /// that `R_make_alt*_class()` failed during registration.
+///
+/// Also records the class name for later duplicate detection via
+/// [`assert_altrep_class_uniqueness`].
 ///
 /// # Arguments
 /// * `cls` - The class handle returned by `R_make_alt*_class()`
@@ -84,7 +95,38 @@ pub fn validate_altrep_class(
             class_name
         );
     }
+    // Record the name for duplicate detection at the end of package_init().
+    REGISTERED_CLASS_NAMES
+        .lock()
+        .expect("REGISTERED_CLASS_NAMES poisoned")
+        .push(class_name.to_string_lossy().into_owned());
     cls
+}
+
+/// Assert that all registered ALTREP class names are unique.
+///
+/// Must be called after all ALTREP registrations (builtin, arrow, user-defined)
+/// have completed in `package_init()`. Panics with a clear message if any
+/// duplicate class name is found.
+pub fn assert_altrep_class_uniqueness() {
+    let names = REGISTERED_CLASS_NAMES
+        .lock()
+        .expect("REGISTERED_CLASS_NAMES poisoned");
+    if names.len() <= 1 {
+        return;
+    }
+    // Sort + dedup to find collisions efficiently.
+    let mut sorted: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    sorted.sort_unstable();
+    for window in sorted.windows(2) {
+        if window[0] == window[1] {
+            panic!(
+                "miniextendr: duplicate ALTREP class name \"{}\" \
+                 — each ALTREP type must have a unique class name within the package",
+                window[0]
+            );
+        }
+    }
 }
 
 /// Create an ALTREP class handle based on the runtime base type.
@@ -92,21 +134,22 @@ pub fn validate_altrep_class(
 /// Validates the returned handle and panics if registration fails.
 ///
 /// # Safety
-/// Must be called during R initialization.
+/// Must be called during R initialization (after `set_altrep_dll_info`).
 pub unsafe fn make_class_by_base(
     class_name: *const i8,
     pkg_name: *const i8,
     base: RBase,
 ) -> R_altrep_class_t {
+    let dll = crate::altrep_dll_info();
     let cls = unsafe {
         match base {
-            RBase::Int => R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::Real => R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::Logical => R_make_altlogical_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::Raw => R_make_altraw_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::String => R_make_altstring_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::List => R_make_altlist_class(class_name, pkg_name, core::ptr::null_mut()),
-            RBase::Complex => R_make_altcomplex_class(class_name, pkg_name, core::ptr::null_mut()),
+            RBase::Int => R_make_altinteger_class(class_name, pkg_name, dll),
+            RBase::Real => R_make_altreal_class(class_name, pkg_name, dll),
+            RBase::Logical => R_make_altlogical_class(class_name, pkg_name, dll),
+            RBase::Raw => R_make_altraw_class(class_name, pkg_name, dll),
+            RBase::String => R_make_altstring_class(class_name, pkg_name, dll),
+            RBase::List => R_make_altlist_class(class_name, pkg_name, dll),
+            RBase::Complex => R_make_altcomplex_class(class_name, pkg_name, dll),
         }
     };
     // SAFETY: class_name was passed to R, so it's still a valid C string

--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -150,6 +150,11 @@ pub unsafe extern "C" fn miniextendr_register_routines(dll: *mut DllInfo) {
         crate::altrep_impl::register_builtin_altrep_classes();
         #[cfg(feature = "arrow")]
         crate::altrep_impl::register_arrow_altrep_classes();
+
+        // Verify no two ALTREP types registered the same class name.
+        // Duplicates cause silent overwrites in R — the wrong type gets
+        // reconstructed on readRDS, leading to memory corruption.
+        crate::altrep::assert_altrep_class_uniqueness();
     }
 
     // 2. Build call method defs with null sentinel


### PR DESCRIPTION
## Summary

- Fix null DllInfo passed to `R_make_alt*_class` for explicit `base=` ALTREP types, breaking cross-session `readRDS` (#62)
- Add runtime uniqueness check for ALTREP class names at package init — panics with clear message if two types register the same name (#66)

## Implementation

- `validate_altrep_class()` now records each class name into a `Mutex<Vec<String>>`
- `assert_altrep_class_uniqueness()` called after all registrations complete in `miniextendr_register_routines()`
- Duplicate names trigger: `miniextendr: duplicate ALTREP class name "X" — each ALTREP type must have a unique class name within the package`

## Test plan

- [x] `cargo check` clean
- [x] `cargo test` passes (5 pass, 202 ignored doc tests)
- [x] `cargo clippy` clean
- [ ] CI

Closes #62, closes #66

Generated with [Claude Code](https://claude.com/claude-code)
