### PR TITLE
refactor: make INTEGER/REAL/LOGICAL/RAW pub(crate)

### DIFF
--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -2126,19 +2126,19 @@ unsafe extern "C-unwind" {
     ///
     /// For ALTREP vectors, this may force materialization.
     /// Prefer `SexpExt::set_logical_elt()` / `SexpExt::logical_elt()`.
-    pub fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
+    pub(crate) fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
 
     /// Get mutable pointer to integer vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
     /// Prefer `SexpExt::set_integer_elt()` / `SexpExt::integer_elt()`.
-    pub fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
+    pub(crate) fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
 
     /// Get mutable pointer to real vector data.
     ///
     /// For ALTREP vectors, this may force materialization.
     /// Prefer `SexpExt::set_real_elt()` / `SexpExt::real_elt()`.
-    pub fn REAL(x: SEXP) -> *mut f64;
+    pub(crate) fn REAL(x: SEXP) -> *mut f64;
 
     /// Get mutable pointer to complex vector data.
     ///
@@ -2150,7 +2150,7 @@ unsafe extern "C-unwind" {
     ///
     /// For ALTREP vectors, this may force materialization.
     /// Prefer `SexpExt::set_raw_elt()` / `SexpExt::raw_elt()`.
-    pub fn RAW(x: SEXP) -> *mut Rbyte;
+    pub(crate) fn RAW(x: SEXP) -> *mut Rbyte;
 
     // endregion
 

--- a/miniextendr-api/tests/bytes.rs
+++ b/miniextendr-api/tests/bytes.rs
@@ -52,14 +52,14 @@ fn bytes_empty() {
 #[test]
 fn bytes_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 100;
-            *ptr.add(1) = 200;
-            *ptr.add(2) = 255;
+            let slice: &mut [u8] = sexp.as_mut_slice();
+            slice[0] = 100;
+            slice[1] = 200;
+            slice[2] = 255;
 
             let bytes: Bytes = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(bytes.len(), 3);
@@ -76,15 +76,15 @@ fn bytes_from_raw_vector() {
 #[test]
 fn bytesmut_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 4));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
-            *ptr.add(3) = 40;
+            let slice: &mut [u8] = sexp.as_mut_slice();
+            slice[0] = 10;
+            slice[1] = 20;
+            slice[2] = 30;
+            slice[3] = 40;
 
             let mut bytes: BytesMut = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(bytes.len(), 4);

--- a/miniextendr-api/tests/fixed_arrays.rs
+++ b/miniextendr-api/tests/fixed_arrays.rs
@@ -46,14 +46,14 @@ fn fixed_array_f64_roundtrip() {
 #[test]
 fn fixed_array_length_mismatch_error() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create R vector with 5 elements
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 5));
-            let ptr = INTEGER(sexp);
-            for i in 0..5 {
-                *ptr.add(i) = i as i32;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            for (i, slot) in slice.iter_mut().enumerate() {
+                *slot = i as i32;
             }
 
             // Try to convert to [i32; 3] (wrong size)

--- a/miniextendr-api/tests/from_r.rs
+++ b/miniextendr-api/tests/from_r.rs
@@ -5,8 +5,7 @@ mod r_test_utils;
 use miniextendr_api::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use miniextendr_api::coerce::Coerced;
 use miniextendr_api::ffi::{
-    INTEGER, LOGICAL, R_xlen_t, RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE,
-    SexpExt,
+    R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
 };
 use miniextendr_api::from_r::{SexpError, TryFromSexp};
 use std::collections::{BTreeSet, HashSet};
@@ -33,7 +32,7 @@ impl Drop for ProtectCount {
 unsafe fn make_int_vec(values: &[i32], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::INTSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(INTEGER(sexp), values.len()) };
+    let slice: &mut [i32] = unsafe { sexp.as_mut_slice() };
     slice.copy_from_slice(values);
     sexp
 }
@@ -49,15 +48,16 @@ unsafe fn make_real_vec(values: &[f64], guard: &mut ProtectCount) -> SEXP {
 unsafe fn make_logical_vec(values: &[i32], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::LGLSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(LOGICAL(sexp), values.len()) };
-    slice.copy_from_slice(values);
+    for (i, &v) in values.iter().enumerate() {
+        sexp.set_logical_elt(i as isize, v);
+    }
     sexp
 }
 
 unsafe fn make_raw_vec(values: &[u8], guard: &mut ProtectCount) -> SEXP {
     let len = values.len() as R_xlen_t;
     let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::RAWSXP, len)) };
-    let slice = unsafe { std::slice::from_raw_parts_mut(RAW(sexp), values.len()) };
+    let slice: &mut [u8] = unsafe { sexp.as_mut_slice() };
     slice.copy_from_slice(values);
     sexp
 }

--- a/miniextendr-api/tests/into_r.rs
+++ b/miniextendr-api/tests/into_r.rs
@@ -3,11 +3,11 @@
 mod r_test_utils;
 
 use miniextendr_api::altrep_traits::NA_LOGICAL;
-use miniextendr_api::ffi::{LOGICAL, R_xlen_t, RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
+use miniextendr_api::ffi::{R_xlen_t, RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 use miniextendr_api::into_r::IntoR;
 
-unsafe fn scalar_logical(sexp: SEXP) -> i32 {
-    unsafe { *LOGICAL(sexp) }
+fn scalar_logical(sexp: SEXP) -> i32 {
+    sexp.logical_elt(0)
 }
 
 fn string_elt_val(sexp: SEXP, idx: usize) -> Option<String> {
@@ -34,11 +34,11 @@ fn into_r_suite() {
 fn test_option_rlogical_scalar() {
     let sexp = Option::<RLogical>::Some(RLogical::TRUE).into_sexp();
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
-    assert_eq!(unsafe { scalar_logical(sexp) }, 1);
+    assert_eq!(scalar_logical(sexp), 1);
 
     let sexp_na = Option::<RLogical>::None.into_sexp();
     assert_eq!(sexp_na.type_of(), SEXPTYPE::LGLSXP);
-    assert_eq!(unsafe { scalar_logical(sexp_na) }, NA_LOGICAL);
+    assert_eq!(scalar_logical(sexp_na), NA_LOGICAL);
 }
 
 fn test_vec_option_rlogical() {
@@ -46,8 +46,8 @@ fn test_vec_option_rlogical() {
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
     assert_eq!(sexp.xlength(), 3);
 
-    let slice = unsafe { std::slice::from_raw_parts(LOGICAL(sexp), 3) };
-    assert_eq!(slice, &[1, NA_LOGICAL, 0]);
+    let elts: Vec<i32> = (0..3).map(|i| sexp.logical_elt(i)).collect();
+    assert_eq!(elts, &[1, NA_LOGICAL, 0]);
 }
 
 fn test_vec_option_rboolean() {
@@ -55,8 +55,8 @@ fn test_vec_option_rboolean() {
     assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
     assert_eq!(sexp.xlength(), 3);
 
-    let slice = unsafe { std::slice::from_raw_parts(LOGICAL(sexp), 3) };
-    assert_eq!(slice, &[1, NA_LOGICAL, 0]);
+    let elts: Vec<i32> = (0..3).map(|i| sexp.logical_elt(i)).collect();
+    assert_eq!(elts, &[1, NA_LOGICAL, 0]);
 }
 
 fn test_string_slice() {
@@ -71,7 +71,7 @@ fn test_string_slice() {
 
 // region: AsNamedList / AsNamedVector tests
 
-use miniextendr_api::ffi::{INTEGER, REAL};
+// SexpExt already imported above
 use miniextendr_api::{AsNamedList, AsNamedListExt, AsNamedVector, AsNamedVectorExt};
 
 /// Extract names from an R SEXP as Vec<String>.
@@ -121,7 +121,7 @@ fn test_as_named_vector_vec() {
 
     let names = extract_names(sexp);
     assert_eq!(names, vec!["alice", "bob"]);
-    let data = unsafe { std::slice::from_raw_parts(INTEGER(sexp), 2) };
+    let data: &[i32] = unsafe { sexp.as_slice() };
     assert_eq!(data, &[95, 87]);
 }
 
@@ -134,7 +134,7 @@ fn test_as_named_vector_array() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["x", "y", "z"]);
 
-    let data = unsafe { std::slice::from_raw_parts(REAL(sexp), 3) };
+    let data: &[f64] = unsafe { sexp.as_slice() };
     assert_eq!(data, &[1.0, 2.0, 3.0]);
 }
 
@@ -147,7 +147,7 @@ fn test_as_named_vector_option() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["a", "b", "c"]);
 
-    let data = unsafe { std::slice::from_raw_parts(INTEGER(sexp), 3) };
+    let data: &[i32] = unsafe { sexp.as_slice() };
     assert_eq!(data[0], 1);
     assert_eq!(data[1], i32::MIN); // NA_integer_
     assert_eq!(data[2], 3);
@@ -172,7 +172,7 @@ fn test_as_named_vector_slice() {
     let names = extract_names(sexp);
     assert_eq!(names, vec!["x", "y"]);
 
-    let data = unsafe { std::slice::from_raw_parts(REAL(sexp), 2) };
+    let data: &[f64] = unsafe { sexp.as_slice() };
     assert_eq!(data, &[1.0, 2.0]);
 }
 // endregion

--- a/miniextendr-api/tests/nalgebra_generic.rs
+++ b/miniextendr-api/tests/nalgebra_generic.rs
@@ -12,14 +12,14 @@ use miniextendr_api::{DMatrix, DVector, SMatrix, SVector};
 fn dvector_i32_blanket_impl() {
     // Verify blanket impl works for i32 (not just f64)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            slice[0] = 10;
+            slice[1] = 20;
+            slice[2] = 30;
 
             let vec: DVector<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(vec.len(), 3);
@@ -54,19 +54,19 @@ fn dvector_f64_roundtrip() {
 fn dmatrix_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x3 matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 3));
-            let ptr = INTEGER(sexp);
+            let slice: &mut [i32] = sexp.as_mut_slice();
             // Column-major: [col1, col2, col3]
-            *ptr.add(0) = 1; // row 1, col 1
-            *ptr.add(1) = 2; // row 2, col 1
-            *ptr.add(2) = 3; // row 1, col 2
-            *ptr.add(3) = 4; // row 2, col 2
-            *ptr.add(4) = 5; // row 1, col 3
-            *ptr.add(5) = 6; // row 2, col 3
+            slice[0] = 1; // row 1, col 1
+            slice[1] = 2; // row 2, col 1
+            slice[2] = 3; // row 1, col 2
+            slice[3] = 4; // row 2, col 2
+            slice[4] = 5; // row 1, col 3
+            slice[5] = 6; // row 2, col 3
 
             let mat: DMatrix<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -88,16 +88,16 @@ fn dmatrix_i32_blanket_impl() {
 fn dmatrix_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw bytes)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 raw matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::RAWSXP, 2, 2));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
-            *ptr.add(3) = 40;
+            let slice: &mut [u8] = sexp.as_mut_slice();
+            slice[0] = 10;
+            slice[1] = 20;
+            slice[2] = 30;
+            slice[3] = 40;
 
             let mat: DMatrix<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -148,15 +148,15 @@ fn svector_f64_roundtrip() {
 #[test]
 fn svector_i32_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 3x1 integer matrix (column vector)
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 3, 1));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            slice[0] = 10;
+            slice[1] = 20;
+            slice[2] = 30;
 
             let vec: SVector<i32, 3> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(vec.len(), 3);
@@ -173,16 +173,16 @@ fn svector_i32_from_r() {
 #[test]
 fn svector_length_mismatch() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{REAL, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 4x1 matrix, but try to convert to SVector<f64, 3>
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::REALSXP, 4, 1));
-            let ptr = REAL(sexp);
-            *ptr.add(0) = 1.0;
-            *ptr.add(1) = 2.0;
-            *ptr.add(2) = 3.0;
-            *ptr.add(3) = 4.0;
+            let slice: &mut [f64] = sexp.as_mut_slice();
+            slice[0] = 1.0;
+            slice[1] = 2.0;
+            slice[2] = 3.0;
+            slice[3] = 4.0;
 
             let result: Result<SVector<f64, 3>, _> = TryFromSexp::try_from_sexp(sexp);
             assert!(result.is_err(), "Should fail: expected 3x1, got 4x1");
@@ -220,16 +220,16 @@ fn smatrix_f64_roundtrip() {
 #[test]
 fn smatrix_i32_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 integer matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 2));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            slice[0] = 1;
+            slice[1] = 2;
+            slice[2] = 3;
+            slice[3] = 4;
 
             let mat: SMatrix<i32, 2, 2> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(mat.nrows(), 2);
@@ -249,14 +249,14 @@ fn smatrix_i32_from_r() {
 #[test]
 fn smatrix_dimension_mismatch() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{REAL, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 3x3 matrix, but try to convert to SMatrix<f64, 2, 2>
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::REALSXP, 3, 3));
-            let ptr = REAL(sexp);
-            for i in 0..9 {
-                *ptr.add(i) = i as f64;
+            let slice: &mut [f64] = sexp.as_mut_slice();
+            for (i, slot) in slice.iter_mut().enumerate() {
+                *slot = i as f64;
             }
 
             let result: Result<SMatrix<f64, 2, 2>, _> = TryFromSexp::try_from_sexp(sexp);

--- a/miniextendr-api/tests/ndarray_all_types.rs
+++ b/miniextendr-api/tests/ndarray_all_types.rs
@@ -13,17 +13,16 @@ fn array1_all_rnative_types() {
     // Verify Array1 blanket impl works for all RNativeType: i32, f64, u8, RLogical
     r_test_utils::with_r_thread(|| {
         use miniextendr_api::ffi::{
-            INTEGER, LOGICAL, RAW, REAL, RLogical, Rf_allocVector, Rf_protect, Rf_unprotect,
-            SEXPTYPE,
+            RLogical, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt,
         };
 
         unsafe {
             // i32
             let sexp_int = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr_int = INTEGER(sexp_int);
-            *ptr_int.add(0) = 1;
-            *ptr_int.add(1) = 2;
-            *ptr_int.add(2) = 3;
+            let int_slice: &mut [i32] = sexp_int.as_mut_slice();
+            int_slice[0] = 1;
+            int_slice[1] = 2;
+            int_slice[2] = 3;
             let arr_i32: Array1<i32> = TryFromSexp::try_from_sexp(sexp_int).unwrap();
             assert_eq!(arr_i32[0], 1);
             assert_eq!(arr_i32[1], 2);
@@ -31,10 +30,10 @@ fn array1_all_rnative_types() {
 
             // f64
             let sexp_real = Rf_protect(Rf_allocVector(SEXPTYPE::REALSXP, 3));
-            let ptr_real = REAL(sexp_real);
-            *ptr_real.add(0) = 1.5;
-            *ptr_real.add(1) = 2.5;
-            *ptr_real.add(2) = 3.5;
+            let real_slice: &mut [f64] = sexp_real.as_mut_slice();
+            real_slice[0] = 1.5;
+            real_slice[1] = 2.5;
+            real_slice[2] = 3.5;
             let arr_f64: Array1<f64> = TryFromSexp::try_from_sexp(sexp_real).unwrap();
             assert_eq!(arr_f64[0], 1.5);
             assert_eq!(arr_f64[1], 2.5);
@@ -42,10 +41,10 @@ fn array1_all_rnative_types() {
 
             // u8
             let sexp_raw = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr_raw = RAW(sexp_raw);
-            *ptr_raw.add(0) = 10;
-            *ptr_raw.add(1) = 20;
-            *ptr_raw.add(2) = 30;
+            let raw_slice: &mut [u8] = sexp_raw.as_mut_slice();
+            raw_slice[0] = 10;
+            raw_slice[1] = 20;
+            raw_slice[2] = 30;
             let arr_u8: Array1<u8> = TryFromSexp::try_from_sexp(sexp_raw).unwrap();
             assert_eq!(arr_u8[0], 10);
             assert_eq!(arr_u8[1], 20);
@@ -53,10 +52,9 @@ fn array1_all_rnative_types() {
 
             // RLogical
             let sexp_lgl = Rf_protect(Rf_allocVector(SEXPTYPE::LGLSXP, 3));
-            let ptr_lgl = LOGICAL(sexp_lgl);
-            *ptr_lgl.add(0) = 1; // TRUE
-            *ptr_lgl.add(1) = 0; // FALSE
-            *ptr_lgl.add(2) = 1; // TRUE
+            sexp_lgl.set_logical_elt(0, 1); // TRUE
+            sexp_lgl.set_logical_elt(1, 0); // FALSE
+            sexp_lgl.set_logical_elt(2, 1); // TRUE
             let arr_lgl: Array1<RLogical> = TryFromSexp::try_from_sexp(sexp_lgl).unwrap();
             assert_eq!(arr_lgl[0], RLogical::from(true));
             assert_eq!(arr_lgl[1], RLogical::from(false));
@@ -97,16 +95,16 @@ fn array0_scalar_all_types() {
 fn array2_u8_blanket_impl() {
     // Verify Array2 works for u8 (raw matrices)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x2 raw matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::RAWSXP, 2, 2));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            let slice: &mut [u8] = sexp.as_mut_slice();
+            slice[0] = 1;
+            slice[1] = 2;
+            slice[2] = 3;
+            slice[3] = 4;
 
             let arr: Array2<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.nrows(), 2);
@@ -126,14 +124,14 @@ fn array2_u8_blanket_impl() {
 fn arrayd_i32_from_vector() {
     // Test ArrayD created from R vector (1D)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
         use ndarray::ArrayD;
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 5));
-            let ptr = INTEGER(sexp);
-            for i in 0..5 {
-                *ptr.add(i) = i as i32;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            for (i, slot) in slice.iter_mut().enumerate() {
+                *slot = i as i32;
             }
 
             let arr: ArrayD<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();

--- a/miniextendr-api/tests/ndarray_generic.rs
+++ b/miniextendr-api/tests/ndarray_generic.rs
@@ -12,15 +12,15 @@ use miniextendr_api::{Array0, Array1, Array2, Array3, ArrayD};
 fn array1_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 4));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 1;
-            *ptr.add(1) = 2;
-            *ptr.add(2) = 3;
-            *ptr.add(3) = 4;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            slice[0] = 1;
+            slice[1] = 2;
+            slice[2] = 3;
+            slice[3] = 4;
 
             let arr: Array1<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.len(), 4);
@@ -39,14 +39,14 @@ fn array1_i32_blanket_impl() {
 fn array1_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw)
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{RAW, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
-            let ptr = RAW(sexp);
-            *ptr.add(0) = 10;
-            *ptr.add(1) = 20;
-            *ptr.add(2) = 30;
+            let slice: &mut [u8] = sexp.as_mut_slice();
+            slice[0] = 10;
+            slice[1] = 20;
+            slice[2] = 30;
 
             let arr: Array1<u8> = TryFromSexp::try_from_sexp(sexp).unwrap();
             assert_eq!(arr.len(), 3);
@@ -64,15 +64,15 @@ fn array1_u8_blanket_impl() {
 fn array2_i32_blanket_impl() {
     // Verify blanket impl works for i32 matrices
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             // Create 2x3 matrix
             let sexp = Rf_protect(Rf_allocMatrix(SEXPTYPE::INTSXP, 2, 3));
-            let ptr = INTEGER(sexp);
+            let slice: &mut [i32] = sexp.as_mut_slice();
             // Column-major layout
-            for i in 0..6 {
-                *ptr.add(i) = i as i32 + 1;
+            for (i, slot) in slice.iter_mut().enumerate() {
+                *slot = i as i32 + 1;
             }
 
             let arr: Array2<i32> = TryFromSexp::try_from_sexp(sexp).unwrap();

--- a/miniextendr-api/tests/std_collections.rs
+++ b/miniextendr-api/tests/std_collections.rs
@@ -87,14 +87,14 @@ fn cow_slice_owned() {
 #[test]
 fn cow_slice_from_r() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
-            let ptr = INTEGER(sexp);
-            *ptr.add(0) = 100;
-            *ptr.add(1) = 200;
-            *ptr.add(2) = 300;
+            let slice: &mut [i32] = sexp.as_mut_slice();
+            slice[0] = 100;
+            slice[1] = 200;
+            slice[2] = 300;
 
             let cow: Cow<'static, [i32]> = TryFromSexp::try_from_sexp(sexp).unwrap();
 

--- a/miniextendr-api/tests/tinyvec.rs
+++ b/miniextendr-api/tests/tinyvec.rs
@@ -122,14 +122,14 @@ fn arrayvec_capacity_ok() {
 #[test]
 fn arrayvec_capacity_error() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::ffi::{INTEGER, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt};
 
         // Create R vector with 10 elements
         let sexp = unsafe {
             let s = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 10));
-            let ptr = INTEGER(s);
-            for i in 0..10 {
-                *ptr.add(i) = i as i32;
+            let slice: &mut [i32] = s.as_mut_slice();
+            for (i, slot) in slice.iter_mut().enumerate() {
+                *slot = i as i32;
             }
             Rf_unprotect(1);
             s

--- a/miniextendr-macros/src/externalptr_derive.rs
+++ b/miniextendr-macros/src/externalptr_derive.rs
@@ -503,11 +503,11 @@ fn generate_setter_body(
         }
         SlotKind::ScalarRaw => {
             quote::quote! {
-                use ::miniextendr_api::ffi::{RAW, SexpExt, SEXPTYPE};
+                use ::miniextendr_api::ffi::{SexpExt, SEXPTYPE};
                 unsafe {
                     #extract_mut
                     let raw_vec = value.coerce(SEXPTYPE::RAWSXP);
-                    data.#field_name = *RAW(raw_vec);
+                    data.#field_name = raw_vec.raw_elt(0);
                     x
                 }
             }


### PR DESCRIPTION
## Summary

- Changed `INTEGER`, `REAL`, `LOGICAL`, `RAW` FFI functions from `pub` to `pub(crate)` in `miniextendr-api/src/ffi.rs` (`COMPLEX` was already `pub(crate)`)
- Updated proc-macro codegen in `externalptr_derive.rs`: `ScalarRaw` setter now uses `SexpExt::raw_elt()` instead of dereferencing `RAW()` pointer
- Migrated all integration tests from raw pointer access (`INTEGER(sexp)` + `slice::from_raw_parts`) to safe `SexpExt` methods (`as_slice`, `as_mut_slice`, `logical_elt`, `set_logical_elt`)

Supersedes #72 (closed due to conflicts with #69 which is now merged).

## Test plan

- [x] `cargo check --manifest-path=miniextendr-api/Cargo.toml`
- [x] `cargo check --manifest-path=rpkg/src/rust/Cargo.toml`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace` (all pass)
- [x] `cargo test --manifest-path=miniextendr-macros/Cargo.toml --lib` (271 pass)

Generated with [Claude Code](https://claude.com/claude-code)
