### PR TITLE
fix: clean up altrep-redesign loose ends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ NOT_CRAN=true just devtools-test # Run R tests
 - **TypedExternal**: Trait providing R-visible type name (`TYPE_NAME_CSTR` for display tag, `TYPE_ID_CSTR` for error messages). No longer used for type safety — `Any::downcast` is authoritative.
 - **ALTREP**: Lazy/compact vectors. Single-struct pattern — no wrapper struct. Two paths:
   - **Field-based derive**: `#[derive(AltrepInteger)]` with `#[altrep(len = "field", elt = "field", class = "Name")]` generates everything (AltrepLen, AltIntegerData, low-level traits, TypedExternal, RegisterAltrep, IntoR, linkme entry, Ref/Mut)
-  - **Manual traits + registration**: `#[derive(Altrep)]` with `#[altrep_derive_opts(class = "Name")]` generates registration only; user implements `AltrepLen`, `Alt*Data`, and calls `impl_alt*_from_data!()` manually
+  - **Manual traits + registration**: `#[derive(Altrep)]` with `#[altrep(class = "Name")]` generates registration only; user implements `AltrepLen`, `Alt*Data`, and calls `impl_alt*_from_data!()` manually
   - **`AltrepExtract` trait**: abstracts data extraction from ALTREP SEXP. Blanket impl for `TypedExternal` (ExternalPtr). Override for custom storage.
   - **`#[miniextendr]` on 1-field structs is removed** — use derives instead
 - **R_UnwindProtect**: Ensures Rust destructors run on R errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ NOT_CRAN=true just devtools-test # Run R tests
 - **TypedExternal**: Trait providing R-visible type name (`TYPE_NAME_CSTR` for display tag, `TYPE_ID_CSTR` for error messages). No longer used for type safety — `Any::downcast` is authoritative.
 - **ALTREP**: Lazy/compact vectors. Single-struct pattern — no wrapper struct. Two paths:
   - **Field-based derive**: `#[derive(AltrepInteger)]` with `#[altrep(len = "field", elt = "field", class = "Name")]` generates everything (AltrepLen, AltIntegerData, low-level traits, TypedExternal, RegisterAltrep, IntoR, linkme entry, Ref/Mut)
-  - **Manual traits + registration**: `#[derive(Altrep)]` with `#[altrep(class = "Name")]` generates registration only; user implements `AltrepLen`, `Alt*Data`, and calls `impl_alt*_from_data!()` manually
+  - **Manual traits + registration**: `#[derive(AltrepInteger)]` (or other family) with `#[altrep(manual)]` generates lowlevel traits + registration; user implements `AltrepLen` and `Alt*Data` manually
   - **`AltrepExtract` trait**: abstracts data extraction from ALTREP SEXP. Blanket impl for `TypedExternal` (ExternalPtr). Override for custom storage.
   - **`#[miniextendr]` on 1-field structs is removed** — use derives instead
 - **R_UnwindProtect**: Ensures Rust destructors run on R errors

--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -1470,123 +1470,149 @@ pub(crate) fn register_arrow_altrep_classes() {
 
 // endregion
 
-// region: Array implementations (const generics - can't use macros)
+// region: Array implementations (const generics)
+//
+// Macro-generated for numeric families (i32, f64, u8, Rcomplex) that share
+// the same pattern: Altrep + AltVec with dataptr + family trait + InferBase.
+// Bool and String arrays are hand-written because they differ structurally
+// (bool has no direct dataptr; String elt returns SEXP).
 
-// Integer arrays
-impl<const N: usize> crate::altrep_traits::Altrep for [i32; N] {
-    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
-        let data =
-            unsafe { <[i32; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltVec for [i32; N] {
-    const HAS_DATAPTR: bool = true;
-
-    fn dataptr(x: crate::ffi::SEXP, _writable: bool) -> *mut std::ffi::c_void {
-        let data =
-            unsafe { <[i32; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x) };
-        data.as_mut_ptr().cast::<std::ffi::c_void>()
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltInteger for [i32; N] {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> i32 {
-        let data =
-            unsafe { <[i32; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        <[i32; N] as crate::altrep_data::AltIntegerData>::elt(data, i.max(0) as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::ffi::SEXP,
-        start: crate::ffi::R_xlen_t,
-        len: crate::ffi::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::ffi::R_xlen_t {
-        if start < 0 || len <= 0 {
-            return 0;
+/// Generate all ALTREP trait impls + InferBase for a numeric [T; N] array family.
+/// Pass optional extra items via `extra { ... }` to include in the family trait impl.
+macro_rules! impl_altrep_array_numeric {
+    (
+        elem = $elem:ty,
+        data_trait = $data_trait:path,
+        alt_trait = $alt_trait:path,
+        rbase = $rbase:expr,
+        make_class_fn = $make_class_fn:path,
+        install_family_fn = $install_family_fn:ident
+        $(, extra { $($extra:tt)* } )?
+        $(,)?
+    ) => {
+        impl<const N: usize> crate::altrep_traits::Altrep for [$elem; N] {
+            fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
+                let data = unsafe {
+                    <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
+                };
+                crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
+            }
         }
-        let data =
-            unsafe { <[i32; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        let len = len as usize;
-        <[i32; N] as crate::altrep_data::AltIntegerData>::get_region(data, start as usize, len, buf)
-            as crate::ffi::R_xlen_t
-    }
 
-    const HAS_NO_NA: bool = true;
+        impl<const N: usize> crate::altrep_traits::AltVec for [$elem; N] {
+            const HAS_DATAPTR: bool = true;
 
-    fn no_na(x: crate::ffi::SEXP) -> i32 {
-        let data =
-            unsafe { <[i32; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        <[i32; N] as crate::altrep_data::AltIntegerData>::no_na(data)
-            .map(|b| if b { 1 } else { 0 })
-            .unwrap_or(0)
-    }
-}
-
-// Real arrays
-impl<const N: usize> crate::altrep_traits::Altrep for [f64; N] {
-    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
-        let data =
-            unsafe { <[f64; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltVec for [f64; N] {
-    const HAS_DATAPTR: bool = true;
-
-    fn dataptr(x: crate::ffi::SEXP, _writable: bool) -> *mut std::ffi::c_void {
-        let data =
-            unsafe { <[f64; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x) };
-        data.as_mut_ptr().cast::<std::ffi::c_void>()
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltReal for [f64; N] {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> f64 {
-        let data =
-            unsafe { <[f64; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        <[f64; N] as crate::altrep_data::AltRealData>::elt(data, i.max(0) as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::ffi::SEXP,
-        start: crate::ffi::R_xlen_t,
-        len: crate::ffi::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::ffi::R_xlen_t {
-        if start < 0 || len <= 0 {
-            return 0;
+            fn dataptr(x: crate::ffi::SEXP, _writable: bool) -> *mut core::ffi::c_void {
+                let data = unsafe {
+                    <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x)
+                };
+                data.as_mut_ptr().cast::<core::ffi::c_void>()
+            }
         }
-        let data =
-            unsafe { <[f64; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        let len = len as usize;
-        <[f64; N] as crate::altrep_data::AltRealData>::get_region(data, start as usize, len, buf)
-            as crate::ffi::R_xlen_t
-    }
 
-    const HAS_NO_NA: bool = true;
+        impl<const N: usize> $alt_trait for [$elem; N] {
+            const HAS_ELT: bool = true;
 
-    fn no_na(x: crate::ffi::SEXP) -> i32 {
-        let data =
-            unsafe { <[f64; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        <[f64; N] as crate::altrep_data::AltRealData>::no_na(data)
-            .map(|b| if b { 1 } else { 0 })
-            .unwrap_or(0)
-    }
+            fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> $elem {
+                let data = unsafe {
+                    <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
+                };
+                <[$elem; N] as $data_trait>::elt(data, i.max(0) as usize)
+            }
+
+            const HAS_GET_REGION: bool = true;
+
+            fn get_region(
+                x: crate::ffi::SEXP,
+                start: crate::ffi::R_xlen_t,
+                len: crate::ffi::R_xlen_t,
+                buf: &mut [$elem],
+            ) -> crate::ffi::R_xlen_t {
+                if start < 0 || len <= 0 {
+                    return 0;
+                }
+                let data = unsafe {
+                    <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
+                };
+                <[$elem; N] as $data_trait>::get_region(data, start as usize, len as usize, buf)
+                    as crate::ffi::R_xlen_t
+            }
+
+            $($($extra)*)?
+        }
+
+        impl<const N: usize> crate::altrep_data::InferBase for [$elem; N] {
+            const BASE: crate::altrep::RBase = $rbase;
+
+            unsafe fn make_class(
+                class_name: *const i8,
+                pkg_name: *const i8,
+            ) -> crate::ffi::altrep::R_altrep_class_t {
+                let cls = unsafe { $make_class_fn(class_name, pkg_name, crate::altrep_dll_info()) };
+                let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
+                crate::altrep::validate_altrep_class(cls, name, Self::BASE)
+            }
+
+            unsafe fn install_methods(cls: crate::ffi::altrep::R_altrep_class_t) {
+                unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
+                unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
+                unsafe { crate::altrep_bridge::$install_family_fn::<Self>(cls) };
+            }
+        }
+    };
 }
 
-// Logical arrays
+/// no_na fragment for families that support it (Integer, Real).
+macro_rules! altrep_array_no_na {
+    ($elem:ty, $data_trait:path) => {
+        const HAS_NO_NA: bool = true;
+
+        fn no_na(x: crate::ffi::SEXP) -> i32 {
+            let data =
+                unsafe { <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
+            <[$elem; N] as $data_trait>::no_na(data)
+                .map(i32::from)
+                .unwrap_or(0)
+        }
+    };
+}
+
+impl_altrep_array_numeric!(
+    elem = i32,
+    data_trait = crate::altrep_data::AltIntegerData,
+    alt_trait = crate::altrep_traits::AltInteger,
+    rbase = crate::altrep::RBase::Int,
+    make_class_fn = crate::ffi::altrep::R_make_altinteger_class,
+    install_family_fn = install_int,
+    extra { altrep_array_no_na!(i32, crate::altrep_data::AltIntegerData); },
+);
+impl_altrep_array_numeric!(
+    elem = f64,
+    data_trait = crate::altrep_data::AltRealData,
+    alt_trait = crate::altrep_traits::AltReal,
+    rbase = crate::altrep::RBase::Real,
+    make_class_fn = crate::ffi::altrep::R_make_altreal_class,
+    install_family_fn = install_real,
+    extra { altrep_array_no_na!(f64, crate::altrep_data::AltRealData); },
+);
+impl_altrep_array_numeric!(
+    elem = u8,
+    data_trait = crate::altrep_data::AltRawData,
+    alt_trait = crate::altrep_traits::AltRaw,
+    rbase = crate::altrep::RBase::Raw,
+    make_class_fn = crate::ffi::altrep::R_make_altraw_class,
+    install_family_fn = install_raw,
+);
+impl_altrep_array_numeric!(
+    elem = crate::ffi::Rcomplex,
+    data_trait = crate::altrep_data::AltComplexData,
+    alt_trait = crate::altrep_traits::AltComplex,
+    rbase = crate::altrep::RBase::Complex,
+    make_class_fn = crate::ffi::altrep::R_make_altcomplex_class,
+    install_family_fn = install_cplx,
+);
+
+// Logical arrays — bool != i32, no direct dataptr, elt returns i32 via to_r_int()
 impl<const N: usize> crate::altrep_traits::Altrep for [bool; N] {
     fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
         let data =
@@ -1612,186 +1638,8 @@ impl<const N: usize> crate::altrep_traits::AltLogical for [bool; N] {
         let data =
             unsafe { <[bool; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         <[bool; N] as crate::altrep_data::AltLogicalData>::no_na(data)
-            .map(|b| if b { 1 } else { 0 })
+            .map(i32::from)
             .unwrap_or(0)
-    }
-}
-
-// Raw arrays
-impl<const N: usize> crate::altrep_traits::Altrep for [u8; N] {
-    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
-        let data = unsafe { <[u8; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltVec for [u8; N] {
-    const HAS_DATAPTR: bool = true;
-
-    fn dataptr(x: crate::ffi::SEXP, _writable: bool) -> *mut std::ffi::c_void {
-        let data = unsafe { <[u8; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x) };
-        data.as_mut_ptr().cast::<std::ffi::c_void>()
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltRaw for [u8; N] {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> crate::ffi::Rbyte {
-        let data = unsafe { <[u8; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        <[u8; N] as crate::altrep_data::AltRawData>::elt(data, i.max(0) as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::ffi::SEXP,
-        start: crate::ffi::R_xlen_t,
-        len: crate::ffi::R_xlen_t,
-        buf: &mut [u8],
-    ) -> crate::ffi::R_xlen_t {
-        if start < 0 || len <= 0 {
-            return 0;
-        }
-        let data = unsafe { <[u8; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        let len = len as usize;
-        <[u8; N] as crate::altrep_data::AltRawData>::get_region(data, start as usize, len, buf)
-            as crate::ffi::R_xlen_t
-    }
-}
-
-// String arrays
-impl<const N: usize> crate::altrep_traits::Altrep for [String; N] {
-    // String ALTREP elt calls Rf_mkCharLenCE (R API) — must use RUnwind.
-    const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
-
-    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
-        let data =
-            unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltVec for [String; N] {}
-
-impl<const N: usize> crate::altrep_traits::AltString for [String; N] {
-    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> crate::ffi::SEXP {
-        let data =
-            unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        match <[String; N] as crate::altrep_data::AltStringData>::elt(data, i.max(0) as usize) {
-            Some(s) => unsafe { checked_mkchar(s) },
-            None => crate::ffi::SEXP::na_string(),
-        }
-    }
-}
-
-// Complex arrays
-impl<const N: usize> crate::altrep_traits::Altrep for [crate::ffi::Rcomplex; N] {
-    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
-        let data = unsafe {
-            <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
-        };
-        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltVec for [crate::ffi::Rcomplex; N] {
-    const HAS_DATAPTR: bool = true;
-
-    fn dataptr(x: crate::ffi::SEXP, _writable: bool) -> *mut std::ffi::c_void {
-        let data = unsafe {
-            <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x)
-        };
-        data.as_mut_ptr().cast::<std::ffi::c_void>()
-    }
-}
-
-impl<const N: usize> crate::altrep_traits::AltComplex for [crate::ffi::Rcomplex; N] {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> crate::ffi::Rcomplex {
-        let data = unsafe {
-            <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
-        };
-        <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltComplexData>::elt(
-            data,
-            i.max(0) as usize,
-        )
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::ffi::SEXP,
-        start: crate::ffi::R_xlen_t,
-        len: crate::ffi::R_xlen_t,
-        buf: &mut [crate::ffi::Rcomplex],
-    ) -> crate::ffi::R_xlen_t {
-        if start < 0 || len <= 0 {
-            return 0;
-        }
-        let data = unsafe {
-            <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
-        };
-        let len = len as usize;
-        <[crate::ffi::Rcomplex; N] as crate::altrep_data::AltComplexData>::get_region(
-            data,
-            start as usize,
-            len,
-            buf,
-        ) as crate::ffi::R_xlen_t
-    }
-}
-// endregion
-
-// region: InferBase implementations for arrays (const generics)
-//
-// These allow arrays to be registered as ALTREP classes.
-// Note: Macros don't work with const generics, so these are hand-written.
-
-impl<const N: usize> crate::altrep_data::InferBase for [i32; N] {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::ffi::altrep::R_altrep_class_t {
-        let cls = unsafe {
-            crate::ffi::altrep::R_make_altinteger_class(
-                class_name,
-                pkg_name,
-                crate::altrep_dll_info(),
-            )
-        };
-        let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
-        crate::altrep::validate_altrep_class(cls, name, Self::BASE)
-    }
-
-    unsafe fn install_methods(cls: crate::ffi::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<const N: usize> crate::altrep_data::InferBase for [f64; N] {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::ffi::altrep::R_altrep_class_t {
-        let cls = unsafe {
-            crate::ffi::altrep::R_make_altreal_class(class_name, pkg_name, crate::altrep_dll_info())
-        };
-        let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
-        crate::altrep::validate_altrep_class(cls, name, Self::BASE)
-    }
-
-    unsafe fn install_methods(cls: crate::ffi::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
     }
 }
 
@@ -1820,24 +1668,27 @@ impl<const N: usize> crate::altrep_data::InferBase for [bool; N] {
     }
 }
 
-impl<const N: usize> crate::altrep_data::InferBase for [u8; N] {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Raw;
+// String arrays — no dataptr, elt returns SEXP via checked_mkchar
+impl<const N: usize> crate::altrep_traits::Altrep for [String; N] {
+    const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
 
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::ffi::altrep::R_altrep_class_t {
-        let cls = unsafe {
-            crate::ffi::altrep::R_make_altraw_class(class_name, pkg_name, core::ptr::null_mut())
-        };
-        let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
-        crate::altrep::validate_altrep_class(cls, name, Self::BASE)
+    fn length(x: crate::ffi::SEXP) -> crate::ffi::R_xlen_t {
+        let data =
+            unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
+        crate::altrep_data::AltrepLen::len(data) as crate::ffi::R_xlen_t
     }
+}
 
-    unsafe fn install_methods(cls: crate::ffi::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_raw::<Self>(cls) };
+impl<const N: usize> crate::altrep_traits::AltVec for [String; N] {}
+
+impl<const N: usize> crate::altrep_traits::AltString for [String; N] {
+    fn elt(x: crate::ffi::SEXP, i: crate::ffi::R_xlen_t) -> crate::ffi::SEXP {
+        let data =
+            unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
+        match <[String; N] as crate::altrep_data::AltStringData>::elt(data, i.max(0) as usize) {
+            Some(s) => unsafe { checked_mkchar(s) },
+            None => crate::ffi::SEXP::na_string(),
+        }
     }
 }
 
@@ -1849,7 +1700,11 @@ impl<const N: usize> crate::altrep_data::InferBase for [String; N] {
         pkg_name: *const i8,
     ) -> crate::ffi::altrep::R_altrep_class_t {
         let cls = unsafe {
-            crate::ffi::altrep::R_make_altstring_class(class_name, pkg_name, core::ptr::null_mut())
+            crate::ffi::altrep::R_make_altstring_class(
+                class_name,
+                pkg_name,
+                crate::altrep_dll_info(),
+            )
         };
         let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
         crate::altrep::validate_altrep_class(cls, name, Self::BASE)
@@ -1859,27 +1714,6 @@ impl<const N: usize> crate::altrep_data::InferBase for [String; N] {
         unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
         unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
         unsafe { crate::altrep_bridge::install_str::<Self>(cls) };
-    }
-}
-
-impl<const N: usize> crate::altrep_data::InferBase for [crate::ffi::Rcomplex; N] {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Complex;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::ffi::altrep::R_altrep_class_t {
-        let cls = unsafe {
-            crate::ffi::altrep::R_make_altcomplex_class(class_name, pkg_name, core::ptr::null_mut())
-        };
-        let name = unsafe { core::ffi::CStr::from_ptr(class_name) };
-        crate::altrep::validate_altrep_class(cls, name, Self::BASE)
-    }
-
-    unsafe fn install_methods(cls: crate::ffi::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_cplx::<Self>(cls) };
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -1431,11 +1431,9 @@ pub(crate) fn register_builtin_altrep_classes() {
     Vec::<Option<String>>::get_or_init_class();
     Vec::<crate::ffi::Rcomplex>::get_or_init_class();
 
-    // Note: Vec<Cow<str>> ALTREP classes don't have RegisterAltrep
-    // (they use impl_altstring_from_data! without a hand-written RegisterAltrep).
-    // They'll be registered lazily on first use. Cross-session readRDS won't
-    // work for Cow ALTREP — but Cow vectors are primarily used for zero-copy
-    // input, not ALTREP output.
+    // Cow string vectors
+    Vec::<std::borrow::Cow<'static, str>>::get_or_init_class();
+    Vec::<Option<std::borrow::Cow<'static, str>>>::get_or_init_class();
 
     // Box<[T]>
     Box::<[i32]>::get_or_init_class();
@@ -2374,5 +2372,12 @@ impl_register_altrep_builtin!(std::borrow::Cow<'static, [u8]>, "Cow_u8");
 impl_register_altrep_builtin!(
     std::borrow::Cow<'static, [crate::ffi::Rcomplex]>,
     "Cow_Rcomplex"
+);
+
+// Cow string vector types
+impl_register_altrep_builtin!(Vec<std::borrow::Cow<'static, str>>, "Vec_Cow_str");
+impl_register_altrep_builtin!(
+    Vec<Option<std::borrow::Cow<'static, str>>>,
+    "Vec_Option_Cow_str"
 );
 // endregion

--- a/miniextendr-api/tests/altrep_extract.rs
+++ b/miniextendr-api/tests/altrep_extract.rs
@@ -62,3 +62,39 @@ fn altrep_extract_implemented_for_primitives() {
     assert_altrep_extract::<bool>();
     assert_altrep_extract::<String>();
 }
+
+// region: Custom AltrepExtract (non-TypedExternal) — compile-time proof
+
+/// A type that does NOT implement TypedExternal, but manually implements AltrepExtract.
+/// This proves the trait is usable for custom storage strategies (e.g., storing data
+/// directly in R SEXPs rather than via ExternalPtr).
+struct CustomStorageData {
+    #[allow(dead_code)]
+    values: Vec<i32>,
+}
+
+/// Manual AltrepExtract: the type extracts itself from an ALTREP SEXP without ExternalPtr.
+/// This is a compile-time test only — runtime testing requires a full ALTREP registration
+/// path that bypasses ExternalPtr, which is future work.
+impl AltrepExtract for CustomStorageData {
+    unsafe fn altrep_extract_ref(x: miniextendr_api::ffi::SEXP) -> &'static Self {
+        // In a real implementation, this would extract data from the SEXP directly
+        // (e.g., from an INTSXP stored in data1). For compile-time testing, we just
+        // prove the trait is implementable.
+        let _ = x;
+        panic!("compile-time only — not callable without R runtime")
+    }
+
+    unsafe fn altrep_extract_mut(x: miniextendr_api::ffi::SEXP) -> &'static mut Self {
+        let _ = x;
+        panic!("compile-time only — not callable without R runtime")
+    }
+}
+
+#[test]
+fn custom_altrep_extract_compiles() {
+    // Proves AltrepExtract is implementable without TypedExternal
+    assert_altrep_extract::<CustomStorageData>();
+}
+
+// endregion

--- a/miniextendr-bench/benches/altrep.rs
+++ b/miniextendr-bench/benches/altrep.rs
@@ -9,7 +9,7 @@ use miniextendr_bench::raw_ffi;
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchInt")]
+#[altrep(class = "BenchInt", base = "Integer", dataptr)]
 pub struct BenchInt {
     data: Vec<i32>,
 }
@@ -40,10 +40,8 @@ impl AltrepDataptr<i32> for BenchInt {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(BenchInt, dataptr);
-
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchReal")]
+#[altrep(class = "BenchReal", base = "Real", dataptr)]
 pub struct BenchReal {
     data: Vec<f64>,
 }
@@ -73,8 +71,6 @@ impl AltrepDataptr<f64> for BenchReal {
         Some(self.data.as_ptr())
     }
 }
-
-miniextendr_api::impl_altreal_from_data!(BenchReal, dataptr);
 
 fn main() {
     miniextendr_bench::init();

--- a/miniextendr-bench/benches/altrep.rs
+++ b/miniextendr-bench/benches/altrep.rs
@@ -8,8 +8,8 @@ use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchInt", base = "Integer", dataptr)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "BenchInt", manual, dataptr)]
 pub struct BenchInt {
     data: Vec<i32>,
 }
@@ -40,8 +40,8 @@ impl AltrepDataptr<i32> for BenchInt {
     }
 }
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchReal", base = "Real", dataptr)]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "BenchReal", manual, dataptr)]
 pub struct BenchReal {
     data: Vec<f64>,
 }

--- a/miniextendr-bench/benches/altrep_advanced.rs
+++ b/miniextendr-bench/benches/altrep_advanced.rs
@@ -52,8 +52,8 @@ pub struct ConstantRealData {
 
 // region: Vec-backed ALTREP types (named-field struct pattern, default guard).
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchIntVec", base = "Integer", dataptr)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "BenchIntVec", manual, dataptr)]
 pub struct BenchIntVec {
     data: Vec<i32>,
 }
@@ -84,8 +84,8 @@ impl AltrepDataptr<i32> for BenchIntVec {
     }
 }
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchRealVec", base = "Real", dataptr)]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "BenchRealVec", manual, dataptr)]
 pub struct BenchRealVec {
     data: Vec<f64>,
 }
@@ -116,8 +116,8 @@ impl AltrepDataptr<f64> for BenchRealVec {
     }
 }
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchString", base = "String")]
+#[derive(miniextendr_api::AltrepString)]
+#[altrep(class = "BenchString", manual)]
 pub struct BenchString {
     data: Vec<Option<String>>,
 }
@@ -134,8 +134,8 @@ impl AltStringData for BenchString {
     }
 }
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchComplex", base = "Complex", dataptr)]
+#[derive(miniextendr_api::AltrepComplex)]
+#[altrep(class = "BenchComplex", manual, dataptr)]
 pub struct BenchComplex {
     data: Vec<Rcomplex>,
 }

--- a/miniextendr-bench/benches/altrep_advanced.rs
+++ b/miniextendr-bench/benches/altrep_advanced.rs
@@ -53,7 +53,7 @@ pub struct ConstantRealData {
 // region: Vec-backed ALTREP types (named-field struct pattern, default guard).
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchIntVec")]
+#[altrep(class = "BenchIntVec", base = "Integer", dataptr)]
 pub struct BenchIntVec {
     data: Vec<i32>,
 }
@@ -84,10 +84,8 @@ impl AltrepDataptr<i32> for BenchIntVec {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(BenchIntVec, dataptr);
-
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchRealVec")]
+#[altrep(class = "BenchRealVec", base = "Real", dataptr)]
 pub struct BenchRealVec {
     data: Vec<f64>,
 }
@@ -118,10 +116,8 @@ impl AltrepDataptr<f64> for BenchRealVec {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(BenchRealVec, dataptr);
-
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchString")]
+#[altrep(class = "BenchString", base = "String")]
 pub struct BenchString {
     data: Vec<Option<String>>,
 }
@@ -138,10 +134,8 @@ impl AltStringData for BenchString {
     }
 }
 
-miniextendr_api::impl_altstring_from_data!(BenchString);
-
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchComplex")]
+#[altrep(class = "BenchComplex", base = "Complex", dataptr)]
 pub struct BenchComplex {
     data: Vec<Rcomplex>,
 }
@@ -171,8 +165,6 @@ impl AltrepDataptr<Rcomplex> for BenchComplex {
         Some(self.data.as_ptr())
     }
 }
-
-miniextendr_api::impl_altcomplex_from_data!(BenchComplex, dataptr);
 
 fn main() {
     miniextendr_bench::init();

--- a/miniextendr-bench/benches/altrep_iter.rs
+++ b/miniextendr-bench/benches/altrep_iter.rs
@@ -8,7 +8,7 @@ use miniextendr_bench::raw_ffi;
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchIterInt")]
+#[altrep(class = "BenchIterInt", base = "Integer")]
 pub struct BenchIterIntData {
     inner: IterIntData<std::ops::Range<i32>>,
 }
@@ -28,8 +28,6 @@ impl AltIntegerData for BenchIterIntData {
         self.inner.as_slice()
     }
 }
-
-miniextendr_api::impl_altinteger_from_data!(BenchIterIntData);
 
 fn main() {
     miniextendr_bench::init();

--- a/miniextendr-bench/benches/altrep_iter.rs
+++ b/miniextendr-bench/benches/altrep_iter.rs
@@ -7,8 +7,8 @@ use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BenchIterInt", base = "Integer")]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "BenchIterInt", manual)]
 pub struct BenchIterIntData {
     inner: IterIntData<std::ops::Range<i32>>,
 }

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -16,7 +16,7 @@
 //! For types with manual trait impls (registration only):
 //! ```ignore
 //! #[derive(Altrep)]
-//! #[altrep_derive_opts(class = "MyCustom")]
+//! #[altrep(class = "MyCustom")]
 //! struct MyCustomData { ... }
 //!
 //! impl AltrepLen for MyCustomData { ... }

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -13,15 +13,15 @@
 //! struct MyConstInt { value: i32, len: usize }
 //! ```
 //!
-//! For types with manual trait impls (registration + low-level traits):
+//! For types with manual trait impls (lowlevel + registration, user writes data traits):
 //! ```ignore
-//! #[derive(Altrep)]
-//! #[altrep(class = "MyCustom", base = "Integer", serialize)]
+//! #[derive(AltrepInteger)]
+//! #[altrep(manual, class = "MyCustom", serialize)]
 //! struct MyCustomData { ... }
 //!
 //! impl AltrepLen for MyCustomData { ... }
 //! impl AltIntegerData for MyCustomData { ... }
-//! // Done — base = "Integer" generates Altrep, AltVec, AltInteger, InferBase.
+//! // Family derived from AltrepInteger — generates Altrep, AltVec, AltInteger, InferBase.
 //! ```
 
 /// Generates full ALTREP registration for a data struct.
@@ -250,21 +250,20 @@ pub(crate) fn generate_direct_altrep_registration(
 
 /// Entry point for `#[derive(Altrep)]`.
 ///
-/// Generates ALTREP registration for a data struct (TypedExternal, AltrepClass,
+/// Generates ALTREP registration only (TypedExternal, AltrepClass,
 /// RegisterAltrep, IntoR, linkme entry, Ref/Mut accessor types).
 ///
-/// When `base` is specified, also generates the low-level ALTREP trait impls
-/// (Altrep, AltVec, family-specific methods, InferBase), eliminating the need
-/// for a manual `impl_alt*_from_data!()` call.
+/// The struct must already have low-level ALTREP traits implemented.
+/// For most use cases, prefer a family-specific derive instead:
+/// `#[derive(AltrepInteger)]`, `#[derive(AltrepReal)]`, etc.
+/// Those generate both the low-level traits AND registration.
+/// Use `#[altrep(manual)]` on a family derive to skip data trait generation
+/// when you provide your own `AltrepLen` + `Alt*Data` impls.
 ///
 /// # Helper attributes
 ///
 /// ```ignore
 /// #[altrep(class = "CustomName")]  // override ALTREP class name (default: struct name)
-/// #[altrep(base = "Integer")]      // generate low-level traits for this family
-/// #[altrep(dataptr)]               // enable DATAPTR (requires base)
-/// #[altrep(serialize)]             // enable serialization (requires base)
-/// #[altrep(subset)]                // enable Extract_subset (requires base)
 /// ```
 pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     use syn::spanned::Spanned;
@@ -278,11 +277,8 @@ pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenS
         ));
     }
 
-    // Parse #[altrep(...)] attributes
+    // Parse class name from #[altrep(class = "...")]
     let mut class_name = None::<String>;
-    let mut base = None::<String>;
-    let mut lowlevel_options = Vec::new();
-    let mut guard = None::<syn::Ident>;
 
     for attr in &input.attrs {
         if !attr.path().is_ident("altrep") {
@@ -292,58 +288,14 @@ pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenS
             if meta.path.is_ident("class") {
                 let value: syn::LitStr = meta.value()?.parse()?;
                 class_name = Some(value.value());
-            } else if meta.path.is_ident("base") {
-                let value: syn::LitStr = meta.value()?.parse()?;
-                base = Some(value.value());
-            } else if meta.path.is_ident("dataptr") {
-                lowlevel_options.push(syn::Ident::new("dataptr", meta.path.span()));
-            } else if meta.path.is_ident("serialize") {
-                lowlevel_options.push(syn::Ident::new("serialize", meta.path.span()));
-            } else if meta.path.is_ident("subset") {
-                lowlevel_options.push(syn::Ident::new("subset", meta.path.span()));
-            } else if meta.path.is_ident("r#unsafe") || meta.path.is_ident("unsafe") {
-                guard = Some(syn::Ident::new("Unsafe", meta.path.span()));
-            } else if meta.path.is_ident("rust_unwind") {
-                guard = Some(syn::Ident::new("RustUnwind", meta.path.span()));
-            } else if meta.path.is_ident("r_unwind") {
-                guard = Some(syn::Ident::new("RUnwind", meta.path.span()));
             } else {
-                return Err(meta.error(
-                    "unknown #[altrep(...)] attribute; expected one of: \
-                     `class`, `base`, `dataptr`, `serialize`, `subset`, \
-                     `unsafe`, `rust_unwind`, `r_unwind`",
-                ));
+                return Err(meta.error("unknown #[altrep(...)] attribute; expected `class`"));
             }
             Ok(())
         })?;
     }
 
-    // Validate: lowlevel options require base
-    if base.is_none() && (!lowlevel_options.is_empty() || guard.is_some()) {
-        return Err(syn::Error::new(
-            ident.span(),
-            "`dataptr`, `serialize`, `subset`, and guard options require `base = \"...\"`",
-        ));
-    }
-
     let class_name = class_name.unwrap_or_else(|| ident.to_string());
 
-    let registration = generate_direct_altrep_registration(ident, &input.generics, &class_name)?;
-
-    let lowlevel = if let Some(ref base_name) = base {
-        crate::altrep_derive::generate_lowlevel_for_base(
-            ident,
-            &input.generics,
-            base_name,
-            lowlevel_options,
-            guard,
-        )?
-    } else {
-        proc_macro2::TokenStream::new()
-    };
-
-    Ok(quote::quote! {
-        #lowlevel
-        #registration
-    })
+    generate_direct_altrep_registration(ident, &input.generics, &class_name)
 }

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -13,15 +13,15 @@
 //! struct MyConstInt { value: i32, len: usize }
 //! ```
 //!
-//! For types with manual trait impls (registration only):
+//! For types with manual trait impls (registration + low-level traits):
 //! ```ignore
 //! #[derive(Altrep)]
-//! #[altrep(class = "MyCustom")]
+//! #[altrep(class = "MyCustom", base = "Integer", serialize)]
 //! struct MyCustomData { ... }
 //!
 //! impl AltrepLen for MyCustomData { ... }
 //! impl AltIntegerData for MyCustomData { ... }
-//! impl_altinteger_from_data!(MyCustomData);
+//! // Done — base = "Integer" generates Altrep, AltVec, AltInteger, InferBase.
 //! ```
 
 /// Generates full ALTREP registration for a data struct.
@@ -253,13 +253,18 @@ pub(crate) fn generate_direct_altrep_registration(
 /// Generates ALTREP registration for a data struct (TypedExternal, AltrepClass,
 /// RegisterAltrep, IntoR, linkme entry, Ref/Mut accessor types).
 ///
-/// The struct must already have low-level ALTREP traits implemented (via
-/// `impl_alt*_from_data!` or a family-specific derive like `#[derive(AltrepInteger)]`).
+/// When `base` is specified, also generates the low-level ALTREP trait impls
+/// (Altrep, AltVec, family-specific methods, InferBase), eliminating the need
+/// for a manual `impl_alt*_from_data!()` call.
 ///
 /// # Helper attributes
 ///
 /// ```ignore
 /// #[altrep(class = "CustomName")]  // override ALTREP class name (default: struct name)
+/// #[altrep(base = "Integer")]      // generate low-level traits for this family
+/// #[altrep(dataptr)]               // enable DATAPTR (requires base)
+/// #[altrep(serialize)]             // enable serialization (requires base)
+/// #[altrep(subset)]                // enable Extract_subset (requires base)
 /// ```
 pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     use syn::spanned::Spanned;
@@ -273,8 +278,11 @@ pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenS
         ));
     }
 
-    // Parse class name from #[altrep(class = "...")]
+    // Parse #[altrep(...)] attributes
     let mut class_name = None::<String>;
+    let mut base = None::<String>;
+    let mut lowlevel_options = Vec::new();
+    let mut guard = None::<syn::Ident>;
 
     for attr in &input.attrs {
         if !attr.path().is_ident("altrep") {
@@ -284,14 +292,58 @@ pub fn derive_altrep(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenS
             if meta.path.is_ident("class") {
                 let value: syn::LitStr = meta.value()?.parse()?;
                 class_name = Some(value.value());
+            } else if meta.path.is_ident("base") {
+                let value: syn::LitStr = meta.value()?.parse()?;
+                base = Some(value.value());
+            } else if meta.path.is_ident("dataptr") {
+                lowlevel_options.push(syn::Ident::new("dataptr", meta.path.span()));
+            } else if meta.path.is_ident("serialize") {
+                lowlevel_options.push(syn::Ident::new("serialize", meta.path.span()));
+            } else if meta.path.is_ident("subset") {
+                lowlevel_options.push(syn::Ident::new("subset", meta.path.span()));
+            } else if meta.path.is_ident("r#unsafe") || meta.path.is_ident("unsafe") {
+                guard = Some(syn::Ident::new("Unsafe", meta.path.span()));
+            } else if meta.path.is_ident("rust_unwind") {
+                guard = Some(syn::Ident::new("RustUnwind", meta.path.span()));
+            } else if meta.path.is_ident("r_unwind") {
+                guard = Some(syn::Ident::new("RUnwind", meta.path.span()));
             } else {
-                return Err(meta.error("unknown #[altrep(...)] attribute; expected `class`"));
+                return Err(meta.error(
+                    "unknown #[altrep(...)] attribute; expected one of: \
+                     `class`, `base`, `dataptr`, `serialize`, `subset`, \
+                     `unsafe`, `rust_unwind`, `r_unwind`",
+                ));
             }
             Ok(())
         })?;
     }
 
+    // Validate: lowlevel options require base
+    if base.is_none() && (!lowlevel_options.is_empty() || guard.is_some()) {
+        return Err(syn::Error::new(
+            ident.span(),
+            "`dataptr`, `serialize`, `subset`, and guard options require `base = \"...\"`",
+        ));
+    }
+
     let class_name = class_name.unwrap_or_else(|| ident.to_string());
 
-    generate_direct_altrep_registration(ident, &input.generics, &class_name)
+    let registration = generate_direct_altrep_registration(ident, &input.generics, &class_name)?;
+
+    let lowlevel = if let Some(ref base_name) = base {
+        crate::altrep_derive::generate_lowlevel_for_base(
+            ident,
+            &input.generics,
+            base_name,
+            lowlevel_options,
+            guard,
+        )?
+    } else {
+        proc_macro2::TokenStream::new()
+    };
+
+    Ok(quote::quote! {
+        #lowlevel
+        #registration
+    })
 }

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -84,6 +84,9 @@ struct AltrepAttrs {
     guard: Option<syn::Ident>,
     /// Override the ALTREP class name. Default: struct name.
     class_name: Option<String>,
+    /// Manual mode: skip `AltrepLen` and `Alt*Data` generation. User provides their own.
+    /// Set by `#[altrep(manual)]`. Lowlevel traits + registration still generated.
+    manual: bool,
 }
 
 impl AltrepAttrs {
@@ -104,6 +107,7 @@ impl AltrepAttrs {
         let mut lowlevel_options = Vec::new();
         let mut guard = None;
         let mut class_name = None;
+        let mut manual = false;
 
         for attr in &input.attrs {
             if !attr.path().is_ident("altrep") {
@@ -125,6 +129,8 @@ impl AltrepAttrs {
                     elt_delegate = Some(syn::Ident::new(&field.value(), field.span()));
                 } else if meta.path.is_ident("no_lowlevel") {
                     generate_lowlevel = false;
+                } else if meta.path.is_ident("manual") {
+                    manual = true;
                 } else if meta.path.is_ident("class") {
                     let _: syn::Token![=] = meta.input.parse()?;
                     let name: syn::LitStr = meta.input.parse()?;
@@ -144,7 +150,7 @@ impl AltrepAttrs {
                 } else {
                     return Err(meta.error(
                         "unknown #[altrep(...)] attribute; expected one of: \
-                         `len`, `elt`, `elt_delegate`, `no_lowlevel`, `class`, \
+                         `len`, `elt`, `elt_delegate`, `manual`, `no_lowlevel`, `class`, \
                          `dataptr`, `serialize`, `subset`, `unsafe`, \
                          `rust_unwind`, `r_unwind`",
                     ));
@@ -161,6 +167,7 @@ impl AltrepAttrs {
             lowlevel_options,
             guard,
             class_name,
+            manual,
         })
     }
 
@@ -442,16 +449,20 @@ fn derive_altrep_generic(
     let name = &input.ident;
     let generics = &input.generics;
     let attrs = AltrepAttrs::parse(&input)?;
-    let len_field = attrs.get_len_field(&input)?;
 
-    let altrep_len_impl = generate_altrep_len(name, generics, &len_field);
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let elt_impl = gen_elt_impl(attrs.elt_field.as_ref(), attrs.elt_delegate.as_ref());
-
-    let data_trait_impl = quote! {
-        impl #impl_generics #data_trait_path for #name #ty_generics #where_clause {
-            #elt_impl
+    // In manual mode, skip AltrepLen + data trait generation — user provides their own.
+    let data_traits = if attrs.manual {
+        quote! {}
+    } else {
+        let len_field = attrs.get_len_field(&input)?;
+        let altrep_len_impl = generate_altrep_len(name, generics, &len_field);
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+        let elt_impl = gen_elt_impl(attrs.elt_field.as_ref(), attrs.elt_delegate.as_ref());
+        quote! {
+            #altrep_len_impl
+            impl #impl_generics #data_trait_path for #name #ty_generics #where_clause {
+                #elt_impl
+            }
         }
     };
 
@@ -468,8 +479,7 @@ fn derive_altrep_generic(
         crate::altrep::generate_direct_altrep_registration(name, generics, &class_name)?;
 
     Ok(quote! {
-        #altrep_len_impl
-        #data_trait_impl
+        #data_traits
         #lowlevel_impl
         #registration_impl
     })
@@ -698,29 +708,35 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let generics = &input.generics;
     let attrs = AltrepAttrs::parse(&input)?;
-    let len_field = attrs.get_len_field(&input)?;
-
-    let altrep_len_impl = generate_altrep_len(name, generics, &len_field);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    // List elt() returns SEXP - if elt_field specified, assume it's a Vec<SEXP> or similar
-    let elt_impl = if let Some(ref elt_field) = attrs.elt_field {
-        quote! {
-            fn elt(&self, i: usize) -> ::miniextendr_api::ffi::SEXP {
-                self.#elt_field[i]
-            }
-        }
+    // In manual mode, skip AltrepLen + AltListData generation.
+    let data_traits = if attrs.manual {
+        quote! {}
     } else {
-        quote! {
-            fn elt(&self, _i: usize) -> ::miniextendr_api::ffi::SEXP {
-                ::miniextendr_api::ffi::SEXP::nil()
-            }
-        }
-    };
+        let len_field = attrs.get_len_field(&input)?;
+        let altrep_len_impl = generate_altrep_len(name, generics, &len_field);
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let alt_list_impl = quote! {
-        impl #impl_generics ::miniextendr_api::altrep_data::AltListData for #name #ty_generics #where_clause {
-            #elt_impl
+        let elt_impl = if let Some(ref elt_field) = attrs.elt_field {
+            quote! {
+                fn elt(&self, i: usize) -> ::miniextendr_api::ffi::SEXP {
+                    self.#elt_field[i]
+                }
+            }
+        } else {
+            quote! {
+                fn elt(&self, _i: usize) -> ::miniextendr_api::ffi::SEXP {
+                    ::miniextendr_api::ffi::SEXP::nil()
+                }
+            }
+        };
+
+        quote! {
+            #altrep_len_impl
+            impl #impl_generics ::miniextendr_api::altrep_data::AltListData for #name #ty_generics #where_clause {
+                #elt_impl
+            }
         }
     };
 
@@ -792,167 +808,10 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
         crate::altrep::generate_direct_altrep_registration(name, generics, &class_name)?;
 
     Ok(quote! {
-        #altrep_len_impl
-        #alt_list_impl
+        #data_traits
         #lowlevel_impl
         #registration_impl
     })
 }
 
 // region: Public helper for derive(Altrep) with base parameter
-
-/// Returns the family config for a given base name (e.g., "Integer", "Real", etc.).
-///
-/// Used by `derive_altrep` when `#[altrep(base = "...")]` is specified.
-fn family_config_for_base(base: &str) -> Option<AltrepFamilyConfig<'static>> {
-    match base {
-        "Integer" | "Int" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altinteger_from_data",
-            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { i32 }))),
-            string_dataptr: false,
-            subset: true,
-            methods_macro: "__impl_altinteger_methods",
-            inferbase_macro: "impl_inferbase_integer",
-            default_guard: "RUnwind",
-        }),
-        "Real" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altreal_from_data",
-            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { f64 }))),
-            string_dataptr: false,
-            subset: true,
-            methods_macro: "__impl_altreal_methods",
-            inferbase_macro: "impl_inferbase_real",
-            default_guard: "RUnwind",
-        }),
-        "Logical" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altlogical_from_data",
-            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { i32 }))),
-            string_dataptr: false,
-            subset: true,
-            methods_macro: "__impl_altlogical_methods",
-            inferbase_macro: "impl_inferbase_logical",
-            default_guard: "RUnwind",
-        }),
-        "Raw" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altraw_from_data",
-            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { u8 }))),
-            string_dataptr: false,
-            subset: true,
-            methods_macro: "__impl_altraw_methods",
-            inferbase_macro: "impl_inferbase_raw",
-            default_guard: "RUnwind",
-        }),
-        "String" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altstring_from_data",
-            dataptr_macro: None,
-            string_dataptr: true,
-            subset: true,
-            methods_macro: "__impl_altstring_methods",
-            inferbase_macro: "impl_inferbase_string",
-            default_guard: "RUnwind",
-        }),
-        "Complex" => Some(AltrepFamilyConfig {
-            macro_base: "impl_altcomplex_from_data",
-            dataptr_macro: Some((
-                "__impl_altvec_dataptr",
-                Some(quote! { ::miniextendr_api::ffi::Rcomplex }),
-            )),
-            string_dataptr: false,
-            subset: true,
-            methods_macro: "__impl_altcomplex_methods",
-            inferbase_macro: "impl_inferbase_complex",
-            default_guard: "RUnwind",
-        }),
-        _ => None,
-    }
-}
-
-/// Generate low-level ALTREP trait impls for `#[derive(Altrep)]` with `base` parameter.
-///
-/// Called from `altrep::derive_altrep` when `#[altrep(base = "...")]` is present.
-pub(crate) fn generate_lowlevel_for_base(
-    name: &syn::Ident,
-    generics: &syn::Generics,
-    base: &str,
-    options: Vec<syn::Ident>,
-    guard: Option<syn::Ident>,
-) -> syn::Result<proc_macro2::TokenStream> {
-    // List has its own code path — doesn't use AltrepFamilyConfig.
-    if base == "List" {
-        // Validate: List rejects dataptr and subset
-        for opt in &options {
-            if opt == "dataptr" || opt == "subset" {
-                return Err(syn::Error::new(
-                    opt.span(),
-                    format!("`{opt}` is not supported for List"),
-                ));
-            }
-        }
-
-        let has_serialize = options.iter().any(|o| o == "serialize");
-        let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
-
-        return if has_serialize {
-            if let Some(ref g) = guard {
-                Ok(quote! {
-                    ::miniextendr_api::__impl_altrep_base_with_serialize!(#name #ty_generics, #g);
-                    impl ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics {}
-                    impl ::miniextendr_api::altrep_traits::AltList for #name #ty_generics {
-                        fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
-                            unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
-                                .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
-                                .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
-                        }
-                    }
-                    ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);
-                })
-            } else {
-                Ok(quote! {
-                    ::miniextendr_api::__impl_altrep_base_with_serialize!(#name #ty_generics);
-                    impl ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics {}
-                    impl ::miniextendr_api::altrep_traits::AltList for #name #ty_generics {
-                        fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
-                            unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
-                                .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
-                                .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
-                        }
-                    }
-                    ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);
-                })
-            }
-        } else if let Some(ref g) = guard {
-            Ok(quote! {
-                ::miniextendr_api::impl_altlist_from_data!(#name #ty_generics, #g);
-            })
-        } else {
-            Ok(quote! {
-                ::miniextendr_api::impl_altlist_from_data!(#name #ty_generics);
-            })
-        };
-    }
-
-    let family = family_config_for_base(base).ok_or_else(|| {
-        syn::Error::new(
-            name.span(),
-            format!(
-                "unknown ALTREP base type `{base}`; \
-                 expected one of: Integer, Int, Real, Logical, Raw, String, Complex, List"
-            ),
-        )
-    })?;
-
-    // Build an AltrepAttrs with the parsed options
-    let attrs = AltrepAttrs {
-        len_field: None,
-        elt_field: None,
-        elt_delegate: None,
-        generate_lowlevel: true,
-        lowlevel_options: options,
-        guard,
-        class_name: None,
-    };
-
-    attrs.generate_lowlevel(name, generics, &family)
-}
-
-// endregion

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -798,3 +798,107 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
         #registration_impl
     })
 }
+
+// region: Public helper for derive(Altrep) with base parameter
+
+/// Returns the family config for a given base name (e.g., "Integer", "Real", etc.).
+///
+/// Used by `derive_altrep` when `#[altrep(base = "...")]` is specified.
+fn family_config_for_base(base: &str) -> Option<AltrepFamilyConfig<'static>> {
+    match base {
+        "Integer" | "Int" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altinteger_from_data",
+            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { i32 }))),
+            string_dataptr: false,
+            subset: true,
+            methods_macro: "__impl_altinteger_methods",
+            inferbase_macro: "impl_inferbase_integer",
+            default_guard: "RUnwind",
+        }),
+        "Real" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altreal_from_data",
+            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { f64 }))),
+            string_dataptr: false,
+            subset: true,
+            methods_macro: "__impl_altreal_methods",
+            inferbase_macro: "impl_inferbase_real",
+            default_guard: "RUnwind",
+        }),
+        "Logical" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altlogical_from_data",
+            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { i32 }))),
+            string_dataptr: false,
+            subset: true,
+            methods_macro: "__impl_altlogical_methods",
+            inferbase_macro: "impl_inferbase_logical",
+            default_guard: "RUnwind",
+        }),
+        "Raw" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altraw_from_data",
+            dataptr_macro: Some(("__impl_altvec_dataptr", Some(quote! { u8 }))),
+            string_dataptr: false,
+            subset: true,
+            methods_macro: "__impl_altraw_methods",
+            inferbase_macro: "impl_inferbase_raw",
+            default_guard: "RUnwind",
+        }),
+        "String" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altstring_from_data",
+            dataptr_macro: None,
+            string_dataptr: true,
+            subset: true,
+            methods_macro: "__impl_altstring_methods",
+            inferbase_macro: "impl_inferbase_string",
+            default_guard: "RUnwind",
+        }),
+        "Complex" => Some(AltrepFamilyConfig {
+            macro_base: "impl_altcomplex_from_data",
+            dataptr_macro: Some((
+                "__impl_altvec_dataptr",
+                Some(quote! { ::miniextendr_api::ffi::Rcomplex }),
+            )),
+            string_dataptr: false,
+            subset: true,
+            methods_macro: "__impl_altcomplex_methods",
+            inferbase_macro: "impl_inferbase_complex",
+            default_guard: "RUnwind",
+        }),
+        _ => None,
+    }
+}
+
+/// Generate low-level ALTREP trait impls for `#[derive(Altrep)]` with `base` parameter.
+///
+/// Called from `altrep::derive_altrep` when `#[altrep(base = "...")]` is present.
+pub(crate) fn generate_lowlevel_for_base(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    base: &str,
+    options: Vec<syn::Ident>,
+    guard: Option<syn::Ident>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let family = family_config_for_base(base).ok_or_else(|| {
+        syn::Error::new(
+            name.span(),
+            format!(
+                "unknown ALTREP base type `{base}`; \
+                 expected one of: Integer, Int, Real, Logical, Raw, String, Complex"
+            ),
+        )
+    })?;
+
+    // Build an AltrepAttrs with the parsed options
+    let attrs = AltrepAttrs {
+        len_field: None,
+        elt_field: None,
+        elt_delegate: None,
+        generate_lowlevel: true,
+        lowlevel_options: options,
+        guard,
+        class_name: None,
+    };
+
+    attrs.generate_lowlevel(name, generics, &family)
+}
+
+// endregion

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -877,12 +877,66 @@ pub(crate) fn generate_lowlevel_for_base(
     options: Vec<syn::Ident>,
     guard: Option<syn::Ident>,
 ) -> syn::Result<proc_macro2::TokenStream> {
+    // List has its own code path — doesn't use AltrepFamilyConfig.
+    if base == "List" {
+        // Validate: List rejects dataptr and subset
+        for opt in &options {
+            if opt == "dataptr" || opt == "subset" {
+                return Err(syn::Error::new(
+                    opt.span(),
+                    format!("`{opt}` is not supported for List"),
+                ));
+            }
+        }
+
+        let has_serialize = options.iter().any(|o| o == "serialize");
+        let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+
+        return if has_serialize {
+            if let Some(ref g) = guard {
+                Ok(quote! {
+                    ::miniextendr_api::__impl_altrep_base_with_serialize!(#name #ty_generics, #g);
+                    impl ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics {}
+                    impl ::miniextendr_api::altrep_traits::AltList for #name #ty_generics {
+                        fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
+                            unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
+                                .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
+                                .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
+                        }
+                    }
+                    ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);
+                })
+            } else {
+                Ok(quote! {
+                    ::miniextendr_api::__impl_altrep_base_with_serialize!(#name #ty_generics);
+                    impl ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics {}
+                    impl ::miniextendr_api::altrep_traits::AltList for #name #ty_generics {
+                        fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
+                            unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
+                                .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
+                                .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
+                        }
+                    }
+                    ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);
+                })
+            }
+        } else if let Some(ref g) = guard {
+            Ok(quote! {
+                ::miniextendr_api::impl_altlist_from_data!(#name #ty_generics, #g);
+            })
+        } else {
+            Ok(quote! {
+                ::miniextendr_api::impl_altlist_from_data!(#name #ty_generics);
+            })
+        };
+    }
+
     let family = family_config_for_base(base).ok_or_else(|| {
         syn::Error::new(
             name.span(),
             format!(
                 "unknown ALTREP base type `{base}`; \
-                 expected one of: Integer, Int, Real, Logical, Raw, String, Complex"
+                 expected one of: Integer, Int, Real, Logical, Raw, String, Complex, List"
             ),
         )
     })?;

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -2312,23 +2312,30 @@ pub fn derive_altrep_list(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// Generates `TypedExternal`, `AltrepClass`, `RegisterAltrep`, `IntoR`,
 /// linkme registration entry, and `Ref`/`Mut` accessor types.
 ///
-/// The struct must already implement the low-level ALTREP traits (via
-/// `impl_alt*_from_data!` or a family-specific derive like `#[derive(AltrepInteger)]`).
+/// When `base` is specified, also generates the low-level trait impls (Altrep,
+/// AltVec, family-specific methods, InferBase), so no manual `impl_alt*_from_data!()`
+/// call is needed. Without `base`, the struct must already have those traits.
 ///
 /// # Attributes
 ///
-/// - `#[altrep(class = "ClassName")]` — custom ALTREP class name (defaults to struct name)
+/// - `#[altrep(class = "Name")]` — custom ALTREP class name (defaults to struct name)
+/// - `#[altrep(base = "Integer")]` — generate low-level traits for this family
+///   (Integer, Int, Real, Logical, Raw, String, Complex)
+/// - `#[altrep(dataptr)]` — enable DATAPTR method (requires `base`)
+/// - `#[altrep(serialize)]` — enable serialization (requires `base`)
+/// - `#[altrep(subset)]` — enable Extract_subset (requires `base`)
+/// - `#[altrep(unsafe)]` / `#[altrep(rust_unwind)]` / `#[altrep(r_unwind)]` — guard mode
 ///
 /// # Example
 ///
 /// ```ignore
 /// #[derive(Altrep)]
-/// #[altrep(class = "MyCustom")]
+/// #[altrep(class = "MyCustom", base = "Integer", serialize)]
 /// struct MyData { ... }
 ///
 /// impl AltrepLen for MyData { ... }
 /// impl AltIntegerData for MyData { ... }
-/// impl_altinteger_from_data!(MyData);
+/// // Done — no impl_altinteger_from_data!() needed.
 /// ```
 #[proc_macro_derive(Altrep, attributes(altrep))]
 pub fn derive_altrep(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -2312,30 +2312,26 @@ pub fn derive_altrep_list(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// Generates `TypedExternal`, `AltrepClass`, `RegisterAltrep`, `IntoR`,
 /// linkme registration entry, and `Ref`/`Mut` accessor types.
 ///
-/// When `base` is specified, also generates the low-level trait impls (Altrep,
-/// AltVec, family-specific methods, InferBase), so no manual `impl_alt*_from_data!()`
-/// call is needed. Without `base`, the struct must already have those traits.
+/// The struct must already have low-level ALTREP traits implemented.
+/// For most use cases, prefer a family-specific derive:
+/// `#[derive(AltrepInteger)]`, `#[derive(AltrepReal)]`, etc.
+/// Use `#[altrep(manual)]` on a family derive to skip data trait generation
+/// when you provide your own `AltrepLen` + `Alt*Data` impls.
 ///
 /// # Attributes
 ///
 /// - `#[altrep(class = "Name")]` — custom ALTREP class name (defaults to struct name)
-/// - `#[altrep(base = "Integer")]` — generate low-level traits for this family
-///   (Integer, Int, Real, Logical, Raw, String, Complex)
-/// - `#[altrep(dataptr)]` — enable DATAPTR method (requires `base`)
-/// - `#[altrep(serialize)]` — enable serialization (requires `base`)
-/// - `#[altrep(subset)]` — enable Extract_subset (requires `base`)
-/// - `#[altrep(unsafe)]` / `#[altrep(rust_unwind)]` / `#[altrep(r_unwind)]` — guard mode
 ///
 /// # Example
 ///
 /// ```ignore
-/// #[derive(Altrep)]
-/// #[altrep(class = "MyCustom", base = "Integer", serialize)]
+/// // Prefer family derives with manual:
+/// #[derive(AltrepInteger)]
+/// #[altrep(manual, class = "MyCustom", serialize)]
 /// struct MyData { ... }
 ///
 /// impl AltrepLen for MyData { ... }
 /// impl AltIntegerData for MyData { ... }
-/// // Done — no impl_altinteger_from_data!() needed.
 /// ```
 #[proc_macro_derive(Altrep, attributes(altrep))]
 pub fn derive_altrep(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/miniextendr-macros/src/struct_enum_dispatch.rs
+++ b/miniextendr-macros/src/struct_enum_dispatch.rs
@@ -215,7 +215,7 @@ fn expand_struct(
         return syn::Error::new(
             item_struct.ident.span(),
             "#[miniextendr] no longer supports ALTREP (class/base attributes). \
-             Use #[derive(miniextendr_api::Altrep)] with #[altrep_derive_opts(class = \"...\")] instead.",
+             Use #[derive(miniextendr_api::Altrep)] with #[altrep(class = \"...\")] instead.",
         )
         .into_compile_error()
         .into();

--- a/miniextendr-macros/tests/ui/derive_altrep_unknown_option.stderr
+++ b/miniextendr-macros/tests/ui/derive_altrep_unknown_option.stderr
@@ -1,4 +1,4 @@
-error: unknown #[altrep(...)] attribute; expected one of: `len`, `elt`, `elt_delegate`, `no_lowlevel`, `class`, `dataptr`, `serialize`, `subset`, `unsafe`, `rust_unwind`, `r_unwind`
+error: unknown #[altrep(...)] attribute; expected one of: `len`, `elt`, `elt_delegate`, `manual`, `no_lowlevel`, `class`, `dataptr`, `serialize`, `subset`, `unsafe`, `rust_unwind`, `r_unwind`
  --> tests/ui/derive_altrep_unknown_option.rs:6:10
   |
 6 | #[altrep(typo_option)]

--- a/miniextendr-macros/tests/ui/struct_altrep_removed.stderr
+++ b/miniextendr-macros/tests/ui/struct_altrep_removed.stderr
@@ -1,4 +1,4 @@
-error: #[miniextendr] no longer supports ALTREP (class/base attributes). Use #[derive(miniextendr_api::Altrep)] with #[altrep_derive_opts(class = "...")] instead.
+error: #[miniextendr] no longer supports ALTREP (class/base attributes). Use #[derive(miniextendr_api::Altrep)] with #[altrep(class = "...")] instead.
  --> tests/ui/struct_altrep_removed.rs:6:12
   |
 6 | pub struct MyWrapper(Vec<i32>);

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -260,7 +260,7 @@ use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen};
 /// Data type that stores a constant value and length.
 /// Uses the direct registration pattern — no wrapper struct needed.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ConstantInt")]
+#[altrep(class = "ConstantInt", base = "Integer", serialize)]
 pub struct ConstantIntData {
     value: i32,
     len: usize,
@@ -313,8 +313,6 @@ impl miniextendr_api::altrep_data::AltrepSerialize for ConstantIntData {
     }
 }
 
-// Generate low-level traits from data traits (also enables base type inference)
-miniextendr_api::impl_altinteger_from_data!(ConstantIntData, materializing_dataptr, serialize);
 
 /// Create a constant-value integer ALTREP vector (10 elements, all 42).
 /// @rdname constant_altrep
@@ -345,7 +343,7 @@ use miniextendr_api::altrep_data::{
 // region: ConstantReal: All elements are PI
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ConstantReal")]
+#[altrep(class = "ConstantReal", base = "Real")]
 pub struct ConstantRealData {
     value: f64,
     len: usize,
@@ -366,7 +364,6 @@ impl AltRealData for ConstantRealData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(ConstantRealData, materializing_dataptr);
 
 /// Create a constant-value real ALTREP vector (10 elements, all pi).
 /// @rdname constant_altrep
@@ -384,7 +381,7 @@ pub fn constant_real() -> ConstantRealData {
 // region: ArithSeq: Arithmetic sequence (like R's seq())
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ArithSeq")]
+#[altrep(class = "ArithSeq", base = "Real")]
 pub struct ArithSeqData {
     start: f64,
     step: f64,
@@ -406,7 +403,6 @@ impl AltRealData for ArithSeqData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(ArithSeqData);
 
 #[miniextendr]
 pub fn arith_seq(from: f64, step: f64, length_out: i32) -> SEXP {
@@ -429,7 +425,7 @@ pub fn arith_seq(from: f64, step: f64, length_out: i32) -> SEXP {
 
 /// Data type for lazy integer sequence with materialization support
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LazyIntSeq")]
+#[altrep(class = "LazyIntSeq", base = "Integer", dataptr, serialize)]
 pub struct LazyIntSeqData {
     start: i32,
     step: i32,
@@ -631,8 +627,6 @@ impl miniextendr_api::altrep_data::AltrepSerialize for LazyIntSeqData {
     }
 }
 
-// Use the dataptr + serialize variant to enable both Dataptr and serialization methods
-miniextendr_api::impl_altinteger_from_data!(LazyIntSeqData, dataptr, serialize);
 
 /// Create a lazy integer sequence ALTREP (like R's `seq()`).
 ///
@@ -912,7 +906,7 @@ pub fn constant_logical(value: i32, n: i32) -> SEXP {
 // region: LogicalVec: Vec<Logical> wrapper (preserves NA)
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LogicalVec")]
+#[altrep(class = "LogicalVec", base = "Logical", serialize)]
 pub struct LogicalVecData {
     data: Vec<Logical>,
 }
@@ -993,14 +987,13 @@ impl miniextendr_api::altrep_data::AltrepSerialize for LogicalVecData {
     }
 }
 
-miniextendr_api::impl_altlogical_from_data!(LogicalVecData, serialize);
 
 // endregion
 
 // region: LazyString: Lazily-generated strings
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LazyString")]
+#[altrep(class = "LazyString", base = "String")]
 pub struct LazyStringData {
     pub prefix: String,
     pub len: usize,
@@ -1024,7 +1017,6 @@ impl AltStringData for LazyStringData {
     } // We return None which is like NA
 }
 
-miniextendr_api::impl_altstring_from_data!(LazyStringData);
 
 /// Create a lazy string ALTREP that computes elements on demand.
 /// @rdname lazy_string_altrep
@@ -1045,7 +1037,7 @@ pub fn lazy_string(prefix: &str, n: i32) -> SEXP {
 // region: RepeatingRaw: Repeating byte pattern
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "RepeatingRaw")]
+#[altrep(class = "RepeatingRaw", base = "Raw")]
 pub struct RepeatingRawData {
     pattern: Vec<u8>,
     total_len: usize,
@@ -1067,7 +1059,6 @@ impl AltRawData for RepeatingRawData {
     }
 }
 
-miniextendr_api::impl_altraw_from_data!(RepeatingRawData);
 
 /// Create a repeating raw byte pattern ALTREP vector.
 /// @rdname lazy_string_altrep
@@ -1093,7 +1084,7 @@ use miniextendr_api::altrep_data::AltComplexData;
 use miniextendr_api::ffi::Rcomplex;
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "UnitCircle")]
+#[altrep(class = "UnitCircle", base = "Complex")]
 pub struct UnitCircleData {
     /// Number of points on the unit circle
     n: usize,
@@ -1124,7 +1115,6 @@ impl AltComplexData for UnitCircleData {
     }
 }
 
-miniextendr_api::impl_altcomplex_from_data!(UnitCircleData);
 
 /// Create a complex ALTREP of n points on the unit circle (e^(i*2*pi*k/n)).
 /// @rdname altrep_special
@@ -1189,7 +1179,7 @@ pub fn integer_sequence_list(n: i32) -> SEXP {
 // region: SimpleVecInt: Vec<i32> wrapper (simplest example)
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecInt")]
+#[altrep(class = "SimpleVecInt", base = "Integer", dataptr, serialize)]
 pub struct SimpleVecIntData {
     data: Vec<i32>,
 }
@@ -1228,13 +1218,12 @@ impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecIntData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(SimpleVecIntData, dataptr, serialize);
 // endregion
 
 // region: SimpleVecString: Vec<Option<String>> wrapper (preserves NA)
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecString")]
+#[altrep(class = "SimpleVecString", base = "String", dataptr, serialize)]
 pub struct StringVecData {
     data: Vec<Option<String>>,
 }
@@ -1267,14 +1256,13 @@ impl miniextendr_api::altrep_data::AltrepSerialize for StringVecData {
     }
 }
 
-miniextendr_api::impl_altstring_from_data!(StringVecData, dataptr, serialize);
 
 // endregion
 
 // region: SimpleVecRaw: Vec<u8> wrapper
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecRaw")]
+#[altrep(class = "SimpleVecRaw", base = "Raw", dataptr, serialize)]
 pub struct SimpleVecRawData {
     data: Vec<u8>,
 }
@@ -1313,14 +1301,13 @@ impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecRawData {
     }
 }
 
-miniextendr_api::impl_altraw_from_data!(SimpleVecRawData, dataptr, serialize);
 // endregion
 
 // region: InferredVecReal: Vec<f64> wrapper with base type inferred from inner type
 
 /// ALTREP class wrapper for inferred real vector.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "InferredVecReal")]
+#[altrep(class = "InferredVecReal", base = "Real", dataptr, serialize)]
 pub struct InferredVecRealData {
     data: Vec<f64>,
 }
@@ -1359,14 +1346,13 @@ impl miniextendr_api::altrep_data::AltrepSerialize for InferredVecRealData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(InferredVecRealData, dataptr, serialize);
 // endregion
 
 // region: BoxedInts: Box<[i32]> wrapper (owned slice example)
 
 /// ALTREP class wrapper for boxed integer slice.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BoxedInts")]
+#[altrep(class = "BoxedInts", base = "Integer", dataptr, serialize)]
 pub struct BoxedIntsData {
     data: Box<[i32]>,
 }
@@ -1405,7 +1391,6 @@ impl miniextendr_api::altrep_data::AltrepSerialize for BoxedIntsData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(BoxedIntsData, dataptr, serialize);
 
 /// Create an ALTREP integer vector backed by a boxed slice (`Box<[i32]>`).
 /// @rdname altrep_special
@@ -1428,7 +1413,7 @@ static STATIC_INTS: [i32; 5] = [10, 20, 30, 40, 50];
 
 /// ALTREP class wrapper for static integer slice.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StaticInts")]
+#[altrep(class = "StaticInts", base = "Integer", dataptr)]
 pub struct StaticIntsData {
     data: &'static [i32],
 }
@@ -1458,7 +1443,6 @@ impl miniextendr_api::altrep_data::AltrepDataptr<i32> for StaticIntsData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(StaticIntsData, dataptr);
 
 /// Create an ALTREP integer vector backed by a static slice (`&'static [i32]`).
 /// @rdname altrep_special
@@ -1496,7 +1480,7 @@ static STATIC_STRINGS: [&str; 4] = ["alpha", "beta", "gamma", "delta"];
 
 /// ALTREP class wrapper for static string slice.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StaticStrings")]
+#[altrep(class = "StaticStrings", base = "String", dataptr)]
 pub struct StaticStringsData {
     data: &'static [&'static str],
 }
@@ -1517,7 +1501,6 @@ impl AltStringData for StaticStringsData {
     }
 }
 
-miniextendr_api::impl_altstring_from_data!(StaticStringsData, dataptr);
 
 /// Create an ALTREP string vector backed by a static string slice.
 /// @rdname altrep_special
@@ -1829,7 +1812,7 @@ type BoxedIntIter = Box<dyn Iterator<Item = i32>>;
 
 /// Wrapper for sparse integer iterator ALTREP
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseIntIter")]
+#[altrep(class = "SparseIntIter", base = "Integer")]
 pub struct SparseIntIterData {
     inner: SparseIterIntData<BoxedIntIter>,
 }
@@ -1854,7 +1837,6 @@ impl miniextendr_api::altrep_data::AltIntegerData for SparseIntIterData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(SparseIntIterData);
 
 /// Create a sparse integer iterator ALTREP that skips elements.
 ///
@@ -1898,7 +1880,7 @@ type BoxedRealIter = Box<dyn Iterator<Item = f64>>;
 
 /// Wrapper for sparse real iterator ALTREP
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseRealIter")]
+#[altrep(class = "SparseRealIter", base = "Real")]
 pub struct SparseRealIterData {
     inner: SparseIterRealData<BoxedRealIter>,
 }
@@ -1923,7 +1905,6 @@ impl miniextendr_api::altrep_data::AltRealData for SparseRealIterData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(SparseRealIterData);
 
 /// Create a sparse real iterator ALTREP with arithmetic progression.
 /// @rdname sparse_altrep
@@ -1947,7 +1928,7 @@ type BoxedLogicalIter = Box<dyn Iterator<Item = bool>>;
 
 /// Wrapper for sparse logical iterator ALTREP
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseLogicalIter")]
+#[altrep(class = "SparseLogicalIter", base = "Logical")]
 pub struct SparseLogicalIterData {
     inner: SparseIterLogicalData<BoxedLogicalIter>,
 }
@@ -1968,7 +1949,6 @@ impl miniextendr_api::altrep_data::AltLogicalData for SparseLogicalIterData {
     }
 }
 
-miniextendr_api::impl_altlogical_from_data!(SparseLogicalIterData);
 
 /// Create a sparse logical iterator ALTREP (alternating TRUE/FALSE).
 /// @rdname sparse_altrep
@@ -1990,7 +1970,7 @@ type BoxedRawIter = Box<dyn Iterator<Item = u8>>;
 
 /// Wrapper for sparse raw iterator ALTREP
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseRawIter")]
+#[altrep(class = "SparseRawIter", base = "Raw")]
 pub struct SparseRawIterData {
     inner: SparseIterRawData<BoxedRawIter>,
 }
@@ -2015,7 +1995,6 @@ impl miniextendr_api::altrep_data::AltRawData for SparseRawIterData {
     }
 }
 
-miniextendr_api::impl_altraw_from_data!(SparseRawIterData);
 
 /// Create a sparse raw iterator ALTREP (cycling bytes 0..255).
 /// @rdname sparse_altrep

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -259,8 +259,8 @@ use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen};
 
 /// Data type that stores a constant value and length.
 /// Uses the direct registration pattern — no wrapper struct needed.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ConstantInt", base = "Integer", serialize)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "ConstantInt", manual, serialize)]
 pub struct ConstantIntData {
     value: i32,
     len: usize,
@@ -342,8 +342,8 @@ use miniextendr_api::altrep_data::{
 
 // region: ConstantReal: All elements are PI
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ConstantReal", base = "Real")]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "ConstantReal", manual)]
 pub struct ConstantRealData {
     value: f64,
     len: usize,
@@ -380,8 +380,8 @@ pub fn constant_real() -> ConstantRealData {
 
 // region: ArithSeq: Arithmetic sequence (like R's seq())
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ArithSeq", base = "Real")]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "ArithSeq", manual)]
 pub struct ArithSeqData {
     start: f64,
     step: f64,
@@ -424,8 +424,8 @@ pub fn arith_seq(from: f64, step: f64, length_out: i32) -> SEXP {
 // -----------------------------------------------------------------------------
 
 /// Data type for lazy integer sequence with materialization support
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LazyIntSeq", base = "Integer", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "LazyIntSeq", manual, dataptr, serialize)]
 pub struct LazyIntSeqData {
     start: i32,
     step: i32,
@@ -905,8 +905,8 @@ pub fn constant_logical(value: i32, n: i32) -> SEXP {
 
 // region: LogicalVec: Vec<Logical> wrapper (preserves NA)
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LogicalVec", base = "Logical", serialize)]
+#[derive(miniextendr_api::AltrepLogical)]
+#[altrep(class = "LogicalVec", manual, serialize)]
 pub struct LogicalVecData {
     data: Vec<Logical>,
 }
@@ -992,8 +992,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for LogicalVecData {
 
 // region: LazyString: Lazily-generated strings
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "LazyString", base = "String")]
+#[derive(miniextendr_api::AltrepString)]
+#[altrep(class = "LazyString", manual)]
 pub struct LazyStringData {
     pub prefix: String,
     pub len: usize,
@@ -1036,8 +1036,8 @@ pub fn lazy_string(prefix: &str, n: i32) -> SEXP {
 
 // region: RepeatingRaw: Repeating byte pattern
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "RepeatingRaw", base = "Raw")]
+#[derive(miniextendr_api::AltrepRaw)]
+#[altrep(class = "RepeatingRaw", manual)]
 pub struct RepeatingRawData {
     pattern: Vec<u8>,
     total_len: usize,
@@ -1083,8 +1083,8 @@ pub fn repeating_raw(pattern: &[u8], n: i32) -> SEXP {
 use miniextendr_api::altrep_data::AltComplexData;
 use miniextendr_api::ffi::Rcomplex;
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "UnitCircle", base = "Complex")]
+#[derive(miniextendr_api::AltrepComplex)]
+#[altrep(class = "UnitCircle", manual)]
 pub struct UnitCircleData {
     /// Number of points on the unit circle
     n: usize,
@@ -1132,8 +1132,8 @@ pub fn unit_circle(n: i32) -> SEXP {
 // This demonstrates ALTREP for list vectors (VECSXP)
 // -----------------------------------------------------------------------------
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "IntegerSequenceList", base = "List")]
+#[derive(miniextendr_api::AltrepList)]
+#[altrep(class = "IntegerSequenceList", manual)]
 pub struct IntegerSequenceListData {
     /// Number of elements in the list
     n: usize,
@@ -1177,8 +1177,8 @@ pub fn integer_sequence_list(n: i32) -> SEXP {
 
 // region: SimpleVecInt: Vec<i32> wrapper (simplest example)
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecInt", base = "Integer", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "SimpleVecInt", manual, dataptr, serialize)]
 pub struct SimpleVecIntData {
     data: Vec<i32>,
 }
@@ -1221,8 +1221,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecIntData {
 
 // region: SimpleVecString: Vec<Option<String>> wrapper (preserves NA)
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecString", base = "String", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepString)]
+#[altrep(class = "SimpleVecString", manual, dataptr, serialize)]
 pub struct StringVecData {
     data: Vec<Option<String>>,
 }
@@ -1260,8 +1260,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for StringVecData {
 
 // region: SimpleVecRaw: Vec<u8> wrapper
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SimpleVecRaw", base = "Raw", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepRaw)]
+#[altrep(class = "SimpleVecRaw", manual, dataptr, serialize)]
 pub struct SimpleVecRawData {
     data: Vec<u8>,
 }
@@ -1305,8 +1305,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecRawData {
 // region: InferredVecReal: Vec<f64> wrapper with base type inferred from inner type
 
 /// ALTREP class wrapper for inferred real vector.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "InferredVecReal", base = "Real", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "InferredVecReal", manual, dataptr, serialize)]
 pub struct InferredVecRealData {
     data: Vec<f64>,
 }
@@ -1350,8 +1350,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for InferredVecRealData {
 // region: BoxedInts: Box<[i32]> wrapper (owned slice example)
 
 /// ALTREP class wrapper for boxed integer slice.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "BoxedInts", base = "Integer", dataptr, serialize)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "BoxedInts", manual, dataptr, serialize)]
 pub struct BoxedIntsData {
     data: Box<[i32]>,
 }
@@ -1411,8 +1411,8 @@ pub fn boxed_ints(n: i32) -> SEXP {
 static STATIC_INTS: [i32; 5] = [10, 20, 30, 40, 50];
 
 /// ALTREP class wrapper for static integer slice.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StaticInts", base = "Integer", dataptr)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "StaticInts", manual, dataptr)]
 pub struct StaticIntsData {
     data: &'static [i32],
 }
@@ -1478,8 +1478,8 @@ pub fn leaked_ints(n: i32) -> SEXP {
 static STATIC_STRINGS: [&str; 4] = ["alpha", "beta", "gamma", "delta"];
 
 /// ALTREP class wrapper for static string slice.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StaticStrings", base = "String", dataptr)]
+#[derive(miniextendr_api::AltrepString)]
+#[altrep(class = "StaticStrings", manual, dataptr)]
 pub struct StaticStringsData {
     data: &'static [&'static str],
 }
@@ -1517,8 +1517,8 @@ pub fn static_strings() -> SEXP {
 
 // region: ListData: list-backed ALTREP (stores original list SEXP)
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ListData", base = "List")]
+#[derive(miniextendr_api::AltrepList)]
+#[altrep(class = "ListData", manual)]
 pub struct ListData {
     list: SEXP,
     len: usize,
@@ -1809,8 +1809,8 @@ use miniextendr_api::altrep_data::{
 type BoxedIntIter = Box<dyn Iterator<Item = i32>>;
 
 /// Wrapper for sparse integer iterator ALTREP
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseIntIter", base = "Integer")]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "SparseIntIter", manual)]
 pub struct SparseIntIterData {
     inner: SparseIterIntData<BoxedIntIter>,
 }
@@ -1877,8 +1877,8 @@ pub fn sparse_iter_int_squares(n: i32) -> SEXP {
 type BoxedRealIter = Box<dyn Iterator<Item = f64>>;
 
 /// Wrapper for sparse real iterator ALTREP
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseRealIter", base = "Real")]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "SparseRealIter", manual)]
 pub struct SparseRealIterData {
     inner: SparseIterRealData<BoxedRealIter>,
 }
@@ -1925,8 +1925,8 @@ pub fn sparse_iter_real(from: f64, step: f64, n: i32) -> SEXP {
 type BoxedLogicalIter = Box<dyn Iterator<Item = bool>>;
 
 /// Wrapper for sparse logical iterator ALTREP
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseLogicalIter", base = "Logical")]
+#[derive(miniextendr_api::AltrepLogical)]
+#[altrep(class = "SparseLogicalIter", manual)]
 pub struct SparseLogicalIterData {
     inner: SparseIterLogicalData<BoxedLogicalIter>,
 }
@@ -1967,8 +1967,8 @@ pub fn sparse_iter_logical(n: i32) -> SEXP {
 type BoxedRawIter = Box<dyn Iterator<Item = u8>>;
 
 /// Wrapper for sparse raw iterator ALTREP
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "SparseRawIter", base = "Raw")]
+#[derive(miniextendr_api::AltrepRaw)]
+#[altrep(class = "SparseRawIter", manual)]
 pub struct SparseRawIterData {
     inner: SparseIterRawData<BoxedRawIter>,
 }

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -1133,7 +1133,7 @@ pub fn unit_circle(n: i32) -> SEXP {
 // -----------------------------------------------------------------------------
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "IntegerSequenceList")]
+#[altrep(class = "IntegerSequenceList", base = "List")]
 pub struct IntegerSequenceListData {
     /// Number of elements in the list
     n: usize,
@@ -1157,7 +1157,6 @@ impl AltListData for IntegerSequenceListData {
     }
 }
 
-miniextendr_api::impl_altlist_from_data!(IntegerSequenceListData);
 
 /// Create a list ALTREP where each element is an integer sequence.
 ///
@@ -1519,7 +1518,7 @@ pub fn static_strings() -> SEXP {
 // region: ListData: list-backed ALTREP (stores original list SEXP)
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "ListData")]
+#[altrep(class = "ListData", base = "List")]
 pub struct ListData {
     list: SEXP,
     len: usize,
@@ -1548,7 +1547,6 @@ impl AltListData for ListData {
     }
 }
 
-miniextendr_api::impl_altlist_from_data!(ListData);
 
 // endregion
 

--- a/rpkg/src/rust/macro_equivalence.rs
+++ b/rpkg/src/rust/macro_equivalence.rs
@@ -119,7 +119,7 @@ pub fn mx_verbosity_check(v: MxVerbosity) -> String {
 
 /// Data struct via derive: generates full ALTREP registration.
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "MxDerivedInts")]
+#[altrep(class = "MxDerivedInts", base = "Integer", dataptr)]
 pub struct MxDerivedIntsData {
     data: Vec<i32>,
 }
@@ -148,7 +148,6 @@ impl miniextendr_api::altrep_data::AltrepDataptr<i32> for MxDerivedIntsData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(MxDerivedIntsData, dataptr);
 
 /// Test creating an ALTREP integer vector via derive(Altrep).
 #[miniextendr]

--- a/rpkg/src/rust/macro_equivalence.rs
+++ b/rpkg/src/rust/macro_equivalence.rs
@@ -118,8 +118,8 @@ pub fn mx_verbosity_check(v: MxVerbosity) -> String {
 // region: 6. #[derive(Altrep)] on data struct → ALTREP registration (direct pattern)
 
 /// Data struct via derive: generates full ALTREP registration.
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "MxDerivedInts", base = "Integer", dataptr)]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "MxDerivedInts", manual, dataptr)]
 pub struct MxDerivedIntsData {
     data: Vec<i32>,
 }

--- a/rpkg/src/rust/streaming_altrep_tests.rs
+++ b/rpkg/src/rust/streaming_altrep_tests.rs
@@ -12,7 +12,7 @@ use miniextendr_api::prelude::*;
 type IntReader = Box<dyn Fn(usize, &mut [i32]) -> usize>;
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StreamingIntRange")]
+#[altrep(class = "StreamingIntRange", base = "Integer")]
 pub struct StreamingIntRangeData {
     inner: StreamingIntData<IntReader>,
 }
@@ -29,7 +29,6 @@ impl AltIntegerData for StreamingIntRangeData {
     }
 }
 
-miniextendr_api::impl_altinteger_from_data!(StreamingIntRangeData);
 
 /// Create a streaming integer ALTREP `1..=n`.
 #[miniextendr]
@@ -57,7 +56,7 @@ pub fn streaming_int_range(n: i32) -> StreamingIntRangeData {
 type RealReader = Box<dyn Fn(usize, &mut [f64]) -> usize>;
 
 #[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StreamingRealSquares")]
+#[altrep(class = "StreamingRealSquares", base = "Real")]
 pub struct StreamingRealSquaresData {
     inner: StreamingRealData<RealReader>,
 }
@@ -74,7 +73,6 @@ impl AltRealData for StreamingRealSquaresData {
     }
 }
 
-miniextendr_api::impl_altreal_from_data!(StreamingRealSquaresData);
 
 /// Create a streaming real ALTREP `1^2, 2^2, ..., n^2`.
 #[miniextendr]

--- a/rpkg/src/rust/streaming_altrep_tests.rs
+++ b/rpkg/src/rust/streaming_altrep_tests.rs
@@ -11,8 +11,8 @@ use miniextendr_api::prelude::*;
 
 type IntReader = Box<dyn Fn(usize, &mut [i32]) -> usize>;
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StreamingIntRange", base = "Integer")]
+#[derive(miniextendr_api::AltrepInteger)]
+#[altrep(class = "StreamingIntRange", manual)]
 pub struct StreamingIntRangeData {
     inner: StreamingIntData<IntReader>,
 }
@@ -55,8 +55,8 @@ pub fn streaming_int_range(n: i32) -> StreamingIntRangeData {
 
 type RealReader = Box<dyn Fn(usize, &mut [f64]) -> usize>;
 
-#[derive(miniextendr_api::Altrep)]
-#[altrep(class = "StreamingRealSquares", base = "Real")]
+#[derive(miniextendr_api::AltrepReal)]
+#[altrep(class = "StreamingRealSquares", manual)]
 pub struct StreamingRealSquaresData {
     inner: StreamingRealData<RealReader>,
 }


### PR DESCRIPTION
## Summary

Addresses all loose ends from PR #119 (ALTREP redesign).

**`manual` flag on family derives — eliminates `impl_alt*_from_data!` in user code:**
```rust
// Before: derive(Altrep) + manual macro call
#[derive(Altrep)]
#[altrep(class = "Foo")]
struct FooData { ... }
impl AltrepLen for FooData { ... }
impl AltIntegerData for FooData { ... }
impl_altinteger_from_data!(FooData, serialize);  // ← gone

// After: family derive infers the base type
#[derive(AltrepInteger)]
#[altrep(manual, class = "Foo", serialize)]
struct FooData { ... }
impl AltrepLen for FooData { ... }
impl AltIntegerData for FooData { ... }
```
- `manual` skips data trait generation, keeps lowlevel + registration
- Family inferred from the derive name — no redundant `base` parameter
- All 30 call sites migrated, zero `impl_alt*_from_data!()` in user code

**Array ALTREP consolidation:**
- `impl_altrep_array_numeric!` macro replaces ~400 lines of hand-written `[T; N]` impls
- Uses `altrep_dll_info()` consistently

**Other fixes:**
- Stale `altrep_derive_opts` references → `#[altrep(...)]`
- Cow string `RegisterAltrep` + eager registration for readRDS
- `AltrepExtract` custom storage compile-time test

## Test plan
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` — 617 passed
- [x] UI tests — 95/95 pass

Generated with [Claude Code](https://claude.com/claude-code)
