### PR TITLE
fix: cargo-revendor direct copy fallback copies vendor/ to vendor/

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -206,7 +206,7 @@ fn main() -> Result<()> {
 
     // Step 1: Load cargo metadata to discover dependencies
     let meta = metadata::load_metadata(&manifest_path)?;
-    let (local_pkgs, _external_pkgs) = metadata::partition_packages(&meta, &manifest_path)?;
+    let (mut local_pkgs, _external_pkgs) = metadata::partition_packages(&meta, &manifest_path)?;
 
     // Also discover ALL workspace members from the source workspace root
     let all_workspace_members = if let Some(ref source_root) = cli.source_root {
@@ -217,6 +217,30 @@ fn main() -> Result<()> {
     } else {
         Vec::new()
     };
+
+    // Fix paths in local_pkgs: when .cargo/config.toml has source replacement
+    // (e.g., [source.vendored-sources] directory = "vendor"), cargo metadata
+    // resolves local workspace crate paths to the vendor directory instead of the
+    // real workspace source. Detect this and replace with the real workspace path.
+    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.clone());
+    for pkg in &mut local_pkgs {
+        let canonical_pkg = pkg.path.canonicalize().unwrap_or_else(|_| pkg.path.clone());
+        if canonical_pkg.starts_with(&canonical_output) {
+            // This path is inside the output vendor directory — find the real source
+            if let Some(ws_pkg) = all_workspace_members.iter().find(|ws| ws.name == pkg.name) {
+                if v.debug() {
+                    eprintln!(
+                        "  Fixed {}: {} -> {}",
+                        pkg.name,
+                        pkg.path.display(),
+                        ws_pkg.path.display()
+                    );
+                }
+                pkg.path = ws_pkg.path.clone();
+                pkg.manifest_path = ws_pkg.manifest_path.clone();
+            }
+        }
+    }
 
     let patch_pkgs = merge_packages(&local_pkgs, &all_workspace_members);
 

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -21,11 +21,8 @@ pub fn run_cargo_vendor(
     // Add [patch.crates-io] to workspace root Cargo.toml so cargo vendor
     // can resolve the dependency graph even with unpublished local crates.
     // NOTE: [patch] only works in Cargo.toml, NOT in .cargo/config.toml.
-    let ws_root = crate::find_workspace_root(
-        manifest_path
-            .parent()
-            .context("manifest has no parent")?,
-    )?;
+    let ws_root =
+        crate::find_workspace_root(manifest_path.parent().context("manifest has no parent")?)?;
     let ws_manifest = ws_root.join("Cargo.toml");
     let ws_original = std::fs::read_to_string(&ws_manifest)?;
 
@@ -644,7 +641,10 @@ pub fn freeze_manifest(
     std::fs::write(manifest_path, doc.to_string())?;
 
     if v.info() {
-        eprintln!("  Frozen: {} now resolves from vendor/ only", manifest_path.display());
+        eprintln!(
+            "  Frozen: {} now resolves from vendor/ only",
+            manifest_path.display()
+        );
     }
 
     Ok(())
@@ -686,7 +686,9 @@ fn rewrite_dep_to_vendor(dep: &mut toml_edit::Item, name: &str, vendor_rel: &str
 
 /// Compute relative path from base to target
 fn pathdiff(target: &Path, base: &Path) -> String {
-    let target = target.canonicalize().unwrap_or_else(|_| target.to_path_buf());
+    let target = target
+        .canonicalize()
+        .unwrap_or_else(|_| target.to_path_buf());
     let base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
 
     let target_parts: Vec<_> = target.components().collect();
@@ -807,4 +809,3 @@ pub fn compress_vendor(
 
     Ok(())
 }
-


### PR DESCRIPTION
## Summary

Fixes #144.

- When `.cargo/config.toml` has source replacement (`[source.vendored-sources] directory = "vendor"`), `cargo metadata` resolves local workspace crate paths to the vendor directory instead of the real workspace source. The direct copy fallback (when `cargo package` fails) then copies vendor/ to vendor/, a no-op that preserves stale content.
- After `partition_packages()` returns `local_pkgs`, detect when paths are inside the output vendor directory and replace them with the real workspace source paths from `all_workspace_members` (discovered from the workspace root). This fixes both the `cargo package` attempt (which now runs on the real source) and the fallback copy path.
- Includes rustfmt fixes for pre-existing formatting issues in `vendor.rs`.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` passes (8 pass, 23 ignored)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual test: run `just vendor` in rpkg with existing `.cargo/config.toml` source replacement

Generated with [Claude Code](https://claude.com/claude-code)
