### PR TITLE
fix(pages): drop rustdoc .lock from site output (#225)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -78,7 +78,9 @@ jobs:
         run: cd site && zola build
 
       - name: Copy rustdoc into site
-        run: cp -r target/doc site/public/rustdoc
+        run: |
+          cp -r target/doc site/public/rustdoc
+          rm -f site/public/rustdoc/.lock
 
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
Closes #225.

## Summary
- `target/doc/.lock` is cargo's per-target-dir transient lock, created with `0600` permissions by the rustdoc build. Copying it into `site/public/rustdoc/` made it surface as a CI "Invalid file permissions automatically fixed" warning and a stray R CMD check NOTE.
- The lock has no role in the deployed rustdoc — delete it right after the `cp` so neither the Pages permissions fix-up nor any downstream packaging step sees it.

## Test plan
- [x] Fix isolated to `.github/workflows/pages.yml`; no R or Rust code touched
- [ ] Pages workflow run on this PR emits no "Invalid file permissions automatically fixed" warning for `rustdoc/.lock`

Generated with [Claude Code](https://claude.com/claude-code)
