### PR TITLE
docs(CLAUDE): clarify site/content/manual is auto-generated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ Zola static site in `site/` → GitHub Pages at `https://a2-ai.github.io/miniext
 
 GitHub Actions auto-deploys on push to `main` when `site/**`, `docs/**`, or `*/src/**` changes: runs `scripts/docs-to-site.sh` → builds nightly rustdoc (`--document-private-items --document-hidden-items --show-type-layout --enable-index-page --generate-link-to-definition -Z rustdoc-map`) → builds Zola → copies rustdoc to `site/public/rustdoc/` → deploys. Rustdoc index at `.../rustdoc/`; individual crates at `.../rustdoc/miniextendr_api/` etc.
 
-`site/content/manual/` is **auto-generated from `docs/`** by `scripts/docs-to-site.sh` (1:1 conversion, not curated summaries). Edit `docs/*.md` only — never edit `site/content/manual/*.md` directly.
+`site/content/manual/` is **auto-generated from `docs/`** by `scripts/docs-to-site.sh` (1:1 conversion, not curated summaries). Edit `docs/*.md` only — never edit `site/content/manual/*.md` directly. The generator derives frontmatter (title + description) from each doc's `# Heading` and first paragraph. `site/content/_index.md` and anything outside `manual/` are hand-authored and must be edited directly.
 
 **After editing `docs/`, regenerate and commit both together**: `bash scripts/docs-to-site.sh && git add docs/ site/content/manual/`. CI runs `docs-to-site.sh` itself before each deploy, so the live site is always correct — but the in-repo `site/content/manual/` drifts out of sync if you skip the regenerate step, making subsequent diffs noisy and masking unrelated site edits.
 


### PR DESCRIPTION
## Summary

The CLAUDE.md section on the docs site says:

> `site/content/` pages are curated summaries of `docs/` — not 1:1 copies. When updating `docs/`, check if the corresponding site page needs updating.

That's wrong and I nearly amended stale site/ edits into #287 and #288 before realising. The truth, confirmed via `.github/workflows/pages.yml`:

1. `pages.yml` runs `scripts/docs-to-site.sh` on every deploy.
2. That script regenerates `site/content/manual/*.md` from `docs/*.md` with derived frontmatter.
3. Whatever is committed under `site/content/manual/` gets overwritten at build time — edits there are discarded.

So the right rule is "edit docs/, leave `site/content/manual/` alone". `site/content/_index.md` and anything outside `manual/` are still hand-authored (the script only touches `manual/`).

## Test plan

- [x] Verified `pages.yml:90` runs `scripts/docs-to-site.sh` on every push to main matching `docs/**`
- [x] Verified `scripts/docs-to-site.sh` writes to `site/content/manual/` (default second arg)
- [ ] No runtime verification needed — this is a CLAUDE.md doc fix

Generated with [Claude Code](https://claude.com/claude-code)
