### PR TITLE
refactor: make INTEGER/REAL/LOGICAL/RAW/COMPLEX private, use SexpExt

### DIFF
--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -357,7 +357,8 @@ macro_rules! __impl_altvec_extract_subset {
 
                 // Convert indx SEXP to slice
                 let len = unsafe { $crate::ffi::Rf_xlength(indx) } as usize;
-                let indices = unsafe { $crate::from_r::r_slice($crate::ffi::INTEGER(indx), len) };
+                let indices =
+                    unsafe { $crate::from_r::r_slice($crate::ffi::INTEGER_unchecked(indx), len) };
 
                 unsafe { $crate::altrep_data1_as::<$ty>(x) }
                     .and_then(|d| {

--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -58,7 +58,8 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         "must be called from R main thread"
     );
     use crate::ffi::{
-        LOGICAL, R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, Rf_xlength, SexpExt,
+        LOGICAL_unchecked, R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, Rf_xlength,
+        SexpExt,
     };
 
     unsafe {
@@ -78,7 +79,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
             let name = std::ffi::CStr::from_ptr(name_ptr);
             if name == c"UTF-8" {
                 let elt = info.vector_elt(i);
-                is_utf8 = LOGICAL(elt).read() != 0;
+                is_utf8 = LOGICAL_unchecked(elt).read() != 0;
                 break;
             }
         }

--- a/miniextendr-api/src/factor.rs
+++ b/miniextendr-api/src/factor.rs
@@ -30,7 +30,7 @@ use std::sync::OnceLock;
 
 use crate::altrep_traits::NA_INTEGER;
 use crate::ffi::{
-    INTEGER, PRINTNAME, Rf_allocVector, Rf_install, Rf_xlength, SEXP, SEXPTYPE, SexpExt,
+    INTEGER_unchecked, PRINTNAME, Rf_allocVector, Rf_install, Rf_xlength, SEXP, SEXPTYPE, SexpExt,
 };
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::into_r::IntoR;
@@ -141,7 +141,7 @@ impl<'a> Factor<'a> {
         }
 
         let len = unsafe { Rf_xlength(sexp) } as usize;
-        let ptr = unsafe { INTEGER(sexp) };
+        let ptr = unsafe { INTEGER_unchecked(sexp) };
         let indices = unsafe { crate::from_r::r_slice(ptr, len) };
         let levels_sexp = sexp.get_levels();
 
@@ -239,7 +239,7 @@ impl<'a> FactorMut<'a> {
         }
 
         let len = unsafe { Rf_xlength(sexp) } as usize;
-        let ptr = unsafe { INTEGER(sexp) };
+        let ptr = unsafe { INTEGER_unchecked(sexp) };
         let indices = unsafe { crate::from_r::r_slice_mut(ptr, len) };
         let levels_sexp = sexp.get_levels();
 

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1249,7 +1249,7 @@ impl RNativeType for i32 {
             if Rf_xlength(sexp) == 0 {
                 std::ptr::NonNull::<Self>::dangling().as_ptr()
             } else {
-                INTEGER(sexp)
+                INTEGER_unchecked(sexp)
             }
         }
     }
@@ -1266,7 +1266,7 @@ impl RNativeType for f64 {
             if Rf_xlength(sexp) == 0 {
                 std::ptr::NonNull::<Self>::dangling().as_ptr()
             } else {
-                REAL(sexp)
+                REAL_unchecked(sexp)
             }
         }
     }
@@ -1283,7 +1283,7 @@ impl RNativeType for u8 {
             if Rf_xlength(sexp) == 0 {
                 std::ptr::NonNull::<Self>::dangling().as_ptr()
             } else {
-                RAW(sexp)
+                RAW_unchecked(sexp)
             }
         }
     }
@@ -1301,7 +1301,7 @@ impl RNativeType for RLogical {
             if Rf_xlength(sexp) == 0 {
                 std::ptr::NonNull::<Self>::dangling().as_ptr()
             } else {
-                LOGICAL(sexp).cast()
+                LOGICAL_unchecked(sexp).cast()
             }
         }
     }
@@ -1318,7 +1318,7 @@ impl RNativeType for Rcomplex {
             if Rf_xlength(sexp) == 0 {
                 std::ptr::NonNull::<Self>::dangling().as_ptr()
             } else {
-                COMPLEX(sexp)
+                COMPLEX_unchecked(sexp)
             }
         }
     }
@@ -2120,27 +2120,32 @@ unsafe extern "C-unwind" {
     /// Get mutable pointer to logical vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
-    pub fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
+    /// Prefer `SexpExt::logical_elt` / `SexpExt::set_logical_elt` instead.
+    pub(crate) fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
 
     /// Get mutable pointer to integer vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
-    pub fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
+    /// Prefer `SexpExt::integer_elt` / `SexpExt::set_integer_elt` instead.
+    pub(crate) fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
 
     /// Get mutable pointer to real vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
-    pub fn REAL(x: SEXP) -> *mut f64;
+    /// Prefer `SexpExt::real_elt` / `SexpExt::set_real_elt` instead.
+    pub(crate) fn REAL(x: SEXP) -> *mut f64;
 
     /// Get mutable pointer to complex vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
+    /// Prefer `SexpExt::complex_elt` / `SexpExt::set_complex_elt` instead.
     pub(crate) fn COMPLEX(x: SEXP) -> *mut Rcomplex;
 
     /// Get mutable pointer to raw vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
-    pub fn RAW(x: SEXP) -> *mut Rbyte;
+    /// Prefer `SexpExt::raw_elt` / `SexpExt::set_raw_elt` instead.
+    pub(crate) fn RAW(x: SEXP) -> *mut Rbyte;
 
     // endregion
 

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -40,8 +40,8 @@ macro_rules! impl_vec_option_try_from_sexp {
     };
 }
 
-impl_vec_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
-impl_vec_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
+impl_vec_option_try_from_sexp!(f64, REALSXP, REAL_unchecked, is_na_real);
+impl_vec_option_try_from_sexp!(i32, INTSXP, INTEGER_unchecked, |v: i32| v == i32::MIN);
 
 /// Macro for NA-aware `R vector → Box<[Option<T>]>` conversions.
 macro_rules! impl_boxed_slice_option_try_from_sexp {
@@ -72,8 +72,8 @@ macro_rules! impl_boxed_slice_option_try_from_sexp {
     };
 }
 
-impl_boxed_slice_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
-impl_boxed_slice_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
+impl_boxed_slice_option_try_from_sexp!(f64, REALSXP, REAL_unchecked, is_na_real);
+impl_boxed_slice_option_try_from_sexp!(i32, INTSXP, INTEGER_unchecked, |v: i32| v == i32::MIN);
 
 /// Convert R logical vector (LGLSXP) to `Vec<Option<bool>>` with NA support.
 impl TryFromSexp for Vec<Option<bool>> {
@@ -90,7 +90,7 @@ impl TryFromSexp for Vec<Option<bool>> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice
@@ -110,7 +110,7 @@ impl TryFromSexp for Vec<Option<bool>> {
         }
 
         let len = unsafe { sexp.len_unchecked() };
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice
@@ -145,7 +145,7 @@ impl TryFromSexp for Vec<Rboolean> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         slice
@@ -180,7 +180,7 @@ impl TryFromSexp for Vec<Option<Rboolean>> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice
@@ -213,7 +213,7 @@ impl TryFromSexp for Vec<crate::altrep_data::Logical> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice
@@ -238,7 +238,7 @@ impl TryFromSexp for Vec<Option<RLogical>> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
+        let ptr = unsafe { crate::ffi::LOGICAL_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice
@@ -322,7 +322,7 @@ impl TryFromSexp for Vec<Option<u8>> {
         }
 
         let len = sexp.len();
-        let ptr = unsafe { crate::ffi::RAW(sexp) };
+        let ptr = unsafe { crate::ffi::RAW_unchecked(sexp) };
         let slice = unsafe { r_slice(ptr, len) };
 
         Ok(slice.iter().map(|&v| Some(v)).collect())

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -440,7 +440,7 @@ impl ProtectScope {
     /// unsafe fn make_ints(n: R_xlen_t) -> SEXP {
     ///     let scope = ProtectScope::new();
     ///     let vec = scope.alloc_vector(SEXPTYPE::INTSXP, n);
-    ///     // fill via INTEGER(vec.get()) ...
+    ///     // fill via vec.get().set_integer_elt(i, val) ...
     ///     vec.get()
     /// }
     /// ```

--- a/miniextendr-api/src/match_arg.rs
+++ b/miniextendr-api/src/match_arg.rs
@@ -158,7 +158,7 @@ pub fn match_arg_from_sexp<T: MatchArg>(sexp: SEXP) -> Result<T, MatchArgError> 
             if len != 1 {
                 return Err(MatchArgError::InvalidLength(len));
             }
-            let idx = unsafe { *ffi::INTEGER(sexp) };
+            let idx = unsafe { *ffi::INTEGER_unchecked(sexp) };
             if idx == i32::MIN {
                 // NA_integer_
                 return Err(MatchArgError::IsNa);

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -51,7 +51,9 @@
 pub use time::{Date, OffsetDateTime};
 
 use crate::cached_class::set_posixct_utc;
-use crate::ffi::{REAL, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{
+    REAL_unchecked, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
+};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -83,7 +85,7 @@ impl TryFromSexp for OffsetDateTime {
             )));
         }
 
-        let secs = unsafe { *REAL(sexp) };
+        let secs = unsafe { *REAL_unchecked(sexp) };
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -123,7 +125,7 @@ impl IntoR for OffsetDateTime {
             let duration = self - UNIX_EPOCH;
             let secs = duration.whole_seconds() as f64
                 + (duration.subsec_nanoseconds() as f64 / 1_000_000_000.0);
-            *REAL(vec) = secs;
+            *REAL_unchecked(vec) = secs;
 
             set_posixct_utc(vec);
 
@@ -160,7 +162,7 @@ impl TryFromSexp for Option<OffsetDateTime> {
             )));
         }
 
-        let secs = unsafe { *REAL(sexp) };
+        let secs = unsafe { *REAL_unchecked(sexp) };
         if secs.is_nan() {
             return Ok(None);
         }
@@ -192,7 +194,7 @@ impl IntoR for Option<OffsetDateTime> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                *REAL_unchecked(vec) = f64::NAN;
                 set_posixct_utc(vec);
                 Rf_unprotect(1);
                 vec
@@ -366,7 +368,7 @@ impl TryFromSexp for Date {
             )));
         }
 
-        let days = unsafe { *REAL(sexp) };
+        let days = unsafe { *REAL_unchecked(sexp) };
         if days.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -397,7 +399,7 @@ impl IntoR for Date {
 
             // Calculate days since epoch
             let days = (self - UNIX_EPOCH_DATE).whole_days() as f64;
-            *REAL(vec) = days;
+            *REAL_unchecked(vec) = days;
 
             // Set class = "Date"
             vec.set_class(crate::cached_class::date_class_sexp());
@@ -435,7 +437,7 @@ impl TryFromSexp for Option<Date> {
             )));
         }
 
-        let days = unsafe { *REAL(sexp) };
+        let days = unsafe { *REAL_unchecked(sexp) };
         if days.is_nan() {
             return Ok(None);
         }
@@ -464,7 +466,7 @@ impl IntoR for Option<Date> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                *REAL_unchecked(vec) = f64::NAN;
 
                 vec.set_class(crate::cached_class::date_class_sexp());
 

--- a/miniextendr-api/src/raw_conversions.rs
+++ b/miniextendr-api/src/raw_conversions.rs
@@ -58,7 +58,7 @@ pub use bytemuck::{Pod, Zeroable};
 use std::fmt;
 use std::mem;
 
-use crate::ffi::{RAW, Rf_allocVector, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{RAW_unchecked, Rf_allocVector, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -340,7 +340,7 @@ fn get_raw_bytes(sexp: SEXP) -> Result<&'static [u8], SexpError> {
         }));
     }
     let len = unsafe { Rf_xlength(sexp) } as usize;
-    let ptr = unsafe { RAW(sexp) };
+    let ptr = unsafe { RAW_unchecked(sexp) };
     Ok(unsafe { crate::from_r::r_slice(ptr, len) })
 }
 
@@ -407,7 +407,7 @@ impl<T: Pod> IntoR for Raw<T> {
         let bytes = bytemuck::bytes_of(&self.0);
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, bytes.len() as isize);
-            let ptr = RAW(sexp);
+            let ptr = RAW_unchecked(sexp);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
             Ok(sexp)
         }
@@ -420,7 +420,7 @@ impl<T: Pod> IntoR for RawSlice<T> {
         let bytes = bytemuck::cast_slice::<T, u8>(&self.0);
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, bytes.len() as isize);
-            let ptr = RAW(sexp);
+            let ptr = RAW_unchecked(sexp);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
             Ok(sexp)
         }
@@ -437,7 +437,7 @@ impl<T: Pod> IntoR for RawTagged<T> {
 
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, total_len as isize);
-            let ptr = RAW(sexp);
+            let ptr = RAW_unchecked(sexp);
             std::ptr::copy_nonoverlapping(header_bytes.as_ptr(), ptr, header_bytes.len());
             std::ptr::copy_nonoverlapping(
                 value_bytes.as_ptr(),
@@ -465,7 +465,7 @@ impl<T: Pod> IntoR for RawSliceTagged<T> {
 
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, total_len as isize);
-            let ptr = RAW(sexp);
+            let ptr = RAW_unchecked(sexp);
             std::ptr::copy_nonoverlapping(header_bytes.as_ptr(), ptr, header_bytes.len());
             std::ptr::copy_nonoverlapping(
                 value_bytes.as_ptr(),

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -414,7 +414,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
         }
 
         let len = self.len();
-        let ptr = unsafe { crate::ffi::RAW(self.sexp) };
+        let ptr = unsafe { crate::ffi::RAW_unchecked(self.sexp) };
         let bytes = unsafe { crate::from_r::r_slice(ptr, len) };
         visitor.visit_bytes(bytes)
     }
@@ -428,7 +428,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
         }
 
         let len = self.len();
-        let ptr = unsafe { crate::ffi::RAW(self.sexp) };
+        let ptr = unsafe { crate::ffi::RAW_unchecked(self.sexp) };
         let bytes = unsafe { crate::from_r::r_slice(ptr, len) };
         visitor.visit_byte_buf(bytes.to_vec())
     }

--- a/miniextendr-api/tests/bytes.rs
+++ b/miniextendr-api/tests/bytes.rs
@@ -52,14 +52,13 @@ fn bytes_empty() {
 #[test]
 fn bytes_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 100;
-            *ptr.add(1) = 200;
-            *ptr.add(2) = 255;
+            sexp.set_raw_elt(0, 100);
+            sexp.set_raw_elt(1, 200);
+            sexp.set_raw_elt(2, 255);
 
             let bytes: Bytes = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(bytes.len(), 3);
@@ -76,15 +75,14 @@ fn bytes_from_raw_vector() {
 #[test]
 fn bytesmut_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 4));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
-            *ptr.add(3) = 40;
+            sexp.set_raw_elt(0, 10);
+            sexp.set_raw_elt(1, 20);
+            sexp.set_raw_elt(2, 30);
+            sexp.set_raw_elt(3, 40);
 
             let mut bytes: BytesMut = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(bytes.len(), 4);

--- a/miniextendr-api/tests/fixed_arrays.rs
+++ b/miniextendr-api/tests/fixed_arrays.rs
@@ -46,14 +46,13 @@ fn fixed_array_f64_roundtrip() {
 #[test]
 fn fixed_array_length_mismatch_error() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create R vector with 5 elements
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 5));
-            let ptr = INTEGER(sexp);
-            for i in 0..5 {
-                *ptr.add(i) = i as i32;
+            for i in 0..5_i32 {
+                sexp.set_integer_elt(i as isize, i);
             }
 
             // Try to convert to [i32; 3] (wrong size)

--- a/miniextendr-api/tests/from_r.rs
+++ b/miniextendr-api/tests/from_r.rs
@@ -5,8 +5,7 @@ mod r_test_utils;
 use miniextendr_api::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use miniextendr_api::coerce::Coerced;
 use miniextendr_api::ffi::{
-    INTEGER, LOGICAL, R_xlen_t, RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE,
-    SexpExt,
+    R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
 };
 use miniextendr_api::from_r::{SexpError, TryFromSexp};
 use std::collections::{BTreeSet, HashSet};
@@ -33,32 +32,36 @@ impl Drop for ProtectCount {
 unsafe fn make_int_vec(values: &[i32], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::INTSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(INTEGER(sexp), values.len()) };
-    slice.copy_from_slice(values);
+    for (i, &v) in values.iter().enumerate() {
+        sexp.set_integer_elt(i as isize, v);
+    }
     sexp
 }
 
 unsafe fn make_real_vec(values: &[f64], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::REALSXP, len)) };
-    let slice: &mut [f64] = unsafe { sexp.as_mut_slice() };
-    slice.copy_from_slice(values);
+    for (i, &v) in values.iter().enumerate() {
+        sexp.set_real_elt(i as isize, v);
+    }
     sexp
 }
 
 unsafe fn make_logical_vec(values: &[i32], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::LGLSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(LOGICAL(sexp), values.len()) };
-    slice.copy_from_slice(values);
+    for (i, &v) in values.iter().enumerate() {
+        sexp.set_logical_elt(i as isize, v);
+    }
     sexp
 }
 
 unsafe fn make_raw_vec(values: &[u8], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::RAWSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(RAW(sexp), values.len()) };
-    slice.copy_from_slice(values);
+    for (i, &v) in values.iter().enumerate() {
+        sexp.set_raw_elt(i as isize, v);
+    }
     sexp
 }
 

--- a/miniextendr-api/tests/into_r.rs
+++ b/miniextendr-api/tests/into_r.rs
@@ -3,11 +3,11 @@
 mod r_test_utils;
 
 use miniextendr_api::altrep_traits::NA_LOGICAL;
-use miniextendr_api::ffi::{LOGICAL, R_xlen_t, RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
+use miniextendr_api::ffi::{R_xlen_t, RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 use miniextendr_api::into_r::IntoR;
 
-unsafe fn scalar_logical(sexp: SEXP) -> i32 {
-    unsafe { *LOGICAL(sexp) }
+fn scalar_logical(sexp: SEXP) -> i32 {
+    sexp.logical_elt(0)
 }
 
 fn string_elt_val(sexp: SEXP, idx: usize) -> Option<String> {
@@ -34,11 +34,11 @@ fn into_r_suite() {
 fn test_option_rlogical_scalar() {
     let sexp = Option::<RLogical>::Some(RLogical::TRUE).into_sexp();
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
-    assert_eq!(unsafe { scalar_logical(sexp) }, 1);
+    assert_eq!(scalar_logical(sexp), 1);
 
     let sexp_na = Option::<RLogical>::None.into_sexp();
     assert_eq!(sexp_na.type_of(), SEXPTYPE::LGLSXP);
-    assert_eq!(unsafe { scalar_logical(sexp_na) }, NA_LOGICAL);
+    assert_eq!(scalar_logical(sexp_na), NA_LOGICAL);
 }
 
 fn test_vec_option_rlogical() {
@@ -46,8 +46,8 @@ fn test_vec_option_rlogical() {
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
     assert_eq!(sexp.xlength(), 3);
 
-    let slice = unsafe { std::slice::from_raw_parts(LOGICAL(sexp), 3) };
-    assert_eq!(slice, &[1, NA_LOGICAL, 0]);
+    let vals: Vec<i32> = (0..3).map(|i| sexp.logical_elt(i)).collect();
+    assert_eq!(vals, &[1, NA_LOGICAL, 0]);
 }
 
 fn test_vec_option_rboolean() {
@@ -55,8 +55,8 @@ fn test_vec_option_rboolean() {
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
     assert_eq!(sexp.xlength(), 3);
 
-    let slice = unsafe { std::slice::from_raw_parts(LOGICAL(sexp), 3) };
-    assert_eq!(slice, &[1, NA_LOGICAL, 0]);
+    let vals: Vec<i32> = (0..3).map(|i| sexp.logical_elt(i)).collect();
+    assert_eq!(vals, &[1, NA_LOGICAL, 0]);
 }
 
 fn test_string_slice() {
@@ -71,7 +71,6 @@ fn test_string_slice() {
 
 // region: AsNamedList / AsNamedVector tests
 
-use miniextendr_api::ffi::{INTEGER, REAL};
 use miniextendr_api::{AsNamedList, AsNamedListExt, AsNamedVector, AsNamedVectorExt};
 
 /// Extract names from an R SEXP as Vec<String>.
@@ -121,8 +120,8 @@ fn test_as_named_vector_vec() {
 
     let names = extract_names(sexp);
     assert_eq!(names, vec!["alice", "bob"]);
-    let data = unsafe { std::slice::from_raw_parts(INTEGER(sexp), 2) };
-    assert_eq!(data, &[95, 87]);
+    assert_eq!(sexp.integer_elt(0), 95);
+    assert_eq!(sexp.integer_elt(1), 87);
 }
 
 fn test_as_named_vector_array() {
@@ -134,8 +133,9 @@ fn test_as_named_vector_array() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["x", "y", "z"]);
 
-    let data = unsafe { std::slice::from_raw_parts(REAL(sexp), 3) };
-    assert_eq!(data, &[1.0, 2.0, 3.0]);
+    assert_eq!(sexp.real_elt(0), 1.0);
+    assert_eq!(sexp.real_elt(1), 2.0);
+    assert_eq!(sexp.real_elt(2), 3.0);
 }
 
 fn test_as_named_vector_option() {
@@ -147,10 +147,9 @@ fn test_as_named_vector_option() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["a", "b", "c"]);
 
-    let data = unsafe { std::slice::from_raw_parts(INTEGER(sexp), 3) };
-    assert_eq!(data[0], 1);
-    assert_eq!(data[1], i32::MIN); // NA_integer_
-    assert_eq!(data[2], 3);
+    assert_eq!(sexp.integer_elt(0), 1);
+    assert_eq!(sexp.integer_elt(1), i32::MIN); // NA_integer_
+    assert_eq!(sexp.integer_elt(2), 3);
 }
 
 fn test_as_named_list_slice() {
@@ -172,7 +171,7 @@ fn test_as_named_vector_slice() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["x", "y"]);
 
-    let data = unsafe { std::slice::from_raw_parts(REAL(sexp), 2) };
-    assert_eq!(data, &[1.0, 2.0]);
+    assert_eq!(sexp.real_elt(0), 1.0);
+    assert_eq!(sexp.real_elt(1), 2.0);
 }
 // endregion

--- a/miniextendr-api/tests/nalgebra_generic.rs
+++ b/miniextendr-api/tests/nalgebra_generic.rs
@@ -12,14 +12,13 @@ use miniextendr_api::{DMatrix, DVector, SMatrix, SVector};
 fn dvector_i32_blanket_impl() {
     // Verify blanket impl works for i32 (not just f64)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            sexp.set_integer_elt(0, 10);
+            sexp.set_integer_elt(1, 20);
+            sexp.set_integer_elt(2, 30);
 
             let vec: DVector<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(vec.len(), 3);
@@ -54,19 +53,18 @@ fn dvector_f64_roundtrip() {
 fn dmatrix_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x3 matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 3));
-            let ptr = INTEGER(sexp);
             // Column-major: [col1, col2, col3]
-            *ptr.add(0) = 1; // row 1, col 1
-            *ptr.add(1) = 2; // row 2, col 1
-            *ptr.add(2) = 3; // row 1, col 2
-            *ptr.add(3) = 4; // row 2, col 2
-            *ptr.add(4) = 5; // row 1, col 3
-            *ptr.add(5) = 6; // row 2, col 3
+            sexp.set_integer_elt(0, 1); // row 1, col 1
+            sexp.set_integer_elt(1, 2); // row 2, col 1
+            sexp.set_integer_elt(2, 3); // row 1, col 2
+            sexp.set_integer_elt(3, 4); // row 2, col 2
+            sexp.set_integer_elt(4, 5); // row 1, col 3
+            sexp.set_integer_elt(5, 6); // row 2, col 3
 
             let mat: DMatrix<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -88,16 +86,15 @@ fn dmatrix_i32_blanket_impl() {
 fn dmatrix_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw bytes)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 raw matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::RAWSXP, 2, 2));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
-            *ptr.add(3) = 40;
+            sexp.set_raw_elt(0, 10);
+            sexp.set_raw_elt(1, 20);
+            sexp.set_raw_elt(2, 30);
+            sexp.set_raw_elt(3, 40);
 
             let mat: DMatrix<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -148,15 +145,14 @@ fn svector_f64_roundtrip() {
 #[test]
 fn svector_i32_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 3x1 integer matrix (column vector)
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 3, 1));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            sexp.set_integer_elt(0, 10);
+            sexp.set_integer_elt(1, 20);
+            sexp.set_integer_elt(2, 30);
 
             let vec: SVector<i32, 3> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(vec.len(), 3);
@@ -173,16 +169,14 @@ fn svector_i32_from_r() {
 #[test]
 fn svector_length_mismatch() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{REAL, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 4x1 matrix, but try to convert to SVector<f64, 3>
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::REALSXP, 4, 1));
-            let ptr = REAL(sexp);
-            *ptr.add(0) = 1.0;
-            *ptr.add(1) = 2.0;
-            *ptr.add(2) = 3.0;
-            *ptr.add(3) = 4.0;
+            for i in 0..4 {
+                sexp.set_real_elt(i as isize, (i + 1) as f64);
+            }
 
             let result: Result<SVector<f64, 3>, _> = TryFromSexp::try_from_sexp(sexp);
             assert!(result.is_err(), "Should fail: expected 3x1, got 4x1");
@@ -220,16 +214,15 @@ fn smatrix_f64_roundtrip() {
 #[test]
 fn smatrix_i32_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 integer matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 2));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            sexp.set_integer_elt(0, 1);
+            sexp.set_integer_elt(1, 2);
+            sexp.set_integer_elt(2, 3);
+            sexp.set_integer_elt(3, 4);
 
             let mat: SMatrix<i32, 2, 2> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -249,14 +242,13 @@ fn smatrix_i32_from_r() {
 #[test]
 fn smatrix_dimension_mismatch() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{REAL, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 3x3 matrix, but try to convert to SMatrix<f64, 2, 2>
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::REALSXP, 3, 3));
-            let ptr = REAL(sexp);
             for i in 0..9 {
-                *ptr.add(i) = i as f64;
+                sexp.set_real_elt(i as isize, i as f64);
             }
 
             let result: Result<SMatrix<f64, 2, 2>, _> = TryFromSexp::try_from_sexp(sexp);

--- a/miniextendr-api/tests/ndarray_all_types.rs
+++ b/miniextendr-api/tests/ndarray_all_types.rs
@@ -13,17 +13,15 @@ fn array1_all_rnative_types() {
     // Verify Array1 blanket impl works for all RNativeType: i32, f64, u8, RLogical
     r_test_utils::with_r_thread(|| {
         use miniextendr_api::ffi::{
-            INTEGER, LOGICAL, RAW, REAL, RLogical, Rf_allocVector, Rf_protect, Rf_unprotect,
-            SEXPTYPE,
+            RLogical, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt,
         };
 
         unsafe {
             // i32
             let sexp_int = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr_int = INTEGER(sexp_int);
-            *ptr_int.add(0) = 1;
-            *ptr_int.add(1) = 2;
-            *ptr_int.add(2) = 3;
+            sexp_int.set_integer_elt(0, 1);
+            sexp_int.set_integer_elt(1, 2);
+            sexp_int.set_integer_elt(2, 3);
             let arr_i32: Array1<i32> = TryFromSexp::try_from_sexp(sexp_int).unwrap();
             assert_eq!(arr_i32[0], 1);
             assert_eq!(arr_i32[1], 2);
@@ -31,10 +29,9 @@ fn array1_all_rnative_types() {
 
             // f64
             let sexp_real = Rf_protect(Rf_allocVector(SEXPTYPE::REALSXP, 3));
-            let ptr_real = REAL(sexp_real);
-            *ptr_real.add(0) = 1.5;
-            *ptr_real.add(1) = 2.5;
-            *ptr_real.add(2) = 3.5;
+            sexp_real.set_real_elt(0, 1.5);
+            sexp_real.set_real_elt(1, 2.5);
+            sexp_real.set_real_elt(2, 3.5);
             let arr_f64: Array1<f64> = TryFromSexp::try_from_sexp(sexp_real).unwrap();
             assert_eq!(arr_f64[0], 1.5);
             assert_eq!(arr_f64[1], 2.5);
@@ -42,10 +39,9 @@ fn array1_all_rnative_types() {
 
             // u8
             let sexp_raw = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr_raw = RAW(sexp_raw);
-            *ptr_raw.add(0) = 10;
-            *ptr_raw.add(1) = 20;
-            *ptr_raw.add(2) = 30;
+            sexp_raw.set_raw_elt(0, 10);
+            sexp_raw.set_raw_elt(1, 20);
+            sexp_raw.set_raw_elt(2, 30);
             let arr_u8: Array1<u8> = TryFromSexp::try_from_sexp(sexp_raw).unwrap();
             assert_eq!(arr_u8[0], 10);
             assert_eq!(arr_u8[1], 20);
@@ -53,10 +49,9 @@ fn array1_all_rnative_types() {
 
             // RLogical
             let sexp_lgl = Rf_protect(Rf_allocVector(SEXPTYPE::LGLSXP, 3));
-            let ptr_lgl = LOGICAL(sexp_lgl);
-            *ptr_lgl.add(0) = 1; // TRUE
-            *ptr_lgl.add(1) = 0; // FALSE
-            *ptr_lgl.add(2) = 1; // TRUE
+            sexp_lgl.set_logical_elt(0, 1); // TRUE
+            sexp_lgl.set_logical_elt(1, 0); // FALSE
+            sexp_lgl.set_logical_elt(2, 1); // TRUE
             let arr_lgl: Array1<RLogical> = TryFromSexp::try_from_sexp(sexp_lgl).unwrap();
             assert_eq!(arr_lgl[0], RLogical::from(true));
             assert_eq!(arr_lgl[1], RLogical::from(false));
@@ -97,16 +92,15 @@ fn array0_scalar_all_types() {
 fn array2_u8_blanket_impl() {
     // Verify Array2 works for u8 (raw matrices)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 raw matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::RAWSXP, 2, 2));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            sexp.set_raw_elt(0, 1);
+            sexp.set_raw_elt(1, 2);
+            sexp.set_raw_elt(2, 3);
+            sexp.set_raw_elt(3, 4);
 
             let arr: Array2<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.nrows(), 2);
@@ -126,14 +120,13 @@ fn array2_u8_blanket_impl() {
 fn arrayd_i32_from_vector() {
     // Test ArrayD created from R vector (1D)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
         use ndarray::ArrayD;
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 5));
-            let ptr = INTEGER(sexp);
             for i in 0..5 {
-                *ptr.add(i) = i as i32;
+                sexp.set_integer_elt(i as isize, i as i32);
             }
 
             let arr: ArrayD<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();

--- a/miniextendr-api/tests/ndarray_generic.rs
+++ b/miniextendr-api/tests/ndarray_generic.rs
@@ -12,15 +12,14 @@ use miniextendr_api::{Array0, Array1, Array2, Array3, ArrayD};
 fn array1_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 4));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            sexp.set_integer_elt(0, 1);
+            sexp.set_integer_elt(1, 2);
+            sexp.set_integer_elt(2, 3);
+            sexp.set_integer_elt(3, 4);
 
             let arr: Array1<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.len(), 4);
@@ -39,14 +38,13 @@ fn array1_i32_blanket_impl() {
 fn array1_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            sexp.set_raw_elt(0, 10);
+            sexp.set_raw_elt(1, 20);
+            sexp.set_raw_elt(2, 30);
 
             let arr: Array1<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.len(), 3);
@@ -64,15 +62,14 @@ fn array1_u8_blanket_impl() {
 fn array2_i32_blanket_impl() {
     // Verify blanket impl works for i32 matrices
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x3 matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 3));
-            let ptr = INTEGER(sexp);
             // Column-major layout
             for i in 0..6 {
-                *ptr.add(i) = i as i32 + 1;
+                sexp.set_integer_elt(i as isize, i as i32 + 1);
             }
 
             let arr: Array2<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();

--- a/miniextendr-api/tests/std_collections.rs
+++ b/miniextendr-api/tests/std_collections.rs
@@ -87,14 +87,13 @@ fn cow_slice_owned() {
 #[test]
 fn cow_slice_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 100;
-            *ptr.add(1) = 200;
-            *ptr.add(2) = 300;
+            sexp.set_integer_elt(0, 100);
+            sexp.set_integer_elt(1, 200);
+            sexp.set_integer_elt(2, 300);
 
             let cow: Cow<'static, [i32]> = TryFromSexp::try_from_sexp(sexp).unwrap();
 

--- a/miniextendr-api/tests/tinyvec.rs
+++ b/miniextendr-api/tests/tinyvec.rs
@@ -122,14 +122,13 @@ fn arrayvec_capacity_ok() {
 #[test]
 fn arrayvec_capacity_error() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         // Create R vector with 10 elements
         let sexp = unsafe {
             let s = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 10));
-            let ptr = INTEGER(s);
             for i in 0..10 {
-                *ptr.add(i) = i as i32;
+                s.set_integer_elt(i as isize, i as i32);
             }
             Rf_unprotect(1);
             s

--- a/miniextendr-macros/src/externalptr_derive.rs
+++ b/miniextendr-macros/src/externalptr_derive.rs
@@ -503,11 +503,11 @@ fn generate_setter_body(
         }
         SlotKind::ScalarRaw => {
             quote::quote! {
-                use ::miniextendr_api::ffi::{RAW, SexpExt, SEXPTYPE};
+                use ::miniextendr_api::ffi::{SexpExt, SEXPTYPE};
                 unsafe {
                     #extract_mut
                     let raw_vec = value.coerce(SEXPTYPE::RAWSXP);
-                    data.#field_name = *RAW(raw_vec);
+                    data.#field_name = raw_vec.raw_elt(0);
                     x
                 }
             }

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_private_methods.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_private_methods.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1835
 expression: generate_r6_r_wrapper(&parsed)
 ---
 #' @title Secure R6 Class
@@ -11,6 +12,7 @@ expression: generate_r6_r_wrapper(&parsed)
 #' @export
 Secure <- R6::R6Class("Secure",
   public = list(
+    #' @description Create a new `Secure`.
     initialize = function(.ptr = NULL) {
       if (!is.null(.ptr)) {
         private$.ptr <- .ptr
@@ -25,6 +27,7 @@ Secure <- R6::R6Class("Secure",
         private$.ptr <- .val
       }
     },
+    #' @description Method `public_api`.
     public_api = function() {
       .val <- .Call(C_Secure__public_api, .call = match.call(), private$.ptr)
       if (inherits(.val, "rust_error_value") && isTRUE(attr(.val, "__rust_error__"))) {

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_with_options.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_r6_with_options.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1822
 expression: generate_r6_r_wrapper(&parsed)
 ---
 #' @title Child R6 Class
@@ -11,6 +12,7 @@ expression: generate_r6_r_wrapper(&parsed)
 #' @export
 Child <- R6::R6Class("Child", inherit = ParentClass,
   public = list(
+    #' @description Create a new `Child`.
     initialize = function(.ptr = NULL) {
       if (!is.null(.ptr)) {
         private$.ptr <- .ptr
@@ -25,6 +27,7 @@ Child <- R6::R6Class("Child", inherit = ParentClass,
         private$.ptr <- .val
       }
     },
+    #' @description Method `greet`.
     greet = function() {
       .val <- .Call(C_Child__greet, .call = match.call(), private$.ptr)
       if (inherits(.val, "rust_error_value") && isTRUE(attr(.val, "__rust_error__"))) {

--- a/rpkg/src/rust/zero_copy_tests.rs
+++ b/rpkg/src/rust/zero_copy_tests.rs
@@ -180,12 +180,10 @@ mod arrow {
         use miniextendr_api::optionals::arrow_impl::alloc_r_backed_buffer;
         let n = n as usize;
         let (buffer, sexp) = unsafe { alloc_r_backed_buffer::<f64>(n) };
-        // Fill via the SEXP's raw pointer
-        unsafe {
-            let ptr = miniextendr_api::ffi::REAL(sexp);
-            for i in 0..n {
-                *ptr.add(i) = (i + 1) as f64 * 100.0;
-            }
+        // Fill via SexpExt element-wise setter
+        use miniextendr_api::ffi::SexpExt;
+        for i in 0..n {
+            sexp.set_real_elt(i as isize, (i + 1) as f64 * 100.0);
         }
         let values = miniextendr_api::optionals::arrow_impl::arrow_buffer::ScalarBuffer::<f64>::from(buffer);
         let array = miniextendr_api::optionals::arrow_impl::Float64Array::new(values, None);


### PR DESCRIPTION
## Summary
- Changed visibility of `INTEGER`, `REAL`, `LOGICAL`, `RAW`, `COMPLEX` FFI functions from `pub` to `pub(crate)` in `miniextendr-api/src/ffi.rs`, preventing external crates from using raw dataptr access
- Internal crate code (`RNativeType::dataptr_mut`, ALTREP, na_vectors, factor, raw_conversions, time_impl, encoding, match_arg, serde) now uses `_unchecked` variants for performance
- External-facing code (proc-macro codegen in `externalptr_derive`, rpkg test fixtures, integration tests) migrated to safe `SexpExt::*_elt()` / `SexpExt::set_*_elt()` methods

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo check --manifest-path=rpkg/src/rust/Cargo.toml` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 271 macro tests + integration tests)
- [x] `cargo test --manifest-path=miniextendr-macros/Cargo.toml --lib` passes
- [x] Accepted 2 pre-existing snapshot drifts (added `@description` roxygen tags)

Generated with [Claude Code](https://claude.com/claude-code)
