### PR TITLE
fix(cargo-revendor): RAII ManifestGuard for panic-safe Cargo.toml mutation (#251)

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -11,6 +11,7 @@
 //! - JSON output for machine consumption
 
 mod cache;
+mod manifest_guard;
 mod metadata;
 mod package;
 mod verify;

--- a/cargo-revendor/src/manifest_guard.rs
+++ b/cargo-revendor/src/manifest_guard.rs
@@ -1,0 +1,154 @@
+//! RAII guard for transient `Cargo.toml` mutations.
+//!
+//! Both `run_cargo_vendor` (vendor.rs) and `package_local_crates` (package.rs)
+//! temporarily append a `[patch.crates-io]` block to the workspace manifest,
+//! shell out to cargo, then restore the original. Without a guard, a panic,
+//! `?`-propagated error, or SIGINT between the mutation and the restore
+//! leaves the user's `Cargo.toml` pointing at paths that don't exist yet —
+//! a confusing state that requires manual `git checkout` to recover.
+//!
+//! `ManifestGuard` captures the original bytes at construction and restores
+//! them in `Drop`, so both the success path and any unwinding path (panic,
+//! `?` return) end with the manifest back to its pre-mutation state.
+//!
+//! **Limitation**: `Drop` does NOT run on `std::process::abort()` or on
+//! SIGKILL. That residual gap is accepted — Rust's drop model cannot cover
+//! uncatchable signals, and the common cases (Ctrl-C via SIGINT, cargo
+//! process crash, panic!) do trigger unwinding and thus the restore.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Snapshot + auto-restore of a single file.
+///
+/// Construct before any mutation to the file; the snapshotted bytes are
+/// restored unconditionally when the guard is dropped — including on panic
+/// unwind or early `?` return.
+///
+/// Use `finish()` to dismiss the guard when the mutation is intentional and
+/// should persist (rare — typical cargo-revendor usage is always transient).
+pub struct ManifestGuard {
+    path: PathBuf,
+    original: Vec<u8>,
+    active: bool,
+}
+
+impl ManifestGuard {
+    /// Capture the file's current bytes. The guard arms immediately — any
+    /// subsequent mutation to the file will be reverted on drop.
+    pub fn snapshot(path: &Path) -> Result<Self> {
+        let original = std::fs::read(path)
+            .with_context(|| format!("failed to snapshot {}", path.display()))?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            original,
+            active: true,
+        })
+    }
+
+    /// Dismiss the guard so Drop does nothing. Use when the mutation is
+    /// intended to persist (cargo-revendor doesn't currently do this, but
+    /// the option is here for future callers).
+    #[allow(dead_code)]
+    pub fn finish(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for ManifestGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        // Best-effort restore. If writing back fails (disk full, permission
+        // issue), there's not much we can do from inside Drop — panicking
+        // here would abort the process. Print a diagnostic so the user at
+        // least knows their manifest needs manual recovery.
+        if let Err(e) = std::fs::write(&self.path, &self.original) {
+            eprintln!(
+                "warning: ManifestGuard failed to restore {}: {e} — \
+                 recover with `git checkout {}`",
+                self.path.display(),
+                self.path.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_restores_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Cargo.toml");
+        std::fs::write(&path, b"[workspace]\n").unwrap();
+
+        {
+            let _guard = ManifestGuard::snapshot(&path).unwrap();
+            std::fs::write(&path, b"mutated").unwrap();
+            assert_eq!(std::fs::read(&path).unwrap(), b"mutated");
+        }
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"[workspace]\n");
+    }
+
+    #[test]
+    fn snapshot_restores_on_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Cargo.toml");
+        let original = b"[workspace]\nmembers = []\n";
+        std::fs::write(&path, original).unwrap();
+
+        let path_for_panic = path.clone();
+        let result = std::panic::catch_unwind(move || {
+            let _guard = ManifestGuard::snapshot(&path_for_panic).unwrap();
+            std::fs::write(&path_for_panic, b"mid-flight mutation").unwrap();
+            panic!("simulated cargo panic");
+        });
+
+        assert!(result.is_err(), "expected panic to propagate");
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn finish_dismisses_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Cargo.toml");
+        std::fs::write(&path, b"original").unwrap();
+
+        let guard = ManifestGuard::snapshot(&path).unwrap();
+        std::fs::write(&path, b"intended new content").unwrap();
+        guard.finish();
+
+        // Guard is dismissed; Drop should not restore.
+        assert_eq!(std::fs::read(&path).unwrap(), b"intended new content");
+    }
+
+    #[test]
+    fn snapshot_of_nonexistent_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does-not-exist.toml");
+        let result = ManifestGuard::snapshot(&path);
+        assert!(result.is_err(), "expected snapshot of missing file to error");
+    }
+
+    #[test]
+    fn back_to_back_snapshot_and_restore() {
+        // Common cargo-revendor pattern: snapshot, mutate, shell out, drop.
+        // Then a second call does it again on the same file.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Cargo.toml");
+        std::fs::write(&path, b"[package]\nname = \"x\"\n").unwrap();
+
+        for i in 0..3 {
+            let before = std::fs::read(&path).unwrap();
+            {
+                let _g = ManifestGuard::snapshot(&path).unwrap();
+                std::fs::write(&path, format!("temp-{i}")).unwrap();
+            }
+            assert_eq!(std::fs::read(&path).unwrap(), before, "iteration {i}");
+        }
+    }
+}

--- a/cargo-revendor/src/package.rs
+++ b/cargo-revendor/src/package.rs
@@ -41,6 +41,18 @@ pub fn package_local_crates(
 
         let target_dir = staging_dir.join("package-target");
 
+        // Find workspace root — needed before guards so we know which manifest
+        // to snapshot.
+        let ws_root = crate::find_workspace_root(&pkg.path)?;
+        let ws_manifest = ws_root.join("Cargo.toml");
+
+        // Snapshot both the inner crate manifest and the workspace manifest.
+        // The guards restore both on drop (scope exits at the end of this
+        // iteration, or earlier via `?` / panic unwind).
+        let _inner_guard =
+            crate::manifest_guard::ManifestGuard::snapshot(&pkg.manifest_path)?;
+        let _ws_guard = crate::manifest_guard::ManifestGuard::snapshot(&ws_manifest)?;
+
         // Temporarily rewrite Cargo.toml to add version = "*" to path-only deps
         // (cargo package rejects path deps without a version)
         let manifest_content = std::fs::read_to_string(&pkg.manifest_path)?;
@@ -52,12 +64,8 @@ pub fn package_local_crates(
             }
         }
 
-        // Find workspace root (where .cargo/config.toml will be placed)
-        // cargo resolves config from CWD upward, so we put it at the workspace root
-        let ws_root = crate::find_workspace_root(&pkg.path)?;
         // Add [patch.crates-io] to workspace root Cargo.toml
         // (cargo ignores [patch] in .cargo/config.toml — only Cargo.toml works)
-        let ws_manifest = ws_root.join("Cargo.toml");
         let ws_manifest_original = std::fs::read_to_string(&ws_manifest)?;
         if !ws_manifest_original.contains("[patch.crates-io]") {
             let patched_ws = format!("{}\n{}", ws_manifest_original, patch_config);
@@ -82,13 +90,8 @@ pub fn package_local_crates(
             .output()
             .with_context(|| format!("failed to run cargo package for {}", pkg.name))?;
 
-        // Restore original Cargo.toml if we patched it
-        if patched != manifest_content {
-            std::fs::write(&pkg.manifest_path, &manifest_content)?;
-        }
-
-        // Restore original workspace Cargo.toml
-        std::fs::write(&ws_manifest, &ws_manifest_original)?;
+        // Guards (_inner_guard, _ws_guard) restore both manifests on drop —
+        // no explicit restore needed. Drops run at end of this iteration.
 
         if !output.status.success() {
             // Fallback: cargo package failed (likely unpublished deps).

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -42,6 +42,12 @@ pub fn run_cargo_vendor(
     let ws_root =
         crate::find_workspace_root(manifest_path.parent().context("manifest has no parent")?)?;
     let ws_manifest = ws_root.join("Cargo.toml");
+
+    // ManifestGuard restores the manifest unconditionally on drop (Ok, Err,
+    // or panic unwind), closing the window where SIGINT / panic between the
+    // patch write and the explicit restore below would leave the user's
+    // Cargo.toml pointing at paths that don't yet exist.
+    let _guard = crate::manifest_guard::ManifestGuard::snapshot(&ws_manifest)?;
     let ws_original = std::fs::read_to_string(&ws_manifest)?;
 
     if !local_pkgs.is_empty() && !ws_original.contains("[patch.crates-io]") {
@@ -67,8 +73,8 @@ pub fn run_cargo_vendor(
     cmd.arg(vendor_dir);
     let output = cmd.output().context("failed to run cargo vendor")?;
 
-    // Restore original workspace Cargo.toml
-    std::fs::write(&ws_manifest, &ws_original)?;
+    // Guard restores on drop — no explicit restore needed. Drop order: guard
+    // restores after this function returns (either normally or via ?/panic).
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
Closes #251.

## Summary

- New `cargo-revendor/src/manifest_guard.rs` with `ManifestGuard` that captures bytes at construction and restores on Drop.
- Applied in `vendor.rs::run_cargo_vendor` (workspace manifest).
- Applied in `package.rs::package_local_crates` — both the inner crate manifest and the workspace manifest, guards scoped to each loop iteration.
- 5 unit tests covering Drop-on-scope-exit, Drop-on-panic-unwind, `finish()` dismissal, missing-file error, and the iterative snapshot-and-restore pattern.

## Before

```rust
let ws_original = fs::read_to_string(&ws_manifest)?;
fs::write(&ws_manifest, format!(\"{}{}\", ws_original, patch))?;
// ... cargo shell-out ...
fs::write(&ws_manifest, &ws_original)?;  // only runs on success path
```

SIGINT / panic / `?` return between the two writes left Cargo.toml dirty.

## After

```rust
let _guard = ManifestGuard::snapshot(&ws_manifest)?;
fs::write(&ws_manifest, patched_bytes)?;
// ... cargo shell-out ...
// guard restores on drop — success, error, and panic paths all covered
```

## Test plan

- [x] `cargo test manifest_guard` — 5/5 pass.
- [x] `cargo test` — 26 pass (21 pre-existing + 5 new), 51 ignored (network-gated).
- [x] 3 ignored tests in edge_cases_diagnostics are pre-existing failures tracked in #250 (PR #258); unrelated to this change.

## Residual gap

`std::process::abort` and SIGKILL don't run Drop — no way around this in Rust. Panics, `?`-propagated errors, and SIGINT (via unwind) are all covered.

Generated with [Claude Code](https://claude.com/claude-code)
