### PR TITLE
fix(cargo-revendor): hash local crate source trees in cache key (#150)

### DIFF
--- a/cargo-revendor/src/cache.rs
+++ b/cargo-revendor/src/cache.rs
@@ -1,53 +1,191 @@
-//! Caching: skip re-vendoring when Cargo.lock is unchanged
+//! Caching: skip re-vendoring when all inputs are unchanged
 //!
-//! Stores a hash of Cargo.lock + Cargo.toml in vendor/.revendor-cache.
-//! If the hash matches on next run, vendoring is skipped.
+//! Stores a hash in `vendor/.revendor-cache` covering:
+//! - The caller's `Cargo.lock` and `Cargo.toml`
+//! - The source tree of each local workspace crate that gets vendored
+//!   (Cargo.toml + every file under `src/`, `tests/`, `examples/`, `benches/`)
+//!
+//! Hashing the lockfile alone misses pure source-file edits to workspace
+//! crates (see issue #150), which leaves a stale `vendor/` copy on disk.
 
 use anyhow::Result;
-use std::path::Path;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 const CACHE_FILE: &str = ".revendor-cache";
 
-/// Check if the vendor directory is cached and up to date
-pub fn is_cached(lockfile: &Path, vendor_dir: &Path) -> Result<bool> {
+/// Check whether `vendor_dir` is up to date relative to `lockfile` plus the
+/// source trees of `local_crate_paths`.
+pub fn is_cached(
+    lockfile: &Path,
+    vendor_dir: &Path,
+    local_crate_paths: &[PathBuf],
+) -> Result<bool> {
     let cache_path = vendor_dir.join(CACHE_FILE);
     if !cache_path.exists() || !vendor_dir.exists() {
         return Ok(false);
     }
 
-    let current = compute_hash(lockfile)?;
+    let current = compute_hash(lockfile, local_crate_paths)?;
     let cached = std::fs::read_to_string(&cache_path)?;
 
     Ok(current.trim() == cached.trim())
 }
 
-/// Save the current hash to the cache file
-pub fn save_cache(lockfile: &Path, vendor_dir: &Path) -> Result<()> {
-    let hash = compute_hash(lockfile)?;
+/// Save the current hash to the cache file.
+pub fn save_cache(
+    lockfile: &Path,
+    vendor_dir: &Path,
+    local_crate_paths: &[PathBuf],
+) -> Result<()> {
+    let hash = compute_hash(lockfile, local_crate_paths)?;
     let cache_path = vendor_dir.join(CACHE_FILE);
     std::fs::write(&cache_path, &hash)?;
     Ok(())
 }
 
-/// Compute a hash from Cargo.lock (and Cargo.toml for good measure)
-fn compute_hash(lockfile: &Path) -> Result<String> {
+/// Compute a hash over `Cargo.lock`, the sibling `Cargo.toml`, and the source
+/// tree of each local workspace crate.
+fn compute_hash(lockfile: &Path, local_crate_paths: &[PathBuf]) -> Result<String> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
     let mut hasher = DefaultHasher::new();
 
-    // Hash Cargo.lock content
     if lockfile.exists() {
-        let content = std::fs::read(lockfile)?;
-        content.hash(&mut hasher);
+        std::fs::read(lockfile)?.hash(&mut hasher);
     }
 
-    // Also hash Cargo.toml (catches dep changes before lock update)
     let manifest = lockfile.with_file_name("Cargo.toml");
     if manifest.exists() {
-        let content = std::fs::read(&manifest)?;
-        content.hash(&mut hasher);
+        std::fs::read(&manifest)?.hash(&mut hasher);
+    }
+
+    // Hash each local crate's source tree in a deterministic order so the
+    // cache key is stable across runs.
+    for crate_path in local_crate_paths {
+        let entries = collect_crate_files(crate_path)?;
+        for (rel, bytes) in entries {
+            rel.hash(&mut hasher);
+            bytes.hash(&mut hasher);
+        }
     }
 
     Ok(format!("{:x}", hasher.finish()))
+}
+
+/// Collect the files under a local crate that should influence the cache
+/// key: `Cargo.toml` plus everything under `src/`, `tests/`, `examples/`,
+/// `benches/`, and `build.rs`. Returns a sorted map of `(relative path,
+/// file bytes)`.
+fn collect_crate_files(crate_path: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut out = BTreeMap::new();
+
+    let root_files = ["Cargo.toml", "build.rs"];
+    for name in root_files {
+        let p = crate_path.join(name);
+        if p.is_file() {
+            out.insert(name.to_string(), std::fs::read(&p)?);
+        }
+    }
+
+    for sub in ["src", "tests", "examples", "benches"] {
+        let dir = crate_path.join(sub);
+        if dir.is_dir() {
+            walk_dir(&dir, crate_path, &mut out)?;
+        }
+    }
+
+    Ok(out)
+}
+
+fn walk_dir(
+    dir: &Path,
+    root: &Path,
+    out: &mut BTreeMap<String, Vec<u8>>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            walk_dir(&path, root, out)?;
+        } else if file_type.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            out.insert(rel, std::fs::read(&path)?);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, PathBuf, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let caller = tmp.path().join("caller");
+        std::fs::create_dir_all(&caller).unwrap();
+        std::fs::write(caller.join("Cargo.toml"), "[package]\nname = \"c\"").unwrap();
+        std::fs::write(caller.join("Cargo.lock"), "version = 3").unwrap();
+
+        let crate_path = tmp.path().join("libx");
+        std::fs::create_dir_all(crate_path.join("src")).unwrap();
+        std::fs::write(crate_path.join("Cargo.toml"), "[package]\nname = \"libx\"").unwrap();
+        std::fs::write(crate_path.join("src/lib.rs"), "// v1").unwrap();
+
+        let vendor = tmp.path().join("vendor");
+        std::fs::create_dir_all(&vendor).unwrap();
+
+        let lockfile = caller.join("Cargo.lock");
+        (tmp, lockfile, vendor)
+    }
+
+    #[test]
+    fn cache_invalidates_on_local_crate_source_change() {
+        let (tmp, lockfile, vendor) = setup();
+        let crate_path = tmp.path().join("libx");
+        let locals = vec![crate_path.clone()];
+
+        save_cache(&lockfile, &vendor, &locals).unwrap();
+        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+
+        std::fs::write(crate_path.join("src/lib.rs"), "// v2 changed").unwrap();
+        assert!(
+            !is_cached(&lockfile, &vendor, &locals).unwrap(),
+            "cache should invalidate when a local crate source file changes"
+        );
+    }
+
+    #[test]
+    fn cache_invalidates_on_local_crate_manifest_change() {
+        let (tmp, lockfile, vendor) = setup();
+        let crate_path = tmp.path().join("libx");
+        let locals = vec![crate_path.clone()];
+
+        save_cache(&lockfile, &vendor, &locals).unwrap();
+        std::fs::write(
+            crate_path.join("Cargo.toml"),
+            "[package]\nname = \"libx\"\nversion = \"0.2.0\"",
+        )
+        .unwrap();
+        assert!(!is_cached(&lockfile, &vendor, &locals).unwrap());
+    }
+
+    #[test]
+    fn cache_stable_when_nothing_changes() {
+        let (_tmp, lockfile, vendor) = setup();
+        let crate_path = _tmp.path().join("libx");
+        let locals = vec![crate_path];
+
+        save_cache(&lockfile, &vendor, &locals).unwrap();
+        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+        // Repeat hit.
+        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+    }
 }

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -177,32 +177,7 @@ fn main() -> Result<()> {
         std::env::current_dir()?.join(&cli.output)
     };
 
-    // Step 0: Check cache — skip if Cargo.lock unchanged
     let lockfile = manifest_path.with_file_name("Cargo.lock");
-    if !cli.force && cache::is_cached(&lockfile, &output)? {
-        if v.info() {
-            eprintln!("cargo-revendor: vendor/ is up to date (Cargo.lock unchanged)");
-        }
-        if cli.json {
-            let count = std::fs::read_dir(&output)
-                .map(|d| {
-                    d.filter_map(|e| e.ok())
-                        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-                        .count()
-                })
-                .unwrap_or(0);
-            let json = JsonOutput {
-                vendor_dir: output.display().to_string(),
-                local_crates: vec![],
-                external_crates: count,
-                total_crates: count,
-                cached: true,
-                stripped: vec![],
-            };
-            println!("{}", serde_json::to_string_pretty(&json)?);
-        }
-        return Ok(());
-    }
 
     // Step 1: Load cargo metadata to discover dependencies
     let meta = metadata::load_metadata(&manifest_path)?;
@@ -260,6 +235,38 @@ fn main() -> Result<()> {
                 patch_pkgs.len() - local_pkgs.len()
             );
         }
+    }
+
+    // Local crate source trees participate in the cache key — pure source
+    // edits to workspace crates leave Cargo.lock untouched (#150), so hashing
+    // only the lockfile would silently serve a stale vendor/ copy.
+    let local_crate_paths: Vec<std::path::PathBuf> =
+        local_pkgs.iter().map(|p| p.path.clone()).collect();
+
+    // Step 0: Check cache — skip if all inputs are unchanged
+    if !cli.force && cache::is_cached(&lockfile, &output, &local_crate_paths)? {
+        if v.info() {
+            eprintln!("cargo-revendor: vendor/ is up to date (inputs unchanged)");
+        }
+        if cli.json {
+            let count = std::fs::read_dir(&output)
+                .map(|d| {
+                    d.filter_map(|e| e.ok())
+                        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                        .count()
+                })
+                .unwrap_or(0);
+            let json = JsonOutput {
+                vendor_dir: output.display().to_string(),
+                local_crates: local_pkgs.iter().map(|p| p.name.clone()).collect(),
+                external_crates: count.saturating_sub(local_pkgs.len()),
+                total_crates: count,
+                cached: true,
+                stripped: vec![],
+            };
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        return Ok(());
     }
 
     // Step 2: Package local crates via `cargo package`
@@ -353,7 +360,7 @@ fn main() -> Result<()> {
     }
 
     // Step 14: Save cache
-    cache::save_cache(&lockfile, &output)?;
+    cache::save_cache(&lockfile, &output, &local_crate_paths)?;
 
     // Count total crates
     let total = std::fs::read_dir(&output)

--- a/cargo-revendor/src/package.rs
+++ b/cargo-revendor/src/package.rs
@@ -160,22 +160,18 @@ fn add_versions_to_path_deps(
 fn ensure_version(dep: &mut toml_edit::Item) -> bool {
     match dep {
         // path-only inline table: { path = "../foo" } → { version = "*", path = "../foo" }
-        toml_edit::Item::Value(toml_edit::Value::InlineTable(table)) => {
-            if table.contains_key("path") && !table.contains_key("version") {
-                table.insert("version", toml_edit::value("*").into_value().unwrap());
-                true
-            } else {
-                false
-            }
+        toml_edit::Item::Value(toml_edit::Value::InlineTable(table))
+            if table.contains_key("path") && !table.contains_key("version") =>
+        {
+            table.insert("version", toml_edit::value("*").into_value().unwrap());
+            true
         }
         // path-only table section: [dependencies.foo] path = "../foo"
-        toml_edit::Item::Table(table) => {
-            if table.contains_key("path") && !table.contains_key("version") {
-                table.insert("version", toml_edit::value("*"));
-                true
-            } else {
-                false
-            }
+        toml_edit::Item::Table(table)
+            if table.contains_key("path") && !table.contains_key("version") =>
+        {
+            table.insert("version", toml_edit::value("*"));
+            true
         }
         _ => false,
     }

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -694,13 +694,13 @@ pub fn freeze_manifest(
     // vendor path deps (unpublished git crates aren't on crates.io).
     let mut patched_names: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (key, val) in doc.as_table().iter() {
-        if key.starts_with("patch") {
-            if let Some(patch_table) = val.as_table() {
-                for (_registry, registry_val) in patch_table.iter() {
-                    if let Some(registry_table) = registry_val.as_table() {
-                        for (crate_name, _) in registry_table.iter() {
-                            patched_names.insert(crate_name.to_string());
-                        }
+        if key.starts_with("patch")
+            && let Some(patch_table) = val.as_table()
+        {
+            for (_registry, registry_val) in patch_table.iter() {
+                if let Some(registry_table) = registry_val.as_table() {
+                    for (crate_name, _) in registry_table.iter() {
+                        patched_names.insert(crate_name.to_string());
                     }
                 }
             }

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -176,29 +176,26 @@ pub fn strip_vendor_path_deps(vendor_dir: &Path, v: crate::Verbosity) -> Result<
 /// Remove `path = "../..."` from a dependency entry (returns true if changed)
 fn remove_relative_path(dep: &mut toml_edit::Item) -> bool {
     match dep {
-        toml_edit::Item::Value(toml_edit::Value::InlineTable(table)) => {
+        toml_edit::Item::Value(toml_edit::Value::InlineTable(table))
             if table
                 .get("path")
                 .and_then(|v| v.as_str())
-                .is_some_and(|p| p.starts_with("../"))
-            {
-                table.remove("path");
-                return true;
-            }
+                .is_some_and(|p| p.starts_with("../")) =>
+        {
+            table.remove("path");
+            true
         }
-        toml_edit::Item::Table(table) => {
+        toml_edit::Item::Table(table)
             if table
                 .get("path")
                 .and_then(|v| v.as_str())
-                .is_some_and(|p| p.starts_with("../"))
-            {
-                table.remove("path");
-                return true;
-            }
+                .is_some_and(|p| p.starts_with("../")) =>
+        {
+            table.remove("path");
+            true
         }
-        _ => {}
+        _ => false,
     }
-    false
 }
 
 /// Rewrite inter-crate path dependencies so local crates reference each other in vendor/


### PR DESCRIPTION
## Summary
`cargo revendor` previously cached on `hash(Cargo.lock, caller Cargo.toml)` only. Edits to workspace crate source files (e.g. `miniextendr-api/src/match_arg.rs`) leave `Cargo.lock` untouched, so `just vendor` silently reported "up to date" and shipped the stale tarball. Required `cargo revendor --force` after every source-only change.

## Fix
- Move the cache check below cargo-metadata loading so we know which packages are local.
- Extend the cache hash to cover every local workspace crate's `Cargo.toml`, `build.rs`, and the contents of `src/`, `tests/`, `examples/`, and `benches/`.
- Walk order is deterministic (sorted map) so the hash is stable across runs.

## Test plan
- [x] `cargo test --manifest-path cargo-revendor/Cargo.toml` — existing tests still pass
- [x] New unit tests in `cache.rs`:
  - `cache_invalidates_on_local_crate_source_change`
  - `cache_invalidates_on_local_crate_manifest_change`
  - `cache_stable_when_nothing_changes`
- [x] `just clippy` — clean
- [ ] CI builds and integration tests

Closes #150.

Generated with [Claude Code](https://claude.com/claude-code)
