### PR TITLE
fix: deploy + website fallout from A2-Ai org move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,7 +509,7 @@ Key paths in R source:
 
 ## Documentation Site
 
-The `site/` directory contains a [Zola](https://www.getzola.org/) static site deployed to GitHub Pages at `https://cgmossa.github.io/miniextendr/`.
+The `site/` directory contains a [Zola](https://www.getzola.org/) static site deployed to GitHub Pages at `https://a2-ai.github.io/miniextendr/`.
 
 ### Structure
 
@@ -554,7 +554,7 @@ GitHub Actions (`.github/workflows/pages.yml`) auto-deploys on push to `main` wh
 3. Copies rustdoc into `site/public/rustdoc/`
 4. Deploys the combined output to GitHub Pages
 
-Rustdoc API reference is at `https://cgmossa.github.io/miniextendr/rustdoc/miniextendr_api/`.
+Rustdoc API reference is at `https://a2-ai.github.io/miniextendr/rustdoc/miniextendr_api/`.
 
 Manual deploy via `workflow_dispatch` is also available.
 

--- a/justfile
+++ b/justfile
@@ -347,17 +347,26 @@ configure-cran:
     NOT_CRAN=false bash ./configure
 
 # Vendor dependencies for CRAN release preparation.
-# Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor
+# Requires cargo-revendor: cargo install --path cargo-revendor (or `just revendor-install`).
 #
 # --force bypasses cargo-revendor's cache (#150): source-only edits to workspace
 # crates leave Cargo.lock untouched, so without --force the cache check skips
 # re-vendoring and ships a stale tarball. Once #150's fix lands on main and is
 # installed, --force becomes harmless (re-runs the full vendor when cache is
 # valid but produces identical output).
+#
+# --source-root points at the monorepo root so cargo-revendor can pre-seed
+# rpkg/vendor/<crate>-<ver>/ before running `cargo metadata`. Required on a
+# fresh clone: rpkg/src/rust/Cargo.toml ships with frozen `path =
+# "../../vendor/..."` deps, and inst/vendor.tar.xz is no longer tracked, so
+# without the source-root pre-seed the first `cargo metadata` call fails
+# with "failed to read .../vendor/miniextendr-api-0.1.0/Cargo.toml" and the
+# whole vendor step aborts. See #280.
 vendor:
     cargo revendor \
       --manifest-path rpkg/src/rust/Cargo.toml \
       --output rpkg/vendor \
+      --source-root . \
       --strip-all \
       --freeze \
       --compress rpkg/inst/vendor.tar.xz \

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://cgmossa.github.io/miniextendr"
+base_url = "https://a2-ai.github.io/miniextendr"
 title = "miniextendr"
 description = "A Rust-R interoperability framework for building R packages with Rust backends"
 compile_sass = false
@@ -20,4 +20,4 @@ lazy_async_image = true
 theme = "github-dark"
 
 [extra]
-repo_url = "https://github.com/CGMossa/miniextendr"
+repo_url = "https://github.com/A2-ai/miniextendr"


### PR DESCRIPTION
Two unrelated issues surfaced after the repo moved from CGMossa to A2-Ai:

### 1. `deploy` workflow's `just vendor` fails (blocks site deploy)

`pages.yml` calls `just vendor`, which calls `cargo revendor --freeze …` with **no** `--source-root`. #280 landed a bootstrap-seed that unblocks the frozen-vendor-path chicken-and-egg, but the seed only fires when `--source-root` is set. The deploy therefore still errored:

```
cargo-revendor: vendoring deps from rpkg/src/rust/Cargo.toml
Error: failed to load metadata from rpkg/src/rust/Cargo.toml
Caused by:
  `cargo metadata` exited with an error: error: failed to load manifest for dependency `miniextendr-api`
  failed to read `rpkg/vendor/miniextendr-api-0.1.0/Cargo.toml`
  No such file or directory (os error 2)
```

Fix: add `--source-root .` to the `vendor` recipe. On warm caches the seed step short-circuits on directories that already contain a Cargo.toml, so no impact.

### 2. Website had no CSS / broken internal links

`site/config.toml` still had:
```
base_url = \"https://cgmossa.github.io/miniextendr\"
[extra] repo_url = \"https://github.com/CGMossa/miniextendr\"
```

Zola uses `base_url` to render every asset URL (stylesheets, JS, favicons, internal anchors). Since the site now deploys at `https://a2-ai.github.io/miniextendr/`, every generated URL pointed at a 404 host and all CSS failed to load. Update both. CLAUDE.md's Documentation Site section picks up the same rename.

### Out of scope

Other `CGMossa/miniextendr` refs in `Cargo.toml` metadata, `minirextendr` install docs, `configure.ac` error messages, etc. — those are a separate repo-wide rename that doesn't affect the deploy or the dead CSS. Leaving for a follow-up so this one stays focused.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
