### PR TITLE
test(cargo-revendor): helpers tolerate versioned-dirs layout (#250)

### DIFF
--- a/cargo-revendor/tests/common/mod.rs
+++ b/cargo-revendor/tests/common/mod.rs
@@ -233,43 +233,123 @@ pub fn create_local_git_crate(name: &str, cargo_toml: &str, lib_rs: &str) -> Loc
 
 // region: vendor assertions
 
-/// Assert that `vendor/<name>/` exists and contains a `Cargo.toml`.
+/// Resolve `vendor/<name>/` or `vendor/<name>-<version>/` to an actual path.
+///
+/// Since cargo-revendor PR #239 flipped `--versioned-dirs` to default, crate
+/// directories live at `vendor/<name>-<version>/`. Tests shouldn't hardcode
+/// either shape — use this helper to probe in order:
+///
+/// 1. Exact `vendor/<name>-<version>/` if `version` is provided.
+/// 2. Any `vendor/<name>-*/` glob match (versioned default).
+/// 3. Flat `vendor/<name>/` fallback (the `--flat-dirs` opt-out path).
+///
+/// Panics with a helpful message if none exists. Mirrors the probe-then-fall-
+/// back pattern in `cargo-revendor/src/verify.rs` (`verify_lock_matches_vendor`)
+/// and `minirextendr/R/vendor.R` (`add_vendor_patches`).
+pub fn vendor_dir_for(vendor: &Path, name: &str, version: Option<&str>) -> PathBuf {
+    if let Some(v) = version {
+        let versioned = vendor.join(format!("{name}-{v}"));
+        if versioned.is_dir() {
+            return versioned;
+        }
+    }
+    if let Ok(entries) = std::fs::read_dir(vendor) {
+        let prefix = format!("{name}-");
+        let mut matches: Vec<PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.is_dir()
+                    && p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with(&prefix))
+            })
+            .collect();
+        if matches.len() == 1 {
+            return matches.pop().unwrap();
+        }
+        if matches.len() > 1 {
+            panic!(
+                "vendor_dir_for({name}): ambiguous — multiple versioned matches in {}: {matches:?}",
+                vendor.display()
+            );
+        }
+    }
+    let flat = vendor.join(name);
+    if flat.is_dir() {
+        return flat;
+    }
+    panic!(
+        "vendor_dir_for({name}): no matching directory in {}",
+        vendor.display()
+    );
+}
+
+/// Does either `vendor/<name>/` or `vendor/<name>-*/` exist?
+///
+/// Use this instead of `vendor.join(name).exists()` in assertions that only
+/// care whether the crate was vendored, not about its exact directory shape.
+pub fn vendor_has(vendor: &Path, name: &str) -> bool {
+    if vendor.join(name).is_dir() {
+        return true;
+    }
+    let prefix = format!("{name}-");
+    std::fs::read_dir(vendor)
+        .ok()
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.path().is_dir())
+                .any(|e| {
+                    e.file_name()
+                        .to_str()
+                        .is_some_and(|n| n.starts_with(&prefix))
+                })
+        })
+        .unwrap_or(false)
+}
+
+/// Assert that `vendor/<name>/` or `vendor/<name>-*/` exists and contains a
+/// `Cargo.toml`.
 pub fn assert_vendor_has(vendor: &Path, name: &str) {
-    let crate_dir = vendor.join(name);
+    let crate_dir = vendor_dir_for(vendor, name, None);
     assert!(
         crate_dir.exists(),
-        "expected vendor/{} to exist at {}",
+        "expected vendor/{} (or versioned equivalent) to exist at {}",
         name,
         vendor.display()
     );
     assert!(
         crate_dir.join("Cargo.toml").exists(),
-        "expected vendor/{}/Cargo.toml",
-        name
+        "expected {}/Cargo.toml",
+        crate_dir.display()
     );
 }
 
-/// Assert that `vendor/<name>/` does NOT exist (matched crate was excluded).
+/// Assert that neither `vendor/<name>/` nor `vendor/<name>-*/` exists (matched
+/// crate was excluded).
 pub fn assert_vendor_missing(vendor: &Path, name: &str) {
     assert!(
-        !vendor.join(name).exists(),
-        "vendor/{} should not exist",
+        !vendor_has(vendor, name),
+        "vendor/{} (or versioned equivalent) should not exist",
         name
     );
 }
 
 /// Read a vendored crate's Cargo.toml as a string (panics on missing file).
 pub fn read_vendor_toml(vendor: &Path, name: &str) -> String {
-    std::fs::read_to_string(vendor.join(name).join("Cargo.toml"))
-        .unwrap_or_else(|_| panic!("failed to read vendor/{}/Cargo.toml", name))
+    let crate_dir = vendor_dir_for(vendor, name, None);
+    std::fs::read_to_string(crate_dir.join("Cargo.toml"))
+        .unwrap_or_else(|_| panic!("failed to read {}/Cargo.toml", crate_dir.display()))
 }
 
 /// Assert a vendored crate's `.cargo-checksum.json` is the empty-files form
 /// (`{"files":{}}`) — what cargo expects from a vendored-sources tree.
 pub fn assert_empty_checksum(vendor: &Path, name: &str) {
-    let cksum = vendor.join(name).join(".cargo-checksum.json");
+    let crate_dir = vendor_dir_for(vendor, name, None);
+    let cksum = crate_dir.join(".cargo-checksum.json");
     let content = std::fs::read_to_string(&cksum)
-        .unwrap_or_else(|_| panic!("no .cargo-checksum.json in vendor/{}", name));
+        .unwrap_or_else(|_| panic!("no .cargo-checksum.json in {}", crate_dir.display()));
     assert_eq!(content, "{\"files\":{}}");
 }
 

--- a/cargo-revendor/tests/edge_cases_diagnostics.rs
+++ b/cargo-revendor/tests/edge_cases_diagnostics.rs
@@ -10,7 +10,9 @@
 
 mod common;
 
-use common::{create_simple_crate, create_workspace, read_vendor_toml, revendor_cmd};
+use common::{
+    create_simple_crate, create_workspace, read_vendor_toml, revendor_cmd, vendor_has,
+};
 
 // region: Edge cases (E1-E5)
 
@@ -75,7 +77,7 @@ path = "lib.rs"
     // or may not land in vendor/ depending on whether dev-deps are resolved
     // in the minimal lockfile. What we care about: the vendored helper (if
     // present) has [dev-dependencies] stripped.
-    if vendor.join("helper").exists() {
+    if vendor_has(&vendor, "helper") {
         let toml = read_vendor_toml(&vendor, "helper");
         assert!(
             !toml.contains("[dev-dependencies]"),
@@ -124,11 +126,11 @@ once_cell = "1"
     // cargo vendor materializes deps for all target triples, not just the
     // host — both cfg-if (unix) and once_cell (windows) should be present.
     assert!(
-        vendor.join("cfg-if").exists(),
+        vendor_has(&vendor, "cfg-if"),
         "expected unix cfg-gated dep to vendor"
     );
     assert!(
-        vendor.join("once_cell").exists(),
+        vendor_has(&vendor, "once_cell"),
         "expected windows cfg-gated dep to vendor"
     );
 }
@@ -168,7 +170,7 @@ my_alias = { package = "cfg-if", version = "1" }
 
     // The renamed dep is stored under the real crate name in vendor/.
     assert!(
-        vendor.join("cfg-if").exists(),
+        vendor_has(&vendor, "cfg-if"),
         "renamed dep should land under its real package name"
     );
 

--- a/cargo-revendor/tests/verify_freeze_compress.rs
+++ b/cargo-revendor/tests/verify_freeze_compress.rs
@@ -12,7 +12,7 @@
 mod common;
 
 use common::{
-    create_simple_crate, diff_trees, extract_tarball, revendor_cmd, TreeDiff,
+    create_simple_crate, diff_trees, extract_tarball, revendor_cmd, vendor_dir_for, TreeDiff,
 };
 
 // region: --verify end-to-end (V1-V5)
@@ -123,7 +123,7 @@ fn verify_catches_stale_tarball() {
         .success();
 
     // Modify a vendored file after the tarball was built.
-    let target = vendor.join("cfg-if").join("Cargo.toml");
+    let target = vendor_dir_for(&vendor, "cfg-if", None).join("Cargo.toml");
     let content = std::fs::read_to_string(&target).unwrap();
     std::fs::write(&target, format!("{content}\n# drift\n")).unwrap();
 


### PR DESCRIPTION
Closes #250.

## Summary

- Adds `vendor_dir_for` + `vendor_has` helpers to `tests/common/mod.rs` that probe versioned first, then flat.
- Rewrites `assert_vendor_has`, `assert_vendor_missing`, `read_vendor_toml`, `assert_empty_checksum` to use them.
- Updates 4 hardcoded `vendor.join(\"<name>\")` sites in `edge_cases_diagnostics.rs` and `verify_freeze_compress.rs`.
- Deliberately leaves the 2 intentional flat-vs-versioned assertions in `multi_workspace.rs` alone, and leaves `integration.rs:1405`'s setup \"stale-crate\" dir alone (arbitrary name, not an assertion).

## Test plan

- [x] `cargo test` — 21 pass, 51 ignored (network-gated).
- [x] `cargo test --test edge_cases_diagnostics -- --ignored` — 6/6 pass.
- [x] `cargo test --test verify_freeze_compress -- --ignored` — 10/10 pass.
- [x] `cargo test --test multi_workspace -- --ignored` — 7/7 pass, including the two intentional flat/versioned assertions.

## Before this fix

The rg gate `rg -n 'vendor\\.join(\"[a-z_][a-zA-Z0-9_-]*\")' cargo-revendor/tests/` returned 8 hits across 4 files — 5 assumption sites + 3 intentional. After this fix, the rg output only shows the 3 intentional sites (`multi_workspace.rs` `flat` vars + `integration.rs` stale-crate setup).

Generated with [Claude Code](https://claude.com/claude-code)
