### PR TITLE
feat(cargo-revendor): opt-in --versioned-dirs flag (#215)

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -144,6 +144,21 @@ struct Cli {
     /// Cargo.lock is also checked by --verify. See #229.
     #[arg(long)]
     sync: Vec<PathBuf>,
+
+    /// Use versioned directory names (`vendor/<name>-<version>/`) for
+    /// EVERY vendored crate — including crates that appear only once.
+    /// Without this flag, `cargo vendor` flattens single-version crates
+    /// to `vendor/<name>/` and only uses versioned names when multiple
+    /// versions of the same crate are locked. That creates drift:
+    /// a `vendor/rand/` that silently holds one of several versions, and
+    /// a regeneration can swap which version lives in the flat slot
+    /// without changing the filename.
+    ///
+    /// Opt-in today because adopting it requires updating downstream
+    /// hardcoded paths (rpkg's Cargo.toml freeze target, minirextendr's
+    /// status probe). See #215.
+    #[arg(long)]
+    versioned_dirs: bool,
 }
 
 impl Cli {
@@ -336,6 +351,7 @@ fn main() -> Result<()> {
         &vendor_staging,
         &patch_pkgs,
         &sync_manifests,
+        cli.versioned_dirs,
         v,
     )?;
 

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -18,6 +18,7 @@ pub fn run_cargo_vendor(
     vendor_dir: &Path,
     local_pkgs: &[LocalPackage],
     sync_manifests: &[PathBuf],
+    versioned_dirs: bool,
     v: crate::Verbosity,
 ) -> Result<()> {
     if v.info() {
@@ -27,6 +28,9 @@ pub fn run_cargo_vendor(
             for m in sync_manifests {
                 eprintln!("      --sync {}", m.display());
             }
+        }
+        if versioned_dirs {
+            eprintln!("    layout: --versioned-dirs");
         }
     }
 
@@ -54,6 +58,9 @@ pub fn run_cargo_vendor(
 
     let mut cmd = Command::new("cargo");
     cmd.arg("vendor").arg("--manifest-path").arg(manifest_path);
+    if versioned_dirs {
+        cmd.arg("--versioned-dirs");
+    }
     for m in sync_manifests {
         cmd.arg("--sync").arg(m);
     }

--- a/cargo-revendor/tests/multi_workspace.rs
+++ b/cargo-revendor/tests/multi_workspace.rs
@@ -372,6 +372,61 @@ autocfg = "=1.5.0"
     assert_autocfg_version_present(&shared_vendor, "1.5.0");
 }
 
+/// **#215** — `--versioned-dirs` forces every crate into
+/// `vendor/<name>-<version>/` instead of flattening single-version crates
+/// to `vendor/<name>/`. Regression test for the opt-in flag.
+#[test]
+#[ignore] // network
+fn versioned_dirs_flag_forces_versioned_layout() {
+    let proj = common::create_simple_crate(
+        r#"[package]
+name = "vd-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+cfg-if = "1"
+"#,
+        "",
+    );
+
+    let vendor = proj.root().join("vendor");
+    revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(proj.root().join("Cargo.toml"))
+        .arg("--output")
+        .arg(&vendor)
+        .arg("--versioned-dirs")
+        .assert()
+        .success();
+
+    // Without --versioned-dirs, cargo vendor would flatten cfg-if (only one
+    // version in the graph) to `vendor/cfg-if/`. With the flag, the dir is
+    // `vendor/cfg-if-<version>/`.
+    let flat = vendor.join("cfg-if");
+    let entries: Vec<String> = std::fs::read_dir(&vendor)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !flat.exists(),
+        "--versioned-dirs should prevent the flat `cfg-if/` slot, saw:\n{entries:#?}"
+    );
+    let versioned = entries
+        .iter()
+        .find(|e| e.starts_with("cfg-if-"))
+        .unwrap_or_else(|| panic!("no cfg-if-<version>/ found in vendor, saw:\n{entries:#?}"));
+    assert!(versioned.starts_with("cfg-if-1."));
+}
+
 /// **M3c** — `--verify` against a shared-sync vendor checks both primary
 /// and sync'd Cargo.lock. Hand-corrupt one of the sync'd lockfiles → the
 /// verify step should flag it.


### PR DESCRIPTION
Opt-in fix for #215. Does NOT close the issue — full rollout needs a coordinated follow-up that also migrates hardcoded vendor paths in rpkg/ and minirextendr/.

## What this adds

A `--versioned-dirs` flag that forwards to `cargo vendor --versioned-dirs`. Every vendored crate ends up at `vendor/<name>-<version>/`, including single-version crates that cargo vendor would otherwise flatten to `vendor/<name>/`.

```
cargo revendor --versioned-dirs --manifest-path ws/Cargo.toml --output vendor/
# → vendor/cfg-if-1.0.4/    (not vendor/cfg-if/)
```

## Why opt-in

Flipping the default on today would break hardcoded paths in:
- `rpkg/src/rust/Cargo.toml` — frozen entries like `miniextendr-api = { path = \"../../vendor/miniextendr-api\" }`
- `minirextendr/R/status.R` + `minirextendr/R/vendor.R` — probes `vendor/<crate>/`
- `minirextendr/tests/testthat/test-scaffold-smoke.R` — fixtures

A follow-up PR can coordinate those migrations. For now the flag is available to callers who want the unambiguous layout (#214 class of drift goes away under it).

## Test

New `versioned_dirs_flag_forces_versioned_layout` in `tests/multi_workspace.rs` — asserts the flat slot doesn't exist and a `cfg-if-<version>/` directory does.

## Test plan
- [x] `cargo test --test multi_workspace versioned_dirs -- --ignored` — 1 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)
