### PR TITLE
fix(install): auto-vendor on downstream git install

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -56,9 +56,15 @@ struct Cli {
     #[arg(hide = true, default_value = "revendor")]
     _subcommand: String,
 
-    /// Path to the Cargo.toml of the R package's Rust crate
-    #[arg(long, default_value = "src/rust/Cargo.toml")]
-    manifest_path: PathBuf,
+    /// Path to the Cargo.toml of the R package's Rust crate.
+    ///
+    /// When omitted, cargo-revendor searches the current directory for a
+    /// plausible R-package layout: first `src/rust/Cargo.toml` (canonical),
+    /// then `./Cargo.toml` (running from inside the Rust crate), then any
+    /// single subdirectory matching `*/src/rust/Cargo.toml` (e.g. running
+    /// from a workspace root where the R package is in a subdir).
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
 
     /// Output directory for vendored crates
     #[arg(long, short, default_value = "vendor")]
@@ -208,10 +214,7 @@ fn main() -> Result<()> {
     // versioned_dirs is default-on; only disable when --flat-dirs is passed
     let versioned_dirs = !cli.flat_dirs;
 
-    let manifest_path = cli
-        .manifest_path
-        .canonicalize()
-        .with_context(|| format!("manifest not found: {}", cli.manifest_path.display()))?;
+    let manifest_path = resolve_manifest_path(cli.manifest_path.as_deref())?;
 
     if v.info() && !cli.verify {
         eprintln!(
@@ -529,6 +532,71 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Resolve `--manifest-path`, auto-discovering a plausible R-package layout
+/// when the flag is omitted.
+///
+/// Search order, from the current working directory:
+/// 1. `src/rust/Cargo.toml` (canonical R-package layout)
+/// 2. `./Cargo.toml` (CWD is the Rust crate itself)
+/// 3. `*/src/rust/Cargo.toml` (R package lives in a subdirectory — e.g.
+///    running from a repo root where the R package is `dvs-rpkg/`)
+///
+/// When the user passes `--manifest-path`, we trust them — no discovery.
+fn resolve_manifest_path(user_path: Option<&std::path::Path>) -> Result<PathBuf> {
+    if let Some(p) = user_path {
+        return p
+            .canonicalize()
+            .with_context(|| format!("manifest not found: {}", p.display()));
+    }
+    let cwd = std::env::current_dir().context("cannot read current directory")?;
+    let canonical = cwd.join("src/rust/Cargo.toml");
+    if canonical.exists() {
+        return canonical.canonicalize().context("manifest not found");
+    }
+    // Running from inside the Rust crate itself (has Cargo.toml + src/lib.rs or src/main.rs).
+    let in_crate = cwd.join("Cargo.toml");
+    if in_crate.exists()
+        && (cwd.join("src/lib.rs").exists() || cwd.join("src/main.rs").exists())
+    {
+        return in_crate.canonicalize().context("manifest not found");
+    }
+    // Subdirectory layout: R package in a subdir (e.g. dvs-rpkg/src/rust/Cargo.toml).
+    let mut hits: Vec<PathBuf> = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(&cwd) {
+        for entry in rd.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let candidate = entry.path().join("src").join("rust").join("Cargo.toml");
+            if candidate.exists() {
+                hits.push(candidate);
+            }
+        }
+    }
+    match hits.len() {
+        0 => anyhow::bail!(
+            "no Cargo.toml found at `src/rust/Cargo.toml`, `./Cargo.toml`, or `*/src/rust/Cargo.toml`.\n\
+             Pass `--manifest-path <path>` or run from your R package's directory."
+        ),
+        1 => hits
+            .into_iter()
+            .next()
+            .unwrap()
+            .canonicalize()
+            .context("manifest not found"),
+        _ => {
+            let list = hits
+                .iter()
+                .map(|p| format!("  {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::bail!(
+                "multiple candidate manifests found; disambiguate with `--manifest-path`:\n{list}"
+            );
+        }
+    }
 }
 
 /// Verify that Cargo.lock, vendor/, and (optionally) the tarball agree.

--- a/cargo-revendor/tests/edge_cases_diagnostics.rs
+++ b/cargo-revendor/tests/edge_cases_diagnostics.rs
@@ -382,3 +382,69 @@ cfg-if = "1"
 }
 
 // endregion
+
+// region: Manifest auto-discovery (no --manifest-path)
+
+/// **D3** — when `--manifest-path` is omitted, pick up a canonical
+/// `src/rust/Cargo.toml` laid out relative to the current directory.
+#[test]
+fn auto_discovers_canonical_rpkg_layout() {
+    use predicates::prelude::PredicateBooleanExt;
+    let dir = tempfile::tempdir().unwrap();
+    let rust = dir.path().join("src/rust");
+    std::fs::create_dir_all(&rust).unwrap();
+    std::fs::write(
+        rust.join("Cargo.toml"),
+        "[package]\nname=\"p\"\nversion=\"0.0.0\"\nedition=\"2021\"\n[lib]\npath=\"lib.rs\"\n",
+    )
+    .unwrap();
+    std::fs::write(rust.join("lib.rs"), "").unwrap();
+
+    // No --manifest-path; should not bail out on discovery.
+    revendor_cmd()
+        .current_dir(dir.path())
+        .args(["revendor", "--verify", "--output", "vendor-never-created"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("no Cargo.toml found").not());
+}
+
+/// **D4** — when `--manifest-path` is omitted and the R package is in a
+/// subdirectory (e.g. `dvs-rpkg/src/rust/Cargo.toml`), auto-discover it.
+#[test]
+fn auto_discovers_subdir_layout() {
+    use predicates::prelude::PredicateBooleanExt;
+    let dir = tempfile::tempdir().unwrap();
+    let rust = dir.path().join("dvs-rpkg/src/rust");
+    std::fs::create_dir_all(&rust).unwrap();
+    std::fs::write(
+        rust.join("Cargo.toml"),
+        "[package]\nname=\"p\"\nversion=\"0.0.0\"\nedition=\"2021\"\n[lib]\npath=\"lib.rs\"\n",
+    )
+    .unwrap();
+    std::fs::write(rust.join("lib.rs"), "").unwrap();
+
+    revendor_cmd()
+        .current_dir(dir.path())
+        .args(["revendor", "--verify", "--output", "vendor-never-created"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("no Cargo.toml found").not());
+}
+
+/// **D5** — when no plausible manifest exists anywhere, fail with a clear
+/// message pointing at `--manifest-path`.
+#[test]
+fn no_manifest_nearby_gives_helpful_error() {
+    let dir = tempfile::tempdir().unwrap();
+
+    revendor_cmd()
+        .current_dir(dir.path())
+        .args(["revendor"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("no Cargo.toml found"))
+        .stderr(predicates::str::contains("--manifest-path"));
+}
+
+// endregion

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -452,14 +452,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -452,14 +452,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3771,13 +3771,34 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+                                            if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+                        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
  ;;
     "post-vendor":C)

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -460,14 +460,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])

--- a/tests/cross-package/consumer.pkg/configure
+++ b/tests/cross-package/consumer.pkg/configure
@@ -3764,13 +3764,34 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+                                            if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+                        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
  ;;
     "post-vendor":C)

--- a/tests/cross-package/consumer.pkg/configure.ac
+++ b/tests/cross-package/consumer.pkg/configure.ac
@@ -452,14 +452,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])

--- a/tests/cross-package/producer.pkg/configure
+++ b/tests/cross-package/producer.pkg/configure
@@ -3764,13 +3764,34 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+                                            if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+                        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
  ;;
     "post-vendor":C)

--- a/tests/cross-package/producer.pkg/configure.ac
+++ b/tests/cross-package/producer.pkg/configure.ac
@@ -452,14 +452,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using existing vendor/"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' to vendor deps." >&2
-      echo "configure:        Requires cargo-revendor: cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])

--- a/tests/model_project/configure
+++ b/tests/model_project/configure
@@ -3747,12 +3747,34 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "configure: dev mode — using vendor/ from scaffolding"
     fi
   else
-        if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' before CRAN submission." >&2
-      exit 1
+                                            if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+                        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
  ;;
     "post-vendor":C)

--- a/tests/model_project/configure.ac
+++ b/tests/model_project/configure.ac
@@ -422,13 +422,46 @@ AC_CONFIG_COMMANDS([cargo-vendor],
       echo "configure: dev mode — using vendor/ from scaffolding"
     fi
   else
-    dnl CRAN/offline mode: vendor/ must exist
+    dnl CRAN/offline mode: vendor/ must exist.
+    dnl
+    dnl Priority 1 (tarball): already attempted at the top of this block —
+    dnl a real CRAN tarball always ships inst/vendor.tar.xz.
+    dnl
+    dnl Priority 2 (downstream first-install): install.packages(),
+    dnl remotes::install_github(), or rv sync cloned from git without a
+    dnl committed vendor tarball. We can't reliably tell this apart from a
+    dnl real CRAN build, so instead of erroring we auto-vendor when
+    dnl cargo-revendor is installed (and the network is available).
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
-      echo "configure: error: CRAN build requires vendored sources." >&2
-      echo "configure:        Run 'just vendor' before CRAN submission." >&2
-      exit 1
+      if command -v cargo-revendor >/dev/null 2>&1; then
+        echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        cargo revendor \
+          --manifest-path src/rust/Cargo.toml \
+          --output "$VENDOR_OUT" \
+          --strip-all \
+          --source-marker \
+          -v || {
+          echo "configure: error: cargo revendor failed" >&2
+          echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
+          echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          exit 1
+        }
+        dnl Strip checksums from Cargo.lock so cargo accepts the vendored
+        dnl copies (same post-step as the tarball-unpack path above).
+        if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+          $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
+        fi
+        echo "configure: auto-vendored — vendor ready"
+      else
+        echo "configure: error: vendored sources required but vendor/ and inst/vendor.tar.xz are both missing." >&2
+        echo "configure:        Install cargo-revendor to auto-vendor on first install:" >&2
+        echo "configure:          cargo install --git https://github.com/CGMossa/miniextendr cargo-revendor" >&2
+        echo "configure:        Or commit inst/vendor.tar.xz alongside the package." >&2
+        exit 1
+      fi
+    else
+      echo "configure: CRAN build — vendor ready"
     fi
-    echo "configure: CRAN build — vendor ready"
   fi
 ],
 [NOT_CRAN="$NOT_CRAN" VENDOR_OUT="$VENDOR_OUT" abs_rpkg_src="$abs_rpkg_src" abs_rpkg_dir="$abs_top_srcdir" SED="$SED" FORCE_VENDOR="$FORCE_VENDOR" CARGO_CMD="$CARGO_CMD" R_HOME="$R_HOME" TAR_FORCE_LOCAL="$TAR_FORCE_LOCAL"])


### PR DESCRIPTION
## Summary

Two root causes blocked `rv sync` / `install.packages()` on git-installed downstream R packages (e.g. `dvs2/dvs-rpkg`):

1. `cargo-revendor` hard-defaulted `--manifest-path` to `src/rust/Cargo.toml`. Non-standard layouts (R package in a subdirectory) hit `manifest not found` on a bare `cargo revendor` invocation.
2. `configure.ac`'s `NOT_CRAN=false` branch errored with `CRAN build requires vendored sources` whenever both `vendor/` and `inst/vendor.tar.xz` were missing — which is exactly the state of a fresh `remotes::install_github()` / `rv sync` on a package that doesn't commit the tarball.

## Changes

**`cargo-revendor`**
- `--manifest-path` is now optional. Auto-discovers in order:
  - `src/rust/Cargo.toml` (canonical R-package layout)
  - `./Cargo.toml` + `src/lib.rs` (running from inside the crate)
  - `*/src/rust/Cargo.toml` (R package in a subdirectory — `dvs-rpkg/` case)
- Ambiguous or missing cases produce a clear error pointing at `--manifest-path`.
- 3 new tests in `tests/edge_cases_diagnostics.rs`.

**`configure.ac` (rpkg + both templates + 2 cross-package fixtures + `tests/model_project`)**
- When `vendor/` and `inst/vendor.tar.xz` are both missing, auto-vendor via `cargo revendor` if it's on PATH.
- Stripping checksums from `Cargo.lock` after auto-vendoring mirrors the tarball-unpack path.
- Only errors out when `cargo-revendor` is also missing, with clear remediation.
- Regenerated all tracked `configure` scripts.

## Test plan

- [x] `cargo test -p cargo-revendor` — 53 passed (includes 3 new auto-discovery tests)
- [x] `cargo clippy --all-targets --locked -- -D warnings` on `cargo-revendor` — clean
- [x] `just templates-check` — no drift
- [x] `just configure` (dev-monorepo mode) — still populates `rpkg/vendor/` and removes dev cargo config
- [x] Simulated dvs2 layout: `cargo-revendor` invoked from a wrapping dir auto-discovers `dvs-rpkg/src/rust/Cargo.toml`
- [ ] Full downstream `install.packages()` cycle verified against `dvs2/dvs-rpkg` — pairs with the dvs2 PR

Generated with [Claude Code](https://claude.com/claude-code)
