### PR TITLE
test(worker): regression test for cooperative shutdown path (#204)

### DIFF
--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -228,6 +228,27 @@ pub extern "C-unwind" fn miniextendr_runtime_shutdown() {
         worker_channel::shutdown();
     }
 }
+
+/// Test-only: block up to `timeout` for the worker thread to exit after
+/// `miniextendr_runtime_shutdown`. Returns `true` if the worker has joined,
+/// `false` on timeout. Covers #204 — asserts the cooperative shutdown path
+/// from #103 actually unblocks the `recv_timeout` loop within a bounded
+/// window (default poll interval is 250ms).
+///
+/// Not intended for production use. Without the `worker-thread` feature this
+/// always returns `true` since there is no worker to join.
+#[doc(hidden)]
+pub fn miniextendr_runtime_join_for_test(timeout: std::time::Duration) -> bool {
+    #[cfg(feature = "worker-thread")]
+    {
+        worker_channel::join_worker_with_timeout(timeout)
+    }
+    #[cfg(not(feature = "worker-thread"))]
+    {
+        let _ = timeout;
+        true
+    }
+}
 // endregion
 
 // region: pub(crate) internals
@@ -282,6 +303,12 @@ mod worker_channel {
     type AnyJob = Box<dyn FnOnce() + Send>;
 
     static JOB_TX: std::sync::OnceLock<SyncSender<AnyJob>> = std::sync::OnceLock::new();
+
+    /// Handle to the spawned worker thread, stored so tests can observe
+    /// shutdown completion (#204). Production code does not join —
+    /// the OS reaps the worker at process exit.
+    static WORKER_JOIN_HANDLE: std::sync::Mutex<Option<thread::JoinHandle<()>>> =
+        std::sync::Mutex::new(None);
 
     /// Cooperative shutdown signal for the worker thread (see `#103`).
     ///
@@ -582,12 +609,52 @@ mod worker_channel {
         // Capacity 0 (rendezvous): the main thread blocks until the worker picks
         // up the job, ensuring at most one job is in flight at a time.
         let (job_tx, job_rx) = mpsc::sync_channel::<AnyJob>(0);
-        thread::Builder::new()
+        let handle = thread::Builder::new()
             .name("miniextendr-worker".into())
             .spawn(move || worker_loop(job_rx))
             .expect("failed to spawn worker thread");
 
+        *WORKER_JOIN_HANDLE.lock().unwrap() = Some(handle);
         JOB_TX.set(job_tx).expect("worker already initialized");
+    }
+
+    /// Block up to `timeout` for the worker thread to finish after
+    /// `miniextendr_runtime_shutdown` signals it to stop. Returns `true` if the
+    /// worker has exited, `false` on timeout (worker still alive).
+    ///
+    /// Polls `JoinHandle::is_finished` every 50ms rather than a blocking join,
+    /// so the test can report a specific failure ("did not exit in 2s") rather
+    /// than deadlocking. See #204.
+    pub(super) fn join_worker_with_timeout(timeout: Duration) -> bool {
+        let start = std::time::Instant::now();
+        loop {
+            // Observe the handle without permanently removing it; later polls
+            // need to see the same handle.
+            let already_joined = {
+                let guard = WORKER_JOIN_HANDLE.lock().unwrap();
+                guard.is_none()
+            };
+            if already_joined {
+                return true;
+            }
+
+            let is_finished = {
+                let guard = WORKER_JOIN_HANDLE.lock().unwrap();
+                guard.as_ref().map(|h| h.is_finished()).unwrap_or(true)
+            };
+            if is_finished {
+                // Take and join to release thread resources.
+                if let Some(h) = WORKER_JOIN_HANDLE.lock().unwrap().take() {
+                    let _ = h.join();
+                }
+                return true;
+            }
+
+            if start.elapsed() >= timeout {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     /// Worker thread body: poll `recv_timeout` and honor the shutdown flag.

--- a/miniextendr-api/tests/worker_shutdown.rs
+++ b/miniextendr-api/tests/worker_shutdown.rs
@@ -1,0 +1,49 @@
+//! Integration test for the cooperative worker shutdown path (#204).
+//!
+//! PR #199 (closes #103) added `recv_timeout(250ms)` + `WORKER_SHOULD_STOP:
+//! AtomicBool` + `miniextendr_runtime_shutdown()`. The previous worker tests
+//! exercised dispatch + re-entry guarding, but never the actual shutdown
+//! transition. This test:
+//!
+//! 1. Initializes the runtime (spawns the worker).
+//! 2. Sends `miniextendr_runtime_shutdown()`.
+//! 3. Polls `miniextendr_runtime_join_for_test` until the worker exits or
+//!    2 s elapse — roughly 8 shutdown polls at the 250 ms poll interval.
+//!
+//! Lives in its own integration binary (each `tests/*.rs` file becomes one)
+//! so taking the worker down here does not disrupt other test binaries that
+//! rely on a live worker.
+
+mod r_test_utils;
+
+use std::time::Duration;
+
+#[test]
+#[cfg(feature = "worker-thread")]
+fn worker_exits_after_runtime_shutdown() {
+    // Boot R + the miniextendr runtime (this spawns the worker thread under
+    // the `worker-thread` feature). We don't need to actually dispatch a job:
+    // the worker is parked on `recv_timeout` from the moment init completes,
+    // which is exactly the state where #103's deadlock would manifest.
+    r_test_utils::with_r_thread(|| ());
+
+    miniextendr_api::worker::miniextendr_runtime_shutdown();
+
+    let joined = miniextendr_api::worker::miniextendr_runtime_join_for_test(Duration::from_secs(2));
+
+    assert!(
+        joined,
+        "worker did not exit within 2 s after miniextendr_runtime_shutdown; \
+         the cooperative shutdown path from #103 appears broken"
+    );
+}
+
+#[test]
+#[cfg(not(feature = "worker-thread"))]
+fn shutdown_is_noop_without_worker_thread_feature() {
+    // Without the feature there is no worker; shutdown + join are both no-ops.
+    miniextendr_api::worker::miniextendr_runtime_shutdown();
+    assert!(miniextendr_api::worker::miniextendr_runtime_join_for_test(
+        Duration::from_millis(10)
+    ));
+}


### PR DESCRIPTION
Closes #204.

## Why

#199 (closes #103) added cooperative worker shutdown via `recv_timeout(250ms)` + `WORKER_SHOULD_STOP: AtomicBool` + `miniextendr_runtime_shutdown()`. The existing worker tests (`run_on_worker_reentry_panics_not_deadlocks`, `has_worker_context_false_outside_worker`, etc.) exercise dispatch + re-entry but never the actual shutdown transition. If a future refactor drops the poll-check or inverts the atomic, #103's deadlock regresses silently — the symptom only appears when a user calls `q(\"no\")` on Windows.

## What this PR adds

1. **`miniextendr_api::worker::miniextendr_runtime_join_for_test(timeout)`** — a polling helper that blocks until the worker's `JoinHandle` is finished or the timeout elapses, and joins it on completion. Used only by tests; a no-op without the `worker-thread` feature.

2. **`miniextendr-api/tests/worker_shutdown.rs`** integration test (its own binary, so taking the worker down here can't break other binaries that need a live worker):

   ```rust
   r_test_utils::with_r_thread(|| ());                      // boot runtime + spawn worker
   miniextendr_api::worker::miniextendr_runtime_shutdown(); // signal stop
   let joined = miniextendr_runtime_join_for_test(Duration::from_secs(2));
   assert!(joined);                                          // worker actually exited
   ```

3. A sibling test for the `worker-thread` feature-off path to keep the no-op behavior covered.

## Impl detail

Added a `WORKER_JOIN_HANDLE: Mutex<Option<JoinHandle<()>>>` static in the worker_channel module, populated in `init_worker`. Production code never joins — the OS reaps the worker at process exit, as before. The helper polls `JoinHandle::is_finished` every 50 ms so failure reports "did not exit in 2 s" rather than deadlocking.

## Test plan
- [x] `cargo test -p miniextendr-api --features worker-thread --test worker_shutdown` — 1 passed
- [x] `cargo fmt --all` clean
- [x] `just vendor` — tarball refreshed

Generated with [Claude Code](https://claude.com/claude-code)
