### PR TITLE
refactor: encapsulate FFI behind types and traits

### DIFF
--- a/miniextendr-api/src/altrep.rs
+++ b/miniextendr-api/src/altrep.rs
@@ -11,7 +11,10 @@
 //!   - Creates the class handle via `R_make_alt*`
 //!   - Installs methods based on trait bounds and HAS_* consts
 
-use crate::ffi::altrep::*;
+use crate::ffi::altrep::{
+    R_altrep_class_t, R_make_altcomplex_class, R_make_altinteger_class, R_make_altlist_class,
+    R_make_altlogical_class, R_make_altraw_class, R_make_altreal_class, R_make_altstring_class,
+};
 use std::ffi::CStr;
 use std::sync::Mutex;
 

--- a/miniextendr-api/src/altrep_bridge.rs
+++ b/miniextendr-api/src/altrep_bridge.rs
@@ -13,7 +13,7 @@ use crate::altrep_traits::{
     AltComplex, AltInteger, AltList, AltLogical, AltRaw, AltReal, AltString, AltVec, Altrep,
     AltrepGuard,
 };
-use crate::ffi::altrep::*;
+use crate::ffi::altrep::R_altrep_class_t;
 use crate::ffi::*;
 use core::ffi::c_void;
 
@@ -430,29 +430,29 @@ pub unsafe extern "C-unwind" fn t_list_set_elt<T: AltList>(x: SEXP, i: R_xlen_t,
 /// Must be called during R initialization with a valid ALTREP class handle.
 pub unsafe fn install_base<T: Altrep>(cls: R_altrep_class_t) {
     // Length is ALWAYS installed (required)
-    unsafe { R_set_altrep_Length_method(cls, Some(t_length::<T>)) };
+    unsafe { cls.set_length_method(Some(t_length::<T>)) };
 
     // Optional methods - only install if HAS_* = true
     if T::HAS_SERIALIZED_STATE {
-        unsafe { R_set_altrep_Serialized_state_method(cls, Some(t_serialized_state::<T>)) };
+        unsafe { cls.set_serialized_state_method(Some(t_serialized_state::<T>)) };
     }
     if T::HAS_UNSERIALIZE {
-        unsafe { R_set_altrep_Unserialize_method(cls, Some(t_unserialize::<T>)) };
+        unsafe { cls.set_unserialize_method(Some(t_unserialize::<T>)) };
     }
     if T::HAS_UNSERIALIZE_EX {
-        unsafe { R_set_altrep_UnserializeEX_method(cls, Some(t_unserialize_ex::<T>)) };
+        unsafe { cls.set_unserialize_ex_method(Some(t_unserialize_ex::<T>)) };
     }
     if T::HAS_DUPLICATE {
-        unsafe { R_set_altrep_Duplicate_method(cls, Some(t_duplicate::<T>)) };
+        unsafe { cls.set_duplicate_method(Some(t_duplicate::<T>)) };
     }
     if T::HAS_DUPLICATE_EX {
-        unsafe { R_set_altrep_DuplicateEX_method(cls, Some(t_duplicate_ex::<T>)) };
+        unsafe { cls.set_duplicate_ex_method(Some(t_duplicate_ex::<T>)) };
     }
     if T::HAS_COERCE {
-        unsafe { R_set_altrep_Coerce_method(cls, Some(t_coerce::<T>)) };
+        unsafe { cls.set_coerce_method(Some(t_coerce::<T>)) };
     }
     if T::HAS_INSPECT {
-        unsafe { R_set_altrep_Inspect_method(cls, Some(t_inspect::<T>)) };
+        unsafe { cls.set_inspect_method(Some(t_inspect::<T>)) };
     }
 }
 
@@ -461,48 +461,48 @@ pub unsafe fn install_base<T: Altrep>(cls: R_altrep_class_t) {
 /// Must be called during R initialization with a valid ALTREP class handle.
 pub unsafe fn install_vec<T: AltVec>(cls: R_altrep_class_t) {
     if T::HAS_DATAPTR {
-        unsafe { R_set_altvec_Dataptr_method(cls, Some(t_dataptr::<T>)) };
+        unsafe { cls.set_dataptr_method(Some(t_dataptr::<T>)) };
     }
     if T::HAS_DATAPTR_OR_NULL {
-        unsafe { R_set_altvec_Dataptr_or_null_method(cls, Some(t_dataptr_or_null::<T>)) };
+        unsafe { cls.set_dataptr_or_null_method(Some(t_dataptr_or_null::<T>)) };
     }
     if T::HAS_EXTRACT_SUBSET {
-        unsafe { R_set_altvec_Extract_subset_method(cls, Some(t_extract_subset::<T>)) };
+        unsafe { cls.set_extract_subset_method(Some(t_extract_subset::<T>)) };
     }
 }
 
 /// Generate a family-specific installer function from a declarative spec.
 ///
-/// Each entry maps a `HAS_*` const to a setter function and trampoline.
+/// Each entry maps a `HAS_*` const to a method on `R_altrep_class_t` and a trampoline.
 /// Optional `always` entries are installed unconditionally (e.g. required Elt).
 macro_rules! def_installer {
     (
         $(#[$meta:meta])*
         $fn_name:ident < T: $trait:ident > {
-            $( $has:ident => $setter:path, $tramp:ident; )*
+            $( $has:ident => $method:ident, $tramp:ident; )*
         }
     ) => {
         $(#[$meta])*
         pub unsafe fn $fn_name<T: $trait>(cls: R_altrep_class_t) {
             $(
-                if T::$has { unsafe { $setter(cls, Some($tramp::<T>)) } }
+                if T::$has { unsafe { cls.$method(Some($tramp::<T>)) } }
             )*
         }
     };
     (
         $(#[$meta:meta])*
         $fn_name:ident < T: $trait:ident > {
-            $( $has:ident => $setter:path, $tramp:ident; )*
+            $( $has:ident => $method:ident, $tramp:ident; )*
         }
-        always { $( $always_setter:path, $always_tramp:ident; )* }
+        always { $( $always_method:ident, $always_tramp:ident; )* }
     ) => {
         $(#[$meta])*
         pub unsafe fn $fn_name<T: $trait>(cls: R_altrep_class_t) {
             $(
-                unsafe { $always_setter(cls, Some($always_tramp::<T>)) }
+                unsafe { cls.$always_method(Some($always_tramp::<T>)) }
             )*
             $(
-                if T::$has { unsafe { $setter(cls, Some($tramp::<T>)) } }
+                if T::$has { unsafe { cls.$method(Some($tramp::<T>)) } }
             )*
         }
     };
@@ -513,13 +513,13 @@ def_installer! {
     /// # Safety
     /// Must be called during R initialization with a valid ALTREP class handle.
     install_int<T: AltInteger> {
-        HAS_ELT => R_set_altinteger_Elt_method, t_int_elt;
-        HAS_GET_REGION => R_set_altinteger_Get_region_method, t_int_get_region;
-        HAS_IS_SORTED => R_set_altinteger_Is_sorted_method, t_int_is_sorted;
-        HAS_NO_NA => R_set_altinteger_No_NA_method, t_int_no_na;
-        HAS_SUM => R_set_altinteger_Sum_method, t_int_sum;
-        HAS_MIN => R_set_altinteger_Min_method, t_int_min;
-        HAS_MAX => R_set_altinteger_Max_method, t_int_max;
+        HAS_ELT => set_integer_elt_method, t_int_elt;
+        HAS_GET_REGION => set_integer_get_region_method, t_int_get_region;
+        HAS_IS_SORTED => set_integer_is_sorted_method, t_int_is_sorted;
+        HAS_NO_NA => set_integer_no_na_method, t_int_no_na;
+        HAS_SUM => set_integer_sum_method, t_int_sum;
+        HAS_MIN => set_integer_min_method, t_int_min;
+        HAS_MAX => set_integer_max_method, t_int_max;
     }
 }
 
@@ -528,13 +528,13 @@ def_installer! {
     /// # Safety
     /// Must be called during R initialization with a valid ALTREP class handle.
     install_real<T: AltReal> {
-        HAS_ELT => R_set_altreal_Elt_method, t_real_elt;
-        HAS_GET_REGION => R_set_altreal_Get_region_method, t_real_get_region;
-        HAS_IS_SORTED => R_set_altreal_Is_sorted_method, t_real_is_sorted;
-        HAS_NO_NA => R_set_altreal_No_NA_method, t_real_no_na;
-        HAS_SUM => R_set_altreal_Sum_method, t_real_sum;
-        HAS_MIN => R_set_altreal_Min_method, t_real_min;
-        HAS_MAX => R_set_altreal_Max_method, t_real_max;
+        HAS_ELT => set_real_elt_method, t_real_elt;
+        HAS_GET_REGION => set_real_get_region_method, t_real_get_region;
+        HAS_IS_SORTED => set_real_is_sorted_method, t_real_is_sorted;
+        HAS_NO_NA => set_real_no_na_method, t_real_no_na;
+        HAS_SUM => set_real_sum_method, t_real_sum;
+        HAS_MIN => set_real_min_method, t_real_min;
+        HAS_MAX => set_real_max_method, t_real_max;
     }
 }
 
@@ -543,11 +543,11 @@ def_installer! {
     /// # Safety
     /// Must be called during R initialization with a valid ALTREP class handle.
     install_lgl<T: AltLogical> {
-        HAS_ELT => R_set_altlogical_Elt_method, t_lgl_elt;
-        HAS_GET_REGION => R_set_altlogical_Get_region_method, t_lgl_get_region;
-        HAS_IS_SORTED => R_set_altlogical_Is_sorted_method, t_lgl_is_sorted;
-        HAS_NO_NA => R_set_altlogical_No_NA_method, t_lgl_no_na;
-        HAS_SUM => R_set_altlogical_Sum_method, t_lgl_sum;
+        HAS_ELT => set_logical_elt_method, t_lgl_elt;
+        HAS_GET_REGION => set_logical_get_region_method, t_lgl_get_region;
+        HAS_IS_SORTED => set_logical_is_sorted_method, t_lgl_is_sorted;
+        HAS_NO_NA => set_logical_no_na_method, t_lgl_no_na;
+        HAS_SUM => set_logical_sum_method, t_lgl_sum;
     }
 }
 
@@ -556,8 +556,8 @@ def_installer! {
     /// # Safety
     /// Must be called during R initialization with a valid ALTREP class handle.
     install_raw<T: AltRaw> {
-        HAS_ELT => R_set_altraw_Elt_method, t_raw_elt;
-        HAS_GET_REGION => R_set_altraw_Get_region_method, t_raw_get_region;
+        HAS_ELT => set_raw_elt_method, t_raw_elt;
+        HAS_GET_REGION => set_raw_get_region_method, t_raw_get_region;
     }
 }
 
@@ -566,8 +566,8 @@ def_installer! {
     /// # Safety
     /// Must be called during R initialization with a valid ALTREP class handle.
     install_cplx<T: AltComplex> {
-        HAS_ELT => R_set_altcomplex_Elt_method, t_cplx_elt;
-        HAS_GET_REGION => R_set_altcomplex_Get_region_method, t_cplx_get_region;
+        HAS_ELT => set_complex_elt_method, t_cplx_elt;
+        HAS_GET_REGION => set_complex_get_region_method, t_cplx_get_region;
     }
 }
 
@@ -577,11 +577,11 @@ def_installer! {
     /// Must be called during R initialization with a valid ALTREP class handle.
     /// Note: Elt is always installed for ALTSTRING (required).
     install_str<T: AltString> {
-        HAS_SET_ELT => R_set_altstring_Set_elt_method, t_str_set_elt;
-        HAS_IS_SORTED => R_set_altstring_Is_sorted_method, t_str_is_sorted;
-        HAS_NO_NA => R_set_altstring_No_NA_method, t_str_no_na;
+        HAS_SET_ELT => set_string_set_elt_method, t_str_set_elt;
+        HAS_IS_SORTED => set_string_is_sorted_method, t_str_is_sorted;
+        HAS_NO_NA => set_string_no_na_method, t_str_no_na;
     }
-    always { R_set_altstring_Elt_method, t_str_elt; }
+    always { set_string_elt_method, t_str_elt; }
 }
 
 def_installer! {
@@ -590,8 +590,8 @@ def_installer! {
     /// Must be called during R initialization with a valid ALTREP class handle.
     /// Note: Elt is always installed for ALTLIST (required).
     install_list<T: AltList> {
-        HAS_SET_ELT => R_set_altlist_Set_elt_method, t_list_set_elt;
+        HAS_SET_ELT => set_list_set_elt_method, t_list_set_elt;
     }
-    always { R_set_altlist_Elt_method, t_list_elt; }
+    always { set_list_elt_method, t_list_elt; }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/coerce.rs
+++ b/miniextendr-api/src/altrep_data/iter/coerce.rs
@@ -591,7 +591,7 @@ impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::AltString for I
                 AltStringData::elt(&*d, i as usize)
                     .map(|s| unsafe { crate::altrep_impl::checked_mkchar(s) })
             })
-            .unwrap_or(unsafe { crate::ffi::R_NaString })
+            .unwrap_or(SEXP::na_string())
     }
 }
 

--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -229,14 +229,15 @@ macro_rules! __impl_altrep_base_with_serialize {
                 // SAFETY: Unserialize is called by R on the main thread.
                 unsafe {
                     use $crate::externalptr::ExternalPtr;
-                    use $crate::ffi::altrep::{R_altrep_class_t, R_new_altrep};
+                    use $crate::ffi::altrep::R_altrep_class_t;
                     use $crate::ffi::{Rf_protect_unchecked, Rf_unprotect_unchecked, SEXP};
 
                     let ext_ptr = ExternalPtr::new_unchecked(data);
                     let data1 = ext_ptr.as_sexp();
-                    // Protect across the allocation in R_new_altrep.
+                    // Protect across the allocation in new_altrep_unchecked.
                     Rf_protect_unchecked(data1);
-                    let out = R_new_altrep(R_altrep_class_t { ptr: class }, data1, SEXP::nil());
+                    let cls = R_altrep_class_t::from_sexp(class);
+                    let out = cls.new_altrep_unchecked(data1, SEXP::nil());
                     Rf_unprotect_unchecked(1);
                     out
                 }

--- a/miniextendr-api/src/altrep_sexp.rs
+++ b/miniextendr-api/src/altrep_sexp.rs
@@ -234,7 +234,7 @@ impl AltrepSexp {
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
             let elt = self.sexp.string_elt(i as ffi::R_xlen_t);
-            if elt == unsafe { ffi::R_NaString } {
+            if elt == SEXP::na_string() {
                 out.push(None);
             } else {
                 let cstr = unsafe { ffi::Rf_translateCharUTF8(elt) };

--- a/miniextendr-api/src/cached_class.rs
+++ b/miniextendr-api/src/cached_class.rs
@@ -106,8 +106,9 @@ pub(crate) use cached_strsxp;
 /// from any module.
 #[doc(hidden)]
 #[inline]
-pub(crate) unsafe fn permanent_charsxp(name: &std::ffi::CStr) -> crate::ffi::SEXP {
-    unsafe { crate::ffi::PRINTNAME(crate::ffi::Rf_install(name.as_ptr())) }
+pub(crate) fn permanent_charsxp(name: &std::ffi::CStr) -> crate::ffi::SEXP {
+    use crate::ffi::SexpExt;
+    unsafe { crate::ffi::Rf_install(name.as_ptr()) }.printname()
 }
 
 // endregion

--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -506,7 +506,7 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
         for i in 0..n_cols {
             unsafe {
                 let name_sexp = names_sexp.string_elt(i);
-                let name_ptr = crate::ffi::R_CHAR(name_sexp);
+                let name_ptr = name_sexp.r_char();
                 let name_cstr = std::ffi::CStr::from_ptr(name_ptr);
                 if let Ok(s) = name_cstr.to_str() {
                     col_names.push(s.to_string());

--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -378,7 +378,7 @@ fn validate_equal_lengths(named: &NamedList) -> Result<usize, DataFrameError> {
             let col_name = if let Some(names) = names_sexp {
                 let name_sexp = names.string_elt(i);
                 if name_sexp != unsafe { ffi::R_NaString } {
-                    let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+                    let name_ptr = name_sexp.r_char();
                     let name_cstr = unsafe { CStr::from_ptr(name_ptr) };
                     name_cstr.to_str().unwrap_or("<invalid>").to_string()
                 } else {

--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -377,7 +377,7 @@ fn validate_equal_lengths(named: &NamedList) -> Result<usize, DataFrameError> {
             // Try to get the column name for the error message
             let col_name = if let Some(names) = names_sexp {
                 let name_sexp = names.string_elt(i);
-                if name_sexp != unsafe { ffi::R_NaString } {
+                if name_sexp != SEXP::na_string() {
                     let name_ptr = name_sexp.r_char();
                     let name_cstr = unsafe { CStr::from_ptr(name_ptr) };
                     name_cstr.to_str().unwrap_or("<invalid>").to_string()

--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -74,7 +74,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         let mut is_utf8 = false;
         for i in 0..n {
             let name_charsxp = names.string_elt(i);
-            let name_ptr = crate::ffi::R_CHAR(name_charsxp);
+            let name_ptr = name_charsxp.r_char();
             let name = std::ffi::CStr::from_ptr(name_ptr);
             if name == c"UTF-8" {
                 let elt = info.vector_elt(i);

--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -426,7 +426,7 @@ unsafe fn get_r_error_message() -> String {
         let result = if ffi::Rf_xlength(msg_sexp) > 0 {
             let charsxp = msg_sexp.string_elt(0);
             if !charsxp.is_null() {
-                let ptr = ffi::R_CHAR(charsxp);
+                let ptr = charsxp.r_char();
                 if !ptr.is_null() {
                     let msg = CStr::from_ptr(ptr).to_string_lossy().into_owned();
                     msg.trim_end().to_string()

--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -26,8 +26,8 @@
 //! ```
 
 use crate::ffi::{
-    self, R_BaseEnv, R_BaseNamespace, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent, Rf_install,
-    Rf_lcons, Rf_protect, Rf_unprotect, SET_TAG, SEXP, SexpExt,
+    self, PairListExt, R_BaseEnv, R_BaseNamespace, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent,
+    Rf_install, Rf_protect, Rf_unprotect, SEXP, SexpExt,
 };
 use std::ffi::{CStr, CString};
 
@@ -333,17 +333,17 @@ impl RCall {
 
             let mut tail = SEXP::nil();
             for (name, value) in self.args.iter().rev() {
-                tail = ffi::Rf_cons(*value, tail);
+                tail = value.cons(tail);
                 Rf_protect(tail);
                 n_protect += 1;
 
                 if let Some(c_name) = name {
-                    SET_TAG(tail, Rf_install(c_name.as_ptr()));
+                    tail.set_tag(Rf_install(c_name.as_ptr()));
                 }
             }
 
             // Prepend the function as LANGSXP head
-            let call = Rf_lcons(self.fun, tail);
+            let call = self.fun.lcons(tail);
             Rf_protect(call);
             n_protect += 1;
 

--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -26,8 +26,8 @@
 //! ```
 
 use crate::ffi::{
-    self, PairListExt, R_BaseEnv, R_BaseNamespace, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent,
-    Rf_install, Rf_protect, Rf_unprotect, SEXP, SexpExt,
+    self, PairListExt, R_BaseEnv, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent, Rf_install, Rf_protect,
+    Rf_unprotect, SEXP, SexpExt,
 };
 use std::ffi::{CStr, CString};
 
@@ -135,7 +135,7 @@ impl REnv {
         }
     }
 
-    /// The base namespace (`R_BaseNamespace`).
+    /// The base namespace (`SEXP::base_namespace()`).
     ///
     /// Unlike [`base()`](Self::base) which is the base *environment* (exported
     /// functions visible to users), this is the base *namespace* (includes
@@ -146,9 +146,9 @@ impl REnv {
     ///
     /// Must be called from the R main thread.
     #[inline]
-    pub unsafe fn base_namespace() -> Self {
+    pub fn base_namespace() -> Self {
         REnv {
-            sexp: unsafe { R_BaseNamespace },
+            sexp: SEXP::base_namespace(),
         }
     }
 
@@ -505,7 +505,7 @@ mod tests {
         assert_env_fn(|| unsafe { REnv::global() });
         assert_env_fn(|| unsafe { REnv::base() });
         assert_env_fn(|| unsafe { REnv::empty() });
-        assert_env_fn(|| unsafe { REnv::base_namespace() });
+        assert_env_fn(REnv::base_namespace);
         assert_env_fn(|| unsafe { REnv::caller() });
         assert_env_result_fn(|| unsafe { REnv::package_namespace("base") });
     }

--- a/miniextendr-api/src/externalptr.rs
+++ b/miniextendr-api/src/externalptr.rs
@@ -202,11 +202,11 @@ unsafe fn type_id_symbol_unchecked<T: TypedExternal>() -> SEXP {
 ///
 /// `sym` must be a valid SYMSXP.
 #[inline]
-unsafe fn symbol_name(sym: SEXP) -> &'static str {
-    // SYMSXP's PRINTNAME is a CHARSXP
-    let printname = unsafe { crate::ffi::PRINTNAME(sym) };
-    let cstr = unsafe { crate::ffi::R_CHAR(printname) };
-    let len = unsafe { crate::ffi::Rf_xlength(printname) as usize };
+fn symbol_name(sym: SEXP) -> &'static str {
+    use crate::ffi::SexpExt;
+    let printname = sym.printname();
+    let cstr = printname.r_char();
+    let len = printname.len();
     unsafe {
         std::str::from_utf8(std::slice::from_raw_parts(cstr.cast(), len))
             .expect("R SYMSXP PRINTNAME is not valid UTF-8")

--- a/miniextendr-api/src/factor.rs
+++ b/miniextendr-api/src/factor.rs
@@ -29,9 +29,7 @@ use std::ops::Deref;
 use std::sync::OnceLock;
 
 use crate::altrep_traits::NA_INTEGER;
-use crate::ffi::{
-    INTEGER, PRINTNAME, Rf_allocVector, Rf_install, Rf_xlength, SEXP, SEXPTYPE, SexpExt,
-};
+use crate::ffi::{INTEGER, Rf_allocVector, Rf_install, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::into_r::IntoR;
 
@@ -45,7 +43,7 @@ pub(crate) fn factor_class_sexp() -> SEXP {
         crate::ffi::R_PreserveObject(class_sexp);
         // Use symbol PRINTNAME for permanent CHARSXP
         let sym = Rf_install(c"factor".as_ptr());
-        class_sexp.set_string_elt(0, PRINTNAME(sym));
+        class_sexp.set_string_elt(0, sym.printname());
         class_sexp
     })
 }
@@ -78,7 +76,7 @@ pub fn build_levels_sexp(levels: &[&str]) -> SEXP {
             // Install as symbol - symbols and their PRINTNAMEs are never GC'd
             let c_str = CString::new(*level).expect("level name contains null byte");
             let sym = Rf_install(c_str.as_ptr());
-            sexp.set_string_elt(i as isize, PRINTNAME(sym));
+            sexp.set_string_elt(i as isize, sym.printname());
         }
         sexp
     }

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -736,6 +736,12 @@ pub trait SexpExt {
     /// Must be called from R's main thread.
     unsafe fn set_attr_unchecked(&self, name: SEXP, val: SEXP);
 
+    /// Get C string pointer from a CHARSXP. No thread check.
+    ///
+    /// # Safety
+    /// Must be called from R's main thread. The SEXP must be a valid CHARSXP.
+    unsafe fn r_char_unchecked(&self) -> *const ::std::os::raw::c_char;
+
     // endregion
 }
 
@@ -1277,6 +1283,11 @@ impl SexpExt for SEXP {
         unsafe {
             Rf_setAttrib_unchecked(*self, name, val);
         }
+    }
+
+    #[inline]
+    unsafe fn r_char_unchecked(&self) -> *const ::std::os::raw::c_char {
+        unsafe { R_CHAR_unchecked(*self) }
     }
 
     // endregion
@@ -2291,9 +2302,9 @@ unsafe extern "C-unwind" {
     pub fn Rf_install(name: *const ::std::os::raw::c_char) -> SEXP;
     /// Get the print name (CHARSXP) of a symbol (SYMSXP)
     fn PRINTNAME(x: SEXP) -> SEXP;
-    /// Get the C string pointer from a CHARSXP
+    /// Get the C string pointer from a CHARSXP — encapsulated by SexpExt::r_char()
     #[doc(alias = "CHAR")]
-    pub(crate) fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
+    fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 
     // Attribute access
     // Attribute accessors — encapsulated by SexpExt methods

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1833,10 +1833,10 @@ unsafe extern "C-unwind" {
     pub static R_NilValue: SEXP;
 
     #[doc(alias = "NA_STRING")]
-    /// Missing string singleton (`NA_STRING`).
-    pub(crate) static R_NaString: SEXP;
-    /// Empty string CHARSXP (length 0).
-    pub(crate) static R_BlankString: SEXP;
+    /// Missing string singleton — encapsulated by SEXP::na_string()
+    static R_NaString: SEXP;
+    /// Empty string CHARSXP — encapsulated by SEXP::blank_string()
+    static R_BlankString: SEXP;
     /// Symbol for `names` attribute.
     pub(crate) static R_NamesSymbol: SEXP;
     /// Symbol for `dim` attribute.

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -2031,27 +2031,27 @@ unsafe extern "C-unwind" {
     ///
     /// `x` must be a pairlist with at least 5 elements
     pub(crate) fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
-    pub(crate) fn LOGICAL_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
-    pub(crate) fn INTEGER_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
-    pub(crate) fn REAL_OR_NULL(x: SEXP) -> *const f64;
-    pub(crate) fn COMPLEX_OR_NULL(x: SEXP) -> *const Rcomplex;
-    pub(crate) fn RAW_OR_NULL(x: SEXP) -> *const Rbyte;
+    fn LOGICAL_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
+    fn INTEGER_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
+    fn REAL_OR_NULL(x: SEXP) -> *const f64;
+    fn COMPLEX_OR_NULL(x: SEXP) -> *const Rcomplex;
+    fn RAW_OR_NULL(x: SEXP) -> *const Rbyte;
 
-    // Element-wise accessors (ALTREP-aware)
-    pub(crate) fn INTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
-    pub(crate) fn REAL_ELT(x: SEXP, i: R_xlen_t) -> f64;
-    pub(crate) fn LOGICAL_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
-    pub(crate) fn COMPLEX_ELT(x: SEXP, i: R_xlen_t) -> Rcomplex;
-    pub(crate) fn RAW_ELT(x: SEXP, i: R_xlen_t) -> Rbyte;
-    pub(crate) fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
-    pub(crate) fn STRING_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
-    pub(crate) fn SET_STRING_ELT(x: SEXP, i: R_xlen_t, v: SEXP);
-    pub(crate) fn SET_LOGICAL_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
-    pub(crate) fn SET_INTEGER_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
-    pub(crate) fn SET_REAL_ELT(x: SEXP, i: R_xlen_t, v: f64);
-    pub(crate) fn SET_COMPLEX_ELT(x: SEXP, i: R_xlen_t, v: Rcomplex);
-    pub(crate) fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
-    pub(crate) fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
+    // Element-wise accessors (ALTREP-aware) — encapsulated by SexpExt methods
+    fn INTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
+    fn REAL_ELT(x: SEXP, i: R_xlen_t) -> f64;
+    fn LOGICAL_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
+    fn COMPLEX_ELT(x: SEXP, i: R_xlen_t) -> Rcomplex;
+    fn RAW_ELT(x: SEXP, i: R_xlen_t) -> Rbyte;
+    fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
+    fn STRING_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
+    fn SET_STRING_ELT(x: SEXP, i: R_xlen_t, v: SEXP);
+    fn SET_LOGICAL_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
+    fn SET_INTEGER_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
+    fn SET_REAL_ELT(x: SEXP, i: R_xlen_t, v: f64);
+    fn SET_COMPLEX_ELT(x: SEXP, i: R_xlen_t, v: Rcomplex);
+    fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
+    fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
 
     // endregion
 
@@ -2061,7 +2061,7 @@ unsafe extern "C-unwind" {
     ///
     /// For long vectors, use `Rf_xlength()` instead.
     /// Returns 0 for R_NilValue.
-    pub(crate) fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
+    fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 
     /// Get the length of a SEXP as `R_xlen_t` (supports long vectors).
     ///
@@ -2107,10 +2107,10 @@ unsafe extern "C-unwind" {
     // region: ALTREP support
 
     pub(crate) fn ALTREP_CLASS(x: SEXP) -> SEXP;
-    pub fn R_altrep_data1(x: SEXP) -> SEXP;
-    pub fn R_altrep_data2(x: SEXP) -> SEXP;
+    pub(crate) fn R_altrep_data1(x: SEXP) -> SEXP;
+    pub(crate) fn R_altrep_data2(x: SEXP) -> SEXP;
     pub(crate) fn R_set_altrep_data1(x: SEXP, v: SEXP);
-    pub fn R_set_altrep_data2(x: SEXP, v: SEXP);
+    pub(crate) fn R_set_altrep_data2(x: SEXP, v: SEXP);
 
     /// Check if a SEXP is an ALTREP object (returns non-zero if true).
     ///
@@ -2163,9 +2163,9 @@ unsafe extern "C-unwind" {
 
     // endregion
 
-    // region: Type checking
+    // region: Type checking — encapsulated by SexpExt::type_of()
 
-    pub(crate) fn TYPEOF(x: SEXP) -> SEXPTYPE;
+    fn TYPEOF(x: SEXP) -> SEXPTYPE;
 
     // endregion
 

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -300,6 +300,58 @@ impl SEXP {
     }
 
     // endregion
+
+    // region: R global symbols and singletons
+
+    /// R's `names` attribute symbol.
+    #[inline]
+    pub fn names_symbol() -> SEXP {
+        unsafe { R_NamesSymbol }
+    }
+
+    /// R's `dim` attribute symbol.
+    #[inline]
+    pub fn dim_symbol() -> SEXP {
+        unsafe { R_DimSymbol }
+    }
+
+    /// R's `dimnames` attribute symbol.
+    #[inline]
+    pub fn dimnames_symbol() -> SEXP {
+        unsafe { R_DimNamesSymbol }
+    }
+
+    /// R's `class` attribute symbol.
+    #[inline]
+    pub fn class_symbol() -> SEXP {
+        unsafe { R_ClassSymbol }
+    }
+
+    /// R's `levels` attribute symbol (factors).
+    #[inline]
+    pub fn levels_symbol() -> SEXP {
+        unsafe { R_LevelsSymbol }
+    }
+
+    /// R's `tsp` attribute symbol (time series).
+    #[inline]
+    pub fn tsp_symbol() -> SEXP {
+        unsafe { R_TspSymbol }
+    }
+
+    /// R's base namespace environment.
+    #[inline]
+    pub fn base_namespace() -> SEXP {
+        unsafe { R_BaseNamespace }
+    }
+
+    /// R's missing argument sentinel.
+    #[inline]
+    pub fn missing_arg() -> SEXP {
+        unsafe { R_MissingArg }
+    }
+
+    // endregion
 }
 
 impl Default for SEXP {
@@ -1838,19 +1890,14 @@ unsafe extern "C-unwind" {
     /// Empty string CHARSXP — encapsulated by SEXP::blank_string()
     static R_BlankString: SEXP;
     /// Symbol for `names` attribute.
-    pub(crate) static R_NamesSymbol: SEXP;
-    /// Symbol for `dim` attribute.
-    pub(crate) static R_DimSymbol: SEXP;
-    /// Symbol for `dimnames` attribute.
-    pub(crate) static R_DimNamesSymbol: SEXP;
-    /// Symbol for `class` attribute.
-    pub(crate) static R_ClassSymbol: SEXP;
-    /// Symbol for row names — encapsulated by SexpExt::get_row_names()/set_row_names()
+    // Attribute symbols — encapsulated by SexpExt methods and SEXP::*_symbol()
+    static R_NamesSymbol: SEXP;
+    static R_DimSymbol: SEXP;
+    static R_DimNamesSymbol: SEXP;
+    static R_ClassSymbol: SEXP;
     static R_RowNamesSymbol: SEXP;
-    /// Symbol for factor levels.
-    pub(crate) static R_LevelsSymbol: SEXP;
-    /// Symbol for `tsp` attribute.
-    pub(crate) static R_TspSymbol: SEXP;
+    static R_LevelsSymbol: SEXP;
+    static R_TspSymbol: SEXP;
 
     /// Global environment (`.GlobalEnv`).
     pub static R_GlobalEnv: SEXP;
@@ -1858,8 +1905,8 @@ unsafe extern "C-unwind" {
     pub static R_BaseEnv: SEXP;
     /// Empty root environment.
     pub static R_EmptyEnv: SEXP;
-    /// Base package namespace (internal base, not user-visible base env).
-    pub(crate) static R_BaseNamespace: SEXP;
+    /// Base package namespace — encapsulated by SEXP::base_namespace()
+    static R_BaseNamespace: SEXP;
 
     /// The "missing argument" sentinel value.
     ///
@@ -1869,7 +1916,8 @@ unsafe extern "C-unwind" {
     /// while NULL is an explicit value.
     ///
     /// In R: `f <- function(x) missing(x); f()` returns `TRUE`.
-    pub(crate) static R_MissingArg: SEXP;
+    /// Encapsulated by SEXP::missing_arg()
+    static R_MissingArg: SEXP;
 
     // Rinterface.h
     pub(crate) fn R_FlushConsole();

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1845,8 +1845,8 @@ unsafe extern "C-unwind" {
     pub(crate) static R_DimNamesSymbol: SEXP;
     /// Symbol for `class` attribute.
     pub(crate) static R_ClassSymbol: SEXP;
-    /// Symbol for row names.
-    pub(crate) static R_RowNamesSymbol: SEXP;
+    /// Symbol for row names — encapsulated by SexpExt::get_row_names()/set_row_names()
+    static R_RowNamesSymbol: SEXP;
     /// Symbol for factor levels.
     pub(crate) static R_LevelsSymbol: SEXP;
     /// Symbol for `tsp` attribute.
@@ -1891,9 +1891,9 @@ unsafe extern "C-unwind" {
 
     // Rinternals.h
     #[doc(alias = "mkChar")]
-    pub(crate) fn Rf_mkChar(s: *const ::std::os::raw::c_char) -> SEXP;
+    fn Rf_mkChar(s: *const ::std::os::raw::c_char) -> SEXP;
     #[doc(alias = "mkCharLen")]
-    pub(crate) fn Rf_mkCharLen(s: *const ::std::os::raw::c_char, len: i32) -> SEXP;
+    fn Rf_mkCharLen(s: *const ::std::os::raw::c_char, len: i32) -> SEXP;
     #[doc(alias = "mkCharLenCE")]
     pub fn Rf_mkCharLenCE(
         x: *const ::std::os::raw::c_char,
@@ -1953,11 +1953,11 @@ unsafe extern "C-unwind" {
     pub(crate) fn R_SetExternalPtrTag(s: SEXP, tag: SEXP);
     pub(crate) fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
     #[doc = " Added in R 3.4.0"]
-    pub(crate) fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
-    pub(crate) fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
-    pub(crate) fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
+    fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
+    fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
+    fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
     pub(crate) fn R_RegisterCFinalizer(s: SEXP, fun: R_CFinalizer_t);
-    pub(crate) fn R_RegisterFinalizerEx(s: SEXP, fun: SEXP, onexit: Rboolean);
+    fn R_RegisterFinalizerEx(s: SEXP, fun: SEXP, onexit: Rboolean);
     pub(crate) fn R_RegisterCFinalizerEx(s: SEXP, fun: R_CFinalizer_t, onexit: Rboolean);
 
     // R_ext/Rdynload.h - C-callable interface
@@ -2067,9 +2067,9 @@ unsafe extern "C-unwind" {
         ncol: ::std::os::raw::c_int,
     ) -> SEXP;
     #[doc(alias = "allocArray")]
-    pub(crate) fn Rf_allocArray(sexptype: SEXPTYPE, dims: SEXP) -> SEXP;
+    fn Rf_allocArray(sexptype: SEXPTYPE, dims: SEXP) -> SEXP;
     #[doc(alias = "alloc3DArray")]
-    pub(crate) fn Rf_alloc3DArray(
+    fn Rf_alloc3DArray(
         sexptype: SEXPTYPE,
         nrow: ::std::os::raw::c_int,
         ncol: ::std::os::raw::c_int,
@@ -2080,11 +2080,11 @@ unsafe extern "C-unwind" {
     #[doc(alias = "allocList")]
     pub(crate) fn Rf_allocList(n: ::std::os::raw::c_int) -> SEXP;
     #[doc(alias = "allocLang")]
-    pub(crate) fn Rf_allocLang(n: ::std::os::raw::c_int) -> SEXP;
+    fn Rf_allocLang(n: ::std::os::raw::c_int) -> SEXP;
     #[doc(alias = "allocS4Object")]
-    pub(crate) fn Rf_allocS4Object() -> SEXP;
+    fn Rf_allocS4Object() -> SEXP;
     #[doc(alias = "allocSExp")]
-    pub(crate) fn Rf_allocSExp(sexptype: SEXPTYPE) -> SEXP;
+    fn Rf_allocSExp(sexptype: SEXPTYPE) -> SEXP;
 
     // Pairlist construction — encapsulated by PairListExt trait
     fn Rf_cons(car: SEXP, cdr: SEXP) -> SEXP;
@@ -2475,22 +2475,22 @@ unsafe extern "C-unwind" {
 
     // Environment operations
     #[doc(alias = "findVar")]
-    pub(crate) fn Rf_findVar(symbol: SEXP, rho: SEXP) -> SEXP;
+    fn Rf_findVar(symbol: SEXP, rho: SEXP) -> SEXP;
     #[doc(alias = "findVarInFrame")]
-    pub(crate) fn Rf_findVarInFrame(rho: SEXP, symbol: SEXP) -> SEXP;
+    fn Rf_findVarInFrame(rho: SEXP, symbol: SEXP) -> SEXP;
     #[doc(alias = "findVarInFrame3")]
-    pub(crate) fn Rf_findVarInFrame3(rho: SEXP, symbol: SEXP, doget: Rboolean) -> SEXP;
+    fn Rf_findVarInFrame3(rho: SEXP, symbol: SEXP, doget: Rboolean) -> SEXP;
     #[doc(alias = "defineVar")]
-    pub(crate) fn Rf_defineVar(symbol: SEXP, value: SEXP, rho: SEXP);
+    fn Rf_defineVar(symbol: SEXP, value: SEXP, rho: SEXP);
     #[doc(alias = "setVar")]
-    pub(crate) fn Rf_setVar(symbol: SEXP, value: SEXP, rho: SEXP);
+    fn Rf_setVar(symbol: SEXP, value: SEXP, rho: SEXP);
     #[doc(alias = "findFun")]
-    pub(crate) fn Rf_findFun(symbol: SEXP, rho: SEXP) -> SEXP;
+    fn Rf_findFun(symbol: SEXP, rho: SEXP) -> SEXP;
 
     /// Find a registered namespace by name. **Longjmps on error** — prefer
     /// `REnv::package_namespace()` which wraps this safely.
     #[doc(alias = "FindNamespace")]
-    pub(crate) fn R_FindNamespace(info: SEXP) -> SEXP;
+    fn R_FindNamespace(info: SEXP) -> SEXP;
 
     /// Return the current execution environment (innermost closure on call
     /// stack, or `R_GlobalEnv` if none).
@@ -2501,7 +2501,7 @@ unsafe extern "C-unwind" {
     #[doc(alias = "eval")]
     pub fn Rf_eval(expr: SEXP, rho: SEXP) -> SEXP;
     #[doc(alias = "applyClosure")]
-    pub(crate) fn Rf_applyClosure(
+    fn Rf_applyClosure(
         call: SEXP,
         op: SEXP,
         args: SEXP,
@@ -2509,17 +2509,13 @@ unsafe extern "C-unwind" {
         suppliedvars: SEXP,
         check: Rboolean,
     ) -> SEXP;
-    pub(crate) fn R_tryEval(
-        expr: SEXP,
-        env: SEXP,
-        error_occurred: *mut ::std::os::raw::c_int,
-    ) -> SEXP;
+    fn R_tryEval(expr: SEXP, env: SEXP, error_occurred: *mut ::std::os::raw::c_int) -> SEXP;
     pub(crate) fn R_tryEvalSilent(
         expr: SEXP,
         env: SEXP,
         error_occurred: *mut ::std::os::raw::c_int,
     ) -> SEXP;
-    pub(crate) fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
+    fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 
 // region: Connections API (R_ext/Connections.h)
@@ -2759,23 +2755,23 @@ pub mod legacy_c {
     unsafe extern "C" {
         /// Register a C finalizer callback.
         #[link_name = "R_RegisterCFinalizer"]
-        pub(crate) fn R_RegisterCFinalizer_C(s: SEXP, fun: R_CFinalizer_t_C);
+        fn R_RegisterCFinalizer_C(s: SEXP, fun: R_CFinalizer_t_C);
 
         /// Register a C finalizer callback with `onexit` behavior.
         #[link_name = "R_RegisterCFinalizerEx"]
-        pub(crate) fn R_RegisterCFinalizerEx_C(s: SEXP, fun: R_CFinalizer_t_C, onexit: Rboolean);
+        fn R_RegisterCFinalizerEx_C(s: SEXP, fun: R_CFinalizer_t_C, onexit: Rboolean);
 
         /// Create function external pointer (`R_MakeExternalPtrFn`).
         #[link_name = "R_MakeExternalPtrFn"]
-        pub(crate) fn R_MakeExternalPtrFn_C(p: DL_FUNC_C, tag: SEXP, prot: SEXP) -> SEXP;
+        fn R_MakeExternalPtrFn_C(p: DL_FUNC_C, tag: SEXP, prot: SEXP) -> SEXP;
 
         /// Extract function pointer from external pointer.
         #[link_name = "R_ExternalPtrAddrFn"]
-        pub(crate) fn R_ExternalPtrAddrFn_C(s: SEXP) -> DL_FUNC_C;
+        fn R_ExternalPtrAddrFn_C(s: SEXP) -> DL_FUNC_C;
 
         /// Register native routines using legacy ABI types.
         #[link_name = "R_registerRoutines"]
-        pub(crate) fn R_registerRoutines_C(
+        fn R_registerRoutines_C(
             info: *mut super::DllInfo,
             croutines: *const ::std::os::raw::c_void,
             callRoutines: *const R_CallMethodDef_C,

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -215,6 +215,24 @@ impl SEXP {
         unsafe { R_BlankString }
     }
 
+    /// Create an R symbol (SYMSXP) from a CHARSXP.
+    ///
+    /// Equivalent to `Rf_installChar(charsxp)`. The symbol is interned
+    /// in R's global symbol table and never garbage collected.
+    #[inline]
+    pub fn install_char(charsxp: SEXP) -> SEXP {
+        unsafe { Rf_installChar(charsxp) }
+    }
+
+    /// Create an R symbol (SYMSXP) from a Rust `&str`.
+    ///
+    /// Combines `SEXP::charsxp()` + `Rf_installChar` into one call.
+    /// The symbol is interned and never garbage collected.
+    #[inline]
+    pub fn symbol(name: &str) -> SEXP {
+        Self::install_char(Self::charsxp(name))
+    }
+
     // endregion
 
     // region: Scalar construction
@@ -626,6 +644,27 @@ pub trait SexpExt {
     fn set_complex_elt(&self, i: isize, v: Rcomplex);
     /// Set the i-th raw element.
     fn set_raw_elt(&self, i: isize, v: u8);
+
+    // endregion
+
+    // region: Vector resizing
+
+    /// Resize a vector to a new length, returning a (possibly new) SEXP.
+    ///
+    /// If the new length is shorter, elements are truncated.
+    /// If longer, new elements are filled with NA/NULL.
+    /// Equivalent to R's `Rf_xlengthgets(x, newlen)`.
+    fn resize(&self, newlen: R_xlen_t) -> SEXP;
+
+    // endregion
+
+    // region: Duplication
+
+    /// Deep-copy this SEXP. Equivalent to R's `Rf_duplicate(x)`.
+    fn duplicate(&self) -> SEXP;
+
+    /// Shallow-copy this SEXP. Equivalent to R's `Rf_shallow_duplicate(x)`.
+    fn shallow_duplicate(&self) -> SEXP;
 
     // endregion
 
@@ -1115,6 +1154,29 @@ impl SexpExt for SEXP {
     #[inline]
     fn set_raw_elt(&self, i: isize, v: u8) {
         unsafe { SET_RAW_ELT(*self, i, v) }
+    }
+
+    // endregion
+
+    // region: Vector resizing
+
+    #[inline]
+    fn resize(&self, newlen: R_xlen_t) -> SEXP {
+        unsafe { Rf_xlengthgets(*self, newlen) }
+    }
+
+    // endregion
+
+    // region: Duplication
+
+    #[inline]
+    fn duplicate(&self) -> SEXP {
+        unsafe { Rf_duplicate(*self) }
+    }
+
+    #[inline]
+    fn shallow_duplicate(&self) -> SEXP {
+        unsafe { Rf_shallow_duplicate(*self) }
     }
 
     // endregion
@@ -2194,9 +2256,9 @@ unsafe extern "C-unwind" {
 
     // Duplication
     #[doc(alias = "duplicate")]
-    pub(crate) fn Rf_duplicate(s: SEXP) -> SEXP;
+    fn Rf_duplicate(s: SEXP) -> SEXP;
     #[doc(alias = "shallow_duplicate")]
-    pub(crate) fn Rf_shallow_duplicate(s: SEXP) -> SEXP;
+    fn Rf_shallow_duplicate(s: SEXP) -> SEXP;
 
     // Object comparison
     /// Check if two R objects are identical (deep semantic equality).
@@ -2250,11 +2312,11 @@ unsafe extern "C-unwind" {
     #[doc(alias = "coerceVector")]
     fn Rf_coerceVector(v: SEXP, sexptype: SEXPTYPE) -> SEXP;
 
-    // Matrix utilities
+    // Matrix utilities — no callers outside ffi.rs
     #[doc(alias = "nrows")]
-    pub(crate) fn Rf_nrows(x: SEXP) -> ::std::os::raw::c_int;
+    fn Rf_nrows(x: SEXP) -> ::std::os::raw::c_int;
     #[doc(alias = "ncols")]
-    pub(crate) fn Rf_ncols(x: SEXP) -> ::std::os::raw::c_int;
+    fn Rf_ncols(x: SEXP) -> ::std::os::raw::c_int;
 
     // Inheritance checking — encapsulated by SexpExt::inherits_class()
     #[doc(alias = "inherits")]
@@ -3600,11 +3662,11 @@ unsafe extern "C-unwind" {
     /// - `object`: Object to convert
     /// - `flag`: Conversion flag
     #[doc(alias = "asS4")]
-    pub(crate) fn Rf_asS4(object: SEXP, flag: Rboolean, complete: ::std::os::raw::c_int) -> SEXP;
+    fn Rf_asS4(object: SEXP, flag: Rboolean, complete: ::std::os::raw::c_int) -> SEXP;
 
     /// Get the S3 class of an S4 object.
     #[doc(alias = "S3Class")]
-    pub(crate) fn Rf_S3Class(object: SEXP) -> SEXP;
+    fn Rf_S3Class(object: SEXP) -> SEXP;
 
     // Option access
 
@@ -3616,29 +3678,29 @@ unsafe extern "C-unwind" {
     ///
     /// - `tag`: Symbol for option name
     #[doc(alias = "GetOption1")]
-    pub(crate) fn Rf_GetOption1(tag: SEXP) -> SEXP;
+    fn Rf_GetOption1(tag: SEXP) -> SEXP;
 
     /// Get the `digits` option.
     ///
     /// Returns the value of `getOption("digits")`.
     #[doc(alias = "GetOptionDigits")]
-    pub(crate) fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
+    fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
 
     /// Get the `width` option.
     ///
     /// Returns the value of `getOption("width")`.
     #[doc(alias = "GetOptionWidth")]
-    pub(crate) fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
+    fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
 
     // Factor functions
 
     /// Check if a factor is ordered.
     #[doc(alias = "isOrdered")]
-    pub(crate) fn Rf_isOrdered(s: SEXP) -> Rboolean;
+    fn Rf_isOrdered(s: SEXP) -> Rboolean;
 
     /// Check if a factor is unordered.
     #[doc(alias = "isUnordered")]
-    pub(crate) fn Rf_isUnordered(s: SEXP) -> Rboolean;
+    fn Rf_isUnordered(s: SEXP) -> Rboolean;
 
     /// Check if a vector is unsorted.
     ///
@@ -3647,7 +3709,7 @@ unsafe extern "C-unwind" {
     /// - `x`: Vector to check
     /// - `strictly`: If TRUE, check for strictly increasing
     #[doc(alias = "isUnsorted")]
-    pub(crate) fn Rf_isUnsorted(x: SEXP, strictly: Rboolean) -> ::std::os::raw::c_int;
+    fn Rf_isUnsorted(x: SEXP, strictly: Rboolean) -> ::std::os::raw::c_int;
 
     // Expression and evaluation
 
@@ -3655,17 +3717,17 @@ unsafe extern "C-unwind" {
     ///
     /// Like R's `substitute()` function.
     #[doc(alias = "substitute")]
-    pub(crate) fn Rf_substitute(lang: SEXP, rho: SEXP) -> SEXP;
+    fn Rf_substitute(lang: SEXP, rho: SEXP) -> SEXP;
 
     /// Set vector length.
     ///
     /// For short vectors (length < 2^31).
     #[doc(alias = "lengthgets")]
-    pub(crate) fn Rf_lengthgets(x: SEXP, newlen: R_xlen_t) -> SEXP;
+    fn Rf_lengthgets(x: SEXP, newlen: R_xlen_t) -> SEXP;
 
     /// Set vector length (long vector version).
     #[doc(alias = "xlengthgets")]
-    pub(crate) fn Rf_xlengthgets(x: SEXP, newlen: R_xlen_t) -> SEXP;
+    fn Rf_xlengthgets(x: SEXP, newlen: R_xlen_t) -> SEXP;
 
     // Protection (indexed — see cost table in the "GC protection" region above)
 
@@ -3721,11 +3783,11 @@ unsafe extern "C-unwind" {
 
     /// Convert a pairlist to a generic vector (list).
     #[doc(alias = "PairToVectorList")]
-    pub(crate) fn Rf_PairToVectorList(x: SEXP) -> SEXP;
+    fn Rf_PairToVectorList(x: SEXP) -> SEXP;
 
     /// Convert a generic vector (list) to a pairlist.
     #[doc(alias = "VectorToPairList")]
-    pub(crate) fn Rf_VectorToPairList(x: SEXP) -> SEXP;
+    fn Rf_VectorToPairList(x: SEXP) -> SEXP;
 
     // Install with CHARSXP
 
@@ -3733,7 +3795,7 @@ unsafe extern "C-unwind" {
     ///
     /// Like `Rf_install()` but takes a CHARSXP instead of C string.
     #[doc(alias = "installChar")]
-    pub(crate) fn Rf_installChar(x: SEXP) -> SEXP;
+    fn Rf_installChar(x: SEXP) -> SEXP;
 }
 
 // endregion

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1220,6 +1220,139 @@ impl SexpExt for SEXP {
     // endregion
 }
 
+/// Extension trait for SEXP providing pairlist (cons cell) operations.
+///
+/// Pairlist nodes have three slots: CAR (value), CDR (next), and TAG (name).
+/// This trait encapsulates the raw C functions behind method calls.
+#[allow(dead_code)]
+pub(crate) trait PairListExt {
+    /// Create a cons cell with this SEXP as CAR and `cdr` as CDR.
+    fn cons(self, cdr: SEXP) -> SEXP;
+
+    /// Create a language cons cell with this SEXP as CAR and `cdr` as CDR.
+    fn lcons(self, cdr: SEXP) -> SEXP;
+
+    /// Get the CAR (head/value) of this pairlist node.
+    fn car(&self) -> SEXP;
+
+    /// Get the CDR (tail/rest) of this pairlist node.
+    fn cdr(&self) -> SEXP;
+
+    /// Get the TAG (name symbol) of this pairlist node.
+    fn tag(&self) -> SEXP;
+
+    /// Set the TAG (name symbol) of this pairlist node.
+    fn set_tag(&self, tag: SEXP);
+
+    /// Set the CAR (value) of this pairlist node.
+    fn set_car(&self, value: SEXP) -> SEXP;
+
+    /// Set the CDR (tail) of this pairlist node.
+    fn set_cdr(&self, tail: SEXP) -> SEXP;
+
+    /// Create a cons cell (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn cons_unchecked(self, cdr: SEXP) -> SEXP;
+
+    /// Get the CAR (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn car_unchecked(&self) -> SEXP;
+
+    /// Get the CDR (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn cdr_unchecked(&self) -> SEXP;
+
+    /// Set the TAG (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn set_tag_unchecked(&self, tag: SEXP);
+
+    /// Set the CAR (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn set_car_unchecked(&self, value: SEXP) -> SEXP;
+
+    /// Set the CDR (no thread check).
+    /// # Safety
+    /// Must be called from R's main thread.
+    unsafe fn set_cdr_unchecked(&self, tail: SEXP) -> SEXP;
+}
+
+impl PairListExt for SEXP {
+    #[inline]
+    fn cons(self, cdr: SEXP) -> SEXP {
+        unsafe { Rf_cons(self, cdr) }
+    }
+
+    #[inline]
+    fn lcons(self, cdr: SEXP) -> SEXP {
+        unsafe { Rf_lcons(self, cdr) }
+    }
+
+    #[inline]
+    fn car(&self) -> SEXP {
+        unsafe { CAR(*self) }
+    }
+
+    #[inline]
+    fn cdr(&self) -> SEXP {
+        unsafe { CDR(*self) }
+    }
+
+    #[inline]
+    fn tag(&self) -> SEXP {
+        unsafe { TAG(*self) }
+    }
+
+    #[inline]
+    fn set_tag(&self, tag: SEXP) {
+        unsafe { SET_TAG(*self, tag) }
+    }
+
+    #[inline]
+    fn set_car(&self, value: SEXP) -> SEXP {
+        unsafe { SETCAR(*self, value) }
+    }
+
+    #[inline]
+    fn set_cdr(&self, tail: SEXP) -> SEXP {
+        unsafe { SETCDR(*self, tail) }
+    }
+
+    #[inline]
+    unsafe fn cons_unchecked(self, cdr: SEXP) -> SEXP {
+        unsafe { Rf_cons_unchecked(self, cdr) }
+    }
+
+    #[inline]
+    unsafe fn car_unchecked(&self) -> SEXP {
+        unsafe { CAR_unchecked(*self) }
+    }
+
+    #[inline]
+    unsafe fn cdr_unchecked(&self) -> SEXP {
+        unsafe { CDR_unchecked(*self) }
+    }
+
+    #[inline]
+    unsafe fn set_tag_unchecked(&self, tag: SEXP) {
+        unsafe { SET_TAG_unchecked(*self, tag) }
+    }
+
+    #[inline]
+    unsafe fn set_car_unchecked(&self, value: SEXP) -> SEXP {
+        unsafe { SETCAR_unchecked(*self, value) }
+    }
+
+    #[inline]
+    unsafe fn set_cdr_unchecked(&self, tail: SEXP) -> SEXP {
+        unsafe { SETCDR_unchecked(*self, tail) }
+    }
+}
+
 /// Marker trait for types that correspond to R's native vector element types.
 ///
 /// This enables blanket implementations for `TryFromSexp` and safe conversions.
@@ -1880,13 +2013,9 @@ unsafe extern "C-unwind" {
     #[doc(alias = "allocSExp")]
     pub(crate) fn Rf_allocSExp(sexptype: SEXPTYPE) -> SEXP;
 
-    // Pairlist construction
-    #[doc(alias = "CONS")]
-    #[doc(alias = "cons")]
-    pub(crate) fn Rf_cons(car: SEXP, cdr: SEXP) -> SEXP;
-    #[doc(alias = "LCONS")]
-    #[doc(alias = "lcons")]
-    pub(crate) fn Rf_lcons(car: SEXP, cdr: SEXP) -> SEXP;
+    // Pairlist construction — encapsulated by PairListExt trait
+    fn Rf_cons(car: SEXP, cdr: SEXP) -> SEXP;
+    fn Rf_lcons(car: SEXP, cdr: SEXP) -> SEXP;
 
     // Attribute manipulation — encapsulated by SexpExt methods
     #[doc(alias = "setAttrib")]
@@ -1938,161 +2067,25 @@ unsafe extern "C-unwind" {
     // Modern R mostly uses generic vectors (VECSXP) instead of pairlists,
     // but pairlists are still used internally for function calls.
 
-    /// Get the CAR (head/value) of a pairlist node.
-    ///
-    /// Returns the value stored in this cons cell.
-    /// For argument lists, this is the argument value.
-    /// For language objects, this is the function or first element.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a valid pairlist (LISTSXP, LANGSXP) or R_NilValue
-    pub(crate) fn CAR(e: SEXP) -> SEXP;
-
-    /// Get the CDR (tail/rest) of a pairlist node.
-    ///
-    /// Returns the remainder of the list after this node.
-    /// This is either another pairlist node or R_NilValue (end of list).
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a valid pairlist (LISTSXP, LANGSXP) or R_NilValue
-    pub(crate) fn CDR(e: SEXP) -> SEXP;
-
-    /// Get the CAR of the CAR (value of the first element's value).
-    ///
-    /// Equivalent to `CAR(CAR(e))`. Useful for nested lists.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a valid nested pairlist
-    pub(crate) fn CAAR(e: SEXP) -> SEXP;
-
-    /// Get the CDR of the CAR (tail of the first element).
-    ///
-    /// Equivalent to `CDR(CAR(e))`.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a valid nested pairlist
-    pub(crate) fn CDAR(e: SEXP) -> SEXP;
-
-    /// Get the CAR of the CDR (second element's value).
-    ///
-    /// Equivalent to `CAR(CDR(e))`. This gets the value of the 2nd list element.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a pairlist with at least 2 elements
-    pub(crate) fn CADR(e: SEXP) -> SEXP;
-
-    /// Get the CDR of the CDR (list starting from 3rd element).
-    ///
-    /// Equivalent to `CDR(CDR(e))`. Skips first two elements.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a pairlist with at least 2 elements
-    pub(crate) fn CDDR(e: SEXP) -> SEXP;
-
-    /// Get the value of the third element.
-    ///
-    /// Equivalent to `CAR(CDR(CDR(e)))`.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a pairlist with at least 3 elements
-    pub(crate) fn CADDR(e: SEXP) -> SEXP;
-
-    /// Get the value of the fourth element.
-    ///
-    /// Equivalent to `CAR(CDR(CDR(CDR(e))))`.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a pairlist with at least 4 elements
-    pub(crate) fn CADDDR(e: SEXP) -> SEXP;
-
-    /// Get the value of the fifth element.
-    ///
-    /// Equivalent to `CAR(CDR(CDR(CDR(CDR(e)))))`.
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a pairlist with at least 5 elements
-    pub(crate) fn CAD4R(e: SEXP) -> SEXP;
-
-    /// Get the TAG (name) of a pairlist node.
-    ///
-    /// Returns the symbol associated with this element, or R_NilValue if unnamed.
-    /// For named arguments like `f(x = 5)`, TAG is the symbol "x".
-    ///
-    /// # Safety
-    ///
-    /// `e` must be a valid pairlist (LISTSXP, LANGSXP) or R_NilValue
-    pub(crate) fn TAG(e: SEXP) -> SEXP;
-
-    /// Set the TAG (name) of a pairlist node.
-    ///
-    /// # Safety
-    ///
-    /// - `x` must be a valid mutable pairlist node
-    /// - `y` must be a symbol (SYMSXP) or R_NilValue
-    pub(crate) fn SET_TAG(x: SEXP, y: SEXP);
-
-    /// Set the CAR (value) of a pairlist node.
-    ///
-    /// # Safety
-    ///
-    /// - `x` must be a valid mutable pairlist node
-    /// - `y` must be a valid SEXP
-    /// - Returns `y` for convenience
-    pub(crate) fn SETCAR(x: SEXP, y: SEXP) -> SEXP;
-
-    /// Set the CDR (tail) of a pairlist node.
-    ///
-    /// # Safety
-    ///
-    /// - `x` must be a valid mutable pairlist node
-    /// - `y` must be a pairlist or R_NilValue
-    /// - Returns `y` for convenience
-    pub(crate) fn SETCDR(x: SEXP, y: SEXP) -> SEXP;
-
-    /// Set the value of the second element.
-    ///
-    /// Equivalent to `SETCAR(CDR(x), y)`.
-    ///
-    /// # Safety
-    ///
-    /// `x` must be a pairlist with at least 2 elements
-    pub(crate) fn SETCADR(x: SEXP, y: SEXP) -> SEXP;
-
-    /// Set the value of the third element.
-    ///
-    /// Equivalent to `SETCAR(CDDR(x), y)`.
-    ///
-    /// # Safety
-    ///
-    /// `x` must be a pairlist with at least 3 elements
-    pub(crate) fn SETCADDR(x: SEXP, y: SEXP) -> SEXP;
-
-    /// Set the value of the fourth element.
-    ///
-    /// Equivalent to `SETCAR(CDR(CDDR(x)), y)`.
-    ///
-    /// # Safety
-    ///
-    /// `x` must be a pairlist with at least 4 elements
-    pub(crate) fn SETCADDDR(x: SEXP, y: SEXP) -> SEXP;
-
-    /// Set the value of the fifth element.
-    ///
-    /// Equivalent to `SETCAR(CAD4R(x), y)`.
-    ///
-    /// # Safety
-    ///
-    /// `x` must be a pairlist with at least 5 elements
-    pub(crate) fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
+    // Pairlist accessors — basic ops encapsulated by PairListExt trait,
+    // compound accessors (CAAR, CADR, etc.) module-private since no callers exist.
+    fn CAR(e: SEXP) -> SEXP;
+    fn CDR(e: SEXP) -> SEXP;
+    fn CAAR(e: SEXP) -> SEXP;
+    fn CDAR(e: SEXP) -> SEXP;
+    fn CADR(e: SEXP) -> SEXP;
+    fn CDDR(e: SEXP) -> SEXP;
+    fn CADDR(e: SEXP) -> SEXP;
+    fn CADDDR(e: SEXP) -> SEXP;
+    fn CAD4R(e: SEXP) -> SEXP;
+    fn TAG(e: SEXP) -> SEXP;
+    fn SET_TAG(x: SEXP, y: SEXP);
+    fn SETCAR(x: SEXP, y: SEXP) -> SEXP;
+    fn SETCDR(x: SEXP, y: SEXP) -> SEXP;
+    fn SETCADR(x: SEXP, y: SEXP) -> SEXP;
+    fn SETCADDR(x: SEXP, y: SEXP) -> SEXP;
+    fn SETCADDDR(x: SEXP, y: SEXP) -> SEXP;
+    fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
     fn LOGICAL_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
     fn INTEGER_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_int;
     fn REAL_OR_NULL(x: SEXP) -> *const f64;

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1806,15 +1806,15 @@ unsafe extern "C-unwind" {
     #[cfg(feature = "nonapi")]
     #[expect(dead_code, reason = "declared for future use")]
     /// Non-API TRUE singleton.
-    pub(crate) static R_TrueValue: SEXP;
+    static R_TrueValue: SEXP;
     #[cfg(feature = "nonapi")]
     #[expect(dead_code, reason = "declared for future use")]
     /// Non-API FALSE singleton.
-    pub(crate) static R_FalseValue: SEXP;
+    static R_FalseValue: SEXP;
     #[cfg(feature = "nonapi")]
     #[expect(dead_code, reason = "declared for future use")]
     /// Non-API NA logical singleton.
-    pub(crate) static R_LogicalNAValue: SEXP;
+    static R_LogicalNAValue: SEXP;
 
     // Rinternals.h
     #[doc(alias = "mkChar")]
@@ -2121,41 +2121,41 @@ unsafe extern "C-unwind" {
     /// Get the length of a SEXP as `R_xlen_t` (supports long vectors).
     ///
     /// ALTREP-aware: will call ALTREP Length method if needed.
-    pub(crate) fn XLENGTH(x: SEXP) -> R_xlen_t;
+    fn XLENGTH(x: SEXP) -> R_xlen_t;
 
     /// Get the true length (allocated capacity) of a vector.
     ///
     /// May be larger than LENGTH for vectors with reserved space.
     /// ALTREP-aware.
-    pub(crate) fn TRUELENGTH(x: SEXP) -> R_xlen_t;
+    fn TRUELENGTH(x: SEXP) -> R_xlen_t;
 
     /// Get the attributes pairlist of a SEXP.
     ///
     /// Returns R_NilValue if no attributes.
-    pub(crate) fn ATTRIB(x: SEXP) -> SEXP;
+    fn ATTRIB(x: SEXP) -> SEXP;
 
     /// Set the attributes pairlist of a SEXP.
     ///
     /// # Safety
     ///
     /// `v` must be a pairlist or R_NilValue
-    pub(crate) fn SET_ATTRIB(x: SEXP, v: SEXP);
+    fn SET_ATTRIB(x: SEXP, v: SEXP);
 
     /// Check if SEXP has the "object" bit set (has a class).
     ///
     /// Returns non-zero if object has a class attribute.
-    pub(crate) fn OBJECT(x: SEXP) -> ::std::os::raw::c_int;
+    fn OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 
     /// Set the "object" bit.
-    pub(crate) fn SET_OBJECT(x: SEXP, v: ::std::os::raw::c_int);
+    fn SET_OBJECT(x: SEXP, v: ::std::os::raw::c_int);
 
     /// Get the LEVELS field (for factors).
-    pub(crate) fn LEVELS(x: SEXP) -> ::std::os::raw::c_int;
+    fn LEVELS(x: SEXP) -> ::std::os::raw::c_int;
 
     /// Set the LEVELS field (for factors).
     ///
     /// Returns the value that was set.
-    pub(crate) fn SETLEVELS(x: SEXP, v: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    fn SETLEVELS(x: SEXP, v: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 
     // endregion
 
@@ -2361,13 +2361,13 @@ unsafe extern "C-unwind" {
 
     // Pairlist utilities
     #[doc(alias = "elt")]
-    pub(crate) fn Rf_elt(list: SEXP, i: ::std::os::raw::c_int) -> SEXP;
+    fn Rf_elt(list: SEXP, i: ::std::os::raw::c_int) -> SEXP;
     #[doc(alias = "lastElt")]
-    pub(crate) fn Rf_lastElt(list: SEXP) -> SEXP;
+    fn Rf_lastElt(list: SEXP) -> SEXP;
     #[doc(alias = "nthcdr")]
-    pub(crate) fn Rf_nthcdr(list: SEXP, n: ::std::os::raw::c_int) -> SEXP;
+    fn Rf_nthcdr(list: SEXP, n: ::std::os::raw::c_int) -> SEXP;
     #[doc(alias = "listAppend")]
-    pub(crate) fn Rf_listAppend(s: SEXP, t: SEXP) -> SEXP;
+    fn Rf_listAppend(s: SEXP, t: SEXP) -> SEXP;
 
     // More attribute setters (using R's "gets" suffix convention)
     //
@@ -2537,7 +2537,7 @@ unsafe extern "C-unwind" {
 unsafe fn Rf_isS4(arg1: SEXP) -> Rboolean {
     unsafe extern "C-unwind" {
         #[link_name = "Rf_isS4"]
-        pub(crate) fn Rf_isS4_original(arg1: SEXP) -> u32;
+        fn Rf_isS4_original(arg1: SEXP) -> u32;
     }
 
     unsafe {
@@ -3134,7 +3134,7 @@ unsafe extern "C-unwind" {
     pub fn R_unif_index(dn: f64) -> f64;
 
     /// Get the current discrete uniform sample method.
-    pub(crate) fn R_sample_kind() -> Sampletype;
+    fn R_sample_kind() -> Sampletype;
 }
 
 // endregion
@@ -3159,7 +3159,7 @@ unsafe extern "C-unwind" {
     ///     vmaxset(watermark); // frees buf
     /// }
     /// ```
-    pub(crate) fn vmaxget() -> *mut ::std::os::raw::c_void;
+    fn vmaxget() -> *mut ::std::os::raw::c_void;
 
     /// Set the R memory stack watermark, freeing memory allocated since the mark.
     ///
@@ -3167,7 +3167,7 @@ unsafe extern "C-unwind" {
     ///
     /// `ovmax` must be a value returned by `vmaxget()` called earlier in the
     /// same R evaluation context.
-    pub(crate) fn vmaxset(ovmax: *const ::std::os::raw::c_void);
+    fn vmaxset(ovmax: *const ::std::os::raw::c_void);
 
     /// Run the R garbage collector.
     ///
@@ -3177,7 +3177,7 @@ unsafe extern "C-unwind" {
     /// Check if the garbage collector is currently running.
     ///
     /// Returns non-zero if GC is in progress.
-    pub(crate) fn R_gc_running() -> ::std::os::raw::c_int;
+    fn R_gc_running() -> ::std::os::raw::c_int;
 
     /// Allocate memory on R's memory stack.
     ///
@@ -3192,17 +3192,14 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Pointer to allocated memory (as `char*` for compatibility with S).
-    pub(crate) fn R_alloc(
-        nelem: usize,
-        eltsize: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
+    fn R_alloc(nelem: usize, eltsize: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 
     /// Allocate an array of long doubles on R's memory stack.
     ///
     /// # Parameters
     ///
     /// - `nelem`: Number of long double elements to allocate
-    pub(crate) fn R_allocLD(nelem: usize) -> *mut f64; // Note: f64 is close enough for most uses
+    fn R_allocLD(nelem: usize) -> *mut f64; // Note: f64 is close enough for most uses
 
     /// S compatibility: allocate zeroed memory on R's memory stack.
     ///
@@ -3210,7 +3207,7 @@ unsafe extern "C-unwind" {
     ///
     /// - `nelem`: Number of elements
     /// - `eltsize`: Size of each element
-    pub(crate) fn S_alloc(
+    fn S_alloc(
         nelem: ::std::os::raw::c_long,
         eltsize: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
@@ -3220,7 +3217,7 @@ unsafe extern "C-unwind" {
     /// # Safety
     ///
     /// `ptr` must have been allocated by `S_alloc`.
-    pub(crate) fn S_realloc(
+    fn S_realloc(
         ptr: *mut ::std::os::raw::c_char,
         newsize: ::std::os::raw::c_long,
         oldsize: ::std::os::raw::c_long,
@@ -3231,22 +3228,19 @@ unsafe extern "C-unwind" {
     ///
     /// Triggers GC if allocation fails, then retries.
     /// Memory must be freed with `free()`.
-    pub(crate) fn R_malloc_gc(size: usize) -> *mut ::std::os::raw::c_void;
+    fn R_malloc_gc(size: usize) -> *mut ::std::os::raw::c_void;
 
     /// GC-aware calloc.
     ///
     /// Triggers GC if allocation fails, then retries.
     /// Memory must be freed with `free()`.
-    pub(crate) fn R_calloc_gc(nelem: usize, eltsize: usize) -> *mut ::std::os::raw::c_void;
+    fn R_calloc_gc(nelem: usize, eltsize: usize) -> *mut ::std::os::raw::c_void;
 
     /// GC-aware realloc.
     ///
     /// Triggers GC if allocation fails, then retries.
     /// Memory must be freed with `free()`.
-    pub(crate) fn R_realloc_gc(
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    fn R_realloc_gc(ptr: *mut ::std::os::raw::c_void, size: usize) -> *mut ::std::os::raw::c_void;
 }
 
 // endregion
@@ -3261,7 +3255,7 @@ unsafe extern "C-unwind" {
     ///
     /// - `x`: Pointer to integer array
     /// - `n`: Number of elements
-    pub(crate) fn R_isort(x: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int);
+    fn R_isort(x: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int);
 
     /// Sort a double vector in place (ascending order).
     ///
@@ -3269,7 +3263,7 @@ unsafe extern "C-unwind" {
     ///
     /// - `x`: Pointer to double array
     /// - `n`: Number of elements
-    pub(crate) fn R_rsort(x: *mut f64, n: ::std::os::raw::c_int);
+    fn R_rsort(x: *mut f64, n: ::std::os::raw::c_int);
 
     /// Sort a complex vector in place.
     ///
@@ -3277,7 +3271,7 @@ unsafe extern "C-unwind" {
     ///
     /// - `x`: Pointer to Rcomplex array
     /// - `n`: Number of elements
-    pub(crate) fn R_csort(x: *mut Rcomplex, n: ::std::os::raw::c_int);
+    fn R_csort(x: *mut Rcomplex, n: ::std::os::raw::c_int);
 
     /// Sort doubles in descending order, carrying along an index array.
     ///
@@ -3287,7 +3281,7 @@ unsafe extern "C-unwind" {
     /// - `ib`: Pointer to integer array (permuted alongside `a`)
     /// - `n`: Number of elements
     #[doc(alias = "Rf_revsort")]
-    pub(crate) fn revsort(a: *mut f64, ib: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int);
+    fn revsort(a: *mut f64, ib: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int);
 
     /// Sort doubles with index array.
     ///
@@ -3296,11 +3290,7 @@ unsafe extern "C-unwind" {
     /// - `x`: Pointer to double array (sorted in place)
     /// - `indx`: Pointer to integer array (permuted alongside `x`)
     /// - `n`: Number of elements
-    pub(crate) fn rsort_with_index(
-        x: *mut f64,
-        indx: *mut ::std::os::raw::c_int,
-        n: ::std::os::raw::c_int,
-    );
+    fn rsort_with_index(x: *mut f64, indx: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int);
 
     /// Partial sort integers (moves k-th smallest to position k).
     ///
@@ -3310,11 +3300,7 @@ unsafe extern "C-unwind" {
     /// - `n`: Number of elements
     /// - `k`: Target position (0-indexed)
     #[doc(alias = "Rf_iPsort")]
-    pub(crate) fn iPsort(
-        x: *mut ::std::os::raw::c_int,
-        n: ::std::os::raw::c_int,
-        k: ::std::os::raw::c_int,
-    );
+    fn iPsort(x: *mut ::std::os::raw::c_int, n: ::std::os::raw::c_int, k: ::std::os::raw::c_int);
 
     /// Partial sort doubles (moves k-th smallest to position k).
     ///
@@ -3324,7 +3310,7 @@ unsafe extern "C-unwind" {
     /// - `n`: Number of elements
     /// - `k`: Target position (0-indexed)
     #[doc(alias = "Rf_rPsort")]
-    pub(crate) fn rPsort(x: *mut f64, n: ::std::os::raw::c_int, k: ::std::os::raw::c_int);
+    fn rPsort(x: *mut f64, n: ::std::os::raw::c_int, k: ::std::os::raw::c_int);
 
     /// Partial sort complex numbers.
     ///
@@ -3334,7 +3320,7 @@ unsafe extern "C-unwind" {
     /// - `n`: Number of elements
     /// - `k`: Target position (0-indexed)
     #[doc(alias = "Rf_cPsort")]
-    pub(crate) fn cPsort(x: *mut Rcomplex, n: ::std::os::raw::c_int, k: ::std::os::raw::c_int);
+    fn cPsort(x: *mut Rcomplex, n: ::std::os::raw::c_int, k: ::std::os::raw::c_int);
 
     /// Quicksort doubles in place.
     ///
@@ -3343,7 +3329,7 @@ unsafe extern "C-unwind" {
     /// - `v`: Pointer to double array
     /// - `i`: Start index (1-indexed for R compatibility)
     /// - `j`: End index (1-indexed)
-    pub(crate) fn R_qsort(v: *mut f64, i: usize, j: usize);
+    fn R_qsort(v: *mut f64, i: usize, j: usize);
 
     /// Quicksort doubles with index array.
     ///
@@ -3353,7 +3339,7 @@ unsafe extern "C-unwind" {
     /// - `indx`: Pointer to index array (permuted alongside v)
     /// - `i`: Start index (1-indexed)
     /// - `j`: End index (1-indexed)
-    pub(crate) fn R_qsort_I(
+    fn R_qsort_I(
         v: *mut f64,
         indx: *mut ::std::os::raw::c_int,
         i: ::std::os::raw::c_int,
@@ -3367,7 +3353,7 @@ unsafe extern "C-unwind" {
     /// - `iv`: Pointer to integer array
     /// - `i`: Start index (1-indexed)
     /// - `j`: End index (1-indexed)
-    pub(crate) fn R_qsort_int(iv: *mut ::std::os::raw::c_int, i: usize, j: usize);
+    fn R_qsort_int(iv: *mut ::std::os::raw::c_int, i: usize, j: usize);
 
     /// Quicksort integers with index array.
     ///
@@ -3377,7 +3363,7 @@ unsafe extern "C-unwind" {
     /// - `indx`: Pointer to index array
     /// - `i`: Start index (1-indexed)
     /// - `j`: End index (1-indexed)
-    pub(crate) fn R_qsort_int_I(
+    fn R_qsort_int_I(
         iv: *mut ::std::os::raw::c_int,
         indx: *mut ::std::os::raw::c_int,
         i: ::std::os::raw::c_int,
@@ -3389,22 +3375,17 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Pointer to expanded path (in R's internal buffer, do not free).
-    pub(crate) fn R_ExpandFileName(
-        s: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    fn R_ExpandFileName(s: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 
     /// Convert string to double, always using '.' as decimal point.
     ///
     /// Also accepts "NA" as input, returning NA_REAL.
-    pub(crate) fn R_atof(str: *const ::std::os::raw::c_char) -> f64;
+    fn R_atof(str: *const ::std::os::raw::c_char) -> f64;
 
     /// Convert string to double with end pointer, using '.' as decimal point.
     ///
     /// Like `strtod()` but locale-independent.
-    pub(crate) fn R_strtod(
-        c: *const ::std::os::raw::c_char,
-        end: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
+    fn R_strtod(c: *const ::std::os::raw::c_char, end: *mut *mut ::std::os::raw::c_char) -> f64;
 
     /// Generate a temporary filename.
     ///
@@ -3416,7 +3397,7 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Newly allocated string (must be freed with `R_free_tmpnam`).
-    pub(crate) fn R_tmpnam(
+    fn R_tmpnam(
         prefix: *const ::std::os::raw::c_char,
         tempdir: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
@@ -3432,26 +3413,26 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Newly allocated string (must be freed with `R_free_tmpnam`).
-    pub(crate) fn R_tmpnam2(
+    fn R_tmpnam2(
         prefix: *const ::std::os::raw::c_char,
         tempdir: *const ::std::os::raw::c_char,
         fileext: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 
     /// Free a temporary filename allocated by `R_tmpnam` or `R_tmpnam2`.
-    pub(crate) fn R_free_tmpnam(name: *mut ::std::os::raw::c_char);
+    fn R_free_tmpnam(name: *mut ::std::os::raw::c_char);
 
     /// Check for R stack overflow.
     ///
     /// Throws an R error if stack is nearly exhausted.
-    pub(crate) fn R_CheckStack();
+    fn R_CheckStack();
 
     /// Check for R stack overflow with extra space requirement.
     ///
     /// # Parameters
     ///
     /// - `extra`: Additional bytes needed
-    pub(crate) fn R_CheckStack2(extra: usize);
+    fn R_CheckStack2(extra: usize);
 
     /// Find the interval containing a value (binary search).
     ///
@@ -3470,7 +3451,7 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Interval index (1-indexed).
-    pub(crate) fn findInterval(
+    fn findInterval(
         xt: *const f64,
         n: ::std::os::raw::c_int,
         x: f64,
@@ -3482,7 +3463,7 @@ unsafe extern "C-unwind" {
 
     /// Extended interval finding with left-open option.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn findInterval2(
+    fn findInterval2(
         xt: *const f64,
         n: ::std::os::raw::c_int,
         x: f64,
@@ -3502,7 +3483,7 @@ unsafe extern "C-unwind" {
     /// - `nc`: Number of columns
     /// - `maxes`: Output array for column maxima indices (1-indexed)
     /// - `ties_meth`: How to handle ties (1=first, 2=random, 3=last)
-    pub(crate) fn R_max_col(
+    fn R_max_col(
         matrix: *const f64,
         nr: *const ::std::os::raw::c_int,
         nc: *const ::std::os::raw::c_int,
@@ -3514,17 +3495,17 @@ unsafe extern "C-unwind" {
     ///
     /// Recognizes "FALSE", "false", "False", "F", "f", etc.
     #[doc(alias = "Rf_StringFalse")]
-    pub(crate) fn StringFalse(s: *const ::std::os::raw::c_char) -> Rboolean;
+    fn StringFalse(s: *const ::std::os::raw::c_char) -> Rboolean;
 
     /// Check if a string represents TRUE in R.
     ///
     /// Recognizes "TRUE", "true", "True", "T", "t", etc.
     #[doc(alias = "Rf_StringTrue")]
-    pub(crate) fn StringTrue(s: *const ::std::os::raw::c_char) -> Rboolean;
+    fn StringTrue(s: *const ::std::os::raw::c_char) -> Rboolean;
 
     /// Check if a string is blank (empty or only whitespace).
     #[doc(alias = "Rf_isBlankString")]
-    pub(crate) fn isBlankString(s: *const ::std::os::raw::c_char) -> Rboolean;
+    fn isBlankString(s: *const ::std::os::raw::c_char) -> Rboolean;
 }
 
 // endregion
@@ -3557,7 +3538,7 @@ unsafe extern "C-unwind" {
     /// # Returns
     ///
     /// Character count or -1 on error.
-    pub(crate) fn R_nchar(
+    fn R_nchar(
         x: SEXP,
         ntype: ::std::os::raw::c_int,
         allowNA: Rboolean,
@@ -3575,7 +3556,7 @@ unsafe extern "C-unwind" {
     ///
     /// Uses R's standard print method for the object.
     #[doc(alias = "PrintValue")]
-    pub(crate) fn Rf_PrintValue(x: SEXP);
+    fn Rf_PrintValue(x: SEXP);
 
     // Environment functions
 
@@ -3623,7 +3604,7 @@ unsafe extern "C-unwind" {
     ///
     /// Integer vector of match positions (1-indexed, nomatch for non-matches).
     #[doc(alias = "match")]
-    pub(crate) fn Rf_match(x: SEXP, table: SEXP, nomatch: ::std::os::raw::c_int) -> SEXP;
+    fn Rf_match(x: SEXP, table: SEXP, nomatch: ::std::os::raw::c_int) -> SEXP;
 
     // Duplication and copying
 
@@ -3631,7 +3612,7 @@ unsafe extern "C-unwind" {
     ///
     /// Copies all attributes except names, dim, and dimnames.
     #[doc(alias = "copyMostAttrib")]
-    pub(crate) fn Rf_copyMostAttrib(source: SEXP, target: SEXP);
+    fn Rf_copyMostAttrib(source: SEXP, target: SEXP);
 
     /// Find first duplicated element.
     ///
@@ -3644,7 +3625,7 @@ unsafe extern "C-unwind" {
     ///
     /// 0 if no duplicates, otherwise 1-indexed position of first duplicate.
     #[doc(alias = "any_duplicated")]
-    pub(crate) fn Rf_any_duplicated(x: SEXP, fromLast: Rboolean) -> R_xlen_t;
+    fn Rf_any_duplicated(x: SEXP, fromLast: Rboolean) -> R_xlen_t;
 
     // S4 functions
 
@@ -3753,24 +3734,19 @@ unsafe extern "C-unwind" {
     /// - `val`: The value to associate
     /// - `fin`: Finalizer function (or R_NilValue)
     /// - `onexit`: Whether to run finalizer on R exit
-    pub(crate) fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
+    fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 
     /// Create a weak reference with C finalizer.
-    pub(crate) fn R_MakeWeakRefC(
-        key: SEXP,
-        val: SEXP,
-        fin: R_CFinalizer_t,
-        onexit: Rboolean,
-    ) -> SEXP;
+    fn R_MakeWeakRefC(key: SEXP, val: SEXP, fin: R_CFinalizer_t, onexit: Rboolean) -> SEXP;
 
     /// Get the key from a weak reference.
-    pub(crate) fn R_WeakRefKey(w: SEXP) -> SEXP;
+    fn R_WeakRefKey(w: SEXP) -> SEXP;
 
     /// Get the value from a weak reference.
-    pub(crate) fn R_WeakRefValue(w: SEXP) -> SEXP;
+    fn R_WeakRefValue(w: SEXP) -> SEXP;
 
     /// Run pending finalizers.
-    pub(crate) fn R_RunPendingFinalizers();
+    fn R_RunPendingFinalizers();
 
     // Conversion list/vector
 

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1826,9 +1826,9 @@ unsafe extern "C-unwind" {
     #[doc(alias = "lcons")]
     pub(crate) fn Rf_lcons(car: SEXP, cdr: SEXP) -> SEXP;
 
-    // Attribute manipulation
+    // Attribute manipulation — encapsulated by SexpExt methods
     #[doc(alias = "setAttrib")]
-    pub(crate) fn Rf_setAttrib(vec: SEXP, name: SEXP, val: SEXP) -> SEXP;
+    fn Rf_setAttrib(vec: SEXP, name: SEXP, val: SEXP) -> SEXP;
 
     // Rinternals.h
     #[doc(alias = "ScalarComplex")]
@@ -2179,17 +2179,18 @@ unsafe extern "C-unwind" {
     pub(crate) fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 
     // Attribute access
+    // Attribute accessors — encapsulated by SexpExt methods
     /// Read an attribute from an object by symbol (e.g. `R_NamesSymbol`).
     ///
     /// Returns `R_NilValue` if the attribute is not set.
     #[doc(alias = "getAttrib")]
-    pub(crate) fn Rf_getAttrib(vec: SEXP, name: SEXP) -> SEXP;
+    fn Rf_getAttrib(vec: SEXP, name: SEXP) -> SEXP;
     /// Set the `names` attribute; returns the updated object.
     #[doc(alias = "namesgets")]
-    pub(crate) fn Rf_namesgets(vec: SEXP, val: SEXP) -> SEXP;
+    fn Rf_namesgets(vec: SEXP, val: SEXP) -> SEXP;
     /// Set the `dim` attribute; returns the updated object.
     #[doc(alias = "dimgets")]
-    pub(crate) fn Rf_dimgets(vec: SEXP, val: SEXP) -> SEXP;
+    fn Rf_dimgets(vec: SEXP, val: SEXP) -> SEXP;
 
     // Duplication
     #[doc(alias = "duplicate")]
@@ -2237,17 +2238,17 @@ pub const IDENT_EXTPTR_AS_REF: ::std::os::raw::c_int = 64;
 #[allow(missing_docs)]
 #[r_ffi_checked]
 unsafe extern "C-unwind" {
-    // Type coercion
+    // Type coercion — encapsulated by SexpExt methods
     #[doc(alias = "asLogical")]
-    pub(crate) fn Rf_asLogical(x: SEXP) -> ::std::os::raw::c_int;
+    fn Rf_asLogical(x: SEXP) -> ::std::os::raw::c_int;
     #[doc(alias = "asInteger")]
-    pub(crate) fn Rf_asInteger(x: SEXP) -> ::std::os::raw::c_int;
+    fn Rf_asInteger(x: SEXP) -> ::std::os::raw::c_int;
     #[doc(alias = "asReal")]
-    pub(crate) fn Rf_asReal(x: SEXP) -> f64;
+    fn Rf_asReal(x: SEXP) -> f64;
     #[doc(alias = "asChar")]
-    pub(crate) fn Rf_asChar(x: SEXP) -> SEXP;
+    fn Rf_asChar(x: SEXP) -> SEXP;
     #[doc(alias = "coerceVector")]
-    pub(crate) fn Rf_coerceVector(v: SEXP, sexptype: SEXPTYPE) -> SEXP;
+    fn Rf_coerceVector(v: SEXP, sexptype: SEXPTYPE) -> SEXP;
 
     // Matrix utilities
     #[doc(alias = "nrows")]
@@ -2255,27 +2256,27 @@ unsafe extern "C-unwind" {
     #[doc(alias = "ncols")]
     pub(crate) fn Rf_ncols(x: SEXP) -> ::std::os::raw::c_int;
 
-    // Inheritance checking
+    // Inheritance checking — encapsulated by SexpExt::inherits_class()
     #[doc(alias = "inherits")]
-    pub(crate) fn Rf_inherits(x: SEXP, klass: *const ::std::os::raw::c_char) -> Rboolean;
+    fn Rf_inherits(x: SEXP, klass: *const ::std::os::raw::c_char) -> Rboolean;
 
-    // Type checking predicates
+    // Type checking predicates — encapsulated by SexpExt type-check methods
     #[doc(alias = "isNull")]
     fn Rf_isNull(s: SEXP) -> Rboolean;
     #[doc(alias = "isSymbol")]
-    pub(crate) fn Rf_isSymbol(s: SEXP) -> Rboolean;
+    fn Rf_isSymbol(s: SEXP) -> Rboolean;
     #[doc(alias = "isLogical")]
-    pub(crate) fn Rf_isLogical(s: SEXP) -> Rboolean;
+    fn Rf_isLogical(s: SEXP) -> Rboolean;
     #[doc(alias = "isReal")]
-    pub(crate) fn Rf_isReal(s: SEXP) -> Rboolean;
+    fn Rf_isReal(s: SEXP) -> Rboolean;
     #[doc(alias = "isComplex")]
-    pub(crate) fn Rf_isComplex(s: SEXP) -> Rboolean;
+    fn Rf_isComplex(s: SEXP) -> Rboolean;
     #[doc(alias = "isExpression")]
-    pub(crate) fn Rf_isExpression(s: SEXP) -> Rboolean;
+    fn Rf_isExpression(s: SEXP) -> Rboolean;
     #[doc(alias = "isEnvironment")]
     fn Rf_isEnvironment(s: SEXP) -> Rboolean;
     #[doc(alias = "isString")]
-    pub(crate) fn Rf_isString(s: SEXP) -> Rboolean;
+    fn Rf_isString(s: SEXP) -> Rboolean;
 
     // Composite type checking (from inline functions)
     #[doc(alias = "isArray")]
@@ -2285,21 +2286,21 @@ unsafe extern "C-unwind" {
     #[doc(alias = "isList")]
     fn Rf_isList(s: SEXP) -> Rboolean;
     #[doc(alias = "isNewList")]
-    pub(crate) fn Rf_isNewList(s: SEXP) -> Rboolean;
+    fn Rf_isNewList(s: SEXP) -> Rboolean;
     #[doc(alias = "isPairList")]
-    pub(crate) fn Rf_isPairList(s: SEXP) -> Rboolean;
+    fn Rf_isPairList(s: SEXP) -> Rboolean;
     #[doc(alias = "isFunction")]
     fn Rf_isFunction(s: SEXP) -> Rboolean;
     #[doc(alias = "isPrimitive")]
-    pub(crate) fn Rf_isPrimitive(s: SEXP) -> Rboolean;
+    fn Rf_isPrimitive(s: SEXP) -> Rboolean;
     #[doc(alias = "isLanguage")]
-    pub(crate) fn Rf_isLanguage(s: SEXP) -> Rboolean;
+    fn Rf_isLanguage(s: SEXP) -> Rboolean;
     #[doc(alias = "isDataFrame")]
     fn Rf_isDataFrame(s: SEXP) -> Rboolean;
     #[doc(alias = "isFactor")]
     fn Rf_isFactor(s: SEXP) -> Rboolean;
     #[doc(alias = "isInteger")]
-    pub(crate) fn Rf_isInteger(s: SEXP) -> Rboolean;
+    fn Rf_isInteger(s: SEXP) -> Rboolean;
     #[doc(alias = "isObject")]
     fn Rf_isObject(s: SEXP) -> Rboolean;
 
@@ -2327,7 +2328,7 @@ unsafe extern "C-unwind" {
     ///
     /// Returns the modified vector (like all "*gets" functions).
     #[doc(alias = "classgets")]
-    pub(crate) fn Rf_classgets(vec: SEXP, klass: SEXP) -> SEXP;
+    fn Rf_classgets(vec: SEXP, klass: SEXP) -> SEXP;
 
     /// Set the dimnames attribute of an array/matrix.
     ///
@@ -2338,7 +2339,7 @@ unsafe extern "C-unwind" {
     ///
     /// Returns the modified vector.
     #[doc(alias = "dimnamesgets")]
-    pub(crate) fn Rf_dimnamesgets(vec: SEXP, val: SEXP) -> SEXP;
+    fn Rf_dimnamesgets(vec: SEXP, val: SEXP) -> SEXP;
     #[doc(alias = "GetRowNames")]
     pub(crate) fn Rf_GetRowNames(dimnames: SEXP) -> SEXP;
     #[doc(alias = "GetColNames")]

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -89,6 +89,18 @@ impl SEXPTYPE {
     /// R defines both `OBJSXP` and `S4SXP` as value 25. `S4SXP` is retained
     /// for backwards compatibility; `OBJSXP` is the preferred name.
     pub const OBJSXP: SEXPTYPE = SEXPTYPE::S4SXP;
+
+    /// Get R's name for this SEXPTYPE (e.g. `"double"`, `"integer"`, `"list"`).
+    ///
+    /// Returns the same string as R's `typeof()` function.
+    #[inline]
+    pub fn type_name(self) -> &'static str {
+        let cstr = unsafe { Rf_type2char(self) };
+        // SAFETY: R's type names are static ASCII strings
+        unsafe { std::ffi::CStr::from_ptr(cstr) }
+            .to_str()
+            .unwrap_or("unknown")
+    }
 }
 
 #[repr(transparent)]
@@ -647,6 +659,29 @@ pub trait SexpExt {
 
     // endregion
 
+    // region: Symbol and CHARSXP access
+
+    /// Get the print name (CHARSXP) of a symbol (SYMSXP).
+    ///
+    /// # Safety
+    ///
+    /// The SEXP must be a valid SYMSXP.
+    fn printname(&self) -> SEXP;
+
+    /// Get the C string pointer from a CHARSXP.
+    ///
+    /// The returned pointer is valid as long as the CHARSXP is protected.
+    ///
+    /// # Safety
+    ///
+    /// The SEXP must be a valid CHARSXP.
+    fn r_char(&self) -> *const ::std::os::raw::c_char;
+
+    /// Get a `&str` from a CHARSXP. Returns `None` for `NA_character_`.
+    fn r_char_str(&self) -> Option<&str>;
+
+    // endregion
+
     // region: Vector resizing
 
     /// Resize a vector to a new length, returning a (possibly new) SEXP.
@@ -1154,6 +1189,33 @@ impl SexpExt for SEXP {
     #[inline]
     fn set_raw_elt(&self, i: isize, v: u8) {
         unsafe { SET_RAW_ELT(*self, i, v) }
+    }
+
+    // endregion
+
+    // region: Symbol and CHARSXP access
+
+    #[inline]
+    fn printname(&self) -> SEXP {
+        unsafe { PRINTNAME(*self) }
+    }
+
+    #[inline]
+    fn r_char(&self) -> *const ::std::os::raw::c_char {
+        unsafe { R_CHAR(*self) }
+    }
+
+    #[inline]
+    fn r_char_str(&self) -> Option<&str> {
+        if self.is_na_string() {
+            return None;
+        }
+        let p = unsafe { R_CHAR(*self) };
+        Some(
+            unsafe { std::ffi::CStr::from_ptr(p) }
+                .to_str()
+                .unwrap_or(""),
+        )
     }
 
     // endregion
@@ -1833,13 +1895,13 @@ unsafe extern "C-unwind" {
     #[doc(alias = "translateCharUTF8")]
     pub fn Rf_translateCharUTF8(x: SEXP) -> *const ::std::os::raw::c_char;
     #[doc(alias = "getCharCE")]
-    pub(crate) fn Rf_getCharCE(x: SEXP) -> cetype_t;
+    fn Rf_getCharCE(x: SEXP) -> cetype_t;
     #[doc(alias = "charIsASCII")]
-    pub(crate) fn Rf_charIsASCII(x: SEXP) -> Rboolean;
+    fn Rf_charIsASCII(x: SEXP) -> Rboolean;
     #[doc(alias = "charIsUTF8")]
-    pub(crate) fn Rf_charIsUTF8(x: SEXP) -> Rboolean;
+    fn Rf_charIsUTF8(x: SEXP) -> Rboolean;
     #[doc(alias = "charIsLatin1")]
-    pub(crate) fn Rf_charIsLatin1(x: SEXP) -> Rboolean;
+    fn Rf_charIsLatin1(x: SEXP) -> Rboolean;
 
     pub(crate) fn R_MakeUnwindCont() -> SEXP;
     pub(crate) fn R_ContinueUnwind(cont: SEXP) -> !;
@@ -2041,7 +2103,7 @@ unsafe extern "C-unwind" {
     #[cfg(feature = "nonapi")]
     pub(crate) fn DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
     pub fn DATAPTR_RO(x: SEXP) -> *const ::std::os::raw::c_void;
-    pub(crate) fn DATAPTR_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_void;
+    fn DATAPTR_OR_NULL(x: SEXP) -> *const ::std::os::raw::c_void;
 
     // region: Cons Cell (Pairlist) Accessors
     //
@@ -2228,7 +2290,7 @@ unsafe extern "C-unwind" {
     #[doc(alias = "install")]
     pub fn Rf_install(name: *const ::std::os::raw::c_char) -> SEXP;
     /// Get the print name (CHARSXP) of a symbol (SYMSXP)
-    pub(crate) fn PRINTNAME(x: SEXP) -> SEXP;
+    fn PRINTNAME(x: SEXP) -> SEXP;
     /// Get the C string pointer from a CHARSXP
     #[doc(alias = "CHAR")]
     pub(crate) fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
@@ -3550,7 +3612,7 @@ unsafe extern "C-unwind" {
     ///
     /// Returns a string like "INTSXP", "REALSXP", etc.
     #[doc(alias = "type2char")]
-    pub(crate) fn Rf_type2char(sexptype: SEXPTYPE) -> *const ::std::os::raw::c_char;
+    fn Rf_type2char(sexptype: SEXPTYPE) -> *const ::std::os::raw::c_char;
 
     /// Print an R value to the console.
     ///
@@ -3572,21 +3634,21 @@ unsafe extern "C-unwind" {
     /// Check if a variable exists in an environment frame.
     ///
     /// Does not search enclosing environments.
-    pub(crate) fn R_existsVarInFrame(rho: SEXP, symbol: SEXP) -> Rboolean;
+    fn R_existsVarInFrame(rho: SEXP, symbol: SEXP) -> Rboolean;
 
     /// Remove a variable from an environment frame.
     ///
     /// # Returns
     ///
     /// The removed value, or R_NilValue if not found.
-    pub(crate) fn R_removeVarFromFrame(symbol: SEXP, env: SEXP) -> SEXP;
+    fn R_removeVarFromFrame(symbol: SEXP, env: SEXP) -> SEXP;
 
     /// Get the top-level environment.
     ///
     /// Walks up enclosing environments until reaching a top-level env
     /// (global, namespace, or base).
     #[doc(alias = "topenv")]
-    pub(crate) fn Rf_topenv(target: SEXP, envir: SEXP) -> SEXP;
+    fn Rf_topenv(target: SEXP, envir: SEXP) -> SEXP;
 
     // Matching functions
 

--- a/miniextendr-api/src/ffi/altrep.rs
+++ b/miniextendr-api/src/ffi/altrep.rs
@@ -182,9 +182,10 @@ unsafe impl Sync for R_altrep_class_t {}
 #[allow(missing_docs)]
 #[miniextendr_macros::r_ffi_checked]
 unsafe extern "C-unwind" {
-    pub fn R_new_altrep(aclass: R_altrep_class_t, data1: SEXP, data2: SEXP) -> SEXP;
+    // ALTREP instance construction (encapsulated by R_altrep_class_t::new_altrep)
+    fn R_new_altrep(aclass: R_altrep_class_t, data1: SEXP, data2: SEXP) -> SEXP;
 
-    // ALTREP class constructors
+    // ALTREP class constructors — pub because proc-macro generates calls from user crates
     pub fn R_make_altstring_class(
         cname: *const ::std::os::raw::c_char,
         pname: *const ::std::os::raw::c_char,
@@ -220,86 +221,478 @@ unsafe extern "C-unwind" {
         pname: *const ::std::os::raw::c_char,
         info: *mut DllInfo,
     ) -> R_altrep_class_t;
-    pub fn R_altrep_inherits(x: SEXP, aclass: R_altrep_class_t) -> Rboolean;
-    pub fn R_set_altrep_UnserializeEX_method(
+    // ALTREP class membership check (encapsulated by R_altrep_class_t::inherits)
+    fn R_altrep_inherits(x: SEXP, aclass: R_altrep_class_t) -> Rboolean;
+
+    // Method setters — private, encapsulated by R_altrep_class_t methods
+    fn R_set_altrep_UnserializeEX_method(
         cls: R_altrep_class_t,
         fun: R_altrep_UnserializeEX_method_t,
     );
-    pub fn R_set_altrep_Unserialize_method(
-        cls: R_altrep_class_t,
-        fun: R_altrep_Unserialize_method_t,
-    );
-    pub fn R_set_altrep_Serialized_state_method(
+    fn R_set_altrep_Unserialize_method(cls: R_altrep_class_t, fun: R_altrep_Unserialize_method_t);
+    fn R_set_altrep_Serialized_state_method(
         cls: R_altrep_class_t,
         fun: R_altrep_Serialized_state_method_t,
     );
-    pub fn R_set_altrep_DuplicateEX_method(
-        cls: R_altrep_class_t,
-        fun: R_altrep_DuplicateEX_method_t,
-    );
-    pub fn R_set_altrep_Duplicate_method(cls: R_altrep_class_t, fun: R_altrep_Duplicate_method_t);
-    pub fn R_set_altrep_Coerce_method(cls: R_altrep_class_t, fun: R_altrep_Coerce_method_t);
-    pub fn R_set_altrep_Inspect_method(cls: R_altrep_class_t, fun: R_altrep_Inspect_method_t);
-    pub fn R_set_altrep_Length_method(cls: R_altrep_class_t, fun: R_altrep_Length_method_t);
-    pub fn R_set_altvec_Dataptr_method(cls: R_altrep_class_t, fun: R_altvec_Dataptr_method_t);
-    pub fn R_set_altvec_Dataptr_or_null_method(
+    fn R_set_altrep_DuplicateEX_method(cls: R_altrep_class_t, fun: R_altrep_DuplicateEX_method_t);
+    fn R_set_altrep_Duplicate_method(cls: R_altrep_class_t, fun: R_altrep_Duplicate_method_t);
+    fn R_set_altrep_Coerce_method(cls: R_altrep_class_t, fun: R_altrep_Coerce_method_t);
+    fn R_set_altrep_Inspect_method(cls: R_altrep_class_t, fun: R_altrep_Inspect_method_t);
+    fn R_set_altrep_Length_method(cls: R_altrep_class_t, fun: R_altrep_Length_method_t);
+    fn R_set_altvec_Dataptr_method(cls: R_altrep_class_t, fun: R_altvec_Dataptr_method_t);
+    fn R_set_altvec_Dataptr_or_null_method(
         cls: R_altrep_class_t,
         fun: R_altvec_Dataptr_or_null_method_t,
     );
-    pub fn R_set_altvec_Extract_subset_method(
+    fn R_set_altvec_Extract_subset_method(
         cls: R_altrep_class_t,
         fun: R_altvec_Extract_subset_method_t,
     );
-    pub fn R_set_altinteger_Elt_method(cls: R_altrep_class_t, fun: R_altinteger_Elt_method_t);
-    pub fn R_set_altinteger_Get_region_method(
+    fn R_set_altinteger_Elt_method(cls: R_altrep_class_t, fun: R_altinteger_Elt_method_t);
+    fn R_set_altinteger_Get_region_method(
         cls: R_altrep_class_t,
         fun: R_altinteger_Get_region_method_t,
     );
-    pub fn R_set_altinteger_Is_sorted_method(
+    fn R_set_altinteger_Is_sorted_method(
         cls: R_altrep_class_t,
         fun: R_altinteger_Is_sorted_method_t,
     );
-    pub fn R_set_altinteger_No_NA_method(cls: R_altrep_class_t, fun: R_altinteger_No_NA_method_t);
-    pub fn R_set_altinteger_Sum_method(cls: R_altrep_class_t, fun: R_altinteger_Sum_method_t);
-    pub fn R_set_altinteger_Min_method(cls: R_altrep_class_t, fun: R_altinteger_Min_method_t);
-    pub fn R_set_altinteger_Max_method(cls: R_altrep_class_t, fun: R_altinteger_Max_method_t);
-    pub fn R_set_altreal_Elt_method(cls: R_altrep_class_t, fun: R_altreal_Elt_method_t);
-    pub fn R_set_altreal_Get_region_method(
-        cls: R_altrep_class_t,
-        fun: R_altreal_Get_region_method_t,
-    );
-    pub fn R_set_altreal_Is_sorted_method(cls: R_altrep_class_t, fun: R_altreal_Is_sorted_method_t);
-    pub fn R_set_altreal_No_NA_method(cls: R_altrep_class_t, fun: R_altreal_No_NA_method_t);
-    pub fn R_set_altreal_Sum_method(cls: R_altrep_class_t, fun: R_altreal_Sum_method_t);
-    pub fn R_set_altreal_Min_method(cls: R_altrep_class_t, fun: R_altreal_Min_method_t);
-    pub fn R_set_altreal_Max_method(cls: R_altrep_class_t, fun: R_altreal_Max_method_t);
-    pub fn R_set_altlogical_Elt_method(cls: R_altrep_class_t, fun: R_altlogical_Elt_method_t);
-    pub fn R_set_altlogical_Get_region_method(
+    fn R_set_altinteger_No_NA_method(cls: R_altrep_class_t, fun: R_altinteger_No_NA_method_t);
+    fn R_set_altinteger_Sum_method(cls: R_altrep_class_t, fun: R_altinteger_Sum_method_t);
+    fn R_set_altinteger_Min_method(cls: R_altrep_class_t, fun: R_altinteger_Min_method_t);
+    fn R_set_altinteger_Max_method(cls: R_altrep_class_t, fun: R_altinteger_Max_method_t);
+    fn R_set_altreal_Elt_method(cls: R_altrep_class_t, fun: R_altreal_Elt_method_t);
+    fn R_set_altreal_Get_region_method(cls: R_altrep_class_t, fun: R_altreal_Get_region_method_t);
+    fn R_set_altreal_Is_sorted_method(cls: R_altrep_class_t, fun: R_altreal_Is_sorted_method_t);
+    fn R_set_altreal_No_NA_method(cls: R_altrep_class_t, fun: R_altreal_No_NA_method_t);
+    fn R_set_altreal_Sum_method(cls: R_altrep_class_t, fun: R_altreal_Sum_method_t);
+    fn R_set_altreal_Min_method(cls: R_altrep_class_t, fun: R_altreal_Min_method_t);
+    fn R_set_altreal_Max_method(cls: R_altrep_class_t, fun: R_altreal_Max_method_t);
+    fn R_set_altlogical_Elt_method(cls: R_altrep_class_t, fun: R_altlogical_Elt_method_t);
+    fn R_set_altlogical_Get_region_method(
         cls: R_altrep_class_t,
         fun: R_altlogical_Get_region_method_t,
     );
-    pub fn R_set_altlogical_Is_sorted_method(
+    fn R_set_altlogical_Is_sorted_method(
         cls: R_altrep_class_t,
         fun: R_altlogical_Is_sorted_method_t,
     );
-    pub fn R_set_altlogical_No_NA_method(cls: R_altrep_class_t, fun: R_altlogical_No_NA_method_t);
-    pub fn R_set_altlogical_Sum_method(cls: R_altrep_class_t, fun: R_altlogical_Sum_method_t);
-    pub fn R_set_altraw_Elt_method(cls: R_altrep_class_t, fun: R_altraw_Elt_method_t);
-    pub fn R_set_altraw_Get_region_method(cls: R_altrep_class_t, fun: R_altraw_Get_region_method_t);
-    pub fn R_set_altcomplex_Elt_method(cls: R_altrep_class_t, fun: R_altcomplex_Elt_method_t);
-    pub fn R_set_altcomplex_Get_region_method(
+    fn R_set_altlogical_No_NA_method(cls: R_altrep_class_t, fun: R_altlogical_No_NA_method_t);
+    fn R_set_altlogical_Sum_method(cls: R_altrep_class_t, fun: R_altlogical_Sum_method_t);
+    fn R_set_altraw_Elt_method(cls: R_altrep_class_t, fun: R_altraw_Elt_method_t);
+    fn R_set_altraw_Get_region_method(cls: R_altrep_class_t, fun: R_altraw_Get_region_method_t);
+    fn R_set_altcomplex_Elt_method(cls: R_altrep_class_t, fun: R_altcomplex_Elt_method_t);
+    fn R_set_altcomplex_Get_region_method(
         cls: R_altrep_class_t,
         fun: R_altcomplex_Get_region_method_t,
     );
-    pub fn R_set_altstring_Elt_method(cls: R_altrep_class_t, fun: R_altstring_Elt_method_t);
-    pub fn R_set_altstring_Set_elt_method(cls: R_altrep_class_t, fun: R_altstring_Set_elt_method_t);
-    pub fn R_set_altstring_Is_sorted_method(
-        cls: R_altrep_class_t,
-        fun: R_altstring_Is_sorted_method_t,
-    );
-    pub fn R_set_altstring_No_NA_method(cls: R_altrep_class_t, fun: R_altstring_No_NA_method_t);
-    pub fn R_set_altlist_Elt_method(cls: R_altrep_class_t, fun: R_altlist_Elt_method_t);
-    pub fn R_set_altlist_Set_elt_method(cls: R_altrep_class_t, fun: R_altlist_Set_elt_method_t);
+    fn R_set_altstring_Elt_method(cls: R_altrep_class_t, fun: R_altstring_Elt_method_t);
+    fn R_set_altstring_Set_elt_method(cls: R_altrep_class_t, fun: R_altstring_Set_elt_method_t);
+    fn R_set_altstring_Is_sorted_method(cls: R_altrep_class_t, fun: R_altstring_Is_sorted_method_t);
+    fn R_set_altstring_No_NA_method(cls: R_altrep_class_t, fun: R_altstring_No_NA_method_t);
+    fn R_set_altlist_Elt_method(cls: R_altrep_class_t, fun: R_altlist_Elt_method_t);
+    fn R_set_altlist_Set_elt_method(cls: R_altrep_class_t, fun: R_altlist_Set_elt_method_t);
+}
+
+impl R_altrep_class_t {
+    /// Create from a raw SEXP pointer.
+    ///
+    /// Rust equivalent of C macro `R_SUBTYPE_INIT(x)`.
+    #[inline(always)]
+    pub const fn from_sexp(ptr: SEXP) -> Self {
+        Self { ptr }
+    }
+
+    /// Get the underlying SEXP.
+    ///
+    /// Rust equivalent of C macro `R_SEXP(x)`.
+    #[inline(always)]
+    pub fn as_sexp(self) -> SEXP {
+        self.ptr
+    }
+
+    /// Create a new ALTREP instance with data1 and data2 slots.
+    ///
+    /// # Safety
+    /// Must be called on R's main thread. `data1` and `data2` must be valid SEXPs.
+    #[inline]
+    pub unsafe fn new_altrep(self, data1: SEXP, data2: SEXP) -> SEXP {
+        unsafe { R_new_altrep(self, data1, data2) }
+    }
+
+    /// Create a new ALTREP instance (no thread check).
+    ///
+    /// # Safety
+    /// Must be called on R's main thread.
+    #[inline]
+    pub unsafe fn new_altrep_unchecked(self, data1: SEXP, data2: SEXP) -> SEXP {
+        unsafe { R_new_altrep_unchecked(self, data1, data2) }
+    }
+
+    /// Check if `x` is an instance of this ALTREP class.
+    ///
+    /// # Safety
+    /// Must be called on R's main thread. `x` must be a valid SEXP.
+    #[inline]
+    pub unsafe fn inherits(self, x: SEXP) -> bool {
+        unsafe { R_altrep_inherits(x, self) != Rboolean::FALSE }
+    }
+
+    // region: Base ALTREP method setters
+
+    /// Set the Length method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_length_method(self, fun: R_altrep_Length_method_t) {
+        unsafe { R_set_altrep_Length_method(self, fun) }
+    }
+
+    /// Set the Serialized_state method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_serialized_state_method(self, fun: R_altrep_Serialized_state_method_t) {
+        unsafe { R_set_altrep_Serialized_state_method(self, fun) }
+    }
+
+    /// Set the Unserialize method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_unserialize_method(self, fun: R_altrep_Unserialize_method_t) {
+        unsafe { R_set_altrep_Unserialize_method(self, fun) }
+    }
+
+    /// Set the UnserializeEX method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_unserialize_ex_method(self, fun: R_altrep_UnserializeEX_method_t) {
+        unsafe { R_set_altrep_UnserializeEX_method(self, fun) }
+    }
+
+    /// Set the Duplicate method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_duplicate_method(self, fun: R_altrep_Duplicate_method_t) {
+        unsafe { R_set_altrep_Duplicate_method(self, fun) }
+    }
+
+    /// Set the DuplicateEX method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_duplicate_ex_method(self, fun: R_altrep_DuplicateEX_method_t) {
+        unsafe { R_set_altrep_DuplicateEX_method(self, fun) }
+    }
+
+    /// Set the Coerce method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_coerce_method(self, fun: R_altrep_Coerce_method_t) {
+        unsafe { R_set_altrep_Coerce_method(self, fun) }
+    }
+
+    /// Set the Inspect method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_inspect_method(self, fun: R_altrep_Inspect_method_t) {
+        unsafe { R_set_altrep_Inspect_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Vector-level method setters
+
+    /// Set the Dataptr method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_dataptr_method(self, fun: R_altvec_Dataptr_method_t) {
+        unsafe { R_set_altvec_Dataptr_method(self, fun) }
+    }
+
+    /// Set the Dataptr_or_null method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_dataptr_or_null_method(self, fun: R_altvec_Dataptr_or_null_method_t) {
+        unsafe { R_set_altvec_Dataptr_or_null_method(self, fun) }
+    }
+
+    /// Set the Extract_subset method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_extract_subset_method(self, fun: R_altvec_Extract_subset_method_t) {
+        unsafe { R_set_altvec_Extract_subset_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Integer method setters
+
+    /// Set the integer Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_elt_method(self, fun: R_altinteger_Elt_method_t) {
+        unsafe { R_set_altinteger_Elt_method(self, fun) }
+    }
+
+    /// Set the integer Get_region method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_get_region_method(self, fun: R_altinteger_Get_region_method_t) {
+        unsafe { R_set_altinteger_Get_region_method(self, fun) }
+    }
+
+    /// Set the integer Is_sorted method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_is_sorted_method(self, fun: R_altinteger_Is_sorted_method_t) {
+        unsafe { R_set_altinteger_Is_sorted_method(self, fun) }
+    }
+
+    /// Set the integer No_NA method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_no_na_method(self, fun: R_altinteger_No_NA_method_t) {
+        unsafe { R_set_altinteger_No_NA_method(self, fun) }
+    }
+
+    /// Set the integer Sum method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_sum_method(self, fun: R_altinteger_Sum_method_t) {
+        unsafe { R_set_altinteger_Sum_method(self, fun) }
+    }
+
+    /// Set the integer Min method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_min_method(self, fun: R_altinteger_Min_method_t) {
+        unsafe { R_set_altinteger_Min_method(self, fun) }
+    }
+
+    /// Set the integer Max method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_integer_max_method(self, fun: R_altinteger_Max_method_t) {
+        unsafe { R_set_altinteger_Max_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Real method setters
+
+    /// Set the real Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_elt_method(self, fun: R_altreal_Elt_method_t) {
+        unsafe { R_set_altreal_Elt_method(self, fun) }
+    }
+
+    /// Set the real Get_region method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_get_region_method(self, fun: R_altreal_Get_region_method_t) {
+        unsafe { R_set_altreal_Get_region_method(self, fun) }
+    }
+
+    /// Set the real Is_sorted method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_is_sorted_method(self, fun: R_altreal_Is_sorted_method_t) {
+        unsafe { R_set_altreal_Is_sorted_method(self, fun) }
+    }
+
+    /// Set the real No_NA method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_no_na_method(self, fun: R_altreal_No_NA_method_t) {
+        unsafe { R_set_altreal_No_NA_method(self, fun) }
+    }
+
+    /// Set the real Sum method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_sum_method(self, fun: R_altreal_Sum_method_t) {
+        unsafe { R_set_altreal_Sum_method(self, fun) }
+    }
+
+    /// Set the real Min method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_min_method(self, fun: R_altreal_Min_method_t) {
+        unsafe { R_set_altreal_Min_method(self, fun) }
+    }
+
+    /// Set the real Max method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_real_max_method(self, fun: R_altreal_Max_method_t) {
+        unsafe { R_set_altreal_Max_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Logical method setters
+
+    /// Set the logical Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_logical_elt_method(self, fun: R_altlogical_Elt_method_t) {
+        unsafe { R_set_altlogical_Elt_method(self, fun) }
+    }
+
+    /// Set the logical Get_region method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_logical_get_region_method(self, fun: R_altlogical_Get_region_method_t) {
+        unsafe { R_set_altlogical_Get_region_method(self, fun) }
+    }
+
+    /// Set the logical Is_sorted method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_logical_is_sorted_method(self, fun: R_altlogical_Is_sorted_method_t) {
+        unsafe { R_set_altlogical_Is_sorted_method(self, fun) }
+    }
+
+    /// Set the logical No_NA method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_logical_no_na_method(self, fun: R_altlogical_No_NA_method_t) {
+        unsafe { R_set_altlogical_No_NA_method(self, fun) }
+    }
+
+    /// Set the logical Sum method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_logical_sum_method(self, fun: R_altlogical_Sum_method_t) {
+        unsafe { R_set_altlogical_Sum_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Raw method setters
+
+    /// Set the raw Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_raw_elt_method(self, fun: R_altraw_Elt_method_t) {
+        unsafe { R_set_altraw_Elt_method(self, fun) }
+    }
+
+    /// Set the raw Get_region method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_raw_get_region_method(self, fun: R_altraw_Get_region_method_t) {
+        unsafe { R_set_altraw_Get_region_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: Complex method setters
+
+    /// Set the complex Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_complex_elt_method(self, fun: R_altcomplex_Elt_method_t) {
+        unsafe { R_set_altcomplex_Elt_method(self, fun) }
+    }
+
+    /// Set the complex Get_region method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_complex_get_region_method(self, fun: R_altcomplex_Get_region_method_t) {
+        unsafe { R_set_altcomplex_Get_region_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: String method setters
+
+    /// Set the string Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_string_elt_method(self, fun: R_altstring_Elt_method_t) {
+        unsafe { R_set_altstring_Elt_method(self, fun) }
+    }
+
+    /// Set the string Set_elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_string_set_elt_method(self, fun: R_altstring_Set_elt_method_t) {
+        unsafe { R_set_altstring_Set_elt_method(self, fun) }
+    }
+
+    /// Set the string Is_sorted method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_string_is_sorted_method(self, fun: R_altstring_Is_sorted_method_t) {
+        unsafe { R_set_altstring_Is_sorted_method(self, fun) }
+    }
+
+    /// Set the string No_NA method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_string_no_na_method(self, fun: R_altstring_No_NA_method_t) {
+        unsafe { R_set_altstring_No_NA_method(self, fun) }
+    }
+
+    // endregion
+
+    // region: List method setters
+
+    /// Set the list Elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_list_elt_method(self, fun: R_altlist_Elt_method_t) {
+        unsafe { R_set_altlist_Elt_method(self, fun) }
+    }
+
+    /// Set the list Set_elt method.
+    /// # Safety
+    /// Must be called during R initialization.
+    #[inline]
+    pub unsafe fn set_list_set_elt_method(self, fun: R_altlist_Set_elt_method_t) {
+        unsafe { R_set_altlist_Set_elt_method(self, fun) }
+    }
+
+    // endregion
 }
 
 // region: ALTREP Helper Functions (Rust equivalents of R's ALTREP macros)

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -80,9 +80,7 @@ pub(crate) unsafe fn charsxp_to_str_unchecked(charsxp: SEXP) -> &'static str {
 #[inline]
 unsafe fn charsxp_to_str_impl(ptr: *const std::os::raw::c_char, charsxp: SEXP) -> &'static str {
     unsafe {
-        let len: usize = crate::ffi::LENGTH(charsxp)
-            .try_into()
-            .expect("CHARSXP LENGTH must be non-negative");
+        let len: usize = charsxp.len();
         let bytes = r_slice(ptr.cast::<u8>(), len);
         // SAFETY: miniextendr_assert_utf8_locale() at init guarantees all
         // CHARSXPs in this session are valid UTF-8 or ASCII.

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -65,13 +65,13 @@ pub(crate) fn is_na_real(value: f64) -> bool {
 /// - The returned `&str` is only valid as long as R doesn't GC the CHARSXP.
 #[inline]
 pub(crate) unsafe fn charsxp_to_str(charsxp: SEXP) -> &'static str {
-    unsafe { charsxp_to_str_impl(crate::ffi::R_CHAR(charsxp), charsxp) }
+    unsafe { charsxp_to_str_impl(charsxp.r_char(), charsxp) }
 }
 
 /// Unchecked version of [`charsxp_to_str`] (skips R thread checks on `R_CHAR`).
 #[inline]
 pub(crate) unsafe fn charsxp_to_str_unchecked(charsxp: SEXP) -> &'static str {
-    unsafe { charsxp_to_str_impl(crate::ffi::R_CHAR_unchecked(charsxp), charsxp) }
+    unsafe { charsxp_to_str_impl(charsxp.r_char_unchecked(), charsxp) }
 }
 
 /// Shared implementation: given a data pointer and CHARSXP, produce `&str`.

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -94,7 +94,7 @@ where
     for i in 0..len {
         let key = if has_names {
             let charsxp = names.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 String::new()
             } else {
                 let c_str = unsafe { Rf_translateCharUTF8(charsxp) };

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -89,9 +89,7 @@ impl TryFromSexp for Vec<Cow<'static, str>> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString }
-                || charsxp == unsafe { crate::ffi::R_BlankString }
-            {
+            if charsxp == SEXP::na_string() || charsxp == SEXP::blank_string() {
                 result.push(Cow::Borrowed(""));
             } else {
                 result.push(unsafe { charsxp_to_cow(charsxp) });
@@ -123,7 +121,7 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
                 // charsxp_to_cow returns Cow::Borrowed("") for R_BlankString-equivalent
@@ -185,7 +183,7 @@ impl TryFromSexp for Vec<String> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            let s = if charsxp == unsafe { crate::ffi::R_NaString } {
+            let s = if charsxp == SEXP::na_string() {
                 String::new()
             } else {
                 let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
@@ -238,11 +236,11 @@ impl TryFromSexp for Vec<&'static str> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 result.push("");
                 continue;
             }
-            if charsxp == unsafe { crate::ffi::R_BlankString } {
+            if charsxp == SEXP::blank_string() {
                 result.push("");
                 continue;
             }
@@ -272,11 +270,11 @@ impl TryFromSexp for Vec<Option<&'static str>> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 result.push(None);
                 continue;
             }
-            if charsxp == unsafe { crate::ffi::R_BlankString } {
+            if charsxp == SEXP::blank_string() {
                 result.push(Some(""));
                 continue;
             }

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -75,8 +75,6 @@ impl TryFromSexp for Vec<Cow<'static, str>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::STRING_ELT;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -90,7 +88,7 @@ impl TryFromSexp for Vec<Cow<'static, str>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = unsafe { STRING_ELT(sexp, i as crate::ffi::R_xlen_t) };
+            let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
             if charsxp == unsafe { crate::ffi::R_NaString }
                 || charsxp == unsafe { crate::ffi::R_BlankString }
             {
@@ -111,8 +109,6 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::STRING_ELT;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -126,7 +122,7 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = unsafe { STRING_ELT(sexp, i as crate::ffi::R_xlen_t) };
+            let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
             if charsxp == unsafe { crate::ffi::R_NaString } {
                 result.push(None);
             } else {

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -275,7 +275,7 @@ impl TryFromSexp for Vec<Option<String>> {
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
 
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
                 let c_str = unsafe { Rf_translateCharUTF8(charsxp) };

--- a/miniextendr-api/src/from_r/strings.rs
+++ b/miniextendr-api/src/from_r/strings.rs
@@ -57,10 +57,10 @@ impl TryFromSexp for &'static str {
         let charsxp = sexp.string_elt(0);
 
         // Check for NA_STRING or R_BlankString
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok("");
         }
-        if charsxp == unsafe { crate::ffi::R_BlankString } {
+        if charsxp == SEXP::blank_string() {
             return Ok("");
         }
 
@@ -92,10 +92,10 @@ impl TryFromSexp for &'static str {
         let charsxp = unsafe { sexp.string_elt_unchecked(0) };
 
         // Check for NA_STRING or R_BlankString
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok("");
         }
-        if charsxp == unsafe { crate::ffi::R_BlankString } {
+        if charsxp == SEXP::blank_string() {
             return Ok("");
         }
 
@@ -132,10 +132,10 @@ impl TryFromSexp for Option<&'static str> {
         }
 
         let charsxp = sexp.string_elt(0);
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(None);
         }
-        if charsxp == unsafe { crate::ffi::R_BlankString } {
+        if charsxp == SEXP::blank_string() {
             return Ok(Some(""));
         }
 
@@ -167,10 +167,10 @@ impl TryFromSexp for Option<&'static str> {
         }
 
         let charsxp = unsafe { sexp.string_elt_unchecked(0) };
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(None);
         }
-        if charsxp == unsafe { crate::ffi::R_BlankString } {
+        if charsxp == SEXP::blank_string() {
             return Ok(Some(""));
         }
 
@@ -257,7 +257,7 @@ impl TryFromSexp for String {
         let charsxp = sexp.string_elt(0);
 
         // Check for NA_STRING
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(String::new());
         }
 
@@ -303,7 +303,7 @@ impl TryFromSexp for String {
         let charsxp = unsafe { sexp.string_elt_unchecked(0) };
 
         // Check for NA_STRING
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(String::new());
         }
 
@@ -366,7 +366,7 @@ impl TryFromSexp for Option<String> {
         let charsxp = sexp.string_elt(0);
 
         // Return None for NA_STRING
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(None);
         }
 

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -166,8 +166,7 @@
 
 use crate::ffi::{
     R_NewEnv, R_ProtectWithIndex, R_Reprotect, R_xlen_t, RNativeType, Rf_allocList, Rf_allocMatrix,
-    Rf_allocVector, Rf_duplicate, Rf_protect, Rf_shallow_duplicate, Rf_unprotect, SEXP, SEXPTYPE,
-    SexpExt,
+    Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
 };
 use core::cell::Cell;
 use core::marker::PhantomData;
@@ -647,7 +646,7 @@ impl ProtectScope {
     /// Must be called from the R main thread. `x` must be a valid SEXP.
     #[inline]
     pub unsafe fn duplicate<'a>(&'a self, x: SEXP) -> Root<'a> {
-        unsafe { self.protect(Rf_duplicate(x)) }
+        unsafe { self.protect(x.duplicate()) }
     }
 
     /// Shallow-duplicate a SEXP, protected.
@@ -657,7 +656,7 @@ impl ProtectScope {
     /// Must be called from the R main thread. `x` must be a valid SEXP.
     #[inline]
     pub unsafe fn shallow_duplicate<'a>(&'a self, x: SEXP) -> Root<'a> {
-        unsafe { self.protect(Rf_shallow_duplicate(x)) }
+        unsafe { self.protect(x.shallow_duplicate()) }
     }
 
     /// Coerce a SEXP to a different type, protected.

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -1320,7 +1320,7 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
                 let idx: crate::ffi::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp(s.as_ref()),
-                    None => crate::ffi::R_NaString,
+                    None => crate::ffi::SEXP::na_string(),
                 };
                 sexp.set_string_elt(idx, charsxp);
             }
@@ -1341,7 +1341,7 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
                 let idx: crate::ffi::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp_unchecked(s.as_ref()),
-                    None => crate::ffi::R_NaString,
+                    None => crate::ffi::SEXP::na_string(),
                 };
                 sexp.set_string_elt_unchecked(idx, charsxp);
             }
@@ -1753,7 +1753,7 @@ impl IntoR for Vec<Option<String>> {
                 let idx: crate::ffi::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp(s),
-                    None => crate::ffi::R_NaString,
+                    None => crate::ffi::SEXP::na_string(),
                 };
                 sexp.set_string_elt(idx, charsxp);
             }
@@ -1777,7 +1777,7 @@ impl IntoR for Vec<Option<String>> {
                 let idx: crate::ffi::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp_unchecked(s),
-                    None => crate::ffi::R_NaString,
+                    None => crate::ffi::SEXP::na_string(),
                 };
                 sexp.set_string_elt_unchecked(idx, charsxp);
             }

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -1322,7 +1322,7 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
                     Some(s) => str_to_charsxp(s.as_ref()),
                     None => crate::ffi::R_NaString,
                 };
-                crate::ffi::SET_STRING_ELT(*sexp, idx, charsxp);
+                sexp.set_string_elt(idx, charsxp);
             }
             *sexp
         }
@@ -1343,7 +1343,7 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
                     Some(s) => str_to_charsxp_unchecked(s.as_ref()),
                     None => crate::ffi::R_NaString,
                 };
-                crate::ffi::SET_STRING_ELT_unchecked(*sexp, idx, charsxp);
+                sexp.set_string_elt_unchecked(idx, charsxp);
             }
             *sexp
         }

--- a/miniextendr-api/src/into_r/altrep.rs
+++ b/miniextendr-api/src/into_r/altrep.rs
@@ -151,10 +151,10 @@ where
         let cls = <T as crate::altrep::RegisterAltrep>::get_or_init_class();
         let ext_ptr = crate::externalptr::ExternalPtr::new(self.0);
         let data1 = ext_ptr.as_sexp();
-        // Protect data1 across R_new_altrep — it may allocate and trigger GC.
+        // Protect data1 across new_altrep — it may allocate and trigger GC.
         unsafe {
             crate::ffi::Rf_protect_unchecked(data1);
-            let out = crate::ffi::altrep::R_new_altrep(cls, data1, crate::ffi::SEXP::nil());
+            let out = cls.new_altrep(data1, crate::ffi::SEXP::nil());
             crate::ffi::Rf_unprotect_unchecked(1);
             out
         }
@@ -165,8 +165,7 @@ where
         let data1 = ext_ptr.as_sexp();
         unsafe {
             crate::ffi::Rf_protect_unchecked(data1);
-            let out =
-                crate::ffi::altrep::R_new_altrep_unchecked(cls, data1, crate::ffi::SEXP::nil());
+            let out = cls.new_altrep_unchecked(data1, crate::ffi::SEXP::nil());
             crate::ffi::Rf_unprotect_unchecked(1);
             out
         }

--- a/miniextendr-api/src/into_r/collections.rs
+++ b/miniextendr-api/src/into_r/collections.rs
@@ -96,7 +96,7 @@ unsafe fn map_to_named_list_unchecked<V: IntoR>(
             names.set_string_elt_unchecked(idx, charsxp);
         }
 
-        list.set_attr_unchecked(crate::ffi::R_NamesSymbol, names);
+        list.set_attr_unchecked(crate::ffi::SEXP::names_symbol(), names);
 
         crate::ffi::Rf_unprotect(2);
         list

--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -409,13 +409,11 @@ impl<T: crate::externalptr::IntoExternalPtr> IntoR for T {
 /// Uses UTF-8 encoding. Empty strings return R_BlankString (static, no allocation).
 #[inline]
 pub(crate) fn str_to_charsxp(s: &str) -> crate::ffi::SEXP {
-    unsafe {
-        if s.is_empty() {
-            crate::ffi::R_BlankString
-        } else {
-            let _len: i32 = s.len().try_into().expect("string exceeds i32::MAX bytes");
-            crate::ffi::SEXP::charsxp(s)
-        }
+    if s.is_empty() {
+        crate::ffi::SEXP::blank_string()
+    } else {
+        let _len: i32 = s.len().try_into().expect("string exceeds i32::MAX bytes");
+        crate::ffi::SEXP::charsxp(s)
     }
 }
 
@@ -424,7 +422,7 @@ pub(crate) fn str_to_charsxp(s: &str) -> crate::ffi::SEXP {
 pub(crate) unsafe fn str_to_charsxp_unchecked(s: &str) -> crate::ffi::SEXP {
     unsafe {
         if s.is_empty() {
-            crate::ffi::R_BlankString
+            crate::ffi::SEXP::blank_string()
         } else {
             let len: i32 = s.len().try_into().expect("string exceeds i32::MAX bytes");
             crate::ffi::Rf_mkCharLenCE_unchecked(s.as_ptr().cast(), len, crate::ffi::CE_UTF8)
@@ -523,20 +521,18 @@ impl IntoR for Option<&str> {
     }
     #[inline]
     fn into_sexp(self) -> crate::ffi::SEXP {
-        unsafe {
-            let charsxp = match self {
-                Some(s) => str_to_charsxp(s),
-                None => crate::ffi::R_NaString,
-            };
-            crate::ffi::SEXP::scalar_string(charsxp)
-        }
+        let charsxp = match self {
+            Some(s) => str_to_charsxp(s),
+            None => crate::ffi::SEXP::na_string(),
+        };
+        crate::ffi::SEXP::scalar_string(charsxp)
     }
     #[inline]
     unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
         unsafe {
             let charsxp = match self {
                 Some(s) => str_to_charsxp_unchecked(s),
-                None => crate::ffi::R_NaString,
+                None => crate::ffi::SEXP::na_string(),
             };
             crate::ffi::Rf_ScalarString_unchecked(charsxp)
         }

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -119,7 +119,7 @@ impl List {
             if name_sexp == unsafe { ffi::R_NaString } {
                 continue;
             }
-            let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+            let name_ptr = name_sexp.r_char();
             let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
             if let Ok(s) = name_cstr.to_str() {
                 if s == name {
@@ -727,7 +727,7 @@ where
                 if name_sexp == unsafe { ffi::R_NaString } {
                     format!("{i}")
                 } else {
-                    let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+                    let name_ptr = name_sexp.r_char();
                     let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
                     name_cstr.to_str().unwrap_or(&format!("{i}")).to_string()
                 }
@@ -784,7 +784,7 @@ where
                 if name_sexp == unsafe { ffi::R_NaString } {
                     format!("{i}")
                 } else {
-                    let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+                    let name_ptr = name_sexp.r_char();
                     let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
                     name_cstr.to_str().unwrap_or(&format!("{i}")).to_string()
                 }
@@ -1107,7 +1107,7 @@ impl TryFromSexp for List {
                     continue;
                 }
                 // Skip empty names
-                let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+                let name_ptr = name_sexp.r_char();
                 let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
                 if let Ok(s) = name_cstr.to_str() {
                     if s.is_empty() {

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -143,25 +143,25 @@ impl List {
     /// Get the `names` attribute if present.
     #[inline]
     pub fn names(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_NamesSymbol })
+        self.get_attr_opt(SEXP::names_symbol())
     }
 
     /// Get the `class` attribute if present.
     #[inline]
     pub fn get_class(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_ClassSymbol })
+        self.get_attr_opt(SEXP::class_symbol())
     }
 
     /// Get the `dim` attribute if present.
     #[inline]
     pub fn get_dim(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_DimSymbol })
+        self.get_attr_opt(SEXP::dim_symbol())
     }
 
     /// Get the `dimnames` attribute if present.
     #[inline]
     pub fn get_dimnames(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_DimNamesSymbol })
+        self.get_attr_opt(SEXP::dimnames_symbol())
     }
 
     /// Get row names from the `dimnames` attribute.
@@ -193,13 +193,13 @@ impl List {
     /// Get the `levels` attribute if present (for factors).
     #[inline]
     pub fn get_levels(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_LevelsSymbol })
+        self.get_attr_opt(SEXP::levels_symbol())
     }
 
     /// Get the `tsp` attribute if present (for time series).
     #[inline]
     pub fn get_tsp(self) -> Option<SEXP> {
-        self.get_attr_opt(unsafe { ffi::R_TspSymbol })
+        self.get_attr_opt(SEXP::tsp_symbol())
     }
     // endregion
 

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -116,7 +116,7 @@ impl List {
         // Search for matching name
         for i in 0..n {
             let name_sexp = names_sexp.string_elt(i);
-            if name_sexp == unsafe { ffi::R_NaString } {
+            if name_sexp == SEXP::na_string() {
                 continue;
             }
             let name_ptr = name_sexp.r_char();
@@ -724,7 +724,7 @@ where
 
             let key = if let Some(names) = names_sexp {
                 let name_sexp = names.string_elt(idx);
-                if name_sexp == unsafe { ffi::R_NaString } {
+                if name_sexp == SEXP::na_string() {
                     format!("{i}")
                 } else {
                     let name_ptr = name_sexp.r_char();
@@ -781,7 +781,7 @@ where
 
             let key = if let Some(names) = names_sexp {
                 let name_sexp = names.string_elt(idx);
-                if name_sexp == unsafe { ffi::R_NaString } {
+                if name_sexp == SEXP::na_string() {
                     format!("{i}")
                 } else {
                     let name_ptr = name_sexp.r_char();
@@ -1103,7 +1103,7 @@ impl TryFromSexp for List {
             for i in 0..n {
                 let name_sexp = names_sexp.string_elt(i);
                 // Skip NA names
-                if name_sexp == unsafe { ffi::R_NaString } {
+                if name_sexp == SEXP::na_string() {
                     continue;
                 }
                 // Skip empty names

--- a/miniextendr-api/src/list/accumulator.rs
+++ b/miniextendr-api/src/list/accumulator.rs
@@ -278,7 +278,7 @@ impl<'a> ListAccumulator<'a> {
                         let charsxp = ffi::SEXP::charsxp(n);
                         names_sexp.get().set_string_elt(idx, charsxp);
                     } else {
-                        names_sexp.get().set_string_elt(idx, ffi::R_BlankString);
+                        names_sexp.get().set_string_elt(idx, SEXP::blank_string());
                     }
                 }
                 root.get().set_names(names_sexp.get());

--- a/miniextendr-api/src/list/accumulator.rs
+++ b/miniextendr-api/src/list/accumulator.rs
@@ -256,7 +256,7 @@ impl<'a> ListAccumulator<'a> {
         let len_isize: isize = self.len.try_into().expect("list length exceeds isize::MAX");
         let root = if self.len < self.cap {
             unsafe {
-                let shrunk = ffi::Rf_xlengthgets(self.list.get(), len_isize);
+                let shrunk = self.list.get().resize(len_isize);
                 // The shrunk list might be the same or a new allocation
                 // Either way, we protect it via the scope
                 self.scope.protect(shrunk)

--- a/miniextendr-api/src/list/named.rs
+++ b/miniextendr-api/src/list/named.rs
@@ -54,7 +54,7 @@ impl NamedList {
             if name_sexp == unsafe { ffi::R_NaString } {
                 continue;
             }
-            let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+            let name_ptr = name_sexp.r_char();
             let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
             if let Ok(s) = name_cstr.to_str() {
                 if !s.is_empty() {

--- a/miniextendr-api/src/list/named.rs
+++ b/miniextendr-api/src/list/named.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use crate::ffi::{self, SEXP, SexpExt};
+use crate::ffi::{SEXP, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -51,7 +51,7 @@ impl NamedList {
         for i in 0..n {
             let idx: isize = i.try_into().expect("index exceeds isize::MAX");
             let name_sexp = names_sexp.string_elt(idx);
-            if name_sexp == unsafe { ffi::R_NaString } {
+            if name_sexp == SEXP::na_string() {
                 continue;
             }
             let name_ptr = name_sexp.r_char();

--- a/miniextendr-api/src/match_arg.rs
+++ b/miniextendr-api/src/match_arg.rs
@@ -114,7 +114,7 @@ pub fn choices_sexp<T: MatchArg>() -> SEXP {
         ffi::Rf_protect(vec);
         for (i, s) in choices.iter().enumerate() {
             let charsxp = if s.is_empty() {
-                ffi::R_BlankString
+                SEXP::blank_string()
             } else {
                 SEXP::charsxp(s)
             };
@@ -140,7 +140,7 @@ pub fn match_arg_from_sexp<T: MatchArg>(sexp: SEXP) -> Result<T, MatchArgError> 
                 return Err(MatchArgError::InvalidLength(len));
             }
             let charsxp = sexp.string_elt(0);
-            if charsxp == unsafe { ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 return Err(MatchArgError::IsNa);
             }
             let c_str = unsafe { ffi::Rf_translateCharUTF8(charsxp) };

--- a/miniextendr-api/src/missing.rs
+++ b/miniextendr-api/src/missing.rs
@@ -1,7 +1,7 @@
 //! Support for R's missing arguments.
 //!
 //! When an R function is called without providing a value for a formal argument,
-//! R passes `R_MissingArg` as a placeholder. This is different from `NULL` -
+//! R passes `SEXP::missing_arg()` as a placeholder. This is different from `NULL` -
 //! a missing argument means "not provided", while `NULL` is an explicit value.
 //!
 //! # Example
@@ -27,7 +27,7 @@
 //! # Difference from `Option<T>`
 //!
 //! - `Option<T>` treats `NULL` as `None` and any other value as `Some(T)`.
-//! - `Missing<T>` treats `R_MissingArg` as missing and any other value (including `NULL`) as present.
+//! - `Missing<T>` treats `SEXP::missing_arg()` as missing and any other value (including `NULL`) as present.
 //!
 //! Use `Missing<Option<T>>` if you need to distinguish between:
 //! - Missing argument (not passed)
@@ -61,13 +61,13 @@
 //! ```
 //!
 //! `quote(expr=)` is an R idiom that captures the "missing" state - calling `quote()`
-//! without providing its `expr` argument returns `R_MissingArg`. This allows:
+//! without providing its `expr` argument returns `SEXP::missing_arg()`. This allows:
 //!
 //! 1. The call to proceed without error
-//! 2. `R_MissingArg` to be passed through `.Call()` to Rust
+//! 2. `SEXP::missing_arg()` to be passed through `.Call()` to Rust
 //! 3. `Missing<T>` to detect it as `Missing::Absent`
 
-use crate::ffi::{R_MissingArg, SEXP};
+use crate::ffi::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
 
 /// Wrapper type that detects if an R argument was not passed (missing).
@@ -247,7 +247,7 @@ impl<T> From<Missing<T>> for Option<T> {
 /// Check if a SEXP is the missing argument sentinel.
 #[inline]
 pub fn is_missing_arg(sexp: SEXP) -> bool {
-    std::ptr::addr_eq(sexp.0, unsafe { R_MissingArg.0 })
+    std::ptr::addr_eq(sexp.0, SEXP::missing_arg().0)
 }
 
 impl<T> TryFromSexp for Missing<T>

--- a/miniextendr-api/src/named_vector.rs
+++ b/miniextendr-api/src/named_vector.rs
@@ -250,7 +250,7 @@ fn extract_names_strict(sexp: SEXP) -> Result<Vec<String>, SexpError> {
         let charsxp = names.string_elt(i as ffi::R_xlen_t);
 
         // Reject NA names
-        if charsxp == unsafe { ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Err(SexpError::InvalidValue(
                 "NamedVector does not allow NA names".to_string(),
             ));

--- a/miniextendr-api/src/optionals/aho_corasick_impl.rs
+++ b/miniextendr-api/src/optionals/aho_corasick_impl.rs
@@ -79,7 +79,7 @@ impl TryFromSexp for AhoCorasick {
         let mut patterns = Vec::with_capacity(len);
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed in patterns",
                     i

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -48,7 +48,7 @@ pub use arrow_schema::{self, DataType, Field, Schema};
 
 use arrow_array::types::ArrowPrimitiveType;
 
-use crate::ffi::{self, R_NaString, R_xlen_t, RNativeType, Rboolean, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{self, R_NaString, R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -587,25 +587,19 @@ pub type StringDictionaryArray = DictionaryArray<Int32Type>;
 
 /// Check if an R SEXP has a specific class (checks "class" attribute).
 ///
-/// `class` must be a NUL-terminated string (e.g., `"factor\0"`).
-unsafe fn r_inherits(sexp: SEXP, class: &str) -> bool {
-    debug_assert!(class.ends_with('\0'), "class must be NUL-terminated");
-    unsafe { ffi::Rf_inherits(sexp, class.as_ptr().cast()) != Rboolean::FALSE }
-}
-
 /// Check if an R SEXP is a factor (INTSXP with "levels" attribute).
-unsafe fn is_factor(sexp: SEXP) -> bool {
-    sexp.type_of() == SEXPTYPE::INTSXP && unsafe { r_inherits(sexp, "factor\0") }
+fn is_factor(sexp: SEXP) -> bool {
+    sexp.type_of() == SEXPTYPE::INTSXP && sexp.inherits_class(c"factor")
 }
 
 /// Check if an R SEXP is a Date (REALSXP with class "Date").
-unsafe fn is_date(sexp: SEXP) -> bool {
-    sexp.type_of() == SEXPTYPE::REALSXP && unsafe { r_inherits(sexp, "Date\0") }
+fn is_date(sexp: SEXP) -> bool {
+    sexp.type_of() == SEXPTYPE::REALSXP && sexp.inherits_class(c"Date")
 }
 
 /// Check if an R SEXP is POSIXct (REALSXP with class "POSIXct").
-unsafe fn is_posixct(sexp: SEXP) -> bool {
-    sexp.type_of() == SEXPTYPE::REALSXP && unsafe { r_inherits(sexp, "POSIXct\0") }
+fn is_posixct(sexp: SEXP) -> bool {
+    sexp.type_of() == SEXPTYPE::REALSXP && sexp.inherits_class(c"POSIXct")
 }
 
 /// Convert R factor to Arrow DictionaryArray<Int32Type> with string values.
@@ -617,7 +611,7 @@ impl TryFromSexp for StringDictionaryArray {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        if !unsafe { is_factor(sexp) } {
+        if !is_factor(sexp) {
             return Err(SexpError::InvalidValue(
                 "expected R factor (integer with levels attribute)".into(),
             ));
@@ -670,7 +664,7 @@ impl TryFromSexp for Date32Array {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        if !unsafe { is_date(sexp) } {
+        if !is_date(sexp) {
             return Err(SexpError::InvalidValue(
                 "expected R Date object (numeric with class 'Date')".into(),
             ));
@@ -702,7 +696,7 @@ impl TryFromSexp for Date32Array {
 /// Arrow TimestampSecondArray uses i64 seconds. Fractional seconds are truncated.
 /// Timezone from R's "tzone" attribute is preserved if present.
 pub fn posixct_to_timestamp(sexp: SEXP) -> Result<TimestampSecondArray, SexpError> {
-    if !unsafe { is_posixct(sexp) } {
+    if !is_posixct(sexp) {
         return Err(SexpError::InvalidValue(
             "expected R POSIXct object (numeric with class 'POSIXct')".into(),
         ));

--- a/miniextendr-api/src/optionals/indexmap_impl.rs
+++ b/miniextendr-api/src/optionals/indexmap_impl.rs
@@ -51,9 +51,7 @@
 
 pub use indexmap::IndexMap;
 
-use crate::ffi::{
-    R_CHAR, R_NaString, R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
-};
+use crate::ffi::{R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -87,11 +85,11 @@ where
             // Get name for this element
             let name = if has_names {
                 let name_charsxp = names_sexp.string_elt(i as R_xlen_t);
-                if name_charsxp == unsafe { R_NaString } || name_charsxp == SEXP::nil() {
+                if name_charsxp == SEXP::na_string() || name_charsxp == SEXP::nil() {
                     // NA or missing name -> generate auto name
                     format!("V{}", i + 1)
                 } else {
-                    let c_str = unsafe { name_charsxp.r_char() };
+                    let c_str = name_charsxp.r_char();
                     if c_str.is_null() {
                         format!("V{}", i + 1)
                     } else {

--- a/miniextendr-api/src/optionals/indexmap_impl.rs
+++ b/miniextendr-api/src/optionals/indexmap_impl.rs
@@ -91,7 +91,7 @@ where
                     // NA or missing name -> generate auto name
                     format!("V{}", i + 1)
                 } else {
-                    let c_str = unsafe { R_CHAR(name_charsxp) };
+                    let c_str = unsafe { name_charsxp.r_char() };
                     if c_str.is_null() {
                         format!("V{}", i + 1)
                     } else {

--- a/miniextendr-api/src/optionals/rayon_bridge.rs
+++ b/miniextendr-api/src/optionals/rayon_bridge.rs
@@ -593,7 +593,7 @@ where
             *slot = d as i32;
         }
 
-        sexp.set_attr_unchecked(crate::ffi::R_DimSymbol, dim_sexp);
+        sexp.set_attr_unchecked(SEXP::dim_symbol(), dim_sexp);
         crate::ffi::Rf_unprotect_unchecked(1); // unprotect dim_sexp, sexp stays protected
 
         let ptr = T::dataptr_mut(sexp);

--- a/miniextendr-api/src/optionals/serde_impl.rs
+++ b/miniextendr-api/src/optionals/serde_impl.rs
@@ -417,7 +417,7 @@ fn sexp_to_json_value(sexp: SEXP, opts: &JsonOptions) -> Result<JsonValue, SexpE
         SEXPTYPE::STRSXP => {
             if len == 1 {
                 let charsxp = sexp.string_elt(0);
-                if charsxp == unsafe { crate::ffi::R_NaString } {
+                if charsxp == SEXP::na_string() {
                     return handle_na(opts, None);
                 }
                 let s = unsafe { charsxp_to_str(charsxp) };
@@ -426,7 +426,7 @@ fn sexp_to_json_value(sexp: SEXP, opts: &JsonOptions) -> Result<JsonValue, SexpE
                 let arr: Result<Vec<JsonValue>, SexpError> = (0..len)
                     .map(|i| {
                         let charsxp = sexp.string_elt(isize::try_from(i).expect("index overflow"));
-                        if charsxp == unsafe { crate::ffi::R_NaString } {
+                        if charsxp == SEXP::na_string() {
                             handle_na(opts, Some(i))
                         } else {
                             let s = unsafe { charsxp_to_str(charsxp) };
@@ -447,7 +447,7 @@ fn sexp_to_json_value(sexp: SEXP, opts: &JsonOptions) -> Result<JsonValue, SexpE
                 let mut map = serde_json::Map::new();
                 for i in 0..len {
                     let charsxp = names.string_elt(isize::try_from(i).expect("index overflow"));
-                    let key = if charsxp == unsafe { crate::ffi::R_NaString } {
+                    let key = if charsxp == SEXP::na_string() {
                         format!("V{}", i + 1) // Auto-name for NA keys
                     } else {
                         unsafe { charsxp_to_str(charsxp) }.to_string()

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -135,7 +135,7 @@ impl TryFromSexp for TomlValue {
         }
 
         let charsxp = sexp.string_elt(0);
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Err(SexpError::InvalidValue(
                 "NA not allowed for TOML parsing".to_string(),
             ));

--- a/miniextendr-api/src/optionals/url_impl.rs
+++ b/miniextendr-api/src/optionals/url_impl.rs
@@ -70,7 +70,7 @@ impl TryFromSexp for Url {
         }
 
         let charsxp = sexp.string_elt(0);
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::STRSXP,
             }));
@@ -123,7 +123,7 @@ impl TryFromSexp for Option<Url> {
         }
 
         let charsxp = sexp.string_elt(0);
-        if charsxp == unsafe { crate::ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Ok(None);
         }
 
@@ -170,7 +170,7 @@ impl TryFromSexp for Vec<Url> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for Vec<Url>",
                     i
@@ -228,7 +228,7 @@ impl TryFromSexp for Vec<Option<Url>> {
 
         for i in 0..len {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
                 let s = unsafe { charsxp_to_str(charsxp) };

--- a/miniextendr-api/src/optionals/uuid_impl.rs
+++ b/miniextendr-api/src/optionals/uuid_impl.rs
@@ -118,7 +118,7 @@ impl TryFromSexp for Vec<Uuid> {
             let charsxp = sexp.string_elt(i as crate::ffi::R_xlen_t);
 
             // Check for NA
-            if charsxp == unsafe { crate::ffi::R_NaString } {
+            if charsxp == SEXP::na_string() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for Vec<Uuid>",
                     i

--- a/miniextendr-api/src/preserve.rs
+++ b/miniextendr-api/src/preserve.rs
@@ -51,10 +51,7 @@
 //!
 //! All functions in this module are unsafe and must be called from the R main thread.
 
-use crate::ffi::{
-    CAR, CDR, R_PreserveObject, Rf_cons, Rf_protect, Rf_unprotect, SET_TAG, SETCAR, SETCDR, SEXP,
-    SexpExt,
-};
+use crate::ffi::{PairListExt, R_PreserveObject, Rf_protect, Rf_unprotect, SEXP, SexpExt};
 use std::cell::OnceCell;
 
 thread_local! {
@@ -76,7 +73,7 @@ thread_local! {
 #[inline]
 unsafe fn init() -> SEXP {
     unsafe {
-        let out = Rf_cons(SEXP::nil(), Rf_cons(SEXP::nil(), SEXP::nil()));
+        let out = SEXP::nil().cons(SEXP::nil().cons(SEXP::nil()));
         R_PreserveObject(out);
         out
     }
@@ -92,10 +89,10 @@ unsafe fn init() -> SEXP {
 /// you're certain you're on the main thread.
 #[inline]
 unsafe fn init_unchecked() -> SEXP {
-    use crate::ffi::{R_PreserveObject_unchecked, Rf_cons_unchecked};
+    use crate::ffi::{PairListExt, R_PreserveObject_unchecked};
 
     unsafe {
-        let out = Rf_cons_unchecked(SEXP::nil(), Rf_cons_unchecked(SEXP::nil(), SEXP::nil()));
+        let out = SEXP::nil().cons_unchecked(SEXP::nil().cons_unchecked(SEXP::nil()));
         R_PreserveObject_unchecked(out);
         out
     }
@@ -192,15 +189,15 @@ pub unsafe fn insert(x: SEXP) -> SEXP {
 
         // head is the list itself; next is the node after head
         let head = list;
-        let next = CDR(list);
+        let next = head.cdr();
 
         // New cell points to current head and next
-        let cell = Rf_protect(Rf_cons(head, next));
-        SET_TAG(cell, x);
+        let cell = Rf_protect(head.cons(next));
+        cell.set_tag(x);
 
         // Splice cell between head and next
-        SETCDR(head, cell);
-        SETCAR(next, cell);
+        head.set_cdr(cell);
+        next.set_car(cell);
 
         Rf_unprotect(2);
 
@@ -220,10 +217,7 @@ pub unsafe fn insert(x: SEXP) -> SEXP {
 /// The returned cell must eventually be passed to [`release_unchecked`].
 #[inline]
 pub unsafe fn insert_unchecked(x: SEXP) -> SEXP {
-    use crate::ffi::{
-        CDR_unchecked, Rf_cons_unchecked, Rf_protect_unchecked, Rf_unprotect_unchecked,
-        SET_TAG_unchecked, SETCAR_unchecked, SETCDR_unchecked,
-    };
+    use crate::ffi::{PairListExt, Rf_protect_unchecked, Rf_unprotect_unchecked};
 
     unsafe {
         if x.is_nil() {
@@ -236,15 +230,15 @@ pub unsafe fn insert_unchecked(x: SEXP) -> SEXP {
 
         // head is the list itself; next is the node after head
         let head = list;
-        let next = CDR_unchecked(list);
+        let next = head.cdr_unchecked();
 
         // New cell points to current head and next
-        let cell = Rf_protect_unchecked(Rf_cons_unchecked(head, next));
-        SET_TAG_unchecked(cell, x);
+        let cell = Rf_protect_unchecked(head.cons_unchecked(next));
+        cell.set_tag_unchecked(x);
 
         // Splice cell between head and next
-        SETCDR_unchecked(head, cell);
-        SETCAR_unchecked(next, cell);
+        head.set_cdr_unchecked(cell);
+        next.set_car_unchecked(cell);
 
         Rf_unprotect_unchecked(2);
 
@@ -264,24 +258,17 @@ pub unsafe fn insert_unchecked(x: SEXP) -> SEXP {
 /// cell returned from [`insert`] and must not have been released already.
 #[inline]
 pub unsafe fn release(cell: SEXP) {
-    unsafe {
-        if cell.is_nil() {
-            return;
-        }
-
-        // Neighbors around the cell
-        let lhs = CAR(cell);
-        let rhs = CDR(cell);
-
-        // Bypass cell
-        SETCDR(lhs, rhs);
-        SETCAR(rhs, lhs);
-
-        // Optional hygiene (unnecessary but can help catch bugs)
-        // SET_TAG(cell, R_NilValue);
-        // SETCAR(cell, R_NilValue);
-        // SETCDR(cell, R_NilValue);
+    if cell.is_nil() {
+        return;
     }
+
+    // Neighbors around the cell
+    let lhs = cell.car();
+    let rhs = cell.cdr();
+
+    // Bypass cell
+    lhs.set_cdr(rhs);
+    rhs.set_car(lhs);
 }
 
 /// Release a previously protected SEXP (unchecked version).
@@ -296,7 +283,7 @@ pub unsafe fn release(cell: SEXP) {
 /// cell returned from [`insert_unchecked`] and must not have been released already.
 #[inline]
 pub unsafe fn release_unchecked(cell: SEXP) {
-    use crate::ffi::{CAR_unchecked, CDR_unchecked, SETCAR_unchecked, SETCDR_unchecked};
+    use crate::ffi::PairListExt;
 
     unsafe {
         if cell.is_nil() {
@@ -304,11 +291,11 @@ pub unsafe fn release_unchecked(cell: SEXP) {
         }
 
         // Neighbors around the cell
-        let lhs = CAR_unchecked(cell);
-        let rhs = CDR_unchecked(cell);
+        let lhs = cell.car_unchecked();
+        let rhs = cell.cdr_unchecked();
 
         // Bypass cell
-        SETCDR_unchecked(lhs, rhs);
-        SETCAR_unchecked(rhs, lhs);
+        lhs.set_cdr_unchecked(rhs);
+        rhs.set_car_unchecked(lhs);
     }
 }

--- a/miniextendr-api/src/rarray.rs
+++ b/miniextendr-api/src/rarray.rs
@@ -474,7 +474,7 @@ impl<T: RNativeType, const NDIM: usize> RArray<T, NDIM> {
     #[inline]
     pub unsafe fn get_names(&self) -> Option<SEXP> {
         // Safety: R_NamesSymbol is a known symbol
-        self.get_attr_opt(unsafe { ffi::R_NamesSymbol })
+        self.get_attr_opt(SEXP::names_symbol())
     }
 
     /// Get the `class` attribute if present.
@@ -487,7 +487,7 @@ impl<T: RNativeType, const NDIM: usize> RArray<T, NDIM> {
     #[inline]
     pub unsafe fn get_class(&self) -> Option<SEXP> {
         // Safety: R_ClassSymbol is a known symbol
-        self.get_attr_opt(unsafe { ffi::R_ClassSymbol })
+        self.get_attr_opt(SEXP::class_symbol())
     }
 
     /// Get the `dimnames` attribute if present.
@@ -500,7 +500,7 @@ impl<T: RNativeType, const NDIM: usize> RArray<T, NDIM> {
     #[inline]
     pub unsafe fn get_dimnames(&self) -> Option<SEXP> {
         // Safety: R_DimNamesSymbol is a known symbol
-        self.get_attr_opt(unsafe { ffi::R_DimNamesSymbol })
+        self.get_attr_opt(SEXP::dimnames_symbol())
     }
 
     /// Get row names from the `dimnames` attribute.

--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -462,10 +462,10 @@ pub unsafe extern "C" fn miniextendr_write_wrappers(
     path_sexp: crate::ffi::SEXP,
 ) -> crate::ffi::SEXP {
     unsafe {
-        use crate::ffi::{R_CHAR_unchecked, SEXP, SexpExt};
+        use crate::ffi::{SEXP, SexpExt};
 
         let char_sexp = path_sexp.string_elt_unchecked(0);
-        let c_str = std::ffi::CStr::from_ptr(R_CHAR_unchecked(char_sexp));
+        let c_str = std::ffi::CStr::from_ptr(char_sexp.r_char_unchecked());
         let path = c_str
             .to_str()
             .unwrap_or_else(|e| panic!("invalid UTF-8 in path: {e}"));

--- a/miniextendr-api/src/s4_helpers.rs
+++ b/miniextendr-api/src/s4_helpers.rs
@@ -137,7 +137,7 @@ pub unsafe fn s4_class_name(obj: SEXP) -> Option<String> {
             return None;
         }
 
-        let ptr = ffi::R_CHAR(first);
+        let ptr = first.r_char();
         if ptr.is_null() {
             return None;
         }

--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -72,7 +72,7 @@ macro_rules! reject_non_struct {
 unsafe fn col_name(names_sexp: SEXP, i: isize) -> &'static str {
     unsafe {
         let s = names_sexp.string_elt(i);
-        let p = crate::ffi::R_CHAR(s);
+        let p = s.r_char();
         std::ffi::CStr::from_ptr(p).to_str().unwrap_or("")
     }
 }

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -5,7 +5,7 @@
 
 use super::error::RSerdeError;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
-use crate::ffi::{R_NaString, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_xlength, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::charsxp_to_str;
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 
@@ -128,7 +128,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
             }
             SEXPTYPE::STRSXP if len == 1 => {
                 let charsxp = self.sexp.string_elt(0);
-                if charsxp == unsafe { R_NaString } {
+                if charsxp == SEXP::na_string() {
                     visitor.visit_none()
                 } else {
                     let s = unsafe { charsxp_to_str(charsxp) };
@@ -463,7 +463,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
                 }
                 SEXPTYPE::STRSXP => {
                     let charsxp = self.sexp.string_elt(0);
-                    if charsxp == unsafe { R_NaString } {
+                    if charsxp == SEXP::na_string() {
                         return visitor.visit_none();
                     }
                 }
@@ -578,7 +578,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
             // String -> unit variant
             SEXPTYPE::STRSXP if self.len() == 1 => {
                 let charsxp = self.sexp.string_elt(0);
-                if charsxp == unsafe { R_NaString } {
+                if charsxp == SEXP::na_string() {
                     return Err(RSerdeError::UnexpectedNa);
                 }
                 let variant = unsafe { charsxp_to_str(charsxp) };
@@ -672,7 +672,7 @@ impl RDeserializer {
         }
 
         let charsxp = self.sexp.string_elt(0);
-        if charsxp == unsafe { R_NaString } {
+        if charsxp == SEXP::na_string() {
             return Err(RSerdeError::UnexpectedNa);
         }
         Ok(unsafe { charsxp_to_str(charsxp) })
@@ -775,7 +775,7 @@ impl<'de> de::Deserializer<'de> for VectorElementDeserializer {
             }
             SEXPTYPE::STRSXP => {
                 let charsxp = self.sexp.string_elt(self.index as isize);
-                if charsxp == unsafe { R_NaString } {
+                if charsxp == SEXP::na_string() {
                     visitor.visit_none()
                 } else {
                     let s = unsafe { charsxp_to_str(charsxp) };

--- a/miniextendr-api/src/serde/ser.rs
+++ b/miniextendr-api/src/serde/ser.rs
@@ -4,7 +4,7 @@
 //! to serialize any serde-compatible Rust type into R data structures.
 
 use super::error::RSerdeError;
-use crate::ffi::{R_NaString, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
 use serde::ser::{self, Serialize};
@@ -532,7 +532,7 @@ fn sexp_to_string(sexp: SEXP) -> Result<String, RSerdeError> {
     }
 
     let charsxp = sexp.string_elt(0);
-    if charsxp == unsafe { R_NaString } {
+    if charsxp == SEXP::na_string() {
         return Err(RSerdeError::NonStringKey);
     }
 

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -66,7 +66,7 @@ impl StrVec {
     pub fn get_str(self, idx: isize) -> Option<&'static str> {
         let charsxp = self.get_charsxp(idx)?;
         unsafe {
-            if charsxp == ffi::R_NaString {
+            if charsxp == SEXP::na_string() {
                 return None;
             }
             Some(charsxp_to_str(charsxp))
@@ -82,7 +82,7 @@ impl StrVec {
     pub fn get_cow(self, idx: isize) -> Option<Cow<'static, str>> {
         let charsxp = self.get_charsxp(idx)?;
         unsafe {
-            if charsxp == ffi::R_NaString {
+            if charsxp == SEXP::na_string() {
                 return None;
             }
             Some(charsxp_to_cow(charsxp))
@@ -192,11 +192,9 @@ impl StrVec {
     /// Panics if `idx` is out of bounds.
     #[inline]
     pub unsafe fn set_na(self, idx: isize) {
-        unsafe {
-            assert!(idx >= 0 && idx < self.len(), "index out of bounds");
-            // R_NaString is a global constant, no protection needed
-            self.0.set_string_elt(idx, ffi::R_NaString);
-        }
+        assert!(idx >= 0 && idx < self.len(), "index out of bounds");
+        // R_NaString is a global constant, no protection needed
+        self.0.set_string_elt(idx, SEXP::na_string());
     }
 
     /// Set an element from an optional string.
@@ -243,7 +241,7 @@ impl Iterator for StrVecIter {
         }
         let charsxp = self.vec.0.string_elt(self.idx);
         self.idx += 1;
-        if charsxp == unsafe { ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             Some(None)
         } else {
             Some(Some(unsafe { charsxp_to_str(charsxp) }))
@@ -278,7 +276,7 @@ impl Iterator for StrVecCowIter {
         }
         let charsxp = self.vec.0.string_elt(self.idx);
         self.idx += 1;
-        if charsxp == unsafe { ffi::R_NaString } {
+        if charsxp == SEXP::na_string() {
             Some(None)
         } else {
             Some(Some(unsafe { charsxp_to_cow(charsxp) }))

--- a/miniextendr-api/src/typed_list.rs
+++ b/miniextendr-api/src/typed_list.rs
@@ -339,7 +339,7 @@ impl TypedList {
         if let Some(names) = names_sexp {
             for i in 0..n {
                 let name_sexp = names.string_elt(i);
-                if name_sexp == unsafe { ffi::R_NaString } {
+                if name_sexp == SEXP::na_string() {
                     continue;
                 }
                 let name_ptr = name_sexp.r_char();
@@ -390,7 +390,7 @@ pub fn validate_list(list: List, spec: &TypedListSpec) -> Result<TypedList, Type
     if let Some(names) = names_sexp {
         for i in 0..n {
             let name_sexp = names.string_elt(i);
-            if name_sexp == unsafe { ffi::R_NaString } {
+            if name_sexp == SEXP::na_string() {
                 continue;
             }
             let name_ptr = name_sexp.r_char();
@@ -695,7 +695,7 @@ pub fn actual_type_string(sexp: SEXP) -> String {
         let class_len = unsafe { ffi::Rf_xlength(class_attr) };
         if class_len > 0 {
             let first_class = class_attr.string_elt(0);
-            if first_class != unsafe { ffi::R_NaString } {
+            if first_class != SEXP::na_string() {
                 let class_ptr = first_class.r_char();
                 let class_cstr = unsafe { CStr::from_ptr(class_ptr) };
                 if let Ok(s) = class_cstr.to_str() {

--- a/miniextendr-api/src/typed_list.rs
+++ b/miniextendr-api/src/typed_list.rs
@@ -342,7 +342,7 @@ impl TypedList {
                 if name_sexp == unsafe { ffi::R_NaString } {
                     continue;
                 }
-                let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+                let name_ptr = name_sexp.r_char();
                 let name_cstr = unsafe { CStr::from_ptr(name_ptr) };
                 if let Ok(s) = name_cstr.to_str() {
                     if s == name {
@@ -393,7 +393,7 @@ pub fn validate_list(list: List, spec: &TypedListSpec) -> Result<TypedList, Type
             if name_sexp == unsafe { ffi::R_NaString } {
                 continue;
             }
-            let name_ptr = unsafe { ffi::R_CHAR(name_sexp) };
+            let name_ptr = name_sexp.r_char();
             let name_cstr = unsafe { CStr::from_ptr(name_ptr) };
             if let Ok(s) = name_cstr.to_str() {
                 if s.is_empty() {
@@ -696,7 +696,7 @@ pub fn actual_type_string(sexp: SEXP) -> String {
         if class_len > 0 {
             let first_class = class_attr.string_elt(0);
             if first_class != unsafe { ffi::R_NaString } {
-                let class_ptr = unsafe { ffi::R_CHAR(first_class) };
+                let class_ptr = first_class.r_char();
                 let class_cstr = unsafe { CStr::from_ptr(class_ptr) };
                 if let Ok(s) = class_cstr.to_str() {
                     return format!("{} (class: {})", base_type, s);

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -366,7 +366,7 @@ pub fn new_rcrd(
             return Err(VctrsBuildError::UnnamedFields);
         }
 
-        let name_cstr = unsafe { std::ffi::CStr::from_ptr(crate::ffi::R_CHAR(name_charsxp)) };
+        let name_cstr = unsafe { std::ffi::CStr::from_ptr(name_charsxp.r_char()) };
         let name = name_cstr.to_str().unwrap_or("");
         if name.is_empty() {
             return Err(VctrsBuildError::UnnamedFields);

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -10,8 +10,7 @@ use crate::ffi::SEXP;
 // region: Construction helpers (Phase A)
 
 use crate::ffi::{
-    R_BlankString, R_NaString, R_xlen_t, Rf_allocVector, Rf_type2char, Rf_xlength, SEXPTYPE,
-    SexpExt,
+    R_BlankString, R_NaString, R_xlen_t, Rf_allocVector, Rf_xlength, SEXPTYPE, SexpExt,
 };
 use crate::gc_protect::OwnedProtect;
 use crate::list::List;
@@ -172,13 +171,8 @@ fn install_symbol(name: &str) -> SEXP {
 ///
 /// # Safety
 ///
-/// Must be called from R's main thread with a valid SEXP.
-unsafe fn get_typeof_name(sexp: SEXP) -> &'static str {
-    let sexptype = sexp.type_of();
-    let cstr = unsafe { Rf_type2char(sexptype) };
-    let cstr = unsafe { std::ffi::CStr::from_ptr(cstr) };
-    // SAFETY: R's type names are ASCII strings
-    cstr.to_str().unwrap_or("unknown")
+fn get_typeof_name(sexp: SEXP) -> &'static str {
+    sexp.type_of().type_name()
 }
 
 /// Repair NA names by replacing them with empty strings.
@@ -278,7 +272,7 @@ pub fn new_vctr(
 
     // Build class vector
     let base_type_name = if inherit {
-        Some(unsafe { get_typeof_name(data) })
+        Some(get_typeof_name(data))
     } else {
         None
     };

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -164,16 +164,8 @@ unsafe fn build_class_vector(classes: &[&str]) -> OwnedProtect {
 }
 
 /// Create an R symbol from a Rust string.
-///
-/// Uses Rf_installChar to create a symbol from a CHARSXP, which properly
-/// handles non-null-terminated strings.
-///
-/// # Safety
-///
-/// Must be called from R's main thread.
-unsafe fn install_symbol(name: &str) -> SEXP {
-    let charsxp = SEXP::charsxp(name);
-    unsafe { crate::ffi::Rf_installChar(charsxp) }
+fn install_symbol(name: &str) -> SEXP {
+    SEXP::symbol(name)
 }
 
 /// Get the R typeof name for a SEXP (e.g., "double", "integer", "list").
@@ -313,7 +305,7 @@ pub fn new_vctr(
 
     // Set additional attributes
     for (name, value) in attrs {
-        let name_sym = unsafe { install_symbol(name) };
+        let name_sym = install_symbol(name);
         data.set_attr(name_sym, *value);
     }
 
@@ -417,7 +409,7 @@ pub fn new_rcrd(
 
     // Set additional attributes
     for (name, value) in attrs {
-        let name_sym = unsafe { install_symbol(name) };
+        let name_sym = install_symbol(name);
         data.set_attr(name_sym, *value);
     }
 
@@ -501,7 +493,7 @@ pub fn new_list_of(
 
     // Set additional attributes
     for (name, value) in attrs {
-        let name_sym = unsafe { install_symbol(name) };
+        let name_sym = install_symbol(name);
         data.set_attr(name_sym, *value);
     }
 

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -9,9 +9,7 @@ use crate::ffi::SEXP;
 
 // region: Construction helpers (Phase A)
 
-use crate::ffi::{
-    R_BlankString, R_NaString, R_xlen_t, Rf_allocVector, Rf_xlength, SEXPTYPE, SexpExt,
-};
+use crate::ffi::{R_xlen_t, Rf_allocVector, Rf_xlength, SEXPTYPE, SexpExt};
 use crate::gc_protect::OwnedProtect;
 use crate::list::List;
 
@@ -189,7 +187,7 @@ unsafe fn repair_na_names(names: SEXP) -> SEXP {
 
     // First pass: check if any NA
     for i in 0..n {
-        if unsafe { names.string_elt(i) == R_NaString } {
+        if names.string_elt(i) == SEXP::na_string() {
             has_na = true;
             break;
         }
@@ -203,8 +201,8 @@ unsafe fn repair_na_names(names: SEXP) -> SEXP {
     let repaired = unsafe { OwnedProtect::new(Rf_allocVector(SEXPTYPE::STRSXP, n)) };
     for i in 0..n {
         let elem = names.string_elt(i);
-        let new_elem = if elem == unsafe { R_NaString } {
-            unsafe { R_BlankString }
+        let new_elem = if elem == SEXP::na_string() {
+            SEXP::blank_string()
         } else {
             elem
         };
@@ -362,7 +360,7 @@ pub fn new_rcrd(
     for i in 0..n_fields {
         // Check name
         let name_charsxp = names_sexp.string_elt(i);
-        if name_charsxp == unsafe { R_NaString } || name_charsxp == SEXP::nil() {
+        if name_charsxp == SEXP::na_string() || name_charsxp == SEXP::nil() {
             return Err(VctrsBuildError::UnnamedFields);
         }
 

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -219,7 +219,6 @@ pub(crate) fn generate_altrep_impls(
                 fn into_sexp(self) -> ::miniextendr_api::ffi::SEXP {
                     use ::miniextendr_api::altrep_registration::RegisterAltrep;
                     use ::miniextendr_api::externalptr::ExternalPtr;
-                    use ::miniextendr_api::ffi::altrep::R_new_altrep;
                     use ::miniextendr_api::ffi::{SEXP, Rf_protect, Rf_unprotect};
 
                     let ext_ptr = ExternalPtr::new(self.0);
@@ -227,7 +226,7 @@ pub(crate) fn generate_altrep_impls(
                     let data1 = ext_ptr.as_sexp();
                     unsafe {
                         Rf_protect(data1);
-                        let altrep = R_new_altrep(cls, data1, SEXP::nil());
+                        let altrep = cls.new_altrep(data1, SEXP::nil());
                         Rf_unprotect(1);
                         altrep
                     }
@@ -236,7 +235,6 @@ pub(crate) fn generate_altrep_impls(
                 unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::ffi::SEXP {
                     use ::miniextendr_api::altrep_registration::RegisterAltrep;
                     use ::miniextendr_api::externalptr::ExternalPtr;
-                    use ::miniextendr_api::ffi::altrep::R_new_altrep_unchecked;
                     use ::miniextendr_api::ffi::{Rf_protect_unchecked, Rf_unprotect_unchecked};
 
                     let ext_ptr = ExternalPtr::new(self.0);
@@ -244,8 +242,7 @@ pub(crate) fn generate_altrep_impls(
                     let data1 = ext_ptr.as_sexp();
                     unsafe {
                         Rf_protect_unchecked(data1);
-                        let altrep = R_new_altrep_unchecked(
-                            cls,
+                        let altrep = cls.new_altrep_unchecked(
                             data1,
                             ::miniextendr_api::ffi::SEXP::nil(),
                         );

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1572,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1738,12 +1738,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]


### PR DESCRIPTION
## Summary

- Reduce `pub(crate)` surface of `ffi.rs` from 248 to 60 items (76% reduction)
- Make 40+ ALTREP FFI functions in `ffi/altrep.rs` module-private (were `pub`)
- Add higher-level types and traits that encapsulate raw FFI calls
- Migrate all callers to use the new APIs

## New APIs

**`R_altrep_class_t` methods** — `new_altrep()`, `set_length_method()`, `set_*_elt_method()`, `inherits()`, etc. (40+ methods wrapping ALTREP setters/constructors)

**`SexpExt` trait additions** — `duplicate()`, `shallow_duplicate()`, `resize()`, `printname()`, `r_char()`, `r_char_str()`, `r_char_unchecked()`

**`PairListExt` trait** (new, `pub(crate)`) — `cons()`, `lcons()`, `car()`, `cdr()`, `tag()`, `set_tag()`, `set_car()`, `set_cdr()` + unchecked variants

**`SEXP` methods** — `symbol()`, `install_char()`, `names_symbol()`, `dim_symbol()`, `dimnames_symbol()`, `class_symbol()`, `levels_symbol()`, `tsp_symbol()`, `base_namespace()`, `missing_arg()`

**`SEXPTYPE::type_name()`** — R's typeof name string

## What was made private

- All ALTREP method setters (via `R_altrep_class_t` methods)
- Element access: `*_ELT`, `SET_*_ELT`, `*_OR_NULL`, `TYPEOF`, `LENGTH`
- Type predicates: all `Rf_is*` functions
- Coercion: `Rf_asLogical/Integer/Real/Char`, `Rf_coerceVector`, `Rf_inherits`
- Attributes: `Rf_getAttrib`, `Rf_setAttrib`, `Rf_namesgets`, `Rf_dimgets`, `Rf_classgets`, `Rf_dimnamesgets`
- Pairlist: all 19 `CAR/CDR/TAG/SET*/Rf_cons/Rf_lcons` functions
- Symbols: `R_NaString`, `R_BlankString`, `R_NamesSymbol`, `R_DimSymbol`, `R_ClassSymbol`, `R_BaseNamespace`, `R_MissingArg`, etc.
- String: `R_CHAR`, `PRINTNAME`, `Rf_type2char`, `Rf_mkChar`, `Rf_mkCharLen`
- Duplication: `Rf_duplicate`, `Rf_shallow_duplicate`
- Plus ~80 more unused utility/sort/alloc/weak-ref functions

## Remaining `pub(crate)` items

60 items remain — see #112 for the design discussion on those.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` — all 48 test suites pass
- [x] `cargo fmt --all --check` clean
- [x] rpkg compiles (`cargo check` on rpkg/src/rust)
- [x] Feature-gated builds: `connections,vctrs,nonapi,worker-thread`

Generated with [Claude Code](https://claude.com/claude-code)
