### PR TITLE
fix(minirextendr): vendor_crates_io uses cargo revendor + xattr-safe tar (#249)

### DIFF
--- a/minirextendr/R/vendor.R
+++ b/minirextendr/R/vendor.R
@@ -432,12 +432,17 @@ detect_miniextendr_local <- function(vendor_dir) {
 
 #' Vendor external crates.io dependencies
 #'
-#' Runs `cargo vendor` to download all external crates.io dependencies
-#' (like proc-macro2, syn, quote) for offline/CRAN builds. This is separate
-#' from [vendor_miniextendr()] which vendors the miniextendr workspace crates.
+#' Runs `cargo revendor` to download all external crates.io dependencies
+#' (like proc-macro2, syn, quote) for offline/CRAN builds, including any
+#' workspace path deps that plain `cargo vendor` silently skips. This is
+#' separate from [vendor_miniextendr()] which vendors the miniextendr
+#' workspace crates.
 #'
 #' Most users should use [miniextendr_vendor()] instead, which calls this
 #' function as part of the full CRAN vendor workflow.
+#'
+#' `cargo revendor` must be installed; see
+#' <https://github.com/A2-ai/miniextendr/tree/main/cargo-revendor>.
 #'
 #' @param path Path to the R package root, or `"."` to use the current directory.
 #' @return Invisibly returns TRUE on success
@@ -446,6 +451,7 @@ detect_miniextendr_local <- function(vendor_dir) {
 vendor_crates_io <- function(path = ".") {
   with_project(path)
   check_rust()
+  check_cargo_revendor()
 
   cargo_toml <- usethis::proj_path("src", "rust", "Cargo.toml")
   if (!fs::file_exists(cargo_toml)) {
@@ -457,21 +463,50 @@ vendor_crates_io <- function(path = ".") {
 
   vendor_dir <- usethis::proj_path("vendor")
 
-  cli::cli_alert("Running cargo vendor...")
+  cli::cli_alert("Running cargo revendor...")
 
   result <- run_with_logging(
     "cargo",
-    args = c("vendor", "--manifest-path", cargo_toml, vendor_dir),
-    log_prefix = "cargo-vendor",
+    args = c(
+      "revendor",
+      "--manifest-path", cargo_toml,
+      "--output", vendor_dir,
+      "--strip-all"
+    ),
+    log_prefix = "cargo-revendor",
     wd = usethis::proj_get()
   )
 
-  check_result(result, "cargo vendor")
+  check_result(result, "cargo revendor")
 
-  # Strip CRAN-unfriendly content from vendored crates
+  # Additional CRAN-targeted stripping beyond cargo-revendor's --strip-all:
+  # docs/, ci/, .circleci/, .github/, dotfiles that cargo-revendor preserves.
   strip_vendored_dir(vendor_dir)
 
   cli::cli_alert_success("External dependencies vendored")
+  invisible(TRUE)
+}
+
+#' Verify `cargo revendor` is installed
+#'
+#' Errors with install instructions if the `cargo-revendor` subcommand is
+#' missing. Called by [vendor_crates_io()].
+#'
+#' @keywords internal
+#' @noRd
+check_cargo_revendor <- function() {
+  probe <- suppressWarnings(tryCatch(
+    system2("cargo", c("revendor", "--help"), stdout = FALSE, stderr = FALSE),
+    error = function(e) 127L
+  ))
+  if (!identical(probe, 0L)) {
+    cli::cli_abort(c(
+      "{.code cargo revendor} is not installed",
+      "i" = "Install from the miniextendr repository:",
+      "*" = "{.code cargo install --path cargo-revendor}",
+      "i" = "Source: {.url https://github.com/A2-ai/miniextendr/tree/main/cargo-revendor}"
+    ))
+  }
   invisible(TRUE)
 }
 

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -161,21 +161,24 @@ miniextendr_vendor <- function(path = ".") {
   with_project(path)
   cli::cli_h1("miniextendr vendor workflow")
 
-  # Check for path dependencies that won't be resolved by cargo vendor
+  # Inform the user about path dependencies. cargo revendor extracts these
+  # into vendor/ (unlike plain cargo vendor), but CRAN still requires that
+  # the source tree referenced by `path = ...` is reachable at build time
+  # — `use_vendor_lib()` handles the packaging side.
   path_deps <- check_path_deps()
   if (nrow(path_deps) > 0) {
-    cli::cli_alert_warning(
-      "Found path dependencies in Cargo.toml (these are NOT vendored by {.code cargo vendor}):"
+    cli::cli_alert_info(
+      "Found path dependencies in Cargo.toml (extracted by {.code cargo revendor}):"
     )
     for (i in seq_len(nrow(path_deps))) {
-      cli::cli_bullets(c("!" = "{.val {path_deps$crate[i]}} -> {.path {path_deps$path[i]}}"))
+      cli::cli_bullets(c("i" = "{.val {path_deps$crate[i]}} -> {.path {path_deps$path[i]}}"))
     }
     cli::cli_alert_info(
-      "Use {.code minirextendr::use_vendor_lib()} to configure these for CRAN builds"
+      "If these paths are outside the R package tree, use {.code minirextendr::use_vendor_lib()}"
     )
   }
 
-  # Step 1: cargo vendor + strip (delegates to vendor_crates_io)
+  # Step 1: cargo revendor + strip (delegates to vendor_crates_io)
   cli::cli_h2("Step 1: vendor all dependencies")
   vendor_crates_io()
 
@@ -208,11 +211,33 @@ miniextendr_vendor <- function(path = ".") {
     writeLines(character(), f)
   }
 
-  # Create xz-compressed tarball
-  tar_output <- system2(
-    "tar", c("-cJf", tarball, "-C", staging, "vendor"),
-    stdout = TRUE, stderr = TRUE
+  # Create xz-compressed tarball.
+  # Suppress macOS xattr metadata (AppleDouble `._*` files + LIBARCHIVE.xattr.*
+  # PAX headers) that trigger GNU tar warnings on CRAN Linux machines.
+  # COPYFILE_DISABLE=1 stops `._*` files; --no-xattrs stops PAX headers.
+  old_copyfile <- Sys.getenv("COPYFILE_DISABLE", unset = NA)
+  Sys.setenv(COPYFILE_DISABLE = "1")
+  on.exit(
+    if (is.na(old_copyfile)) Sys.unsetenv("COPYFILE_DISABLE")
+    else Sys.setenv(COPYFILE_DISABLE = old_copyfile),
+    add = TRUE
   )
+  tar_args <- c("-cJf", tarball, "-C", staging, "vendor")
+  has_no_xattrs <- identical(
+    suppressWarnings(tryCatch(
+      system2(
+        "tar",
+        c("--no-xattrs", "-cf", "/dev/null", "--files-from", "/dev/null"),
+        stdout = FALSE, stderr = FALSE
+      ),
+      error = function(e) 127L
+    )),
+    0L
+  )
+  if (has_no_xattrs) {
+    tar_args <- c("--no-xattrs", tar_args)
+  }
+  tar_output <- system2("tar", tar_args, stdout = TRUE, stderr = TRUE)
   if (!is.null(attr(tar_output, "status"))) {
     cli::cli_abort(c(
       "Failed to create vendor tarball",

--- a/minirextendr/man/vendor_crates_io.Rd
+++ b/minirextendr/man/vendor_crates_io.Rd
@@ -13,12 +13,17 @@ vendor_crates_io(path = ".")
 Invisibly returns TRUE on success
 }
 \description{
-Runs \verb{cargo vendor} to download all external crates.io dependencies
-(like proc-macro2, syn, quote) for offline/CRAN builds. This is separate
-from \code{\link[=vendor_miniextendr]{vendor_miniextendr()}} which vendors the miniextendr workspace crates.
+Runs \verb{cargo revendor} to download all external crates.io dependencies
+(like proc-macro2, syn, quote) for offline/CRAN builds, including any
+workspace path deps that plain \verb{cargo vendor} silently skips. This is
+separate from \code{\link[=vendor_miniextendr]{vendor_miniextendr()}} which vendors the miniextendr
+workspace crates.
 }
 \details{
 Most users should use \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} instead, which calls this
 function as part of the full CRAN vendor workflow.
+
+\verb{cargo revendor} must be installed; see
+\url{https://github.com/A2-ai/miniextendr/tree/main/cargo-revendor}.
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #249.

## Summary

- `vendor_crates_io()` now invokes `cargo revendor --strip-all` instead of plain `cargo vendor`. Workspace path deps (which `cargo vendor` silently skips) are now extracted into `vendor/`.
- `miniextendr_vendor()`'s tar step sets `COPYFILE_DISABLE=1` and probes `--no-xattrs` before passing it, mirroring cargo-revendor's `compress_vendor` (vendor.rs:1001–1009). Stops macOS AppleDouble `._*` files and `LIBARCHIVE.xattr.*` PAX headers from contaminating the tarball.
- `check_cargo_revendor()` verifies `cargo-revendor` is on PATH and errors with install instructions if missing.
- The path-deps info message is reworded — cargo-revendor does vendor them, so the old \"NOT vendored by cargo vendor\" language was misleading.

## Test plan

- [x] `just minirextendr-test` — 402 pass, 3 skip (CI-gated network tests), 0 fail.
- [x] Scaffold smoke tests under `devtools::test(filter=\"scaffold-smoke\")`, `CI=false`, `NOT_CRAN=true` — 19/19 pass. Both `miniextendr_vendor()` end-to-end flows (package scaffold + monorepo scaffold) succeed under the new cargo-revendor path, tarballs produced, `cargo check --offline` against the vendored deps works.
- [x] Manual inspection: produced tarball on macOS contains no `._*` AppleDouble entries.

## Out of scope

- `patch_cargo_toml` hardcoded values (#253) — still has two other callers (`vendor_miniextendr()`, not `vendor_crates_io()`), so it can't be deleted here.
- Passing `--freeze` / `--compress` to cargo-revendor — would restructure the `miniextendr_vendor()` flow more than necessary for the critical fix; deferred.

Generated with [Claude Code](https://claude.com/claude-code)
