### PR TITLE
fix ALTREP: stale methods, silent unknown keys, missing subset

### DIFF
--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -957,8 +957,12 @@ macro_rules! __impl_altinteger_methods {
 /// // With serialization (type must implement AltrepSerialize):
 /// impl_altreal_from_data!(MyType, serialize);
 ///
-/// // With both dataptr and serialization:
+/// // With subset optimization (type must implement AltrepExtractSubset):
+/// impl_altreal_from_data!(MyType, subset);
+///
+/// // Combine multiple options:
 /// impl_altreal_from_data!(MyType, dataptr, serialize);
+/// impl_altreal_from_data!(MyType, subset, serialize);
 /// ```
 #[macro_export]
 macro_rules! impl_altreal_from_data {
@@ -993,6 +997,21 @@ macro_rules! impl_altreal_from_data {
     };
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altreal_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, subset) => {
+        $crate::__impl_alt_from_data!($ty, __impl_altreal_methods, impl_inferbase_real, subset);
+    };
+    ($ty:ty, subset, serialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altreal_methods,
+            impl_inferbase_real,
+            subset,
+            serialize
+        );
+    };
+    ($ty:ty, serialize, subset) => {
+        $crate::impl_altreal_from_data!($ty, subset, serialize);
     };
     // Materializing dataptr only (no serialization)
     ($ty:ty, materializing_dataptr) => {
@@ -1067,8 +1086,12 @@ macro_rules! __impl_altreal_methods {
 /// // With serialization (type must implement AltrepSerialize):
 /// impl_altlogical_from_data!(MyType, serialize);
 ///
-/// // With both dataptr and serialization:
+/// // With subset optimization (type must implement AltrepExtractSubset):
+/// impl_altlogical_from_data!(MyType, subset);
+///
+/// // Combine multiple options:
 /// impl_altlogical_from_data!(MyType, dataptr, serialize);
+/// impl_altlogical_from_data!(MyType, subset, serialize);
 /// ```
 #[macro_export]
 macro_rules! impl_altlogical_from_data {
@@ -1103,6 +1126,26 @@ macro_rules! impl_altlogical_from_data {
     };
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altlogical_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, subset) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altlogical_methods,
+            impl_inferbase_logical,
+            subset
+        );
+    };
+    ($ty:ty, subset, serialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altlogical_methods,
+            impl_inferbase_logical,
+            subset,
+            serialize
+        );
+    };
+    ($ty:ty, serialize, subset) => {
+        $crate::impl_altlogical_from_data!($ty, subset, serialize);
     };
     // Materializing dataptr only (no serialization)
     ($ty:ty, materializing_dataptr) => {
@@ -1176,8 +1219,12 @@ macro_rules! __impl_altlogical_methods {
 /// // With serialization (type must implement AltrepSerialize):
 /// impl_altraw_from_data!(MyType, serialize);
 ///
-/// // With both dataptr and serialization:
+/// // With subset optimization (type must implement AltrepExtractSubset):
+/// impl_altraw_from_data!(MyType, subset);
+///
+/// // Combine multiple options:
 /// impl_altraw_from_data!(MyType, dataptr, serialize);
+/// impl_altraw_from_data!(MyType, subset, serialize);
 /// ```
 #[macro_export]
 macro_rules! impl_altraw_from_data {
@@ -1208,6 +1255,21 @@ macro_rules! impl_altraw_from_data {
     ($ty:ty, serialize, dataptr) => {
         $crate::impl_altraw_from_data!($ty, dataptr, serialize);
     };
+    ($ty:ty, subset) => {
+        $crate::__impl_alt_from_data!($ty, __impl_altraw_methods, impl_inferbase_raw, subset);
+    };
+    ($ty:ty, subset, serialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altraw_methods,
+            impl_inferbase_raw,
+            subset,
+            serialize
+        );
+    };
+    ($ty:ty, serialize, subset) => {
+        $crate::impl_altraw_from_data!($ty, subset, serialize);
+    };
 }
 
 /// Internal macro for AltRaw method implementations.
@@ -1231,8 +1293,18 @@ macro_rules! __impl_altraw_methods {
 /// // Basic (no serialization):
 /// impl_altstring_from_data!(MyType);
 ///
+/// // With dataptr (materialized STRSXP):
+/// impl_altstring_from_data!(MyType, dataptr);
+///
 /// // With serialization (type must implement AltrepSerialize):
 /// impl_altstring_from_data!(MyType, serialize);
+///
+/// // With subset optimization (type must implement AltrepExtractSubset):
+/// impl_altstring_from_data!(MyType, subset);
+///
+/// // Combine multiple options:
+/// impl_altstring_from_data!(MyType, dataptr, serialize);
+/// impl_altstring_from_data!(MyType, subset, serialize);
 /// ```
 #[macro_export]
 macro_rules! impl_altstring_from_data {
@@ -1264,6 +1336,21 @@ macro_rules! impl_altstring_from_data {
             string_dataptr,
             serialize
         );
+    };
+    ($ty:ty, subset) => {
+        $crate::__impl_alt_from_data!($ty, __impl_altstring_methods, impl_inferbase_string, subset);
+    };
+    ($ty:ty, subset, serialize) => {
+        $crate::__impl_alt_from_data!(
+            $ty,
+            __impl_altstring_methods,
+            impl_inferbase_string,
+            subset,
+            serialize
+        );
+    };
+    ($ty:ty, serialize, subset) => {
+        $crate::impl_altstring_from_data!($ty, subset, serialize);
     };
 }
 

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -115,6 +115,7 @@ fn generate_explicit_setters(base_name: &str, tramp_ty: &syn::Type) -> proc_macr
                     "t_lgl_is_sorted",
                 ),
                 ("HAS_NO_NA", "R_set_altlogical_No_NA_method", "t_lgl_no_na"),
+                ("HAS_SUM", "R_set_altlogical_Sum_method", "t_lgl_sum"),
             ][..],
             &[][..],
         ),
@@ -488,7 +489,9 @@ pub(crate) fn generate_altrep_impls(
             // Base optional methods
             set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_SERIALIZED_STATE, R_set_altrep_Serialized_state_method, bridge::t_serialized_state::<#tramp_ty>);
             set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_UNSERIALIZE, R_set_altrep_Unserialize_method, bridge::t_unserialize::<#tramp_ty>);
+            set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_UNSERIALIZE_EX, R_set_altrep_UnserializeEX_method, bridge::t_unserialize_ex::<#tramp_ty>);
             set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_DUPLICATE, R_set_altrep_Duplicate_method, bridge::t_duplicate::<#tramp_ty>);
+            set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_DUPLICATE_EX, R_set_altrep_DuplicateEX_method, bridge::t_duplicate_ex::<#tramp_ty>);
             set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_COERCE, R_set_altrep_Coerce_method, bridge::t_coerce::<#tramp_ty>);
             set_if!(<#tramp_ty as ::miniextendr_api::altrep_traits::Altrep>::HAS_INSPECT, R_set_altrep_Inspect_method, bridge::t_inspect::<#tramp_ty>);
 

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -87,11 +87,12 @@ impl AltrepAttrs {
     /// Parses all `#[altrep(...)]` attributes from a derive input struct.
     ///
     /// Multiple `#[altrep(...)]` attributes are supported and their contents are merged.
-    /// Unknown keys are silently ignored.
+    /// Unknown keys produce a compile error.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if an `#[altrep(...)]` attribute has malformed syntax.
+    /// Returns `Err` if an `#[altrep(...)]` attribute has malformed syntax or contains
+    /// an unknown key.
     fn parse(input: &syn::DeriveInput) -> syn::Result<Self> {
         let mut len_field = None;
         let mut elt_field = None;
@@ -132,6 +133,12 @@ impl AltrepAttrs {
                     guard = Some(syn::Ident::new("RustUnwind", meta.path.span()));
                 } else if meta.path.is_ident("r_unwind") {
                     guard = Some(syn::Ident::new("RUnwind", meta.path.span()));
+                } else {
+                    return Err(meta.error(
+                        "unknown #[altrep(...)] attribute; expected one of: \
+                         `len`, `elt`, `elt_delegate`, `no_lowlevel`, `dataptr`, \
+                         `serialize`, `subset`, `unsafe`, `rust_unwind`, `r_unwind`",
+                    ));
                 }
                 Ok(())
             })?;

--- a/miniextendr-macros/tests/ui/derive_altrep_unknown_option.rs
+++ b/miniextendr-macros/tests/ui/derive_altrep_unknown_option.rs
@@ -1,0 +1,11 @@
+//! Test: ALTREP derive rejects unknown #[altrep(...)] keys.
+
+use miniextendr_macros::AltrepInteger;
+
+#[derive(AltrepInteger)]
+#[altrep(typo_option)]
+struct MyData {
+    len: usize,
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_altrep_unknown_option.stderr
+++ b/miniextendr-macros/tests/ui/derive_altrep_unknown_option.stderr
@@ -1,0 +1,5 @@
+error: unknown #[altrep(...)] attribute; expected one of: `len`, `elt`, `elt_delegate`, `no_lowlevel`, `dataptr`, `serialize`, `subset`, `unsafe`, `rust_unwind`, `r_unwind`
+ --> tests/ui/derive_altrep_unknown_option.rs:6:10
+  |
+6 | #[altrep(typo_option)]
+  |          ^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- **Explicit-base registration path** now installs `HAS_UNSERIALIZE_EX`, `HAS_DUPLICATE_EX`, and `HAS_SUM` (logical family), matching the bridge installers in `altrep_bridge.rs`
- **`#[altrep(...)]` derive parser** now errors on unknown keys instead of silently ignoring them (typos previously caused silent capability degradation)
- **Runtime macros** `impl_altreal_from_data!`, `impl_altlogical_from_data!`, `impl_altraw_from_data!`, and `impl_altstring_from_data!` now support `subset` and `subset, serialize` variants, matching the derive layer

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 90 UI tests, all unit tests)
- [x] `cargo fmt --check` passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)
