### PR TITLE
macros: support ExternalPtr self receiver in impl blocks

### DIFF
--- a/miniextendr-macros/src/method_return_builder.rs
+++ b/miniextendr-macros/src/method_return_builder.rs
@@ -3,7 +3,7 @@
 //! This module provides helpers for generating consistent return value handling
 //! across all class systems (Env, R6, S7, S3, S4).
 
-use crate::miniextendr_impl::{ParsedMethod, ReceiverKind};
+use crate::miniextendr_impl::ParsedMethod;
 
 // region: Shared R error-check code for error_in_r mode
 
@@ -105,7 +105,7 @@ impl ReturnStrategy {
     pub fn for_method(method: &ParsedMethod) -> Self {
         if method.returns_self() {
             ReturnStrategy::ReturnSelf
-        } else if method.env == ReceiverKind::RefMut && method.returns_unit() {
+        } else if method.env.is_mut() && method.returns_unit() {
             ReturnStrategy::ChainableMutation
         } else {
             ReturnStrategy::Direct

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -79,6 +79,7 @@
 //! | `&mut self` | `RefMut` | Instance method (mutable, chainable) |
 //! | `self: &ExternalPtr<Self>` | `ExternalPtrRef` | Instance method (immutable, full ExternalPtr access) |
 //! | `self: &mut ExternalPtr<Self>` | `ExternalPtrRefMut` | Instance method (mutable, full ExternalPtr access) |
+//! | `self: ExternalPtr<Self>` | `ExternalPtrValue` | Instance method (owned ExternalPtr, full access) |
 //! | `self` | `Value` | Consuming method (not supported in v1) |
 //! | (none) | `None` | Static method or constructor |
 //!
@@ -152,12 +153,15 @@ fn replace_self_in_tokens(
         .collect()
 }
 
-/// Rewrite methods with `self: &ExternalPtr<Self>` or `self: &mut ExternalPtr<Self>`
-/// receivers so they compile on stable Rust (which lacks `arbitrary_self_types`).
+/// Rewrite methods with ExternalPtr-based receivers so they compile on stable Rust
+/// (which lacks `arbitrary_self_types`).
 ///
-/// Transforms:
-/// - The `self` receiver → a regular parameter `__miniextendr_self: &[mut] ExternalPtr<Self>`
-/// - All `self` references in the method body → `__miniextendr_self`
+/// Handles:
+/// - `self: &ExternalPtr<Self>` → `__miniextendr_self: &ExternalPtr<Self>`
+/// - `self: &mut ExternalPtr<Self>` → `__miniextendr_self: &mut ExternalPtr<Self>`
+/// - `self: ExternalPtr<Self>` → `__miniextendr_self: ExternalPtr<Self>`
+///
+/// Also replaces all `self` references in the method body with `__miniextendr_self`.
 fn rewrite_external_ptr_receivers(mut item_impl: syn::ItemImpl) -> syn::ItemImpl {
     for item in &mut item_impl.items {
         let syn::ImplItem::Fn(method) = item else {
@@ -169,20 +173,32 @@ fn rewrite_external_ptr_receivers(mut item_impl: syn::ItemImpl) -> syn::ItemImpl
         if receiver.colon_token.is_none() {
             continue;
         }
-        let syn::Type::Reference(type_ref) = receiver.ty.as_ref() else {
-            continue;
-        };
-        if !is_external_ptr_type(&type_ref.elem) {
-            continue;
-        }
 
-        // This is an ExternalPtr receiver — rewrite it.
-        let mutability = type_ref.mutability;
-        let inner_ty = &type_ref.elem;
+        // Determine if this is an ExternalPtr receiver and build the replacement param.
+        let new_param: Option<syn::FnArg> =
+            if let syn::Type::Reference(type_ref) = receiver.ty.as_ref() {
+                // self: &ExternalPtr<Self> or self: &mut ExternalPtr<Self>
+                if is_external_ptr_type(&type_ref.elem) {
+                    let mutability = type_ref.mutability;
+                    let inner_ty = &type_ref.elem;
+                    Some(syn::parse_quote! {
+                        __miniextendr_self: &#mutability #inner_ty
+                    })
+                } else {
+                    None
+                }
+            } else if is_external_ptr_type(receiver.ty.as_ref()) {
+                // self: ExternalPtr<Self> (by value)
+                let inner_ty = &receiver.ty;
+                Some(syn::parse_quote! {
+                    __miniextendr_self: #inner_ty
+                })
+            } else {
+                None
+            };
 
-        // Create new first parameter: __miniextendr_self: &[mut] ExternalPtr<Self>
-        let new_param: syn::FnArg = syn::parse_quote! {
-            __miniextendr_self: &#mutability #inner_ty
+        let Some(new_param) = new_param else {
+            continue;
         };
 
         // Replace first parameter
@@ -368,6 +384,8 @@ pub enum ReceiverKind {
     ExternalPtrRef,
     /// `self: &mut ExternalPtr<Self>` — mutable borrow of the wrapping ExternalPtr
     ExternalPtrRefMut,
+    /// `self: ExternalPtr<Self>` — owned ExternalPtr (not consuming the inner T)
+    ExternalPtrValue,
 }
 
 impl ReceiverKind {
@@ -379,6 +397,7 @@ impl ReceiverKind {
                 | ReceiverKind::RefMut
                 | ReceiverKind::ExternalPtrRef
                 | ReceiverKind::ExternalPtrRefMut
+                | ReceiverKind::ExternalPtrValue
         )
     }
 
@@ -1708,9 +1727,10 @@ impl ParsedMethod {
     /// Detect the [`ReceiverKind`] from a method's function signature.
     ///
     /// Inspects the first parameter to determine whether this is a static function
-    /// (`None`), immutable borrow (`Ref`), mutable borrow (`RefMut`), or consuming
-    /// method (`Value`). Handles both standard receivers (`&self`, `&mut self`) and
-    /// typed receivers (`self: &Self`, `self: &mut Self`, `self: Box<Self>`).
+    /// (`None`), immutable borrow (`Ref`), mutable borrow (`RefMut`), consuming
+    /// method (`Value`), or ExternalPtr receiver (`ExternalPtrRef`, `ExternalPtrRefMut`,
+    /// `ExternalPtrValue`). Handles both standard receivers (`&self`, `&mut self`) and
+    /// typed receivers (`self: &Self`, `self: ExternalPtr<Self>`, etc.).
     fn detect_env(sig: &syn::Signature) -> ReceiverKind {
         match sig.inputs.first() {
             Some(syn::FnArg::Receiver(r)) => {
@@ -1736,6 +1756,9 @@ impl ParsedMethod {
                         } else {
                             ReceiverKind::Ref
                         }
+                    } else if is_external_ptr_type(r.ty.as_ref()) {
+                        // self: ExternalPtr<Self> — owned ExternalPtr
+                        ReceiverKind::ExternalPtrValue
                     } else {
                         // self: Box<Self>, self: Rc<Self>, etc. - treat as by value
                         ReceiverKind::Value
@@ -2352,6 +2375,14 @@ pub fn generate_method_c_wrapper(
                     };
                 }
             }
+            ReceiverKind::ExternalPtrValue => {
+                quote! {
+                    let __self_ptr = unsafe {
+                        ::miniextendr_api::externalptr::ExternalPtr::<#type_ident>::wrap_sexp(self_sexp)
+                            .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"))
+                    };
+                }
+            }
             _ => unreachable!(),
         };
         vec![self_extraction]
@@ -2369,6 +2400,9 @@ pub fn generate_method_c_wrapper(
         }
         ReceiverKind::ExternalPtrRefMut => {
             quote! { #type_ident::#method_ident(&mut __self_ptr, #(#rust_args),*) }
+        }
+        ReceiverKind::ExternalPtrValue => {
+            quote! { #type_ident::#method_ident(__self_ptr, #(#rust_args),*) }
         }
         ReceiverKind::None | ReceiverKind::Value => {
             quote! { #type_ident::#method_ident(#(#rust_args),*) }

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -77,6 +77,8 @@
 //! |----------|------------------|--------------|
 //! | `&self` | `Ref` | Instance method (immutable) |
 //! | `&mut self` | `RefMut` | Instance method (mutable, chainable) |
+//! | `self: &ExternalPtr<Self>` | `ExternalPtrRef` | Instance method (immutable, full ExternalPtr access) |
+//! | `self: &mut ExternalPtr<Self>` | `ExternalPtrRefMut` | Instance method (mutable, full ExternalPtr access) |
 //! | `self` | `Value` | Consuming method (not supported in v1) |
 //! | (none) | `None` | Static method or constructor |
 //!
@@ -110,7 +112,94 @@
 //! - Registration entries for R's `.Call()` interface
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
+
+/// Check if a type is `ExternalPtr<...>` (possibly fully qualified).
+fn is_external_ptr_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = ty {
+        type_path
+            .path
+            .segments
+            .last()
+            .map(|seg| seg.ident == "ExternalPtr")
+            .unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+/// Replace every occurrence of the `self` keyword/ident in a TokenStream
+/// with a replacement identifier. Does NOT touch `Self` (capital S).
+fn replace_self_in_tokens(
+    tokens: proc_macro2::TokenStream,
+    replacement: &str,
+) -> proc_macro2::TokenStream {
+    let replacement_ident = proc_macro2::Ident::new(replacement, proc_macro2::Span::call_site());
+    tokens
+        .into_iter()
+        .map(|tt| match tt {
+            proc_macro2::TokenTree::Ident(ref ident) if ident == "self" => {
+                proc_macro2::TokenTree::Ident(replacement_ident.clone())
+            }
+            proc_macro2::TokenTree::Group(group) => {
+                let new_stream = replace_self_in_tokens(group.stream(), replacement);
+                let mut new_group = proc_macro2::Group::new(group.delimiter(), new_stream);
+                new_group.set_span(group.span());
+                proc_macro2::TokenTree::Group(new_group)
+            }
+            other => other,
+        })
+        .collect()
+}
+
+/// Rewrite methods with `self: &ExternalPtr<Self>` or `self: &mut ExternalPtr<Self>`
+/// receivers so they compile on stable Rust (which lacks `arbitrary_self_types`).
+///
+/// Transforms:
+/// - The `self` receiver → a regular parameter `__miniextendr_self: &[mut] ExternalPtr<Self>`
+/// - All `self` references in the method body → `__miniextendr_self`
+fn rewrite_external_ptr_receivers(mut item_impl: syn::ItemImpl) -> syn::ItemImpl {
+    for item in &mut item_impl.items {
+        let syn::ImplItem::Fn(method) = item else {
+            continue;
+        };
+        let Some(syn::FnArg::Receiver(receiver)) = method.sig.inputs.first() else {
+            continue;
+        };
+        if receiver.colon_token.is_none() {
+            continue;
+        }
+        let syn::Type::Reference(type_ref) = receiver.ty.as_ref() else {
+            continue;
+        };
+        if !is_external_ptr_type(&type_ref.elem) {
+            continue;
+        }
+
+        // This is an ExternalPtr receiver — rewrite it.
+        let mutability = type_ref.mutability;
+        let inner_ty = &type_ref.elem;
+
+        // Create new first parameter: __miniextendr_self: &[mut] ExternalPtr<Self>
+        let new_param: syn::FnArg = syn::parse_quote! {
+            __miniextendr_self: &#mutability #inner_ty
+        };
+
+        // Replace first parameter
+        let inputs: Vec<syn::FnArg> = method.sig.inputs.iter().cloned().collect();
+        let mut new_inputs: Vec<syn::FnArg> = Vec::with_capacity(inputs.len());
+        new_inputs.push(new_param);
+        new_inputs.extend(inputs.into_iter().skip(1));
+        method.sig.inputs = new_inputs.into_iter().collect();
+
+        // Replace `self` in method body
+        let old_body = method.block.clone();
+        let new_tokens = replace_self_in_tokens(old_body.into_token_stream(), "__miniextendr_self");
+        method.block =
+            syn::parse2(new_tokens).expect("failed to reparse method body after self replacement");
+    }
+    item_impl
+}
 
 /// Strip `#[miniextendr(...)]` attributes and roxygen doc tags from an impl block and
 /// all of its items (functions, constants, types, macros).
@@ -275,12 +364,27 @@ pub enum ReceiverKind {
     RefMut,
     /// `self` - consuming (not supported in v1)
     Value,
+    /// `self: &ExternalPtr<Self>` — immutable borrow of the wrapping ExternalPtr
+    ExternalPtrRef,
+    /// `self: &mut ExternalPtr<Self>` — mutable borrow of the wrapping ExternalPtr
+    ExternalPtrRefMut,
 }
 
 impl ReceiverKind {
     /// Returns true if this is an instance method (has self).
     pub fn is_instance(&self) -> bool {
-        matches!(self, ReceiverKind::Ref | ReceiverKind::RefMut)
+        matches!(
+            self,
+            ReceiverKind::Ref
+                | ReceiverKind::RefMut
+                | ReceiverKind::ExternalPtrRef
+                | ReceiverKind::ExternalPtrRefMut
+        )
+    }
+
+    /// Returns true if this is a mutable instance receiver.
+    pub fn is_mut(&self) -> bool {
+        matches!(self, ReceiverKind::RefMut | ReceiverKind::ExternalPtrRefMut)
     }
 }
 
@@ -1618,9 +1722,16 @@ impl ParsedMethod {
                         ReceiverKind::Ref
                     }
                 } else if r.colon_token.is_some() {
-                    // Check for typed receiver (self: &Self, self: &mut Self)
+                    // Check for typed receiver (self: &Self, self: &mut Self,
+                    // self: &ExternalPtr<Self>, self: &mut ExternalPtr<Self>)
                     if let syn::Type::Reference(type_ref) = r.ty.as_ref() {
-                        if type_ref.mutability.is_some() {
+                        if is_external_ptr_type(&type_ref.elem) {
+                            if type_ref.mutability.is_some() {
+                                ReceiverKind::ExternalPtrRefMut
+                            } else {
+                                ReceiverKind::ExternalPtrRef
+                            }
+                        } else if type_ref.mutability.is_some() {
                             ReceiverKind::RefMut
                         } else {
                             ReceiverKind::Ref
@@ -1990,8 +2101,11 @@ impl ParsedImpl {
             label: attrs.label,
             doc_tags,
             methods,
-            // Strip miniextendr attributes (and roxygen tags) before re-emitting.
-            original_impl: strip_miniextendr_attrs_from_impl(item_impl),
+            // Strip miniextendr attributes (and roxygen tags) before re-emitting,
+            // then rewrite ExternalPtr receivers for stable Rust compatibility.
+            original_impl: rewrite_external_ptr_receivers(strip_miniextendr_attrs_from_impl(
+                item_impl,
+            )),
             cfg_attrs,
             vctrs_attrs: attrs.vctrs_attrs,
             r6_inherit: attrs.r6_inherit,
@@ -2203,22 +2317,42 @@ pub fn generate_method_c_wrapper(
     // Generate self extraction for instance methods
     // SEXP is now Send+Sync, so this works for both main and worker threads
     let pre_call = if method.env.is_instance() {
-        let self_extraction = if method.env == ReceiverKind::RefMut {
-            quote! {
-                let mut self_ptr = unsafe {
-                    ::miniextendr_api::externalptr::ErasedExternalPtr::from_sexp(self_sexp)
-                };
-                let self_ref = self_ptr.downcast_mut::<#type_ident>()
-                    .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"));
+        let self_extraction = match method.env {
+            ReceiverKind::RefMut => {
+                quote! {
+                    let mut self_ptr = unsafe {
+                        ::miniextendr_api::externalptr::ErasedExternalPtr::from_sexp(self_sexp)
+                    };
+                    let self_ref = self_ptr.downcast_mut::<#type_ident>()
+                        .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"));
+                }
             }
-        } else {
-            quote! {
-                let self_ptr = unsafe {
-                    ::miniextendr_api::externalptr::ErasedExternalPtr::from_sexp(self_sexp)
-                };
-                let self_ref = self_ptr.downcast_ref::<#type_ident>()
-                    .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"));
+            ReceiverKind::Ref => {
+                quote! {
+                    let self_ptr = unsafe {
+                        ::miniextendr_api::externalptr::ErasedExternalPtr::from_sexp(self_sexp)
+                    };
+                    let self_ref = self_ptr.downcast_ref::<#type_ident>()
+                        .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"));
+                }
             }
+            ReceiverKind::ExternalPtrRef => {
+                quote! {
+                    let __self_ptr = unsafe {
+                        ::miniextendr_api::externalptr::ExternalPtr::<#type_ident>::wrap_sexp(self_sexp)
+                            .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"))
+                    };
+                }
+            }
+            ReceiverKind::ExternalPtrRefMut => {
+                quote! {
+                    let mut __self_ptr = unsafe {
+                        ::miniextendr_api::externalptr::ExternalPtr::<#type_ident>::wrap_sexp(self_sexp)
+                            .expect(concat!("expected ExternalPtr<", stringify!(#type_ident), ">"))
+                    };
+                }
+            }
+            _ => unreachable!(),
         };
         vec![self_extraction]
     } else {
@@ -2226,10 +2360,19 @@ pub fn generate_method_c_wrapper(
     };
 
     // Generate call expression
-    let call_expr = if method.env.is_instance() {
-        quote! { self_ref.#method_ident(#(#rust_args),*) }
-    } else {
-        quote! { #type_ident::#method_ident(#(#rust_args),*) }
+    let call_expr = match method.env {
+        ReceiverKind::Ref | ReceiverKind::RefMut => {
+            quote! { self_ref.#method_ident(#(#rust_args),*) }
+        }
+        ReceiverKind::ExternalPtrRef => {
+            quote! { #type_ident::#method_ident(&__self_ptr, #(#rust_args),*) }
+        }
+        ReceiverKind::ExternalPtrRefMut => {
+            quote! { #type_ident::#method_ident(&mut __self_ptr, #(#rust_args),*) }
+        }
+        ReceiverKind::None | ReceiverKind::Value => {
+            quote! { #type_ident::#method_ident(#(#rust_args),*) }
+        }
     };
 
     // Determine return handling strategy

--- a/rpkg/src/rust/externalptr_self_tests.rs
+++ b/rpkg/src/rust/externalptr_self_tests.rs
@@ -1,0 +1,41 @@
+//! Tests for `self: &ExternalPtr<Self>` and `self: &mut ExternalPtr<Self>` receivers.
+
+use miniextendr_api::externalptr::ExternalPtr;
+use miniextendr_api::miniextendr;
+
+/// A test struct for ExternalPtr self-receiver methods.
+#[derive(miniextendr_api::ExternalPtr)]
+pub struct PtrSelfTest {
+    value: i32,
+}
+
+/// @name rpkg_externalptr_self
+/// @aliases PtrSelfTest
+#[miniextendr(env)]
+impl PtrSelfTest {
+    /// Create a new PtrSelfTest.
+    /// @param value Integer value.
+    pub fn new(value: i32) -> Self {
+        PtrSelfTest { value }
+    }
+
+    /// Regular &self method — returns the stored value.
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+
+    /// ExternalPtr self — can check pointer state.
+    pub fn is_null_ptr(self: &ExternalPtr<Self>) -> bool {
+        self.is_null()
+    }
+
+    /// ExternalPtr self — access inner value via Deref.
+    pub fn value_via_ptr(self: &ExternalPtr<Self>) -> i32 {
+        self.value
+    }
+
+    /// Mutable ExternalPtr self — modify inner value via DerefMut.
+    pub fn set_value_via_ptr(self: &mut ExternalPtr<Self>, new_val: i32) {
+        self.value = new_val;
+    }
+}

--- a/rpkg/src/rust/externalptr_self_tests.rs
+++ b/rpkg/src/rust/externalptr_self_tests.rs
@@ -1,4 +1,5 @@
-//! Tests for `self: &ExternalPtr<Self>` and `self: &mut ExternalPtr<Self>` receivers.
+//! Tests for ExternalPtr-based self receivers:
+//! `self: &ExternalPtr<Self>`, `self: &mut ExternalPtr<Self>`, and `self: ExternalPtr<Self>`.
 
 use miniextendr_api::externalptr::ExternalPtr;
 use miniextendr_api::miniextendr;
@@ -37,5 +38,10 @@ impl PtrSelfTest {
     /// Mutable ExternalPtr self — modify inner value via DerefMut.
     pub fn set_value_via_ptr(self: &mut ExternalPtr<Self>, new_val: i32) {
         self.value = new_val;
+    }
+
+    /// By-value ExternalPtr self — access inner value via Deref on owned ptr.
+    pub fn value_owned_ptr(self: ExternalPtr<Self>) -> i32 {
+        self.value
     }
 }

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -150,6 +150,7 @@ mod encoding_tests;
 mod error_in_r_tests;
 mod export_control_tests;
 mod externalptr_any_tests;
+mod externalptr_self_tests;
 mod externalptr_tests;
 mod externalslice_tests;
 mod factor_tests;

--- a/rpkg/tests/testthat/test-externalptr-self.R
+++ b/rpkg/tests/testthat/test-externalptr-self.R
@@ -1,0 +1,12 @@
+test_that("ExternalPtr self receiver works", {
+  obj <- PtrSelfTest$new(42L)
+  expect_equal(obj$value(), 42L)
+  expect_false(obj$is_null_ptr())
+  expect_equal(obj$value_via_ptr(), 42L)
+})
+
+test_that("Mutable ExternalPtr self receiver works", {
+  obj <- PtrSelfTest$new(10L)
+  obj$set_value_via_ptr(20L)
+  expect_equal(obj$value(), 20L)
+})

--- a/rpkg/tests/testthat/test-externalptr-self.R
+++ b/rpkg/tests/testthat/test-externalptr-self.R
@@ -10,3 +10,8 @@ test_that("Mutable ExternalPtr self receiver works", {
   obj$set_value_via_ptr(20L)
   expect_equal(obj$value(), 20L)
 })
+
+test_that("By-value ExternalPtr self receiver works", {
+  obj <- PtrSelfTest$new(99L)
+  expect_equal(obj$value_owned_ptr(), 99L)
+})


### PR DESCRIPTION
## Summary

- Allow `self: &ExternalPtr<Self>` and `self: &mut ExternalPtr<Self>` receivers in `#[miniextendr]` impl blocks
- Methods gain access to the wrapping ExternalPtr (`.as_sexp()`, `.tag()`, `.protected()`, `.ptr_eq()`, etc.) while still accessing inner T via Deref
- The macro rewrites these for stable Rust compatibility (`arbitrary_self_types` is unstable) — `self` is replaced with `__miniextendr_self` in the emitted impl block
- C wrapper codegen uses typed `ExternalPtr::<T>::wrap_sexp()` instead of erased downcast
- Added `ReceiverKind::ExternalPtrRef` / `ExternalPtrRefMut` variants
- Added `is_mut()` helper, updated all ReceiverKind match sites

### User-facing API

```rust
#[miniextendr(env)]
impl MyType {
    // Regular — gets &MyType
    pub fn value(&self) -> i32 { self.value }

    // NEW — gets &ExternalPtr<MyType>, Deref still works
    pub fn is_null_ptr(self: &ExternalPtr<Self>) -> bool {
        self.is_null()
    }

    // NEW — gets &mut ExternalPtr<MyType>
    pub fn set_value_via_ptr(self: &mut ExternalPtr<Self>, v: i32) {
        self.value = v;  // via DerefMut
    }
}
```

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean
- [x] `cargo test` — 271 macro tests pass, all UI tests pass
- [x] `cargo fmt` — formatted
- [x] Lint check on rpkg clean
- [ ] `just rcmdinstall && just devtools-test` (R integration tests, requires rebuild)

Generated with [Claude Code](https://claude.com/claude-code)
