### PR TITLE
fix(cargo-revendor): sort [patch.crates-io] entries deterministically (#205)

### DIFF
--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -689,7 +689,7 @@ pub fn freeze_manifest(
     // Step 2: Collect all crate names from existing [patch.*] sections,
     // then remove those sections. We need the names to re-add them as
     // vendor path deps (unpublished git crates aren't on crates.io).
-    let mut patched_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut patched_names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for (key, val) in doc.as_table().iter() {
         if key.starts_with("patch")
             && let Some(patch_table) = val.as_table()
@@ -1004,6 +1004,42 @@ version = "0.1.0"
         assert!(result.contains("crate-b"));
         assert!(result.contains("version"));
         assert!(!result.contains("path"));
+    }
+
+    #[test]
+    fn freeze_manifest_patch_crates_io_is_alphabetical() {
+        let dir = tempfile::tempdir().unwrap();
+        let vendor = dir.path().join("vendor");
+        for name in ["miniextendr-api", "miniextendr-macros", "miniextendr-lint", "miniextendr-macros-core"] {
+            std::fs::create_dir_all(vendor.join(name)).unwrap();
+        }
+        let manifest = dir.path().join("Cargo.toml");
+        // Start with a [patch.crates-io] section whose keys are in non-sorted order
+        // — this exercises the old HashSet nondeterminism bug (#205).
+        std::fs::write(
+            &manifest,
+            r#"[package]
+name = "example"
+version = "0.1.0"
+
+[dependencies]
+
+[patch.crates-io]
+miniextendr-api = { path = "/tmp/a" }
+miniextendr-macros = { path = "/tmp/m" }
+miniextendr-lint = { path = "/tmp/l" }
+miniextendr-macros-core = { path = "/tmp/mc" }
+"#,
+        )
+        .unwrap();
+
+        freeze_manifest(&manifest, &vendor, &[], Verbosity(0)).unwrap();
+        let result = std::fs::read_to_string(&manifest).unwrap();
+        let api = result.find("miniextendr-api =").unwrap();
+        let lint = result.find("miniextendr-lint =").unwrap();
+        let macros = result.find("miniextendr-macros =").unwrap();
+        let macros_core = result.find("miniextendr-macros-core =").unwrap();
+        assert!(api < lint && lint < macros && macros < macros_core, "patch.crates-io entries not alphabetical: {}", result);
     }
 
     #[test]

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -2437,9 +2437,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2653,7 +2653,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3049,9 +3049,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -3751,3 +3751,19 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[patch.unused]]
+name = "miniextendr-api"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-lint"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-macros"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-macros-core"
+version = "0.1.0"

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -3751,19 +3751,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "miniextendr-api"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "miniextendr-lint"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "miniextendr-macros"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "miniextendr-macros-core"
-version = "0.1.0"

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -94,5 +94,5 @@ codegen-units = 1
 [patch.crates-io]
 miniextendr-api = { path = "../../vendor/miniextendr-api" }
 miniextendr-lint = { path = "../../vendor/miniextendr-lint" }
-miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }
 miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
+miniextendr-macros-core = { path = "../../vendor/miniextendr-macros-core" }


### PR DESCRIPTION
Closes #205.

## Summary
- Freeze step collected patched crate names into a `HashSet`, which randomized iteration order per process, producing different `[patch.crates-io]` orderings on every `just vendor`.
- Switched to `BTreeSet` so output is alphabetical and stable.
- Added regression test.

## Test plan
- [x] `cargo test --manifest-path cargo-revendor/Cargo.toml freeze_manifest` passes
- [x] `just revendor-test` (full cargo-revendor suite) passes
- [x] `just vendor` run twice in a row produces identical `rpkg/src/rust/Cargo.toml`
- [x] `just clippy` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean (CI `clippy_default`)
- [x] `cargo clippy --workspace --all-targets --locked --features rayon,rand,...` clean (CI `clippy_all`)
- [x] `just fmt`
- [x] `just vendor` (regenerates `inst/vendor.tar.xz`)

Generated with [Claude Code](https://claude.com/claude-code)
