### PR TITLE
rpkg: fix all 36 rustdoc warnings

### DIFF
--- a/rpkg/src/rust/externalptr_any_tests.rs
+++ b/rpkg/src/rust/externalptr_any_tests.rs
@@ -1,7 +1,7 @@
-//! Test fixtures for ExternalPtr Box<dyn Any> storage.
+//! Test fixtures for `ExternalPtr` `Box<dyn Any>` storage.
 //!
 //! Verifies the Any-based type checking, non-generic finalizer,
-//! and downcast paths introduced by the Box<Box<dyn Any>> refactor.
+//! and downcast paths introduced by the `Box<Box<dyn Any>>` refactor.
 
 use miniextendr_api::externalptr::{ErasedExternalPtr, ExternalPtr};
 use miniextendr_api::ffi::SEXP;

--- a/rpkg/src/rust/lazy_tests.rs
+++ b/rpkg/src/rust/lazy_tests.rs
@@ -1,4 +1,4 @@
-//! Test fixtures for Lazy<T> ALTREP wrappers.
+//! Test fixtures for `Lazy<T>` ALTREP wrappers.
 
 use miniextendr_api::into_r::Altrep;
 type Lazy<T> = Altrep<T>;

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - [`panic_tests`]: Panic, drop, and R error handling tests
 //! - [`unwind_protect_tests`]: `with_r_unwind_protect` mechanism tests
-//! - [`worker_tests`]: Worker thread and `with_r_thread` tests
+//! - `worker_tests`: Worker thread and `with_r_thread` tests
 //! - [`thread_tests`]: RThreadBuilder and thread safety tests
 //! - [`interrupt_tests`]: R interrupt checking tests
 //!
@@ -48,37 +48,37 @@
 //!
 //! These modules require specific Cargo features to be enabled:
 //!
-//! - [`rayon_tests`]: Parallel iteration tests (feature: `rayon`)
-//! - [`serde_r_tests`]: Serde R serialization tests (feature: `serde`)
-//! - [`ndarray_tests`]: N-dimensional array tests (feature: `ndarray`)
-//! - [`vctrs_tests`]: vctrs compatibility tests (feature: `vctrs`)
-//! - [`vctrs_class_example`]: vctrs class implementation example (feature: `vctrs`)
-//! - [`nonapi`]: Non-API R internals tests (feature: `nonapi`)
-//! - [`connection_tests`]: R connection handling tests (feature: `connections`)
+//! - `rayon_tests`: Parallel iteration tests (feature: `rayon`)
+//! - `serde_r_tests`: Serde R serialization tests (feature: `serde`)
+//! - `ndarray_tests`: N-dimensional array tests (feature: `ndarray`)
+//! - `vctrs_tests`: vctrs compatibility tests (feature: `vctrs`)
+//! - `vctrs_class_example`: vctrs class implementation example (feature: `vctrs`)
+//! - `nonapi`: Non-API R internals tests (feature: `nonapi`)
+//! - `connection_tests`: R connection handling tests (feature: `connections`)
 //!
 //! # Adapter Tests (Feature-Gated)
 //!
 //! Each adapter has its own feature flag:
 //!
-//! - [`uuid_adapter_tests`]: UUID type adapter (feature: `uuid`)
-//! - [`regex_adapter_tests`]: Regex type adapter (feature: `regex`)
-//! - [`time_adapter_tests`]: Time/date type adapter (feature: `time`)
-//! - [`ordered_float_adapter_tests`]: OrderedFloat adapter (feature: `ordered-float`)
-//! - [`bigint_adapter_tests`]: BigInt type adapter (feature: `num-bigint`)
-//! - [`decimal_adapter_tests`]: Decimal type adapter (feature: `rust_decimal`)
-//! - [`indexmap_adapter_tests`]: IndexMap type adapter (feature: `indexmap`)
-//! - [`bytes_adapter_tests`]: Bytes/BytesMut adapter (feature: `bytes`)
-//! - [`bitflags_adapter_tests`]: Bitflags adapter (feature: `bitflags`)
-//! - [`bitvec_adapter_tests`]: BitVec adapter (feature: `bitvec`)
-//! - [`tinyvec_adapter_tests`]: TinyVec/ArrayVec adapter (feature: `tinyvec`)
-//! - [`sha2_adapter_tests`]: SHA-2 hashing adapter (feature: `sha2`)
-//! - [`url_adapter_tests`]: URL parsing adapter (feature: `url`)
-//! - [`aho_corasick_adapter_tests`]: Aho-Corasick string search adapter (feature: `aho-corasick`)
-//! - [`toml_adapter_tests`]: TOML parsing adapter (feature: `toml`)
-//! - [`tabled_adapter_tests`]: Table formatting adapter (feature: `tabled`)
-//! - [`nalgebra_adapter_tests`]: Linear algebra adapter (feature: `nalgebra`)
-//! - [`either_adapter_tests`]: Either type adapter (feature: `either`)
-//! - [`serde_json_adapter_tests`]: JSON serialization adapter (feature: `serde_json`)
+//! - `uuid_adapter_tests`: UUID type adapter (feature: `uuid`)
+//! - `regex_adapter_tests`: Regex type adapter (feature: `regex`)
+//! - `time_adapter_tests`: Time/date type adapter (feature: `time`)
+//! - `ordered_float_adapter_tests`: OrderedFloat adapter (feature: `ordered-float`)
+//! - `bigint_adapter_tests`: BigInt type adapter (feature: `num-bigint`)
+//! - `decimal_adapter_tests`: Decimal type adapter (feature: `rust_decimal`)
+//! - `indexmap_adapter_tests`: IndexMap type adapter (feature: `indexmap`)
+//! - `bytes_adapter_tests`: Bytes/BytesMut adapter (feature: `bytes`)
+//! - `bitflags_adapter_tests`: Bitflags adapter (feature: `bitflags`)
+//! - `bitvec_adapter_tests`: BitVec adapter (feature: `bitvec`)
+//! - `tinyvec_adapter_tests`: TinyVec/ArrayVec adapter (feature: `tinyvec`)
+//! - `sha2_adapter_tests`: SHA-2 hashing adapter (feature: `sha2`)
+//! - `url_adapter_tests`: URL parsing adapter (feature: `url`)
+//! - `aho_corasick_adapter_tests`: Aho-Corasick string search adapter (feature: `aho-corasick`)
+//! - `toml_adapter_tests`: TOML parsing adapter (feature: `toml`)
+//! - `tabled_adapter_tests`: Table formatting adapter (feature: `tabled`)
+//! - `nalgebra_adapter_tests`: Linear algebra adapter (feature: `nalgebra`)
+//! - `either_adapter_tests`: Either type adapter (feature: `either`)
+//! - `serde_json_adapter_tests`: JSON serialization adapter (feature: `serde_json`)
 //!
 //! # Miscellaneous
 //!
@@ -1451,7 +1451,7 @@ pub fn iter_real_from_f32(n: i32) -> Altrep<Vec<f64>> {
     Altrep((0..len).map(|i| i as f64 * 1.5).collect())
 }
 
-/// Create a Vec<i32> ALTREP integer vector.
+/// Create a `Vec<i32>` ALTREP integer vector.
 /// @rdname altrep_vec
 /// @param n Number of elements.
 /// @return An ALTREP integer vector (1..=n).
@@ -1462,7 +1462,7 @@ pub fn vec_int_altrep(n: i32) -> Altrep<Vec<i32>> {
     Altrep((1..=len as i32).collect())
 }
 
-/// Create a Vec<f64> ALTREP real vector.
+/// Create a `Vec<f64>` ALTREP real vector.
 /// @rdname altrep_vec
 /// @param n Number of elements.
 /// @return An ALTREP real vector (0.5, 1.0, 1.5, ...).
@@ -1473,7 +1473,7 @@ pub fn vec_real_altrep(n: i32) -> Altrep<Vec<f64>> {
     Altrep((1..=len).map(|i| i as f64 * 0.5).collect())
 }
 
-/// Create a Vec<Rcomplex> ALTREP complex vector.
+/// Create a `Vec<Rcomplex>` ALTREP complex vector.
 /// @rdname altrep_vec
 /// @param n Number of elements.
 /// @return An ALTREP complex vector (k + -k*i for k in 0..n).
@@ -1569,7 +1569,7 @@ pub fn boxed_complex(n: i32) -> Altrep<Box<[Rcomplex]>> {
     Altrep(data)
 }
 
-/// Create a Range<i32> ALTREP integer vector.
+/// Create a `Range<i32>` ALTREP integer vector.
 /// @rdname altrep_vec
 /// @param from Start of range (inclusive).
 /// @param to End of range (exclusive).
@@ -1580,7 +1580,7 @@ pub fn range_int_altrep(from: i32, to: i32) -> Altrep<std::ops::Range<i32>> {
     Altrep(from..to)
 }
 
-/// Create a Range<i64> ALTREP real vector (i64 stored as f64 bit patterns).
+/// Create a `Range<i64>` ALTREP real vector (i64 stored as f64 bit patterns).
 /// @rdname altrep_vec
 /// @param from Start of range (inclusive).
 /// @param to End of range (exclusive).
@@ -1591,7 +1591,7 @@ pub fn range_i64_altrep(from: i64, to: i64) -> Altrep<std::ops::Range<i64>> {
     Altrep(from..to)
 }
 
-/// Create a Range<f64> ALTREP real vector.
+/// Create a `Range<f64>` ALTREP real vector.
 /// @rdname altrep_vec
 /// @param from Start of range (inclusive).
 /// @param to End of range (exclusive).


### PR DESCRIPTION
## Summary

- Fix 27 broken intra-doc links in `lib.rs` — feature-gated module references used link syntax but aren't in scope during doc generation. Converted to backtick-quoted names.
- Fix 9 unclosed HTML tag warnings — generic types like `Vec<i32>`, `Box<dyn Any>`, `Lazy<T>` in doc comments need backtick-quoting to avoid being parsed as HTML tags.

## Test plan

- [x] `RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps` — zero warnings
- [x] `cargo check` — clean
- [x] `cargo clippy` — clean

Generated with [Claude Code](https://claude.com/claude-code)
