### PR TITLE
fix: reject several_ok on scalar parameter types at compile time (#146)

### DIFF
--- a/miniextendr-macros/src/miniextendr_fn.rs
+++ b/miniextendr-macros/src/miniextendr_fn.rs
@@ -145,6 +145,38 @@ pub(crate) fn is_missing_type(ty: &syn::Type) -> bool {
     type_ends_with(ty, "Missing")
 }
 
+/// Check if a type is a vector-like type that `several_ok` can populate.
+///
+/// Accepts `Vec<T>`, `Box<[T]>`, and `&[T]` / `&mut [T]`. Rejects scalar types
+/// (like `Mode`, `String`, `&str`) so `several_ok` — which produces a
+/// multi-element R character vector via `match.arg(..., several.ok = TRUE)` —
+/// fails at compile time instead of deserialization time.
+pub(crate) fn is_vector_like_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(tp) => {
+            let Some(seg) = tp.path.segments.last() else {
+                return false;
+            };
+            if seg.ident == "Vec" {
+                return true;
+            }
+            if seg.ident == "Box" {
+                let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+                    return false;
+                };
+                return matches!(
+                    args.args.first(),
+                    Some(syn::GenericArgument::Type(syn::Type::Slice(_)))
+                );
+            }
+            false
+        }
+        syn::Type::Reference(r) => matches!(&*r.elem, syn::Type::Slice(_)),
+        syn::Type::Slice(_) => true,
+        _ => false,
+    }
+}
+
 /// Extract the inner type `T` from `Missing<T>`, if the type is `Missing<T>`.
 ///
 /// Returns `None` if the type is not `Missing<T>` or has no generic argument.
@@ -242,6 +274,23 @@ pub(crate) fn validate_per_param_attr_conflicts(
                 param_name
             ),
         ));
+    }
+    if attr.has_several_ok
+        && let Some(ty) = ty
+    {
+        // Unwrap Missing<T> so several_ok is allowed on optional vector params.
+        let check_ty = get_missing_inner_type(ty).unwrap_or(ty);
+        if !is_vector_like_type(check_ty) {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "several_ok requires a vector type on parameter `{}`; \
+                     several_ok enables multi-value match.arg which returns a character vector. \
+                     Use `Vec<T>`, `Box<[T]>`, or `&[T]` instead of a scalar type",
+                    param_name
+                ),
+            ));
+        }
     }
     if is_dots && attr.default_value.is_some() {
         return Err(syn::Error::new(

--- a/miniextendr-macros/tests/ui/several_ok_on_scalar_type.rs
+++ b/miniextendr-macros/tests/ui/several_ok_on_scalar_type.rs
@@ -1,0 +1,8 @@
+//! Test: several_ok with a scalar Rust type should error at compile time.
+
+use miniextendr_macros::miniextendr;
+
+#[miniextendr]
+fn bad_several_ok_scalar(#[miniextendr(choices("a", "b"), several_ok)] x: String) {}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/several_ok_on_scalar_type.stderr
+++ b/miniextendr-macros/tests/ui/several_ok_on_scalar_type.stderr
@@ -1,0 +1,5 @@
+error: several_ok requires a vector type on parameter `x`; several_ok enables multi-value match.arg which returns a character vector. Use `Vec<T>`, `Box<[T]>`, or `&[T]` instead of a scalar type
+ --> tests/ui/several_ok_on_scalar_type.rs:6:75
+  |
+6 | fn bad_several_ok_scalar(#[miniextendr(choices("a", "b"), several_ok)] x: String) {}
+  |                                                                           ^^^^^^

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
-miniextendr-api = { path = "../../vendor/miniextendr-api" }
+miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
 miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
 miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
-miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
+miniextendr-api = { path = "../../vendor/miniextendr-api" }


### PR DESCRIPTION
## Summary
- `several_ok` generates `match.arg(param, several.ok = TRUE)` in the R wrapper, which returns a character vector. Previously, pairing it with a scalar Rust parameter (e.g. `Mode`, `String`, `&str`) compiled fine and then failed at runtime when R handed the C wrapper a multi-element STRSXP.
- Reject the combination at parse time via a new `is_vector_like_type()` check in `validate_per_param_attr_conflicts()`.

## Accepted parameter types
- `Vec<T>`
- `Box<[T]>`
- `&[T]` / `&mut [T]`
- `Missing<Vec<T>>` etc. — `Missing` is unwrapped before the check.

## Error example
```
error: several_ok requires a vector type on parameter `x`; several_ok enables
multi-value match.arg which returns a character vector. Use `Vec<T>`, `Box<[T]>`,
or `&[T]` instead of a scalar type
 --> tests/ui/several_ok_on_scalar_type.rs:6:75
  |
6 | fn bad_several_ok_scalar(#[miniextendr(choices(\"a\", \"b\"), several_ok)] x: String) {}
  |                                                                           ^^^^^^
```

## Test plan
- [x] `cargo test -p miniextendr-macros --test ui` — new UI test passes
- [x] `cargo test -p miniextendr-api --lib` — 193/193 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Pre-commit regenerated `rpkg/inst/vendor.tar.xz`

Closes #146.

Generated with [Claude Code](https://claude.com/claude-code)
