### PR TITLE
fix(vendor-crates.R): reject git URLs in parse_tree_packages (#36)

### DIFF
--- a/tests/cross-package/consumer.pkg/tools/vendor-crates.R
+++ b/tests/cross-package/consumer.pkg/tools/vendor-crates.R
@@ -117,6 +117,13 @@ parse_tree_packages <- function(lines) {
     path <- NA_character_
     if (grepl(" \\([^()]*[/\\\\][^()]*\\)$", line)) {
       path <- sub("^.* \\(([^()]*[/\\\\][^()]*)\\)$", "\\1", line)
+      # cargo tree emits git/registry sources in the same (…) slot as local
+      # paths (e.g. "foo v0.1.0 (https://github.com/x/y#deadbeef)"). Those
+      # are not filesystem paths — reject them so downstream callers don't
+      # try to feed a URL to --manifest-path.
+      if (grepl("^https?://", path) || grepl("^git[+@]", path)) {
+        path <- NA_character_
+      }
     }
 
     data.frame(

--- a/tests/cross-package/producer.pkg/tools/vendor-crates.R
+++ b/tests/cross-package/producer.pkg/tools/vendor-crates.R
@@ -117,6 +117,13 @@ parse_tree_packages <- function(lines) {
     path <- NA_character_
     if (grepl(" \\([^()]*[/\\\\][^()]*\\)$", line)) {
       path <- sub("^.* \\(([^()]*[/\\\\][^()]*)\\)$", "\\1", line)
+      # cargo tree emits git/registry sources in the same (…) slot as local
+      # paths (e.g. "foo v0.1.0 (https://github.com/x/y#deadbeef)"). Those
+      # are not filesystem paths — reject them so downstream callers don't
+      # try to feed a URL to --manifest-path.
+      if (grepl("^https?://", path) || grepl("^git[+@]", path)) {
+        path <- NA_character_
+      }
     }
 
     data.frame(


### PR DESCRIPTION
Closes #36 (scope below).

## Summary

`cargo tree --format {p}` emits git and registry sources in the same `(…)` slot as local paths:

```
miniextendr-api v0.1.0 (https://github.com/CGMossa/miniextendr#dcf727bc)
serde v1.0.228 (git+ssh://git@gh.com/serde-rs/serde.git#abcdef)
```

`parse_tree_packages` was extracting the URL as a filesystem path, which then fed into `--manifest-path` downstream. The fix rejects anything matching `^https?://` or `^git[+@]` after the regex match, leaving `path = NA_character_` for those rows.

## Scope

The issue suggested applying the fix to `rpkg/tools/vendor-crates.R` and the minirextendr templates. Those files no longer exist — `cargo-revendor` (the standalone crate at `cargo-revendor/`) superseded the R-based vendor flow in the main package. The only remaining copies of `parse_tree_packages` live in the cross-package test fixtures (`tests/cross-package/{producer,consumer}.pkg/tools/vendor-crates.R`), so the fix lands there, synced between both.

The second half of #36 — CRAN-mode rewriting for monorepo path deps in `configure.ac` and `use_vendor_lib` injecting path rewrites — is a larger architectural change and should be tracked in its own issue/PR. I'll leave #36 open for that half; happy to adjust scope if preferred.

## Test plan

- [x] Hand-verified the regex with fixture lines (git https, git+ssh, git@, local path, no paren):

```
             name version              path
1 miniextendr-api   0.1.0              <NA>
2             dvs   0.1.0 /Users/me/dev/dvs
3           serde 1.0.228              <NA>
4           rayon  1.12.0              <NA>
5             foo   0.1.0              <NA>
```

- [x] No Rust code touched; clippy / fmt / rebuild / vendor not required.

Generated with [Claude Code](https://claude.com/claude-code)
