### PR TITLE
refactor: migrate Rf_translateCharUTF8 call sites to charsxp_to_str (#143)

### DIFF
--- a/miniextendr-api/src/altrep_sexp.rs
+++ b/miniextendr-api/src/altrep_sexp.rs
@@ -230,6 +230,7 @@ impl AltrepSexp {
     ///
     /// Must be called on the R main thread. The SEXP must be STRSXP.
     pub unsafe fn materialize_strings(&self) -> Vec<Option<String>> {
+        use crate::from_r::charsxp_to_str;
         let n = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
@@ -237,11 +238,7 @@ impl AltrepSexp {
             if elt == SEXP::na_string() {
                 out.push(None);
             } else {
-                let cstr = unsafe { ffi::Rf_translateCharUTF8(elt) };
-                let s = unsafe { std::ffi::CStr::from_ptr(cstr) }
-                    .to_string_lossy()
-                    .into_owned();
-                out.push(Some(s));
+                out.push(Some(unsafe { charsxp_to_str(elt) }.to_owned()));
             }
         }
         out

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -10,7 +10,7 @@
 //! | LGLSXP | `RLogical`, `&[RLogical]` | `LOGICAL()` / `DATAPTR_RO` |
 //! | RAWSXP | `u8`, `&[u8]` | `RAW()` / `DATAPTR_RO` |
 //! | CPLXSXP | `Rcomplex` | `COMPLEX()` / `DATAPTR_RO` |
-//! | STRSXP | `&str`, `String` | `)` + `R_CHAR()` / `Rf_translateCharUTF8()` |
+//! | STRSXP | `&str`, `String` | `STRING_ELT()` + `R_CHAR()` (UTF-8 locale asserted at init) |
 //!
 //! # Submodules
 //!

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::ffi::{RLogical, SEXP, SEXPTYPE, SexpExt};
-use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
+use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str};
 
 macro_rules! impl_map_try_from_sexp {
     ($(#[$meta:meta])* $map_ty:ident, $create:expr) => {
@@ -70,8 +70,6 @@ where
     M: Extend<(String, V)>,
     F: FnOnce(usize) -> M,
 {
-    use crate::ffi::Rf_translateCharUTF8;
-
     let actual = sexp.type_of();
     if actual != SEXPTYPE::VECSXP {
         return Err(SexpTypeError {
@@ -97,15 +95,7 @@ where
             if charsxp == SEXP::na_string() {
                 String::new()
             } else {
-                let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-                if c_str.is_null() {
-                    String::new()
-                } else {
-                    unsafe { std::ffi::CStr::from_ptr(c_str) }
-                        .to_str()
-                        .unwrap_or("")
-                        .to_owned()
-                }
+                unsafe { charsxp_to_str(charsxp) }.to_owned()
             }
         } else {
             // Use index as key if no names

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -64,8 +64,9 @@ impl TryFromSexp for Cow<'static, str> {
 
 /// Convert R character vector to `Vec<Cow<'static, str>>` — zero-copy per element.
 ///
-/// Each element borrows directly from R's CHARSXP data when UTF-8 (the common case).
-/// Non-UTF-8 elements fall back to `Rf_translateCharUTF8` (copies only those).
+/// Each element borrows directly from R's CHARSXP data. UTF-8 validity is asserted
+/// at package init via `miniextendr_assert_utf8_locale()`, so no per-string
+/// encoding translation is needed.
 ///
 /// # NA Handling
 ///
@@ -167,8 +168,6 @@ impl TryFromSexp for Vec<String> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -186,15 +185,7 @@ impl TryFromSexp for Vec<String> {
             let s = if charsxp == SEXP::na_string() {
                 String::new()
             } else {
-                let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-                if c_str.is_null() {
-                    String::new()
-                } else {
-                    unsafe { std::ffi::CStr::from_ptr(c_str) }
-                        .to_str()
-                        .unwrap_or("")
-                        .to_owned()
-                }
+                unsafe { charsxp_to_str(charsxp) }.to_owned()
             };
             result.push(s);
         }

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -8,7 +8,8 @@
 use crate::coerce::TryCoerce;
 use crate::ffi::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{
-    SexpError, SexpNaError, SexpTypeError, TryFromSexp, coerce_value, is_na_real, r_slice,
+    SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str, coerce_value, is_na_real,
+    r_slice,
 };
 
 /// Macro for NA-aware `R vector → Vec<Option<T>>` conversions.
@@ -258,8 +259,6 @@ impl TryFromSexp for Vec<Option<String>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -278,18 +277,7 @@ impl TryFromSexp for Vec<Option<String>> {
             if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
-                let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-                if c_str.is_null() {
-                    result.push(Some(String::new()));
-                } else {
-                    let rust_str = unsafe { std::ffi::CStr::from_ptr(c_str) };
-                    result.push(Some(rust_str.to_str().map(|s| s.to_owned()).map_err(
-                        |_| SexpTypeError {
-                            expected: SEXPTYPE::STRSXP,
-                            actual: SEXPTYPE::STRSXP,
-                        },
-                    )?));
-                }
+                result.push(Some(unsafe { charsxp_to_str(charsxp) }.to_owned()));
             }
         }
 

--- a/miniextendr-api/src/from_r/strings.rs
+++ b/miniextendr-api/src/from_r/strings.rs
@@ -233,8 +233,6 @@ impl TryFromSexp for String {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -253,34 +251,17 @@ impl TryFromSexp for String {
             .into());
         }
 
-        // Get the CHARSXP at index 0
         let charsxp = sexp.string_elt(0);
 
-        // Check for NA_STRING
         if charsxp == SEXP::na_string() {
             return Ok(String::new());
         }
 
-        // Translate to UTF-8 in an R-managed buffer, then copy to an owned Rust String.
-        let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-        if c_str.is_null() {
-            return Ok(String::new());
-        }
-
-        let rust_str = unsafe { std::ffi::CStr::from_ptr(c_str) };
-        rust_str.to_str().map(|s| s.to_owned()).map_err(|_| {
-            SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual: SEXPTYPE::STRSXP,
-            }
-            .into()
-        })
+        Ok(unsafe { charsxp_to_str(charsxp) }.to_owned())
     }
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8_unchecked;
-
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
             return Err(SexpTypeError {
@@ -299,28 +280,13 @@ impl TryFromSexp for String {
             .into());
         }
 
-        // Get the CHARSXP at index 0
         let charsxp = unsafe { sexp.string_elt_unchecked(0) };
 
-        // Check for NA_STRING
         if charsxp == SEXP::na_string() {
             return Ok(String::new());
         }
 
-        // Translate to UTF-8 in an R-managed buffer, then copy to an owned Rust String.
-        let c_str = unsafe { Rf_translateCharUTF8_unchecked(charsxp) };
-        if c_str.is_null() {
-            return Ok(String::new());
-        }
-
-        let rust_str = unsafe { std::ffi::CStr::from_ptr(c_str) };
-        rust_str.to_str().map(|s| s.to_owned()).map_err(|_| {
-            SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual: SEXPTYPE::STRSXP,
-            }
-            .into()
-        })
+        Ok(unsafe { charsxp_to_str_unchecked(charsxp) }.to_owned())
     }
 }
 
@@ -339,8 +305,6 @@ impl TryFromSexp for Option<String> {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8;
-
         let actual = sexp.type_of();
         // NULL -> None
         if actual == SEXPTYPE::NILSXP {
@@ -370,19 +334,7 @@ impl TryFromSexp for Option<String> {
             return Ok(None);
         }
 
-        let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-        if c_str.is_null() {
-            return Ok(Some(String::new()));
-        }
-
-        let rust_str = unsafe { std::ffi::CStr::from_ptr(c_str) };
-        rust_str.to_str().map(|s| Some(s.to_owned())).map_err(|_| {
-            SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual: SEXPTYPE::STRSXP,
-            }
-            .into()
-        })
+        Ok(Some(unsafe { charsxp_to_str(charsxp) }.to_owned()))
     }
 
     #[inline]

--- a/miniextendr-api/src/named_vector.rs
+++ b/miniextendr-api/src/named_vector.rs
@@ -232,7 +232,7 @@ pub(crate) unsafe fn set_names_on_sexp<S: AsRef<str>>(sexp: SEXP, keys: &[S]) {
 ///
 /// Errors on: missing names attribute, NA names, empty names, duplicate names.
 fn extract_names_strict(sexp: SEXP) -> Result<Vec<String>, SexpError> {
-    use ffi::Rf_translateCharUTF8;
+    use crate::from_r::charsxp_to_str;
 
     let names = sexp.get_names();
     let len = sexp.len();
@@ -256,16 +256,7 @@ fn extract_names_strict(sexp: SEXP) -> Result<Vec<String>, SexpError> {
             ));
         }
 
-        let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-        if c_str.is_null() {
-            return Err(SexpError::InvalidValue(
-                "NamedVector does not allow NA names".to_string(),
-            ));
-        }
-
-        let name = unsafe { std::ffi::CStr::from_ptr(c_str) }
-            .to_str()
-            .unwrap_or("");
+        let name = unsafe { charsxp_to_str(charsxp) };
 
         // Reject empty names
         if name.is_empty() {

--- a/miniextendr-api/src/optionals/uuid_impl.rs
+++ b/miniextendr-api/src/optionals/uuid_impl.rs
@@ -100,7 +100,7 @@ impl TryFromSexp for Vec<Uuid> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::ffi::Rf_translateCharUTF8;
+        use crate::from_r::charsxp_to_str;
 
         let actual = sexp.type_of();
         if actual != SEXPTYPE::STRSXP {
@@ -125,17 +125,9 @@ impl TryFromSexp for Vec<Uuid> {
                 )));
             }
 
-            let c_str = unsafe { Rf_translateCharUTF8(charsxp) };
-            let s = if c_str.is_null() {
-                String::new()
-            } else {
-                unsafe { std::ffi::CStr::from_ptr(c_str) }
-                    .to_str()
-                    .map_err(|_| SexpError::InvalidValue(format!("invalid UTF-8 at index {}", i)))?
-                    .to_owned()
-            };
+            let s = unsafe { charsxp_to_str(charsxp) };
 
-            let uuid = Uuid::parse_str(&s).map_err(|e| {
+            let uuid = Uuid::parse_str(s).map_err(|e| {
                 SexpError::InvalidValue(format!("invalid UUID at index {}: {}", i, e))
             })?;
             result.push(uuid);

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
+miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
+miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
 miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
 miniextendr-api = { path = "../../vendor/miniextendr-api" }
-miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
-miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }

--- a/tests/cross-package/consumer.pkg/src/rust/lib.rs
+++ b/tests/cross-package/consumer.pkg/src/rust/lib.rs
@@ -62,10 +62,10 @@ pub fn has_class(x: SEXP, class_name: String) -> bool {
     }
     let len = class_attr.len();
     for i in 0..len {
-        if let Some(name) = class_attr.string_elt_str(i as miniextendr_api::ffi::R_xlen_t) {
-            if name == class_name {
-                return true;
-            }
+        if let Some(name) = class_attr.string_elt_str(i as miniextendr_api::ffi::R_xlen_t)
+            && name == class_name
+        {
+            return true;
         }
     }
     false


### PR DESCRIPTION
## Summary
- Migrates remaining `Rf_translateCharUTF8` call sites in `miniextendr-api/src/` to `charsxp_to_str` (#143).
- `charsxp_to_str` uses `R_CHAR` + `LENGTH` for O(1), zero-copy `&'static str`; UTF-8 validity is already asserted at package init via `miniextendr_assert_utf8_locale()`, so the per-element translation is redundant.
- Eliminates `CStr::from_ptr` indirection, null-ptr fallbacks, and `to_str().unwrap_or("")` paths that are unreachable under the init-time locale guarantee.

## Migrated call sites
- `from_r/strings.rs` — `TryFromSexp for String`, `Option<String>` (both checked + unchecked)
- `from_r/na_vectors.rs` — `TryFromSexp for Vec<Option<String>>`
- `from_r/cow_and_paths.rs` — `TryFromSexp for Vec<String>`
- `from_r/collections.rs` — named list key extraction in `named_list_to_map`
- `named_vector.rs` — `extract_names_strict`
- `altrep_sexp.rs` — `AltrepSexp::materialize_strings`
- `optionals/uuid_impl.rs` — `TryFromSexp for Vec<Uuid>`

## Not migrated
- `ffi.rs:1975` — the FFI binding itself (intentionally kept).
- `strvec.rs` — doc comments only.
- `miniextendr-bench/` — benchmarks that intentionally compare translate vs. `R_CHAR`.

## Test plan
- [x] `cargo check -p miniextendr-api` (default + `uuid` feature)
- [x] `cargo clippy -p miniextendr-api -- -D warnings` — clean
- [x] `cargo test -p miniextendr-api --lib` — 193/193 pass
- [x] Pre-commit hook regenerated `rpkg/inst/vendor.tar.xz`
- [ ] CI runs full R test suite

Closes #143.

Generated with [Claude Code](https://claude.com/claude-code)
