### PR TITLE
test(s3): regression test for bare S3 generic export (#213)

### DIFF
--- a/rpkg/tests/testthat/test-class-systems.R
+++ b/rpkg/tests/testthat/test-class-systems.R
@@ -13,6 +13,26 @@ test_that("S3Counter S3 helpers exist through method names", {
   expect_equal(s3_add.S3Counter(c, 4L), 7L)
 })
 
+# Regression test for #213 — a prior bug had `#' @export` drift onto the
+# method block in s3_class.rs, emitting `export(s3_value.S3Counter)` without
+# the bare `export(s3_value)` generic. Inside the package's own tests the bare
+# call still worked (methods are in-namespace), but external callers of the
+# generic from a downstream package or a fresh R session would hit
+# "could not find function s3_value". Assert the generic is in the package's
+# exported names so the wrapper regeneration can never silently drop it again.
+test_that("S3 generics are exported from the package namespace (#213)", {
+  exports <- getNamespaceExports(asNamespace("miniextendr"))
+  for (generic in c("s3_value", "s3_inc", "s3_add")) {
+    expect_true(
+      generic %in% exports,
+      info = sprintf(
+        "bare S3 generic `%s` missing from NAMESPACE exports; expected it alongside `%s.S3Counter`",
+        generic, generic
+      )
+    )
+  }
+})
+
 test_that("S4Counter lifecycle works", {
   c <- S4Counter(2L)
   expect_equal(s4_value(c), 2L)


### PR DESCRIPTION
Closes #213.

## Why

#207 fixed a latent bug where the S3 impl-block codegen drifted `#' @export` onto the method block, emitting `export(s3_value.S3Counter)` without the bare `export(s3_value)` generic. The bug sat unnoticed for months because:

- `devtools::test()` attaches the package, so in-package testthat blocks can call both exported and non-exported functions freely.
- rpkg's own tests never exercised "external caller finds the generic through the package namespace."
- Bench files used the bare generics but benchmarks don't run in CI.

Downstream packages (cross-package tests, real consumers) hit `could not find function s3_value`.

## What this adds

A NAMESPACE-level assertion in `test-class-systems.R`:

```r
test_that("S3 generics are exported from the package namespace (#213)", {
  exports <- getNamespaceExports(asNamespace("miniextendr"))
  for (generic in c("s3_value", "s3_inc", "s3_add")) {
    expect_true(generic %in% exports, ...)
  }
})
```

Checks `getNamespaceExports` directly instead of calling the function — that side-steps the devtools attach behavior and reads the actual NAMESPACE contract.

## Test plan

- [x] `grep export(s3_value) rpkg/NAMESPACE` — present on current main (bug is fixed)
- [x] If the bug were reintroduced by a wrapper regeneration, this test would fail with a clear message

Generated with [Claude Code](https://claude.com/claude-code)
