### PR TITLE
api: add ExternalPtr::reborrow() for identity-preserving returns

### DIFF
--- a/miniextendr-api/src/externalptr.rs
+++ b/miniextendr-api/src/externalptr.rs
@@ -714,6 +714,37 @@ impl<T: TypedExternal> ExternalPtr<T> {
         self.sexp
     }
 
+    /// Create a lightweight alias of this ExternalPtr sharing the same R object.
+    ///
+    /// The returned `ExternalPtr` points to the **same** underlying EXTPTRSXP.
+    /// No data is copied and no new R object is allocated -- both the original
+    /// and the alias refer to the same R-level external pointer.
+    ///
+    /// This is the correct way to return "self" from a method that takes
+    /// `self: &ExternalPtr<Self>`, preserving R object identity:
+    ///
+    /// ```ignore
+    /// #[miniextendr(env)]
+    /// impl MyType {
+    ///     pub fn identity(self: &ExternalPtr<Self>) -> ExternalPtr<Self> {
+    ///         self.reborrow()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Safety note
+    ///
+    /// The caller must not use the original and the alias to create overlapping
+    /// mutable references (`as_mut`). In typical use (returning from a method),
+    /// the borrow of the original ends when the method returns, so this is safe.
+    #[inline]
+    pub fn reborrow(&self) -> Self {
+        // SAFETY: self.sexp is a valid live EXTPTRSXP that we already hold.
+        // wrap_sexp re-extracts the data pointer from the same SEXP.
+        unsafe { Self::wrap_sexp(self.sexp) }
+            .expect("reborrow of live ExternalPtr should never fail")
+    }
+
     /// Returns the tag SEXP (type identifier symbol).
     #[inline]
     pub fn tag(&self) -> SEXP {

--- a/rpkg/src/rust/externalptr_identity_tests.rs
+++ b/rpkg/src/rust/externalptr_identity_tests.rs
@@ -1,0 +1,53 @@
+//! Tests for ExternalPtr identity preservation through function round-trips.
+//!
+//! Verifies that passing an ExternalPtr through a Rust function and back
+//! returns the **same** R object (same SEXP), not a deep copy.
+
+use miniextendr_api::externalptr::ExternalPtr;
+use miniextendr_api::miniextendr;
+
+/// A simple struct for identity-preservation tests.
+#[derive(miniextendr_api::ExternalPtr)]
+pub struct PtrIdentityTest {
+    value: i32,
+}
+
+#[miniextendr(env)]
+impl PtrIdentityTest {
+    pub fn new(value: i32) -> Self {
+        PtrIdentityTest { value }
+    }
+
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+}
+
+/// Returns the ExternalPtr unchanged -- should preserve R identity.
+/// @param x An ExternalPtr wrapping a PtrIdentityTest.
+#[miniextendr]
+/// @name rpkg_externalptr_identity
+/// @examples
+/// a <- PtrIdentityTest$new(10L)
+/// b <- ptr_identity(a)
+/// identical(a, b) # TRUE
+/// @aliases ptr_identity ptr_pick_larger
+pub fn ptr_identity(x: ExternalPtr<PtrIdentityTest>) -> ExternalPtr<PtrIdentityTest> {
+    x
+}
+
+/// Takes two ExternalPtrs, returns the one with the larger value.
+/// The returned SEXP should be the same as the input's SEXP.
+/// @param a An ExternalPtr wrapping a PtrIdentityTest.
+/// @param b An ExternalPtr wrapping a PtrIdentityTest.
+#[miniextendr]
+pub fn ptr_pick_larger(
+    a: ExternalPtr<PtrIdentityTest>,
+    b: ExternalPtr<PtrIdentityTest>,
+) -> ExternalPtr<PtrIdentityTest> {
+    if a.value >= b.value {
+        a
+    } else {
+        b
+    }
+}

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -34,6 +34,7 @@
 //! - [`dots_tests`]: R dots (`...`) handling tests
 //! - [`default_tests`]: Default parameter value tests
 //! - [`externalptr_tests`]: ExternalPtr functionality tests
+//! - [`externalptr_identity_tests`]: ExternalPtr identity preservation tests
 //! - [`visibility_tests`]: R return value visibility tests
 //! - [`identical_tests`]: R identical() comparison tests
 //! - [`factor_tests`]: R factor handling tests
@@ -150,6 +151,7 @@ mod encoding_tests;
 mod error_in_r_tests;
 mod export_control_tests;
 mod externalptr_any_tests;
+mod externalptr_identity_tests;
 mod externalptr_self_tests;
 mod externalptr_tests;
 mod externalslice_tests;

--- a/rpkg/tests/testthat/test-externalptr-identity.R
+++ b/rpkg/tests/testthat/test-externalptr-identity.R
@@ -1,0 +1,35 @@
+test_that("ExternalPtr round-trip preserves identity", {
+  a <- PtrIdentityTest$new(10L)
+  b <- ptr_identity(a)
+  # Both should be the exact same R object (same SEXP)
+  expect_identical(a, b)
+})
+
+test_that("ptr_pick_larger returns the correct ExternalPtr with identity", {
+  a <- PtrIdentityTest$new(10L)
+  b <- PtrIdentityTest$new(20L)
+
+  # b has larger value, so result should be identical to b
+
+  result <- ptr_pick_larger(a, b)
+  expect_identical(result, b)
+
+  # Reversed args: b still has larger value
+  result2 <- ptr_pick_larger(b, a)
+  expect_identical(result2, b)
+})
+
+test_that("ptr_pick_larger with equal values returns first arg", {
+  a <- PtrIdentityTest$new(5L)
+  b <- PtrIdentityTest$new(5L)
+
+  # When equal, a (first arg) is returned (>= check)
+  result <- ptr_pick_larger(a, b)
+  expect_identical(result, a)
+})
+
+test_that("ExternalPtr identity preserved through multiple round-trips", {
+  a <- PtrIdentityTest$new(42L)
+  b <- ptr_identity(ptr_identity(ptr_identity(a)))
+  expect_identical(a, b)
+})


### PR DESCRIPTION
## Summary

- Add `ExternalPtr::reborrow(&self) -> Self` — creates a lightweight Rust-side alias sharing the same underlying SEXP, with no data copy or R allocation
- Completes the identity-preservation story: `TryFromSexp` preserves SEXP via `wrap_sexp`, `IntoR` preserves via `as_sexp()`, and now `reborrow()` handles the borrowed-to-owned case (`&ExternalPtr<T>` → `ExternalPtr<T>`)
- When a method receives multiple ExternalPtrs and returns one, the correct SEXP is returned to R (no re-creation)

### Use case

```rust
// Without reborrow — deep copy, new R object:
let copy = self.clone();  // BAD: new allocation, new SEXP

// With reborrow — same R object:
let alias = self.reborrow();  // GOOD: same SEXP, no allocation
```

### Identity verification

Added test fixtures (`ptr_identity`, `ptr_pick_larger`) and R tests that verify `identical(a, f(a))` holds — the returned R object is the **same** external pointer, not a copy.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean
- [x] `cargo test` passes
- [ ] `just rcmdinstall && just devtools-test` (R integration, requires rebuild)

Generated with [Claude Code](https://claude.com/claude-code)
