### PR TITLE
feat: IntoR for Vec<MatchArg enum> (#148)

### DIFF
--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -282,28 +282,43 @@ pub(crate) use large_integers::{str_to_charsxp, str_to_charsxp_unchecked};
 
 // region: Vector conversions
 
-impl<T> IntoR for Vec<T>
-where
-    T: crate::ffi::RNativeType,
-{
-    type Error = std::convert::Infallible;
-    #[inline]
-    fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
-        Ok(unsafe { vec_to_sexp(&self) })
-    }
-    #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::ffi::SEXP, Self::Error> {
-        Ok(unsafe { self.into_sexp_unchecked() })
-    }
-    #[inline]
-    fn into_sexp(self) -> crate::ffi::SEXP {
-        unsafe { vec_to_sexp(&self) }
-    }
-    #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
-        unsafe { vec_to_sexp_unchecked(&self) }
-    }
+// Concrete IntoR impls for Vec<T> where T: RNativeType.
+//
+// These are written as concrete impls rather than a blanket
+// `impl<T: RNativeType> IntoR for Vec<T>` to avoid a coherence conflict
+// with `impl<T: MatchArg> IntoR for Vec<T>` in match_arg.rs.
+// Both blankets would target `Vec<_>` for the same foreign trait, and the
+// Rust coherence checker (E0119) rejects them even when the bounds are
+// disjoint in practice, because negative trait bounds are not stable.
+macro_rules! impl_into_r_vec_native {
+    ($t:ty) => {
+        impl IntoR for Vec<$t> {
+            type Error = std::convert::Infallible;
+            #[inline]
+            fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
+                Ok(unsafe { vec_to_sexp(&self) })
+            }
+            #[inline]
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::ffi::SEXP, Self::Error> {
+                Ok(unsafe { self.into_sexp_unchecked() })
+            }
+            #[inline]
+            fn into_sexp(self) -> crate::ffi::SEXP {
+                unsafe { vec_to_sexp(&self) }
+            }
+            #[inline]
+            unsafe fn into_sexp_unchecked(self) -> crate::ffi::SEXP {
+                unsafe { vec_to_sexp_unchecked(&self) }
+            }
+        }
+    };
 }
+
+impl_into_r_vec_native!(i32);
+impl_into_r_vec_native!(f64);
+impl_into_r_vec_native!(u8);
+impl_into_r_vec_native!(crate::ffi::RLogical);
+impl_into_r_vec_native!(crate::ffi::Rcomplex);
 
 impl<T> IntoR for &[T]
 where
@@ -2064,7 +2079,10 @@ fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::ffi::SEXP {
 
 /// Convert `Vec<HashSet<T>>` to R list of vectors (for RNativeType elements).
 /// Each HashSet becomes an R vector (unordered).
-impl<T: crate::ffi::RNativeType> IntoR for Vec<std::collections::HashSet<T>> {
+impl<T: crate::ffi::RNativeType> IntoR for Vec<std::collections::HashSet<T>>
+where
+    Vec<T>: IntoR,
+{
     type Error = std::convert::Infallible;
     fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
         Ok(self.into_sexp())
@@ -2080,7 +2098,10 @@ impl<T: crate::ffi::RNativeType> IntoR for Vec<std::collections::HashSet<T>> {
 
 /// Convert `Vec<BTreeSet<T>>` to R list of vectors (for RNativeType elements).
 /// Each BTreeSet becomes an R vector (sorted).
-impl<T: crate::ffi::RNativeType> IntoR for Vec<std::collections::BTreeSet<T>> {
+impl<T: crate::ffi::RNativeType> IntoR for Vec<std::collections::BTreeSet<T>>
+where
+    Vec<T>: IntoR,
+{
     type Error = std::convert::Infallible;
     fn try_into_sexp(self) -> Result<crate::ffi::SEXP, Self::Error> {
         Ok(self.into_sexp())

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -935,6 +935,7 @@ pub use raw_conversions::{
 pub mod match_arg;
 pub use match_arg::{
     MatchArg, MatchArgError, choices_sexp, match_arg_from_sexp, match_arg_vec_from_sexp,
+    match_arg_vec_into_sexp,
 };
 
 /// Factor support for enum ↔ R factor conversions.

--- a/miniextendr-api/src/match_arg.rs
+++ b/miniextendr-api/src/match_arg.rs
@@ -29,6 +29,7 @@
 
 use crate::ffi::{self, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::charsxp_to_str;
+use crate::into_r::IntoR;
 
 /// Trait for enum types that support `match.arg`-style string conversion.
 ///
@@ -234,6 +235,54 @@ fn match_choice<T: MatchArg>(input: &str) -> Result<T, MatchArgError> {
             input: input.to_string(),
             choices: <T as MatchArg>::CHOICES,
         }),
+    }
+}
+
+/// Convert a `Vec<T: MatchArg>` to an R character vector (STRSXP).
+///
+/// Each element is written as its canonical choice string via [`MatchArg::to_choice`].
+/// Empty choice strings are stored as `R_BlankString` (parity with [`choices_sexp`]).
+///
+/// Called by the `impl IntoR for Vec<T>` block emitted by `#[derive(MatchArg)]`.
+pub fn match_arg_vec_into_sexp<T: MatchArg>(values: Vec<T>) -> SEXP {
+    unsafe {
+        let n = values.len();
+        let vec = ffi::Rf_allocVector(SEXPTYPE::STRSXP, n as ffi::R_xlen_t);
+        ffi::Rf_protect(vec);
+        for (i, v) in values.into_iter().enumerate() {
+            let s = v.to_choice();
+            let charsxp = if s.is_empty() {
+                SEXP::blank_string()
+            } else {
+                SEXP::charsxp(s)
+            };
+            vec.set_string_elt(i as ffi::R_xlen_t, charsxp);
+        }
+        ffi::Rf_unprotect(1);
+        vec
+    }
+}
+
+/// Blanket [`IntoR`] for any vector of `MatchArg` values.
+///
+/// Converts to an R character vector (STRSXP) via [`match_arg_vec_into_sexp`].
+/// This blanket impl lives in `miniextendr-api` (not in a derive macro) because
+/// `impl<T: MatchArg> IntoR for Vec<T>` in the user's crate would conflict
+/// with `impl<T: RNativeType> IntoR for Vec<T>` (E0119: coherence); stable
+/// Rust has no negative trait bounds to prove the two constraints are disjoint.
+impl<T: MatchArg> IntoR for Vec<T> {
+    type Error = std::convert::Infallible;
+
+    fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
+        Ok(self.into_sexp())
+    }
+
+    unsafe fn try_into_sexp_unchecked(self) -> Result<SEXP, Self::Error> {
+        self.try_into_sexp()
+    }
+
+    fn into_sexp(self) -> SEXP {
+        match_arg_vec_into_sexp(self)
     }
 }
 

--- a/miniextendr-api/src/optionals/ndarray_impl.rs
+++ b/miniextendr-api/src/optionals/ndarray_impl.rs
@@ -326,12 +326,12 @@ impl<T: RNativeType + Clone> IntoR for Array0<T> {
     type Error = std::convert::Infallible;
 
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
-        // Extract the single element and convert to R scalar via Vec
-        Ok(vec![self.into_scalar()].into_sexp())
+        // Extract the single element and convert to R scalar via slice
+        Ok([self.into_scalar()].into_sexp())
     }
 
     unsafe fn try_into_sexp_unchecked(self) -> Result<SEXP, Self::Error> {
-        Ok(unsafe { vec![self.into_scalar()].into_sexp_unchecked() })
+        Ok(unsafe { [self.into_scalar()].into_sexp_unchecked() })
     }
 }
 // endregion

--- a/miniextendr-macros/src/match_arg_derive.rs
+++ b/miniextendr-macros/src/match_arg_derive.rs
@@ -117,6 +117,11 @@ fn apply_rename_all(name: &str, rename_all: Option<&str>) -> String {
 /// - `impl TryFromSexp` -- converts R character scalar to enum variant via `match_arg_from_sexp`
 /// - `impl IntoR` -- converts enum variant to R character scalar via `to_choice().into_sexp()`
 ///
+/// `impl IntoR for Vec<Self>` is provided automatically by the blanket
+/// `impl<T: MatchArg> IntoR for Vec<T>` in `miniextendr-api::match_arg`,
+/// so returning `Vec<EnumName>` from a `#[miniextendr]` function works
+/// without any extra code in the user's crate.
+///
 /// Validates:
 /// - Only enums are accepted (not structs or unions)
 /// - Generic enums are rejected
@@ -250,6 +255,7 @@ pub fn derive_match_arg(input: DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+
     })
 }
 
@@ -340,6 +346,28 @@ mod tests {
 
         let result = derive_match_arg(input);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_into_r_impl_present() {
+        // The derive emits IntoR for the scalar EnumName.
+        // Vec<EnumName> IntoR is covered by the blanket impl<T: MatchArg> IntoR for Vec<T>
+        // in miniextendr-api — it is NOT emitted by the derive.
+        let input: DeriveInput = syn::parse_quote! {
+            enum Mode {
+                Fast,
+                Safe,
+                Debug,
+            }
+        };
+
+        let result = derive_match_arg(input).unwrap();
+        let code = result.to_string();
+        // Scalar IntoR impl must be present
+        assert!(code.contains("IntoR for Mode"));
+        // Vec<Mode> IntoR must NOT be emitted by the derive (covered by blanket in miniextendr-api)
+        assert!(!code.contains("IntoR for :: std :: vec :: Vec < Mode >"));
+        assert!(!code.contains("match_arg_vec_into_sexp"));
     }
 
     #[test]

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
-miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
+miniextendr-api = { path = "../../vendor/miniextendr-api" }
 miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
 miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
-miniextendr-api = { path = "../../vendor/miniextendr-api" }
+miniextendr-macros = { path = "../../vendor/miniextendr-macros" }

--- a/rpkg/src/rust/match_arg_tests.rs
+++ b/rpkg/src/rust/match_arg_tests.rs
@@ -172,6 +172,22 @@ pub fn choices_multi_metrics(
 }
 // endregion
 
+// region: Test functions returning Vec<MatchArgEnum>
+
+/// Return a Vec of Mode values as an R character vector.
+///
+/// Exercises `IntoR for Vec<Mode>` emitted by `#[derive(MatchArg)]`.
+///
+/// @param modes One or more Mode values (several.ok input).
+/// @export
+#[miniextendr_api::miniextendr]
+pub fn match_arg_return_modes(
+    #[miniextendr(match_arg, several_ok)] modes: Vec<Mode>,
+) -> Vec<Mode> {
+    modes
+}
+// endregion
+
 // region: Test functions using #[miniextendr(match_arg, several_ok)] on enum Vec
 
 /// Select multiple modes (enum-based several_ok).

--- a/rpkg/tests/testthat/test-match-arg.R
+++ b/rpkg/tests/testthat/test-match-arg.R
@@ -162,3 +162,26 @@ test_that("match_arg several_ok: mixed with regular params", {
   # priorities defaults to all choices
   expect_equal(match_arg_multi_priority(1L), "n=1, priorities=lo+med+hi")
 })
+
+# ============================================================================
+# IntoR for Vec<MatchArgEnum> — round-trip return test (#148)
+# ============================================================================
+
+test_that("Vec<Mode> round-trips to R character vector", {
+  # Default (NULL → all variants)
+  result <- match_arg_return_modes()
+  expect_type(result, "character")
+  expect_equal(result, c("Fast", "Safe", "Debug"))
+})
+
+test_that("Vec<Mode> subset round-trips to R character vector", {
+  result <- match_arg_return_modes(c("Safe", "Debug"))
+  expect_type(result, "character")
+  expect_equal(result, c("Safe", "Debug"))
+})
+
+test_that("Vec<Mode> single value round-trips to R character vector", {
+  result <- match_arg_return_modes("Fast")
+  expect_type(result, "character")
+  expect_equal(result, "Fast")
+})


### PR DESCRIPTION
## Summary
- Functions returning `Vec<SomeMatchArgEnum>` previously failed with `IntoR not implemented for Vec<Mode>`. Scalar `IntoR` is emitted by `#[derive(MatchArg)]`, but `Vec<Enum>` hit orphan rules.
- Added a blanket `impl<T: MatchArg> IntoR for Vec<T>` in `miniextendr-api`, backed by a new `match_arg_vec_into_sexp` helper.
- To avoid E0119 coherence conflict with the existing blanket `impl<T: RNativeType> IntoR for Vec<T>`, the RNativeType blanket was demacro'd into concrete impls for the 5 native types (`i32`, `f64`, `u8`, `RLogical`, `Rcomplex`).

## Changes
- `miniextendr-api/src/match_arg.rs` — new `match_arg_vec_into_sexp`, blanket `IntoR for Vec<T: MatchArg>`, commentary on the coherence conflict.
- `miniextendr-api/src/into_r.rs` — replace `Vec<T: RNativeType>` blanket with 5 concrete impls via `impl_into_r_vec_native!`.
- `miniextendr-macros/src/match_arg_derive.rs` — doc update + sanity test that the Vec impl is NOT emitted by the derive (it comes from the blanket).
- `rpkg/src/rust/match_arg_tests.rs` + `rpkg/tests/testthat/test-match-arg.R` — round-trip test Vec<Mode> → R → Rust.
- Pre-existing `clippy::collapsible_if` fixed in `tests/cross-package/consumer.pkg/src/rust/lib.rs`.

## Test plan
- [x] `just check` — clean
- [x] `just clippy` — clean
- [x] `cargo test -p miniextendr-macros` — 280/280 pass
- [x] `rpkg/inst/vendor.tar.xz` regenerated with `--force`

Closes #148.

Generated with [Claude Code](https://claude.com/claude-code)
