### PR TITLE
docs: correct ExternalPtr thread-safety and init snippets

### DIFF
--- a/docs/EXTERNALPTR.md
+++ b/docs/EXTERNALPTR.md
@@ -287,14 +287,17 @@ The internal layout of an `ExternalPtr`-created `EXTPTRSXP`:
 
 ```text
 EXTPTRSXP
-  addr  → *mut T (heap-allocated Rust value)
+  addr  → *mut Box<dyn Any> (thin pointer → heap-allocated fat pointer)
+            └→ Box<T> (the actual Rust value)
   tag   → SYMSXP (TYPE_NAME_CSTR, for display)
   prot  → VECSXP[2]
             [0] → SYMSXP (TYPE_ID_CSTR, for type checking)
             [1] → user-protected SEXP (set via set_protected)
 ```
 
-The `prot` slot holds a two-element list. Slot 0 is the namespaced type ID symbol for fast pointer-based type comparison. Slot 1 is available for user-protected R objects that should be kept alive alongside the pointer.
+Internally the value is stored as `Box<Box<dyn Any>>`: the outer `Box` is a thin pointer that fits in R's `EXTPTRSXP` `addr` slot, and the inner `Box<dyn Any>` carries the trait-object vtable needed for `Any::downcast` at retrieval time. This lets one non-generic finalizer (`release_any`) free any `T` without per-type monomorphization. Type safety relies on `Any::downcast`, not on the `prot` symbols.
+
+The `prot` slot holds a two-element list. Slot 0 is the namespaced type ID symbol, retained for display/debug parity; authoritative type checking is `Any::downcast`. Slot 1 is available for user-protected R objects that should be kept alive alongside the pointer.
 
 ## Thread Safety
 

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -120,14 +120,22 @@ Similar to `SendablePtr` but allows null (for allocation failures).
 
 ## ExternalPtr<T> Thread Safety
 
-`ExternalPtr<T>` is **not** `Send` or `Sync` because:
+`ExternalPtr<T>` is `Send` when `T: Send` (declared as
+`unsafe impl<T: TypedExternal + Send> Send for ExternalPtr<T>` in
+`miniextendr-api/src/externalptr.rs`). It is **not** `Sync` — there is no
+interior synchronization, and R's runtime is single-threaded.
 
-1. The underlying SEXP is an R object that should only be accessed on the main thread
-2. R's finalizer registration (`R_RegisterCFinalizerEx`) must happen on main thread
-3. The data pointer can become invalid if R garbage collects the SEXP
+This is sound because the `ExternalPtr` value itself is just an owning handle
+over a heap allocation (`Box<Box<dyn Any>>`); transferring the handle to
+another thread moves ownership, no shared state is created. What is *not*
+allowed from off-thread is calling R API functions on the underlying SEXP —
+R's GC, finalizer registration, and pointer dereference all require the main
+thread.
 
-**Safe pattern**: Create `ExternalPtr` on main thread, return to R. Access only
-via `.Call` entry points (which run on main thread).
+**Safe pattern**: Freely move `ExternalPtr<T: Send>` between Rust threads for
+compute-only work, but perform all R API calls (including construction from
+a SEXP, finalizer registration, and returning to R) on the main thread.
+`.Call` entry points always run on the main thread.
 
 ## R_UnwindProtect
 
@@ -251,16 +259,16 @@ thread panics (there is no routing infrastructure to fall back on).
 
 ## Initialization Requirements
 
-`miniextendr_runtime_init()` must be called before any R API use:
+`miniextendr_runtime_init()` must be called before any R API use. In practice
+this happens via the `miniextendr_init!` macro, which generates
+`R_init_<pkgname>` and calls `package_init()` (which runs
+`miniextendr_runtime_init()` plus wrapper/registration setup):
 
-```c
-void R_init_pkgname(DllInfo *dll) {
-    miniextendr_runtime_init();  // First!
-    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-}
+```rust
+miniextendr_api::miniextendr_init!(pkgname);
 ```
 
-This function:
+See [ENTRYPOINT.md](ENTRYPOINT.md) for the full init sequence. `package_init()`:
 1. Records `R_MAIN_THREAD_ID` for thread checks
 2. With `worker-thread` feature: spawns the worker thread and sets up channels
 3. Without `worker-thread`: only records the thread ID (no thread spawned)
@@ -274,7 +282,7 @@ will cause all subsequent thread checks to be incorrect.
 |-----------|-----------|
 | `R_MAIN_THREAD_ID` | Set once, from main thread, during init |
 | `Sendable<T>` | Value moved, not shared; accessed only at destination |
-| `ExternalPtr<T>` | Not Send/Sync; main thread only |
+| `ExternalPtr<T>` | `Send` when `T: Send`; not `Sync`; R API calls require main thread |
 | `AltrepSexp` | !Send + !Sync; materialization on main thread only |
 | SEXP (via `TryFromSexp`) | ALTREP auto-materialized before function body runs |
 | `R_CONTINUATION_TOKEN` | Created once, preserved for session lifetime |


### PR DESCRIPTION
## Summary

Three factual fixes to `docs/SAFETY.md` and `docs/EXTERNALPTR.md` — the docs drifted from code. Caught while auditing docs during the dvs2 scaffolding refresh.

### Fixes

1. **`SAFETY.md` §ExternalPtr<T> Thread Safety** — claimed `ExternalPtr<T>` is "not Send or Sync". Code (`miniextendr-api/src/externalptr.rs:331`):
   ```rust
   unsafe impl<T: TypedExternal + Send> Send for ExternalPtr<T> {}
   ```
   Rewrote to explain: `Send` when `T: Send`, never `Sync`, and the single-thread rule applies to R API calls on the underlying SEXP — not to movement of the owning handle.

2. **`SAFETY.md` §Initialization Requirements** — showed a manual C `R_init_pkgname` stub. That's been obsolete since the cdylib entrypoint landed (commit c14092f0, 2026-03-09). Replaced with `miniextendr_api::miniextendr_init!(pkgname);` and a pointer to `ENTRYPOINT.md`.

3. **`SAFETY.md` summary-of-invariants table** — updated the `ExternalPtr<T>` row to match the new text.

4. **`EXTERNALPTR.md` §SEXP Layout** — diagram said `addr → *mut T`. Actual storage is `Box<Box<dyn Any>>` (thin outer pointer fits in `EXTPTRSXP`, fat inner pointer carries the vtable for `Any::downcast`). Updated the diagram and clarified that authoritative type checking is `Any::downcast`, not the prot-slot type-id symbol.

## Test plan

- [x] `git grep` confirms no remaining "not Send/Sync" / "!Send ExternalPtr" claims in `docs/`
- [ ] Visual review of rendered markdown on the PR

Generated with [Claude Code](https://claude.com/claude-code)
