### PR TITLE
fix(pages): deploy docs without R, autoconf, or cargo-revendor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,14 +23,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
+    steps:
+      - uses: actions/checkout@v6
+
       # miniextendr-api/build.rs calls `R RHOME` to resolve libR for linking.
       # Rustdoc-only builds don't link — build.rs just has to not panic. The
       # valid-directory check passes with any existing path, so $RUNNER_TEMP
-      # is enough. Same pattern used by dvs2's CI workflow.
-      R_HOME: ${{ runner.temp }}
-    steps:
-      - uses: actions/checkout@v6
+      # is enough. Must be set from a step (the `runner` context is NOT
+      # available in job-level `env:`). Same pattern used by dvs2's CI.
+      - name: Set dummy R_HOME
+        run: echo "R_HOME=$RUNNER_TEMP" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # miniextendr-api/build.rs calls `R RHOME` to resolve libR for linking.
+      # Rustdoc-only builds don't link — build.rs just has to not panic. The
+      # valid-directory check passes with any existing path, so $RUNNER_TEMP
+      # is enough. Same pattern used by dvs2's CI workflow.
+      R_HOME: ${{ runner.temp }}
     steps:
       - uses: actions/checkout@v6
 
@@ -34,21 +40,27 @@ jobs:
           RUSTDOCFLAGS: --cfg=docsrs -Z unstable-options --document-private-items
         run: cargo doc --no-deps -Z rustdoc-map -p miniextendr-api -p miniextendr-macros -p miniextendr-lint
 
-      - name: Install autoconf
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+      # rpkg/src/rust/Cargo.toml [patch.crates-io] points at
+      # ../../vendor/miniextendr-api-0.1.0 etc. The vendor tarball is
+      # committed to the repo — unpack it so the patch paths resolve.
+      # No R / autoconf / cargo-revendor / just configure needed.
+      - name: Restore rpkg vendor directory cache
+        id: rpkg-vendor-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: rpkg/vendor
+          key: ${{ runner.os }}-rpkg-vendor-${{ hashFiles('rpkg/inst/vendor.tar.xz') }}
 
-      - name: Install just
-        uses: taiki-e/install-action@just
+      - name: Unpack rpkg vendor tarball
+        if: steps.rpkg-vendor-cache.outputs.cache-hit != 'true'
+        run: tar -xJf rpkg/inst/vendor.tar.xz -C rpkg
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
-
-      - name: Configure and vendor rpkg
-        run: |
-          just configure
-          just vendor
+      - name: Save rpkg vendor directory cache
+        if: steps.rpkg-vendor-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: rpkg/vendor
+          key: ${{ steps.rpkg-vendor-cache.outputs.cache-primary-key }}
 
       - name: Build rustdoc (rpkg)
         env:


### PR DESCRIPTION
## Summary

The website deploy just runs rustdoc — it doesn't link libR, doesn't run `R CMD` anything, and doesn't need rpkg to go through `./configure`. The pre-#240 workflow was dragging in a full R install + autoconf + cargo-revendor + `just configure && just vendor` for no reason; #240 partially simplified this by removing `setup-r` but broke deploys because `miniextendr-api/build.rs:64` panics on `R RHOME` NotFound.

The dvs2 repo already runs the correct pattern — copy it here.

## Changes

- **Dummy `R_HOME`**: set job-level `R_HOME: \${{ runner.temp }}` so `build.rs`'s directory-exists check passes without a real R install. Rustdoc never consumes `rustc-link-lib=R`.
- **Drop unneeded tooling**: remove `Install autoconf`, `Install just`, `Install cargo-revendor`, and `Configure and vendor rpkg` steps. The rpkg rustdoc only needs cargo to resolve `[patch.crates-io]` paths — the committed `rpkg/inst/vendor.tar.xz` provides those.
- **Cache vendor dir**: `actions/cache` keyed on `hashFiles('rpkg/inst/vendor.tar.xz')` so repeat deploys skip the 22 MB decompress.

## Alternatives considered

- Reinstate `r-lib/actions/setup-r@v2` (first iteration of this PR). Works but adds ~1 min per deploy and is wrong in principle — nothing in the deploy path actually invokes R.
- Gate `build.rs`'s `R RHOME` call behind a `DOCS_RS`-like cfg. More invasive, and the dummy-`R_HOME` approach is already used by the `rust-lint` job in `ci.yml` and the whole dvs2 CI.

## Test plan

- [ ] Workflow runs to completion on this branch
- [ ] Both rustdoc steps succeed (workspace + rpkg)
- [ ] Zola build + artifact upload succeed
- [ ] Second push hits the vendor cache

Unblocks the Pages CI signal on #272/#273/#274 (currently all blocked by failed Pages runs on main).

Generated with [Claude Code](https://claude.com/claude-code)
