### PR TITLE
fix: upgrade Zola 0.19.2 → 0.22.1 for syntax highlighting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install Zola
         run: |
-          ZOLA_VERSION="0.19.2"
+          ZOLA_VERSION="0.22.1"
           curl -sL "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz
           sudo mv zola /usr/local/bin/
 


### PR DESCRIPTION
## Summary

- Upgrades Zola from 0.19.2 to 0.22.1 in the GitHub Pages deployment workflow
- The site config uses `[markdown.highlighting]` with `theme = "github-dark"`, which is a Zola 0.22+ config format
- Zola 0.19.2 uses `highlight_code`/`highlight_theme` under `[markdown]` and silently ignores the nested `[markdown.highlighting]` section, so **all code blocks on the deployed site render without syntax highlighting**

## Test plan

- [ ] Verify the Pages workflow runs successfully after merge
- [ ] Check that code blocks on the deployed site have syntax highlighting (e.g. `/getting-started/`, `/manual/getting-started/`)
- [ ] Locally confirmed: `zola build` with 0.22.1 produces inline color styles in all code blocks

Generated with [Claude Code](https://claude.com/claude-code)
