### PR TITLE
feat(cargo-revendor): --sync flag for shared vendor across disjoint workspaces (#229)

### DIFF
--- a/cargo-revendor/src/cache.rs
+++ b/cargo-revendor/src/cache.rs
@@ -15,9 +15,12 @@ use std::path::{Path, PathBuf};
 const CACHE_FILE: &str = ".revendor-cache";
 
 /// Check whether `vendor_dir` is up to date relative to `lockfile` plus the
-/// source trees of `local_crate_paths`.
+/// source trees of `local_crate_paths`, plus any additional manifests
+/// supplied via `--sync` (#229). Each sync manifest's sibling `Cargo.lock`
+/// and `Cargo.toml` are hashed into the key.
 pub fn is_cached(
     lockfile: &Path,
+    sync_manifests: &[PathBuf],
     vendor_dir: &Path,
     local_crate_paths: &[PathBuf],
 ) -> Result<bool> {
@@ -26,7 +29,7 @@ pub fn is_cached(
         return Ok(false);
     }
 
-    let current = compute_hash(lockfile, local_crate_paths)?;
+    let current = compute_hash(lockfile, sync_manifests, local_crate_paths)?;
     let cached = std::fs::read_to_string(&cache_path)?;
 
     Ok(current.trim() == cached.trim())
@@ -35,18 +38,24 @@ pub fn is_cached(
 /// Save the current hash to the cache file.
 pub fn save_cache(
     lockfile: &Path,
+    sync_manifests: &[PathBuf],
     vendor_dir: &Path,
     local_crate_paths: &[PathBuf],
 ) -> Result<()> {
-    let hash = compute_hash(lockfile, local_crate_paths)?;
+    let hash = compute_hash(lockfile, sync_manifests, local_crate_paths)?;
     let cache_path = vendor_dir.join(CACHE_FILE);
     std::fs::write(&cache_path, &hash)?;
     Ok(())
 }
 
-/// Compute a hash over `Cargo.lock`, the sibling `Cargo.toml`, and the source
-/// tree of each local workspace crate.
-fn compute_hash(lockfile: &Path, local_crate_paths: &[PathBuf]) -> Result<String> {
+/// Compute a hash over `Cargo.lock`, the sibling `Cargo.toml`, the source
+/// tree of each local workspace crate, and each `--sync` manifest's
+/// Cargo.toml + Cargo.lock pair (#229).
+fn compute_hash(
+    lockfile: &Path,
+    sync_manifests: &[PathBuf],
+    local_crate_paths: &[PathBuf],
+) -> Result<String> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -59,6 +68,21 @@ fn compute_hash(lockfile: &Path, local_crate_paths: &[PathBuf]) -> Result<String
     let manifest = lockfile.with_file_name("Cargo.toml");
     if manifest.exists() {
         std::fs::read(&manifest)?.hash(&mut hasher);
+    }
+
+    // Each --sync manifest contributes its own Cargo.toml + Cargo.lock pair.
+    // Sort by path so ordering of --sync args doesn't affect the key — two
+    // equivalent sync sets pass cache regardless of CLI order.
+    let mut sorted_sync: Vec<&PathBuf> = sync_manifests.iter().collect();
+    sorted_sync.sort();
+    for sync_manifest in sorted_sync {
+        if sync_manifest.exists() {
+            std::fs::read(sync_manifest)?.hash(&mut hasher);
+        }
+        let sync_lock = sync_manifest.with_file_name("Cargo.lock");
+        if sync_lock.exists() {
+            std::fs::read(&sync_lock)?.hash(&mut hasher);
+        }
     }
 
     // Hash each local crate's source tree in a deterministic order so the
@@ -152,12 +176,12 @@ mod tests {
         let crate_path = tmp.path().join("libx");
         let locals = vec![crate_path.clone()];
 
-        save_cache(&lockfile, &vendor, &locals).unwrap();
-        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+        save_cache(&lockfile, &[], &vendor, &locals).unwrap();
+        assert!(is_cached(&lockfile, &[], &vendor, &locals).unwrap());
 
         std::fs::write(crate_path.join("src/lib.rs"), "// v2 changed").unwrap();
         assert!(
-            !is_cached(&lockfile, &vendor, &locals).unwrap(),
+            !is_cached(&lockfile, &[], &vendor, &locals).unwrap(),
             "cache should invalidate when a local crate source file changes"
         );
     }
@@ -168,13 +192,13 @@ mod tests {
         let crate_path = tmp.path().join("libx");
         let locals = vec![crate_path.clone()];
 
-        save_cache(&lockfile, &vendor, &locals).unwrap();
+        save_cache(&lockfile, &[], &vendor, &locals).unwrap();
         std::fs::write(
             crate_path.join("Cargo.toml"),
             "[package]\nname = \"libx\"\nversion = \"0.2.0\"",
         )
         .unwrap();
-        assert!(!is_cached(&lockfile, &vendor, &locals).unwrap());
+        assert!(!is_cached(&lockfile, &[], &vendor, &locals).unwrap());
     }
 
     #[test]
@@ -183,9 +207,69 @@ mod tests {
         let crate_path = _tmp.path().join("libx");
         let locals = vec![crate_path];
 
-        save_cache(&lockfile, &vendor, &locals).unwrap();
-        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+        save_cache(&lockfile, &[], &vendor, &locals).unwrap();
+        assert!(is_cached(&lockfile, &[], &vendor, &locals).unwrap());
         // Repeat hit.
-        assert!(is_cached(&lockfile, &vendor, &locals).unwrap());
+        assert!(is_cached(&lockfile, &[], &vendor, &locals).unwrap());
+    }
+
+    #[test]
+    fn cache_invalidates_on_sync_manifest_change() {
+        // #229: when --sync manifests are passed, edits to their
+        // Cargo.toml or Cargo.lock must invalidate the cache — otherwise
+        // cargo-revendor will serve a stale vendor/ tree after a sync'd
+        // workspace's dep graph changes.
+        let (tmp, lockfile, vendor) = setup();
+        let crate_path = tmp.path().join("libx");
+        let locals = vec![crate_path];
+
+        // Prime a sync'd workspace with a manifest + lockfile.
+        let sync_ws = tmp.path().join("sync-ws");
+        std::fs::create_dir_all(&sync_ws).unwrap();
+        let sync_manifest = sync_ws.join("Cargo.toml");
+        let sync_lock = sync_ws.join("Cargo.lock");
+        std::fs::write(&sync_manifest, "[package]\nname = \"syncpkg\"").unwrap();
+        std::fs::write(&sync_lock, "version = 3").unwrap();
+
+        let sync = vec![sync_manifest.clone()];
+        save_cache(&lockfile, &sync, &vendor, &locals).unwrap();
+        assert!(is_cached(&lockfile, &sync, &vendor, &locals).unwrap());
+
+        // Bump the sync manifest; cache should invalidate.
+        std::fs::write(&sync_manifest, "[package]\nname = \"syncpkg\"\nversion = \"0.2.0\"").unwrap();
+        assert!(
+            !is_cached(&lockfile, &sync, &vendor, &locals).unwrap(),
+            "cache should invalidate when a --sync manifest changes"
+        );
+
+        // Restore + bump the sync lockfile; again cache should invalidate.
+        std::fs::write(&sync_manifest, "[package]\nname = \"syncpkg\"").unwrap();
+        save_cache(&lockfile, &sync, &vendor, &locals).unwrap();
+        std::fs::write(&sync_lock, "version = 4").unwrap();
+        assert!(
+            !is_cached(&lockfile, &sync, &vendor, &locals).unwrap(),
+            "cache should invalidate when a --sync Cargo.lock changes"
+        );
+    }
+
+    #[test]
+    fn cache_stable_when_sync_order_differs() {
+        // Re-ordering the --sync arg list must NOT invalidate the cache;
+        // cargo vendor doesn't care about order either.
+        let (tmp, lockfile, vendor) = setup();
+        let locals: Vec<std::path::PathBuf> = Vec::new();
+
+        let a = tmp.path().join("a.toml");
+        let b = tmp.path().join("b.toml");
+        std::fs::write(&a, "[package]\nname = \"a\"").unwrap();
+        std::fs::write(&b, "[package]\nname = \"b\"").unwrap();
+        std::fs::write(a.with_file_name("a.lock"), "1").ok();
+        std::fs::write(b.with_file_name("b.lock"), "2").ok();
+
+        save_cache(&lockfile, &[a.clone(), b.clone()], &vendor, &locals).unwrap();
+        assert!(
+            is_cached(&lockfile, &[b, a], &vendor, &locals).unwrap(),
+            "swapped --sync order should still hit the cache"
+        );
     }
 }

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -132,6 +132,18 @@ struct Cli {
     /// vendor.tar.xz matches Cargo.lock.
     #[arg(long)]
     verify: bool,
+
+    /// Additional manifests to include in the vendor graph — mirrors
+    /// `cargo vendor --sync <extra.toml>`. Each path points at the
+    /// `Cargo.toml` of a disjoint workspace whose dep graph should be
+    /// unioned into a single shared `vendor/` tree.
+    ///
+    /// Use case: one R package (`rpkg/src/rust/Cargo.toml`) and a
+    /// separate benchmarks workspace (`miniextendr-bench/Cargo.toml`)
+    /// that want to share one offline artifact. Each --sync manifest's
+    /// Cargo.lock is also checked by --verify. See #229.
+    #[arg(long)]
+    sync: Vec<PathBuf>,
 }
 
 impl Cli {
@@ -189,9 +201,30 @@ fn main() -> Result<()> {
 
     let lockfile = manifest_path.with_file_name("Cargo.lock");
 
+    // Canonicalize each --sync manifest path once. Used by both the verify
+    // shortcut above and the vendor flow below (plus cache hashing).
+    let sync_manifests: Vec<std::path::PathBuf> = cli
+        .sync
+        .iter()
+        .map(|p| {
+            p.canonicalize()
+                .unwrap_or_else(|_| std::env::current_dir().unwrap().join(p))
+        })
+        .collect();
+
     // Verify-only: don't vendor; just assert existing artifacts are in sync.
     if cli.verify {
-        return run_verify(&lockfile, &output, cli.compress.as_deref(), v);
+        let sync_lockfiles: Vec<std::path::PathBuf> = sync_manifests
+            .iter()
+            .map(|m| m.with_file_name("Cargo.lock"))
+            .collect();
+        return run_verify(
+            &lockfile,
+            &sync_lockfiles,
+            &output,
+            cli.compress.as_deref(),
+            v,
+        );
     }
 
     // Step 1: Load cargo metadata to discover dependencies
@@ -259,7 +292,7 @@ fn main() -> Result<()> {
         local_pkgs.iter().map(|p| p.path.clone()).collect();
 
     // Step 0: Check cache — skip if all inputs are unchanged
-    if !cli.force && cache::is_cached(&lockfile, &output, &local_crate_paths)? {
+    if !cli.force && cache::is_cached(&lockfile, &sync_manifests, &output, &local_crate_paths)? {
         if v.info() {
             eprintln!("cargo-revendor: vendor/ is up to date (inputs unchanged)");
         }
@@ -298,7 +331,13 @@ fn main() -> Result<()> {
     )?;
 
     // Step 3: Run `cargo vendor` for external deps
-    vendor::run_cargo_vendor(&manifest_path, &vendor_staging, &patch_pkgs, v)?;
+    vendor::run_cargo_vendor(
+        &manifest_path,
+        &vendor_staging,
+        &patch_pkgs,
+        &sync_manifests,
+        v,
+    )?;
 
     // Step 4: Extract packaged local crates into vendor staging
     for (pkg_name, crate_path) in &packaged {
@@ -375,7 +414,7 @@ fn main() -> Result<()> {
     }
 
     // Step 14: Save cache
-    cache::save_cache(&lockfile, &output, &local_crate_paths)?;
+    cache::save_cache(&lockfile, &sync_manifests, &output, &local_crate_paths)?;
 
     // Count total crates
     let total = std::fs::read_dir(&output)
@@ -411,6 +450,7 @@ fn main() -> Result<()> {
 /// Verify that Cargo.lock, vendor/, and (optionally) the tarball agree.
 fn run_verify(
     lockfile: &std::path::Path,
+    sync_lockfiles: &[std::path::PathBuf],
     vendor_dir: &std::path::Path,
     tarball: Option<&std::path::Path>,
     v: Verbosity,
@@ -421,6 +461,22 @@ fn run_verify(
     verify::verify_lock_matches_vendor(lockfile, vendor_dir)?;
     if v.info() {
         eprintln!("  Cargo.lock ↔ vendor/: OK");
+    }
+
+    // Every --sync manifest carries its own Cargo.lock; each must agree with
+    // the shared vendor/ too.
+    for sync_lock in sync_lockfiles {
+        if v.info() {
+            eprintln!(
+                "cargo-revendor: verifying {} ↔ {}",
+                sync_lock.display(),
+                vendor_dir.display()
+            );
+        }
+        verify::verify_lock_matches_vendor(sync_lock, vendor_dir)?;
+        if v.info() {
+            eprintln!("  {} ↔ vendor/: OK", sync_lock.display());
+        }
     }
 
     if let Some(tarball) = tarball {

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -5,15 +5,29 @@ use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Run `cargo vendor` for external (registry/git) dependencies
+/// Run `cargo vendor` for external (registry/git) dependencies.
+///
+/// `sync_manifests` mirrors `cargo vendor --sync <path>`: additional
+/// manifests whose dep graphs are unioned into the same output tree.
+/// Use case (#229): one R-package workspace plus a disjoint benchmarks
+/// workspace sharing one offline artifact; two packages pinning different
+/// versions of the same transitive dep both coexist in `vendor/` as
+/// separate dirs.
 pub fn run_cargo_vendor(
     manifest_path: &Path,
     vendor_dir: &Path,
     local_pkgs: &[LocalPackage],
+    sync_manifests: &[PathBuf],
     v: crate::Verbosity,
 ) -> Result<()> {
     if v.info() {
         eprintln!("  Running cargo vendor...");
+        if !sync_manifests.is_empty() {
+            eprintln!("    syncing {} additional manifest(s)", sync_manifests.len());
+            for m in sync_manifests {
+                eprintln!("      --sync {}", m.display());
+            }
+        }
     }
 
     std::fs::create_dir_all(vendor_dir)?;
@@ -38,13 +52,13 @@ pub fn run_cargo_vendor(
         std::fs::write(&ws_manifest, format!("{}{}", ws_original, patch))?;
     }
 
-    let output = Command::new("cargo")
-        .arg("vendor")
-        .arg("--manifest-path")
-        .arg(manifest_path)
-        .arg(vendor_dir)
-        .output()
-        .context("failed to run cargo vendor")?;
+    let mut cmd = Command::new("cargo");
+    cmd.arg("vendor").arg("--manifest-path").arg(manifest_path);
+    for m in sync_manifests {
+        cmd.arg("--sync").arg(m);
+    }
+    cmd.arg(vendor_dir);
+    let output = cmd.output().context("failed to run cargo vendor")?;
 
     // Restore original workspace Cargo.toml
     std::fs::write(&ws_manifest, &ws_original)?;


### PR DESCRIPTION
Closes #229. Unblocks #230 (multi-workspace tests).

## What

New `--sync <path>` flag that mirrors `cargo vendor --sync`:

```
cargo revendor \\
  --manifest-path ws1/Cargo.toml \\
  --sync ws2/Cargo.toml \\
  --sync ws3/Cargo.toml \\
  --output shared-vendor/
```

Two disjoint workspaces (e.g. an rpkg workspace + a benchmarks workspace) can share one vendor/ tree. When they pin incompatible versions of the same transitive dep, both materialize as separate `vendor/<name>-<version>/` dirs.

## Changes

| File | Change |
|---|---|
| `main.rs` | New `sync: Vec<PathBuf>` on Cli. Canonicalized once, reused by the verify shortcut and the vendor flow. |
| `vendor.rs` | `run_cargo_vendor` takes `&[PathBuf]` and forwards each as `--sync` to cargo vendor. |
| `main.rs::run_verify` | Takes additional lockfiles; each sync'd Cargo.lock is checked against the shared vendor/ same as the primary. |
| `cache.rs` | `is_cached` / `save_cache` / `compute_hash` take a slice of sync manifests. Each sync'd Cargo.toml + Cargo.lock hashed into the key. Sync paths sorted so arg order doesn't affect cache. |

## Tests

Existing tests updated to the new 4-arg signature. Two new unit tests in `cache.rs`:

- `cache_invalidates_on_sync_manifest_change` — editing a sync'd Cargo.toml or Cargo.lock blows the cache.
- `cache_stable_when_sync_order_differs` — `--sync a --sync b` vs `--sync b --sync a` yield the same cache key.

```
cargo test            → 21 passed, 38 ignored
cargo test -- --ignored → 38 passed, 21 filtered
cargo clippy --all-targets -- -D warnings → clean
```

## Generated with [Claude Code](https://claude.com/claude-code)
