### PR TITLE
fix(install): bootstrap-clone miniextendr for auto-vendor on isolated install

### DIFF
--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3774,17 +3774,43 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
                                             if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
       if command -v cargo-revendor >/dev/null 2>&1; then
         echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+                                                                        _source_root_arg=""
+        _bootstrap_clone=""
+        if grep -q 'path = "\.\./\.\./vendor/' src/rust/Cargo.toml; then
+          if command -v git >/dev/null 2>&1; then
+            _bootstrap_clone="`mktemp -d 2>/dev/null || mktemp -d -t miniextendr-bootstrap.XXXXXX`"
+            echo "configure: cloning miniextendr for --source-root bootstrap: $_bootstrap_clone"
+            if git clone --depth=1 --quiet https://github.com/CGMossa/miniextendr "$_bootstrap_clone"; then
+              _source_root_arg="--source-root $_bootstrap_clone"
+            else
+              echo "configure: error: git clone of miniextendr failed" >&2
+              echo "configure:        Auto-vendor requires network access to bootstrap path deps." >&2
+              rm -rf "$_bootstrap_clone"
+              exit 1
+            fi
+          else
+            echo "configure: error: git required to bootstrap path deps for auto-vendor" >&2
+            exit 1
+          fi
+        fi
         cargo revendor \
           --manifest-path src/rust/Cargo.toml \
           --output "$VENDOR_OUT" \
           --strip-all \
           --source-marker \
+          $_source_root_arg \
           -v || {
           echo "configure: error: cargo revendor failed" >&2
           echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
           echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          if test -n "$_bootstrap_clone" && test -d "$_bootstrap_clone"; then
+            rm -rf "$_bootstrap_clone"
+          fi
           exit 1
         }
+        if test -n "$_bootstrap_clone" && test -d "$_bootstrap_clone"; then
+          rm -rf "$_bootstrap_clone"
+        fi
                         if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
           $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
         fi

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -473,17 +473,51 @@ AC_CONFIG_COMMANDS([cargo-vendor],
     if test ! -d "$VENDOR_OUT" || test -z "`ls -A \"$VENDOR_OUT\" 2>/dev/null`"; then
       if command -v cargo-revendor >/dev/null 2>&1; then
         echo "configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)"
+        dnl rpkg/src/rust/Cargo.toml uses path deps pointing at ../../vendor/
+        dnl (miniextendr-api, miniextendr-lint, miniextendr-macros). cargo
+        dnl metadata cannot resolve them when vendor/ is empty, so
+        dnl cargo-revendor also can't run. The --source-root bootstrap in
+        dnl cargo-revendor pre-seeds vendor/<name>/ from a workspace
+        dnl checkout; in an isolated install (R extracted rpkg/ alone, no
+        dnl monorepo in sight), clone miniextendr from github and hand
+        dnl that to --source-root so cargo metadata can walk the graph.
+        _source_root_arg=""
+        _bootstrap_clone=""
+        if grep -q 'path = "\.\./\.\./vendor/' src/rust/Cargo.toml; then
+          if command -v git >/dev/null 2>&1; then
+            _bootstrap_clone="`mktemp -d 2>/dev/null || mktemp -d -t miniextendr-bootstrap.XXXXXX`"
+            echo "configure: cloning miniextendr for --source-root bootstrap: $_bootstrap_clone"
+            if git clone --depth=1 --quiet https://github.com/CGMossa/miniextendr "$_bootstrap_clone"; then
+              _source_root_arg="--source-root $_bootstrap_clone"
+            else
+              echo "configure: error: git clone of miniextendr failed" >&2
+              echo "configure:        Auto-vendor requires network access to bootstrap path deps." >&2
+              rm -rf "$_bootstrap_clone"
+              exit 1
+            fi
+          else
+            echo "configure: error: git required to bootstrap path deps for auto-vendor" >&2
+            exit 1
+          fi
+        fi
         cargo revendor \
           --manifest-path src/rust/Cargo.toml \
           --output "$VENDOR_OUT" \
           --strip-all \
           --source-marker \
+          $_source_root_arg \
           -v || {
           echo "configure: error: cargo revendor failed" >&2
           echo "configure:        If offline, either commit inst/vendor.tar.xz alongside the" >&2
           echo "configure:        package, or run 'cargo revendor' manually with network access." >&2
+          if test -n "$_bootstrap_clone" && test -d "$_bootstrap_clone"; then
+            rm -rf "$_bootstrap_clone"
+          fi
           exit 1
         }
+        if test -n "$_bootstrap_clone" && test -d "$_bootstrap_clone"; then
+          rm -rf "$_bootstrap_clone"
+        fi
         dnl Strip checksums from Cargo.lock so cargo accepts the vendored
         dnl copies (same post-step as the tarball-unpack path above).
         if test -f "$abs_rpkg_src/rust/Cargo.lock"; then


### PR DESCRIPTION
## What

Stacked on top of #292. On fresh isolated install of miniextendr's own `rpkg` (no `vendor/`, no `inst/vendor.tar.xz`), the auto-vendor fallback added in #292 couldn't run because `cargo metadata` failed before cargo-revendor even started. This PR fixes that by cloning miniextendr from github and passing it to cargo-revendor as `--source-root`.

## Why

`rpkg/src/rust/Cargo.toml` uses path deps pointing into `vendor/`:

```toml
[dependencies]
miniextendr-api = { version = "*", path = "../../vendor/miniextendr-api" }

[build-dependencies]
miniextendr-lint = { version = "*", path = "../../vendor/miniextendr-lint" }

[patch.crates-io]
miniextendr-api    = { path = "../../vendor/miniextendr-api" }
miniextendr-lint   = { path = "../../vendor/miniextendr-lint" }
miniextendr-macros = { path = "../../vendor/miniextendr-macros" }
```

When `vendor/` is empty (fresh git extract, no committed tarball), `cargo metadata` errors with \"failed to read vendor/miniextendr-api/Cargo.toml\" before cargo-revendor can do anything. Downstream packages don't hit this because they declare git deps (see A2-ai/dvs2#133 for the equivalent downstream fix).

In monorepo dev, `configure.ac` hands cargo-revendor the workspace root via `--source-root`, which triggers its bootstrap-seed step — copies workspace crates into `vendor/<name>/` so `cargo metadata` can resolve. Isolated install never had a workspace root to hand over.

## Fix

In the auto-vendor fallback (CRAN-mode branch), detect the `path = \"../../vendor/\"` pattern in `Cargo.toml`. When it's present:

1. `git clone --depth=1` miniextendr into a tempdir
2. Pass `--source-root <tempdir>` to `cargo revendor`
3. cargo-revendor's existing bootstrap-seeding takes it from there
4. Clean up the tempdir afterward (on success and failure)

Path-dep shape keeps the monorepo dev iteration flow intact — local changes to `miniextendr-api/` still propagate through `just configure` because the monorepo detection is unchanged.

Downstream packages (no `path = \"../../vendor/\"` in their manifest) skip the clone and hit the original #292 fallback unchanged.

## Verified

Ran `bash ./configure` against an rpkg copy with `vendor/`, `inst/vendor.tar.xz`, and `Cargo.lock` all removed:

```
configure: cloning miniextendr for --source-root bootstrap: /tmp/…/tmp.pzmoyz4TC9
cargo-revendor: vendoring deps from …/rpkg/src/rust/Cargo.toml
  bootstrapped 6 workspace crate(s) into vendor/ so metadata can resolve
  …
cargo-revendor: vendored 3 local + 358 external deps
configure: auto-vendored — vendor ready
```

`vendor/` contains `miniextendr-api/`, `miniextendr-lint/`, `miniextendr-macros/` and the full transitive dep closure.

## Test plan

- [ ] Existing CI green (monorepo dev + CRAN tarball flows unchanged)
- [ ] Manual `install.packages()` / `remotes::install_github(\"A2-ai/miniextendr\", subdir = \"rpkg\")` from a host with `cargo-revendor` installed
- [ ] `rv sync` of a demo project that pulls miniextendr as a git source
