### PR TITLE
feat: materializing serialization for iterator/streaming ALTREP types

### DIFF
--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -49,6 +49,97 @@ pub unsafe fn altrep_region_buf<T>(buf: *mut T, len: usize) -> &'static mut [T] 
 }
 // endregion
 
+// region: Materializing serialization helpers
+//
+// These functions materialize ALTREP data into plain R vectors for serialization.
+// They read elements via the ALTREP Elt method (which delegates to the data trait's
+// `elt()` implementation). Used by `serialize_materialize` macro variants.
+
+/// Materialize an ALTINTEGER ALTREP into a plain R integer vector.
+///
+/// Reads elements via `INTEGER_ELT` (ALTREP-aware) and copies them into
+/// a freshly allocated plain R integer vector.
+///
+/// Called from ALTREP `serialized_state` trampolines (already on R main thread).
+pub fn materialize_integer_for_serialize(x: crate::ffi::SEXP) -> crate::ffi::SEXP {
+    use crate::ffi::{Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
+    unsafe {
+        let n = SexpExt::xlength(&x);
+        let out = Rf_protect(crate::ffi::Rf_allocVector(SEXPTYPE::INTSXP, n));
+        for i in 0..n {
+            SexpExt::set_integer_elt(&out, i, SexpExt::integer_elt(&x, i));
+        }
+        Rf_unprotect(1);
+        out
+    }
+}
+
+/// Materialize an ALTREAL ALTREP into a plain R real vector.
+///
+/// Called from ALTREP `serialized_state` trampolines (already on R main thread).
+pub fn materialize_real_for_serialize(x: crate::ffi::SEXP) -> crate::ffi::SEXP {
+    use crate::ffi::{Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
+    unsafe {
+        let n = SexpExt::xlength(&x);
+        let out = Rf_protect(crate::ffi::Rf_allocVector(SEXPTYPE::REALSXP, n));
+        for i in 0..n {
+            SexpExt::set_real_elt(&out, i, SexpExt::real_elt(&x, i));
+        }
+        Rf_unprotect(1);
+        out
+    }
+}
+
+/// Materialize an ALTLOGICAL ALTREP into a plain R logical vector.
+///
+/// Called from ALTREP `serialized_state` trampolines (already on R main thread).
+pub fn materialize_logical_for_serialize(x: crate::ffi::SEXP) -> crate::ffi::SEXP {
+    use crate::ffi::{Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
+    unsafe {
+        let n = SexpExt::xlength(&x);
+        let out = Rf_protect(crate::ffi::Rf_allocVector(SEXPTYPE::LGLSXP, n));
+        for i in 0..n {
+            SexpExt::set_logical_elt(&out, i, SexpExt::logical_elt(&x, i));
+        }
+        Rf_unprotect(1);
+        out
+    }
+}
+
+/// Materialize an ALTRAW ALTREP into a plain R raw vector.
+///
+/// Called from ALTREP `serialized_state` trampolines (already on R main thread).
+pub fn materialize_raw_for_serialize(x: crate::ffi::SEXP) -> crate::ffi::SEXP {
+    use crate::ffi::{Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
+    unsafe {
+        let n = SexpExt::xlength(&x);
+        let out = Rf_protect(crate::ffi::Rf_allocVector(SEXPTYPE::RAWSXP, n));
+        for i in 0..n {
+            SexpExt::set_raw_elt(&out, i, SexpExt::raw_elt(&x, i));
+        }
+        Rf_unprotect(1);
+        out
+    }
+}
+
+/// Materialize an ALTCOMPLEX ALTREP into a plain R complex vector.
+///
+/// Called from ALTREP `serialized_state` trampolines (already on R main thread).
+pub fn materialize_complex_for_serialize(x: crate::ffi::SEXP) -> crate::ffi::SEXP {
+    use crate::ffi::{Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
+    unsafe {
+        let n = SexpExt::xlength(&x);
+        let out = Rf_protect(crate::ffi::Rf_allocVector(SEXPTYPE::CPLXSXP, n));
+        for i in 0..n {
+            SexpExt::set_complex_elt(&out, i, SexpExt::complex_elt(&x, i));
+        }
+        Rf_unprotect(1);
+        out
+    }
+}
+
+// endregion
+
 // region: Macros for generating trait implementations
 
 /// Generate ALTREP trait implementations for a type that implements AltIntegerData.
@@ -69,6 +160,12 @@ pub unsafe fn altrep_region_buf<T>(buf: *mut T, len: usize) -> &'static mut [T] 
 ///
 /// // With serialization (type must implement AltrepSerialize):
 /// impl_altinteger_from_data!(MyType, serialize);
+///
+/// // With materializing serialization (no trait impl needed):
+/// // Materializes via Elt into a plain R vector. On deserialize, returns
+/// // the plain vector (ALTREP class lost, data preserved). Use for
+/// // iterator/streaming types that can't reconstruct from serialized state.
+/// impl_altinteger_from_data!(MyType, serialize_materialize);
 ///
 /// // With subset optimization (type must implement AltrepExtractSubset):
 /// impl_altinteger_from_data!(MyType, subset);
@@ -129,6 +226,14 @@ macro_rules! impl_altinteger_from_data {
     };
     ($ty:ty, serialize, subset) => {
         $crate::impl_altinteger_from_data!($ty, subset, serialize);
+    };
+    ($ty:ty, serialize_materialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altinteger_methods,
+            impl_inferbase_integer,
+            serialize_materialize($crate::altrep_impl::materialize_integer_for_serialize)
+        );
     };
 }
 
@@ -224,6 +329,58 @@ macro_rules! __impl_altrep_base_with_serialize {
                     Rf_unprotect_unchecked(1);
                     out
                 }
+            }
+        }
+    };
+}
+
+/// Internal macro: impl Altrep with length + materializing serialization.
+///
+/// Unlike `__impl_altrep_base_with_serialize` which delegates to `AltrepSerialize`,
+/// this variant materializes the ALTREP data into a plain R vector for serialization.
+/// On deserialization, the plain R vector is returned as-is (no ALTREP reconstruction).
+///
+/// This is designed for iterator/streaming types where the original data source (closures,
+/// iterators) cannot be reconstructed from serialized state.
+///
+/// The `$serialize_fn` must be a function `fn(SEXP) -> SEXP` that takes the ALTREP SEXP,
+/// reads elements via Elt/Get_region, and allocates a native R vector.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __impl_altrep_base_with_serialize_materialize {
+    ($ty:ty, $serialize_fn:path) => {
+        $crate::__impl_altrep_base_with_serialize_materialize!($ty, $serialize_fn, RUnwind);
+    };
+    ($ty:ty, $serialize_fn:path, $guard:ident) => {
+        #[allow(clippy::not_unsafe_ptr_arg_deref)]
+        impl $crate::altrep_traits::Altrep for $ty {
+            const GUARD: $crate::altrep_traits::AltrepGuard =
+                $crate::altrep_traits::AltrepGuard::$guard;
+
+            fn length(x: $crate::ffi::SEXP) -> $crate::ffi::R_xlen_t {
+                unsafe { $crate::altrep_data1_as::<$ty>(x) }
+                    .map(|d| {
+                        <$ty as $crate::altrep_data::AltrepLen>::len(&*d) as $crate::ffi::R_xlen_t
+                    })
+                    .unwrap_or(0)
+            }
+
+            const HAS_SERIALIZED_STATE: bool = true;
+
+            fn serialized_state(x: $crate::ffi::SEXP) -> $crate::ffi::SEXP {
+                $serialize_fn(x)
+            }
+
+            const HAS_UNSERIALIZE: bool = true;
+
+            fn unserialize(
+                _class: $crate::ffi::SEXP,
+                state: $crate::ffi::SEXP,
+            ) -> $crate::ffi::SEXP {
+                // Return the plain R vector as-is. The ALTREP class is lost on
+                // deserialization, but the data is preserved. This is the correct
+                // behavior for iterator/streaming types that cannot be reconstructed.
+                state
             }
         }
     };
@@ -560,6 +717,13 @@ macro_rules! __impl_alt_from_data {
         $crate::$methods!($ty);
         $crate::$inferbase!($ty);
     };
+    // Serialize-materialize: materialize via Elt into plain R vector
+    ($ty:ty, $methods:ident, $inferbase:ident, serialize_materialize($serialize_fn:path)) => {
+        $crate::__impl_altrep_base_with_serialize_materialize!($ty, $serialize_fn);
+        impl $crate::altrep_traits::AltVec for $ty {}
+        $crate::$methods!($ty);
+        $crate::$inferbase!($ty);
+    };
 }
 // endregion
 
@@ -659,6 +823,14 @@ macro_rules! impl_altreal_from_data {
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altreal_from_data!($ty, dataptr, serialize);
     };
+    ($ty:ty, serialize_materialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altreal_methods,
+            impl_inferbase_real,
+            serialize_materialize($crate::altrep_impl::materialize_real_for_serialize)
+        );
+    };
 }
 
 /// Internal macro for AltReal method implementations.
@@ -754,6 +926,14 @@ macro_rules! impl_altlogical_from_data {
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altlogical_from_data!($ty, dataptr, serialize);
     };
+    ($ty:ty, serialize_materialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altlogical_methods,
+            impl_inferbase_logical,
+            serialize_materialize($crate::altrep_impl::materialize_logical_for_serialize)
+        );
+    };
 }
 
 /// Internal macro: impl AltLogical methods from AltLogicalData
@@ -837,6 +1017,14 @@ macro_rules! impl_altraw_from_data {
     };
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altraw_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, serialize_materialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altraw_methods,
+            impl_inferbase_raw,
+            serialize_materialize($crate::altrep_impl::materialize_raw_for_serialize)
+        );
     };
 }
 
@@ -1087,6 +1275,14 @@ macro_rules! impl_altcomplex_from_data {
     };
     ($ty:ty, serialize, subset) => {
         $crate::impl_altcomplex_from_data!($ty, subset, serialize);
+    };
+    ($ty:ty, serialize_materialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altcomplex_methods,
+            impl_inferbase_complex,
+            serialize_materialize($crate::altrep_impl::materialize_complex_for_serialize)
+        );
     };
 }
 // endregion

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -287,7 +287,7 @@ impl AltIntegerData for ConstantIntData {
 }
 
 // Generate low-level traits from data traits (also enables base type inference)
-miniextendr_api::impl_altinteger_from_data!(ConstantIntData);
+miniextendr_api::impl_altinteger_from_data!(ConstantIntData, serialize_materialize);
 
 /// ALTREP class wrapper for constant integer data.
 #[miniextendr(class = "ConstantInt")]
@@ -342,7 +342,7 @@ impl AltRealData for ConstantRealData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(ConstantRealData);
+miniextendr_api::impl_altreal_from_data!(ConstantRealData, serialize_materialize);
 
 #[miniextendr(class = "ConstantReal")]
 pub struct ConstantRealClass(pub ConstantRealData);
@@ -384,7 +384,7 @@ impl AltRealData for ArithSeqData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(ArithSeqData);
+miniextendr_api::impl_altreal_from_data!(ArithSeqData, serialize_materialize);
 
 #[miniextendr(class = "ArithSeq")]
 pub struct ArithSeqClass(pub ArithSeqData);
@@ -1053,7 +1053,7 @@ impl AltRawData for RepeatingRawData {
     }
 }
 
-miniextendr_api::impl_altraw_from_data!(RepeatingRawData);
+miniextendr_api::impl_altraw_from_data!(RepeatingRawData, serialize_materialize);
 
 #[miniextendr(class = "RepeatingRaw")]
 pub struct RepeatingRawClass(pub RepeatingRawData);
@@ -1112,7 +1112,7 @@ impl AltComplexData for UnitCircleData {
     }
 }
 
-miniextendr_api::impl_altcomplex_from_data!(UnitCircleData);
+miniextendr_api::impl_altcomplex_from_data!(UnitCircleData, serialize_materialize);
 
 /// ALTREP class wrapper for unit circle complex data.
 #[miniextendr(class = "UnitCircle")]
@@ -1625,7 +1625,7 @@ impl miniextendr_api::altrep_data::AltIntegerData for SparseIntIterData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(SparseIntIterData);
+miniextendr_api::impl_altinteger_from_data!(SparseIntIterData, serialize_materialize);
 
 /// ALTREP class wrapper for sparse integer iterator.
 #[miniextendr(class = "SparseIntIter")]
@@ -1697,7 +1697,7 @@ impl miniextendr_api::altrep_data::AltRealData for SparseRealIterData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(SparseRealIterData);
+miniextendr_api::impl_altreal_from_data!(SparseRealIterData, serialize_materialize);
 
 /// ALTREP class wrapper for sparse real iterator.
 #[miniextendr(class = "SparseRealIter")]
@@ -1745,7 +1745,7 @@ impl miniextendr_api::altrep_data::AltLogicalData for SparseLogicalIterData {
     }
 }
 
-miniextendr_api::impl_altlogical_from_data!(SparseLogicalIterData);
+miniextendr_api::impl_altlogical_from_data!(SparseLogicalIterData, serialize_materialize);
 
 /// ALTREP class wrapper for sparse logical iterator.
 #[miniextendr(class = "SparseLogicalIter")]
@@ -1795,7 +1795,7 @@ impl miniextendr_api::altrep_data::AltRawData for SparseRawIterData {
     }
 }
 
-miniextendr_api::impl_altraw_from_data!(SparseRawIterData);
+miniextendr_api::impl_altraw_from_data!(SparseRawIterData, serialize_materialize);
 
 /// ALTREP class wrapper for sparse raw byte iterator.
 #[miniextendr(class = "SparseRawIter")]

--- a/rpkg/src/rust/streaming_altrep_tests.rs
+++ b/rpkg/src/rust/streaming_altrep_tests.rs
@@ -28,7 +28,7 @@ impl AltIntegerData for StreamingIntRangeData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(StreamingIntRangeData);
+miniextendr_api::impl_altinteger_from_data!(StreamingIntRangeData, serialize_materialize);
 
 /// ALTREP class for streaming integer range 1..=n.
 #[miniextendr(class = "StreamingIntRange")]
@@ -76,7 +76,7 @@ impl AltRealData for StreamingRealSquaresData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(StreamingRealSquaresData);
+miniextendr_api::impl_altreal_from_data!(StreamingRealSquaresData, serialize_materialize);
 
 /// ALTREP class for streaming real squares 1^2, 2^2, ..., n^2.
 #[miniextendr(class = "StreamingRealSquares")]

--- a/rpkg/tests/testthat/test-altrep-iterator-serialization.R
+++ b/rpkg/tests/testthat/test-altrep-iterator-serialization.R
@@ -1,0 +1,215 @@
+# Serialization tests for iterator/streaming ALTREP types (#61)
+#
+# Without explicit serialization support, iterator/streaming ALTREP types
+# that lack DATAPTR error on saveRDS because R's default serialization
+# calls DATAPTR() which has no fallback for ALTREP types without it.
+#
+# The serialize_materialize macro variant provides materializing serialization:
+# serialized_state collects all elements into a plain R vector, and
+# unserialize returns it as-is (ALTREP class is lost, data is preserved).
+
+# ===========================================================================
+# Streaming ALTREP
+# ===========================================================================
+
+test_that("streaming integer ALTREP survives saveRDS/readRDS", {
+  v <- streaming_int_range(10L)
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 10L)
+  expect_equal(restored[1], 1L)
+  expect_equal(restored[5], 5L)
+  expect_equal(restored[10], 10L)
+  expect_equal(sum(restored), 55L)
+})
+
+test_that("streaming real ALTREP survives saveRDS/readRDS", {
+  v <- streaming_real_squares(5L)
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  expect_equal(restored[1], 1.0)
+  expect_equal(restored[2], 4.0)
+  expect_equal(restored[3], 9.0)
+  expect_equal(restored[4], 16.0)
+  expect_equal(restored[5], 25.0)
+})
+
+# ===========================================================================
+# Sparse iterator ALTREP
+# ===========================================================================
+
+test_that("sparse integer iterator ALTREP survives saveRDS/readRDS", {
+  v <- sparse_iter_int(1L, 11L)  # 1..11 = [1,2,...,10]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 10L)
+  expect_equal(restored[1], 1L)
+  expect_equal(restored[5], 5L)
+  expect_equal(restored[10], 10L)
+  expect_equal(sum(restored), 55L)
+})
+
+test_that("sparse integer squares ALTREP survives saveRDS/readRDS", {
+  v <- sparse_iter_int_squares(5L)  # [0, 1, 4, 9, 16]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  expect_equal(restored[1], 0L)
+  expect_equal(restored[2], 1L)
+  expect_equal(restored[3], 4L)
+  expect_equal(restored[4], 9L)
+  expect_equal(restored[5], 16L)
+})
+
+test_that("sparse real iterator ALTREP survives saveRDS/readRDS", {
+  v <- sparse_iter_real(0.0, 0.5, 5L)  # [0.0, 0.5, 1.0, 1.5, 2.0]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  expect_equal(restored[1], 0.0)
+  expect_equal(restored[2], 0.5)
+  expect_equal(restored[3], 1.0)
+  expect_equal(restored[5], 2.0)
+})
+
+test_that("sparse logical iterator ALTREP survives saveRDS/readRDS", {
+  v <- sparse_iter_logical(5L)  # [TRUE, FALSE, TRUE, FALSE, TRUE]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  # Element-by-element checks (no vector comparisons for logical ALTREP)
+  expect_equal(restored[1], TRUE)
+  expect_equal(restored[2], FALSE)
+  expect_equal(restored[3], TRUE)
+  expect_equal(restored[4], FALSE)
+  expect_equal(restored[5], TRUE)
+})
+
+test_that("sparse raw iterator ALTREP survives saveRDS/readRDS", {
+  v <- sparse_iter_raw(5L)  # [0x00, 0x01, 0x02, 0x03, 0x04]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  # Element-by-element checks (no vector comparisons for raw ALTREP)
+  expect_equal(restored[1], as.raw(0x00))
+  expect_equal(restored[2], as.raw(0x01))
+  expect_equal(restored[3], as.raw(0x02))
+  expect_equal(restored[4], as.raw(0x03))
+  expect_equal(restored[5], as.raw(0x04))
+})
+
+# ===========================================================================
+# Constant/compute ALTREP types (also without DATAPTR)
+# ===========================================================================
+
+test_that("constant integer ALTREP survives saveRDS/readRDS", {
+  v <- constant_int()  # 10 elements, all 42
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 10L)
+  expect_equal(restored[1], 42L)
+  expect_equal(restored[10], 42L)
+  expect_equal(sum(restored), 420L)
+})
+
+test_that("constant real ALTREP survives saveRDS/readRDS", {
+  v <- constant_real()  # 10 elements, all pi
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 10L)
+  expect_equal(restored[1], pi)
+  expect_equal(restored[10], pi)
+})
+
+test_that("arith_seq ALTREP survives saveRDS/readRDS", {
+  v <- arith_seq(1.0, 0.5, 5L)  # [1.0, 1.5, 2.0, 2.5, 3.0]
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 5L)
+  expect_equal(restored[1], 1.0)
+  expect_equal(restored[2], 1.5)
+  expect_equal(restored[5], 3.0)
+})
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+test_that("empty streaming integer ALTREP survives saveRDS/readRDS", {
+  v <- streaming_int_range(0L)
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 0L)
+})
+
+test_that("large streaming integer ALTREP survives saveRDS/readRDS", {
+  v <- streaming_int_range(10000L)
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  expect_equal(length(restored), 10000L)
+  expect_equal(restored[1], 1L)
+  expect_equal(restored[10000], 10000L)
+  expect_equal(sum(restored), sum(1:10000))
+})
+
+test_that("deserialized iterator ALTREP is a plain vector (not ALTREP)", {
+  v <- streaming_int_range(5L)
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp))
+
+  saveRDS(v, tmp)
+  restored <- readRDS(tmp)
+
+  # After deserialization, the result should be a plain vector
+  # (the ALTREP class is lost, which is expected)
+  expect_equal(restored, 1:5)
+})


### PR DESCRIPTION
## Summary

Iterator-backed, streaming, sparse, and windowed ALTREP types now have serialization support via a materializing serialize path. On saveRDS, all elements are collected via Elt into a plain R vector for the serialized state. On readRDS, the plain vector is returned (no ALTREP reconstruction — the lazy behavior is lost after serialization, but data is preserved).

Closes #61

Generated with [Claude Code](https://claude.com/claude-code)
