### PR TITLE
fix(macros): accept [T; N] arrays in several_ok vector-like check

### DIFF
--- a/miniextendr-macros/src/miniextendr_fn.rs
+++ b/miniextendr-macros/src/miniextendr_fn.rs
@@ -147,10 +147,11 @@ pub(crate) fn is_missing_type(ty: &syn::Type) -> bool {
 
 /// Check if a type is a vector-like type that `several_ok` can populate.
 ///
-/// Accepts `Vec<T>`, `Box<[T]>`, and `&[T]` / `&mut [T]`. Rejects scalar types
-/// (like `Mode`, `String`, `&str`) so `several_ok` — which produces a
-/// multi-element R character vector via `match.arg(..., several.ok = TRUE)` —
-/// fails at compile time instead of deserialization time.
+/// Accepts `Vec<T>`, `Box<[T]>`, `&[T]` / `&mut [T]`, and `[T; N]`. Rejects
+/// scalar types (like `Mode`, `String`, `&str`) so `several_ok` — which
+/// produces a multi-element R character vector via
+/// `match.arg(..., several.ok = TRUE)` — fails at compile time instead of
+/// deserialization time.
 pub(crate) fn is_vector_like_type(ty: &syn::Type) -> bool {
     match ty {
         syn::Type::Path(tp) => {
@@ -173,6 +174,7 @@ pub(crate) fn is_vector_like_type(ty: &syn::Type) -> bool {
         }
         syn::Type::Reference(r) => matches!(&*r.elem, syn::Type::Slice(_)),
         syn::Type::Slice(_) => true,
+        syn::Type::Array(_) => true,
         _ => false,
     }
 }
@@ -286,7 +288,7 @@ pub(crate) fn validate_per_param_attr_conflicts(
                 format!(
                     "several_ok requires a vector type on parameter `{}`; \
                      several_ok enables multi-value match.arg which returns a character vector. \
-                     Use `Vec<T>`, `Box<[T]>`, or `&[T]` instead of a scalar type",
+                     Use `Vec<T>`, `Box<[T]>`, `&[T]`, or `[T; N]` instead of a scalar type",
                     param_name
                 ),
             ));

--- a/miniextendr-macros/tests/ui/several_ok_on_scalar_type.stderr
+++ b/miniextendr-macros/tests/ui/several_ok_on_scalar_type.stderr
@@ -1,4 +1,4 @@
-error: several_ok requires a vector type on parameter `x`; several_ok enables multi-value match.arg which returns a character vector. Use `Vec<T>`, `Box<[T]>`, or `&[T]` instead of a scalar type
+error: several_ok requires a vector type on parameter `x`; several_ok enables multi-value match.arg which returns a character vector. Use `Vec<T>`, `Box<[T]>`, `&[T]`, or `[T; N]` instead of a scalar type
  --> tests/ui/several_ok_on_scalar_type.rs:6:75
   |
 6 | fn bad_several_ok_scalar(#[miniextendr(choices("a", "b"), several_ok)] x: String) {}

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -92,7 +92,7 @@ codegen-units = 1
 [patch]
 
 [patch.crates-io]
-miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
-miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
 miniextendr-api = { path = "../../vendor/miniextendr-api" }
+miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
+miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
 miniextendr-macros = { path = "../../vendor/miniextendr-macros" }


### PR DESCRIPTION
## Summary

- `#181` rejected scalar types for `several_ok` but `is_vector_like_type` didn't cover `syn::Type::Array` — so `[T; N]` was rejected
- `#191` added `[Mode; 2]` codegen support and test fixtures; they passed local clippy because `cargo clippy --workspace` from repo root skips the rpkg standalone workspace
- on main the two merged cleanly textually but deploy rustdoc and any fresh rpkg build now panic at macro-expansion time

## Fix

- Add `syn::Type::Array(_) => true` to `is_vector_like_type`
- Update the error message and UI-test .stderr to mention `[T; N]`

## Test plan

- [x] `just check` (all manifests including rpkg) — green
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — green
- [x] `cargo clippy --workspace --all-targets --locked --features …` (clippy_all) — green
- [x] `cargo test -p miniextendr-macros --test ui` — pass
- [ ] CI rustdoc deploy job — green

Generated with [Claude Code](https://claude.com/claude-code)
