### PR TITLE
fix(clippy): fix Rust 1.95 lints (collapsible_match, manual_checked_ops, useless_conversion)

### DIFF
--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -736,7 +736,7 @@ unsafe extern "C-unwind" fn read_trampoline<T: RConnectionImpl>(
         let slice = unsafe { std::slice::from_raw_parts_mut(buf.cast::<u8>(), total_bytes) };
         let bytes_read = state.read(slice);
         // Return number of items read
-        if size > 0 { bytes_read / size } else { 0 }
+        bytes_read.checked_div(size).unwrap_or(0)
     })
 }
 
@@ -759,7 +759,7 @@ unsafe extern "C-unwind" fn write_trampoline<T: RConnectionImpl>(
         let slice = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), total_bytes) };
         let bytes_written = state.write(slice);
         // Return number of items written
-        if size > 0 { bytes_written / size } else { 0 }
+        bytes_written.checked_div(size).unwrap_or(0)
     })
 }
 

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -257,7 +257,7 @@ impl IntoR for Vec<OffsetDateTime> {
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
             Rf_protect(vec);
 
-            for (slot, dt) in dst.iter_mut().zip(self.into_iter()) {
+            for (slot, dt) in dst.iter_mut().zip(self) {
                 let duration = dt - UNIX_EPOCH;
                 *slot = duration.whole_seconds() as f64
                     + (duration.subsec_nanoseconds() as f64 / 1_000_000_000.0);
@@ -324,7 +324,7 @@ impl IntoR for Vec<Option<OffsetDateTime>> {
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
             Rf_protect(vec);
 
-            for (slot, opt) in dst.iter_mut().zip(self.into_iter()) {
+            for (slot, opt) in dst.iter_mut().zip(self) {
                 *slot = match opt {
                     Some(dt) => {
                         let duration = dt - UNIX_EPOCH;
@@ -528,7 +528,7 @@ impl IntoR for Vec<Date> {
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
             Rf_protect(vec);
 
-            for (slot, d) in dst.iter_mut().zip(self.into_iter()) {
+            for (slot, d) in dst.iter_mut().zip(self) {
                 *slot = (d - UNIX_EPOCH_DATE).whole_days() as f64;
             }
 
@@ -590,7 +590,7 @@ impl IntoR for Vec<Option<Date>> {
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
             Rf_protect(vec);
 
-            for (slot, opt) in dst.iter_mut().zip(self.into_iter()) {
+            for (slot, opt) in dst.iter_mut().zip(self) {
                 *slot = match opt {
                     Some(d) => (d - UNIX_EPOCH_DATE).whole_days() as f64,
                     None => f64::NAN,

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -368,33 +368,28 @@ fn parse_file(path: &Path) -> Result<FileData, String> {
 fn collect_items_recursive(items: &[Item], data: &mut FileData) {
     for item in items {
         match item {
-            Item::Fn(item_fn) => {
-                if has_miniextendr_attr(&item_fn.attrs) {
-                    let line = item_fn.sig.ident.span().start().line;
-                    let name = item_fn.sig.ident.to_string();
+            Item::Fn(item_fn) if has_miniextendr_attr(&item_fn.attrs) => {
+                let line = item_fn.sig.ident.span().start().line;
+                let name = item_fn.sig.ident.to_string();
 
-                    data.miniextendr_items.push(LintItem::new(
-                        LintKind::Function,
-                        name.clone(),
-                        line,
-                    ));
+                data.miniextendr_items
+                    .push(LintItem::new(LintKind::Function, name.clone(), line));
 
-                    // Track visibility
-                    let is_pub = matches!(item_fn.vis, syn::Visibility::Public(_));
-                    data.fn_visibility.insert(name.clone(), is_pub);
+                // Track visibility
+                let is_pub = matches!(item_fn.vis, syn::Visibility::Public(_));
+                data.fn_visibility.insert(name.clone(), is_pub);
 
-                    // Track export control
-                    let attrs = parse_miniextendr_impl_attrs(&item_fn.attrs);
-                    if attrs.internal || attrs.noexport {
-                        data.export_control
-                            .insert(name.clone(), (attrs.internal, attrs.noexport, line));
-                    }
+                // Track export control
+                let attrs = parse_miniextendr_impl_attrs(&item_fn.attrs);
+                if attrs.internal || attrs.noexport {
+                    data.export_control
+                        .insert(name.clone(), (attrs.internal, attrs.noexport, line));
+                }
 
-                    // Track doc-comment roxygen tags
-                    let doc_tags = extract_roxygen_tags(&item_fn.attrs);
-                    if !doc_tags.is_empty() {
-                        data.fn_doc_tags.insert(name, doc_tags);
-                    }
+                // Track doc-comment roxygen tags
+                let doc_tags = extract_roxygen_tags(&item_fn.attrs);
+                if !doc_tags.is_empty() {
+                    data.fn_doc_tags.insert(name, doc_tags);
                 }
             }
             Item::Struct(item_struct) => {

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -2297,9 +2297,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3222,9 +3222,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
-miniextendr-api = { path = "../../vendor/miniextendr-api" }
 miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
+miniextendr-api = { path = "../../vendor/miniextendr-api" }
 miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
 miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }


### PR DESCRIPTION
## Summary

Rust 1.95 (released 2026-04-14) enforces three new/stricter clippy lints that `-D warnings` now rejects. CI's `clippy_default` + `clippy_all` jobs fail on `R CMD check / Linux release` for every open PR that doesn't carry the fix:

- `clippy::collapsible_match` — nested `if has_miniextendr_attr(...)` inside `match` arm
- `clippy::manual_checked_ops` — manual `if x != 0 { y / x } else { 0 }` pattern
- `clippy::useless_conversion` — redundant `.into_iter()` on things that already implement `IntoIterator`

Fixed in three files (same change as PR #179's commit `adf9ab74`, extracted here as a standalone fast-track PR so the other stalled PRs can rebase cleanly).

## Test plan

- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --locked --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,default-strict,default-coerce,default-r6,default-worker -- -D warnings` — clean
- [x] Vendor tarball regenerated by `just vendor` (pre-commit hook auto-staged)

Unblocks PRs #180, #181, #184 which currently fail Linux release CI on these exact lints.

Generated with [Claude Code](https://claude.com/claude-code)
