### PR TITLE
fix: escape special chars in match_arg choices formal default (#151)

### DIFF
--- a/miniextendr-api/src/match_arg.rs
+++ b/miniextendr-api/src/match_arg.rs
@@ -103,6 +103,28 @@ impl From<MatchArgError> for crate::from_r::SexpError {
     }
 }
 
+/// Escape a Rust `&str` for embedding inside an R double-quoted string literal.
+///
+/// Handles `\`, `"`, newline, carriage return, and tab — the characters R
+/// recognises as escape sequences inside `"..."`. Used when formatting
+/// `MatchArg::CHOICES` into the default of a generated R wrapper formal, so
+/// that a choice like `say "hi"` or `c:\path` cannot produce syntactically
+/// invalid R code.
+pub fn escape_r_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str(r#"\""#),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// Build an R character vector (STRSXP) from the choices of a `MatchArg` type.
 ///
 /// This is called by generated choices-helper C wrappers to provide the
@@ -250,5 +272,30 @@ pub fn match_arg_vec_from_sexp<T: MatchArg>(sexp: SEXP) -> Result<Vec<T>, MatchA
                 .collect()
         }
         _ => Err(MatchArgError::InvalidType(actual_type)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_r_string;
+
+    #[test]
+    fn escapes_backslash_and_quote() {
+        assert_eq!(escape_r_string(r#"say "hi""#), r#"say \"hi\""#);
+        assert_eq!(escape_r_string(r"c:\path"), r"c:\\path");
+    }
+
+    #[test]
+    fn escapes_control_characters() {
+        assert_eq!(escape_r_string("line1\nline2"), r"line1\nline2");
+        assert_eq!(escape_r_string("tab\there"), r"tab\there");
+        assert_eq!(escape_r_string("cr\rlf"), r"cr\rlf");
+    }
+
+    #[test]
+    fn passes_through_plain_strings() {
+        assert_eq!(escape_r_string("Fast"), "Fast");
+        assert_eq!(escape_r_string("it's"), "it's");
+        assert_eq!(escape_r_string(""), "");
     }
 }

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1838,7 +1838,10 @@ pub fn miniextendr(
                         choices_str: || {
                             <#choices_ty as ::miniextendr_api::match_arg::MatchArg>::CHOICES
                                 .iter()
-                                .map(|c| format!("\"{}\"", c))
+                                .map(|c| format!(
+                                    "\"{}\"",
+                                    ::miniextendr_api::match_arg::escape_r_string(c)
+                                ))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         },

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
+miniextendr-api = { path = "../../vendor/miniextendr-api" }
 miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
 miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
 miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
-miniextendr-api = { path = "../../vendor/miniextendr-api" }


### PR DESCRIPTION
## Summary
- Enum variant choice strings are embedded directly into the generated R wrapper formal as `c(\"choice1\", \"choice2\")`. If a choice contained `\"`, ``, or a control character (e.g. via `#[match_arg(rename = ...)]`), the generated R code was syntactically invalid.
- Adds `miniextendr_api::match_arg::escape_r_string()` that escapes the characters R recognises inside double-quoted literals (``, `\"`, `\\n`, `\\r`, `\\t`) and uses it in the `MX_MATCH_ARG_CHOICES` replacement emitted by the proc macro.

## Example
Before:
```rust
#[derive(MatchArg)]
enum Quoting {
    #[match_arg(rename = "say \"hello\"")] Greeting,
}
```
generated broken R: `mode = c("say "hello"")`.

After: `mode = c("say \"hello\"")` — valid R.

## Test plan
- [x] `cargo test -p miniextendr-api --lib match_arg` — 3 new unit tests for `escape_r_string` pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Pre-commit regenerated `rpkg/inst/vendor.tar.xz`
- [ ] CI runs full R test suite

Closes #151.

Generated with [Claude Code](https://claude.com/claude-code)

