### PR TITLE
ci: gate sync-checks with vendor-verify (#216)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Check vendor sync
         run: just vendor-sync-check
 
+      - name: Verify Cargo.lock ↔ vendor/ ↔ vendor.tar.xz consistency
+        run: just vendor-verify
+
       - name: Check templates sync
         run: just templates-check
 


### PR DESCRIPTION
Closes #216.

## Summary

Wire `just vendor-verify` (added in #217, false-positive fixed in #218) into the existing `sync-checks` CI job. Any drift between `rpkg/src/rust/Cargo.lock`, `rpkg/vendor/`, and `rpkg/inst/vendor.tar.xz` now fails CI instead of silently shipping to downstream offline consumers.

## Change

One step inserted after the existing `Check vendor sync` step:

```yaml
- name: Verify Cargo.lock ↔ vendor/ ↔ vendor.tar.xz consistency
  run: just vendor-verify
```

## Why now

#216 was filed as blocked on #214 (real drift on main). Since the sprint merges + #217 + #218 landed, `just vendor-verify` is clean on main — verified locally:

```
$ just vendor-verify
  Cargo.lock ↔ vendor/: OK
  tarball ↔ vendor/: OK
```

Turning on the CI gate now locks in that clean state.

## Test plan

- [x] `just vendor-verify` passes on current main
- [ ] CI green on this PR (validates the workflow itself)

Generated with [Claude Code](https://claude.com/claude-code)
