### PR TITLE
docs: fix broken external links flagged by zola check

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -57,8 +57,12 @@ Only `default` features are enabled automatically.
 | `sha2` | SHA-256/SHA-512 hashing helpers | sha2 |
 | **Formatting** | | |
 | `tabled` | ASCII/Unicode table formatting | tabled |
+| **Arrow / DataFusion** | | |
+| `arrow` | Zero-copy R vector / data.frame to Apache Arrow array conversions | arrow-array, arrow-buffer, arrow-schema, arrow-select |
+| `datafusion` | SQL query engine on R data frames via DataFusion (implies `arrow`) | datafusion, tokio |
+| **Logging** | | |
+| `log` | Routes Rust `log` macros (`info!`, `warn!`, `error!`) to R console | log |
 | **Diagnostics** | | |
-| `materialization-tracking` | Logs ALTREP materializations for diagnostics | (none) |
 | `macro-coverage` | Macro expansion coverage module for auditing | (none) |
 
 ---
@@ -863,20 +867,56 @@ cat(format_scores(c("Alice", "Bob"), c(95, 87)))
 
 ---
 
-## Diagnostic Features
+## Arrow / DataFusion Features
 
-### `materialization-tracking`
+### `arrow`
 
-Logs every ALTREP `Dataptr` call, which is when R forces a lazy/compact vector to
-materialize into contiguous memory. Useful for diagnosing unexpected materializations
-that negate ALTREP performance benefits.
+Zero-copy conversions between R vectors/data.frames and Apache Arrow arrays/RecordBatch.
+Foundation for DataFusion and other Arrow-based tools.
 
-Zero-cost when disabled (no runtime overhead).
+**Supported types (zero-copy where R memory layout matches Arrow):**
+- Scalar arrays: `Float64Array`, `Int32Array`, `BooleanArray`, `StringArray`, etc.
+- `RecordBatch` -- round-trips R data.frames column by column
 
-**From R:**
-```r
-miniextendr:::altrep_materialization_count()
+See [ARROW.md](ARROW.md) for the full guide.
+
+### `datafusion`
+
+SQL query engine on R data frames via Apache DataFusion. Depends on `arrow`.
+Provides `RSessionContext` for running SQL queries on R data frames.
+
+Uses Tokio internally (`current_thread` / `block_on`) -- NOT `rt-multi-thread`.
+
+**Provides:**
+- `RSessionContext` -- register R data frames as tables, execute SQL
+- `execute_sql()`, `collect_to_r()` helpers
+
+---
+
+## Logging Features
+
+### `log`
+
+Routes Rust `log` macros (`info!`, `warn!`, `error!`, `debug!`, `trace!`) to R's
+console output (`Rprintf`/`REprintf`). The logger is installed automatically during
+`package_init()` -- no setup needed beyond enabling the feature.
+
+```rust
+use log::{info, warn};
+
+#[miniextendr]
+pub fn process_data(n: i32) -> i32 {
+    info!("Processing {} rows", n);
+    if n > 10000 {
+        warn!("Large input -- this may be slow");
+    }
+    n * 2
+}
 ```
+
+---
+
+## Diagnostic Features
 
 ### `macro-coverage`
 
@@ -953,6 +993,8 @@ Feature implications (automatically enabled):
 | `serde_json` | `serde` |
 | `rand_distr` | `rand` |
 | `indicatif` | `nonapi` |
+| `datafusion` | `arrow` |
+| `default-worker` | `worker-thread` |
 
 ---
 

--- a/docs/LINKING.md
+++ b/docs/LINKING.md
@@ -158,4 +158,4 @@ miniextendr always links dynamically to `libR`:
 ## See Also
 
 - [R Installation and Administration](https://cran.r-project.org/doc/manuals/r-release/R-admin.html)
-- [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front-ends-to-R)
+- [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front_002dends-to-R)

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -293,5 +293,5 @@ will cause all subsequent thread checks to be incorrect.
 ## Reporting Safety Issues
 
 If you discover a soundness issue in miniextendr, please report it via
-[GitHub Issues](https://github.com/miniextendr/miniextendr/issues) with the
+[GitHub Issues](https://github.com/A2-ai/miniextendr/issues) with the
 `[SAFETY]` tag.

--- a/docs/archive/ALTREP_PERFORMANCE_REPORT.md
+++ b/docs/archive/ALTREP_PERFORMANCE_REPORT.md
@@ -651,7 +651,7 @@ Memory allocation measured via:
 
 2. **ALTREP System**: R Core Team. (2019). "ALTREP: Alternative Representations for R Objects" in *R Internals*. https://cran.r-project.org/doc/manuals/r-release/R-ints.html#ALTREP
 
-3. **miniextendr**: miniextendr Development Team. (2026). *miniextendr: Rust-R Interoperability Framework*. https://github.com/miniextendr/miniextendr
+3. **miniextendr**: miniextendr Development Team. (2026). *miniextendr: Rust-R Interoperability Framework*. https://github.com/A2-ai/miniextendr
 
 4. **Performance Best Practices**: Neal, R. (2014). "Inaccurate results from microbenchmark". https://radfordneal.wordpress.com/2014/02/02/inaccurate-results-from-microbenchmark/
 
@@ -665,4 +665,4 @@ Memory allocation measured via:
 
 ---
 
-**For questions or feedback**, please file an issue at: https://github.com/miniextendr/miniextendr/issues
+**For questions or feedback**, please file an issue at: https://github.com/A2-ai/miniextendr/issues

--- a/scripts/docs-to-site.sh
+++ b/scripts/docs-to-site.sh
@@ -162,10 +162,18 @@ for doc in "$DOCS_DIR"/*.md; do
     fi
     echo "+++"
     echo ""
-    # Skip the first line (# Title) and any blank line immediately after
+    # Skip the first line (# Title) and any blank line immediately after.
+    # Also rewrite cross-doc links: FOO_BAR.md → ../foo-bar/ so they resolve
+    # correctly in Zola (which serves pages at /manual/foo-bar/, not /manual/FOO_BAR.md).
     tail -n +2 "$doc" | sed '1{
 /^$/d
-}'
+}' | perl -pe '
+  s{\(([A-Z][A-Z0-9_]+)\.md(#[^)]+)?\)}{
+    my ($name, $anchor) = ($1, $2 // "");
+    my $slug = lc($name) =~ s/_/-/gr;
+    "(../$slug/$anchor)"
+  }ge
+'
   } > "$CONTENT_DIR/${slug}.md"
 done
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -22,6 +22,24 @@ diffs noisy and masks unrelated site edits.
 (`cd site && zola serve`) do **not** call `docs-to-site.sh`. Run the
 script by hand when previewing doc edits locally.
 
+Inter-doc links in `docs/*.md` use bare `UPPERCASE.md` references
+(house style). `docs-to-site.sh` rewrites these to Zola-compatible
+`../kebab-case/` paths during conversion, so `[SAFETY.md](SAFETY.md)`
+in a doc becomes `[SAFETY.md](../safety/)` in the generated page.
+Anchor fragments (`GAPS.md#41-r-...`) are preserved.
+
+Verify links after editing:
+
+```bash
+bash scripts/docs-to-site.sh
+cd site && zola check
+```
+
+`zola check` validates both internal links (anchors, page paths) and
+external URLs. Internal breakage means a cross-reference in `docs/`
+points at a file that no longer exists; fix in `docs/`, not the
+generated page.
+
 Other files under `site/` (`templates/`, `sass/`, `static/`,
 `config.toml`, landing pages like `content/_index.md` and
 `content/getting-started.md`) are hand-written — edit those directly.

--- a/site/content/features.md
+++ b/site/content/features.md
@@ -4,19 +4,49 @@ weight = 10
 description = "Cargo features, derive macros, and optional subsystems"
 +++
 
-## Cargo Features
+## Optional Cargo Features
 
-miniextendr uses cargo features to gate optional functionality:
+miniextendr-api gates optional functionality behind Cargo feature flags. Only
+`default` features (`doc-lint`, `refcount-fast-hash`) are enabled automatically.
 
-| Feature | Description |
-|---------|-------------|
-| `serde_r` | Direct Rust-R serialization via serde |
-| `serde_full` | Both JSON and native R serialization |
-| `worker-thread` | Dedicated worker thread for Rust code |
-| `default-worker` | Implies `worker-thread`, makes it the default |
-| `nonapi` | Access to non-API R functions (`DATAPTR`, etc.) |
-| `rayon` | Parallel computation via rayon |
-| `materialization-tracking` | ALTREP materialization diagnostics |
+Add features to the `miniextendr-api` dependency in your package's `Cargo.toml`:
+
+```toml
+[dependencies]
+miniextendr-api = { version = "0.1", features = ["rayon", "serde", "ndarray"] }
+```
+
+The prelude re-exports upstream crates for every enabled feature, so you rarely need
+to add optional crates as separate direct dependencies.
+
+### Categories at a glance
+
+| Category | Features |
+|----------|---------|
+| Core / R | `nonapi`, `rayon`, `worker-thread`, `connections`, `indicatif`, `vctrs` |
+| Serialization | `serde`, `serde_json`, `toml` |
+| Matrix / Array | `ndarray`, `nalgebra` |
+| Numeric | `num-bigint`, `rust_decimal`, `ordered-float`, `num-complex` |
+| Adapters | `num-traits`, `bytes` |
+| String / Text | `uuid`, `regex`, `url`, `aho-corasick` |
+| Date / Time | `time` |
+| RNG | `rand`, `rand_distr` |
+| Collections | `indexmap`, `tinyvec` |
+| Either | `either` |
+| Binary | `borsh`, `raw_conversions` |
+| Hashing | `sha2` |
+| Bitflags | `bitflags`, `bitvec` |
+| Formatting | `tabled` |
+| Arrow / DataFusion | `arrow`, `datafusion` |
+| Logging | `log` |
+| Project defaults | `default-strict`, `default-coerce`, `default-r6`, `default-s7`, `default-worker` |
+| Diagnostics | `macro-coverage`, `debug-preserve`, `growth-debug` |
+
+For the complete entry-by-entry reference -- including descriptions, type tables, and
+code examples for every feature -- see the
+[Feature Flags Reference](/miniextendr/manual/features/) in the manual.
+
+---
 
 ## Derive Macros
 
@@ -35,25 +65,25 @@ Typed derives generate the full ALTREP class from field attributes. The manual `
 
 | Derive | Purpose |
 |--------|---------|
-| `#[derive(AltrepInteger)]` | Integer ALTREP class from `#[altrep(len, elt, class, …)]` fields |
+| `#[derive(AltrepInteger)]` | Integer ALTREP class from `#[altrep(len, elt, class, ...)]` fields |
 | `#[derive(AltrepReal)]` | Real (double) ALTREP class |
 | `#[derive(AltrepLogical)]` | Logical ALTREP class |
 | `#[derive(AltrepRaw)]` | Raw (byte) ALTREP class |
 | `#[derive(AltrepString)]` | Character ALTREP class (`Vec<Option<String>>` preserves `NA_character_`) |
 | `#[derive(AltrepComplex)]` | Complex ALTREP class |
 | `#[derive(AltrepList)]` | List ALTREP class |
-| `#[derive(Altrep)]` | Manual pattern — registers the class; you implement `AltrepLen` and `Alt*Data` |
+| `#[derive(Altrep)]` | Manual pattern -- registers the class; you implement `AltrepLen` and `Alt*Data` |
 
 ### List / data-frame round-tripping
 
 | Derive | Purpose |
 |--------|---------|
-| `#[derive(IntoList)]` | Convert struct → named R list |
-| `#[derive(TryFromList)]` | Convert named R list → struct |
+| `#[derive(IntoList)]` | Convert struct to a named R list |
+| `#[derive(TryFromList)]` | Convert named R list to struct |
 | `#[derive(DataFrameRow)]` | Treat struct as a data-frame row; generates a companion DataFrame type |
 | `#[derive(Vctrs)]` | vctrs-compatible S3 vector class (`Vctr`, `Rcrd`, `ListOf` kinds) |
 
-### Enums ↔ R
+### Enums to R
 
 | Derive | Purpose |
 |--------|---------|
@@ -70,6 +100,8 @@ Control which `IntoR` / `TryFromSexp` path a type takes when multiple are possib
 | `#[derive(PreferDataFrame)]` | Prefer data-frame representation |
 | `#[derive(PreferList)]` | Prefer named-list representation |
 | `#[derive(PreferRNativeType)]` | Prefer native R scalar representation |
+
+---
 
 ## Attribute Options
 
@@ -93,6 +125,8 @@ The `#[miniextendr]` attribute supports many options:
 #[miniextendr(label = "name")]       // Label for multiple impl blocks
 ```
 
+---
+
 ## Variadic Arguments (Dots)
 
 R's `...` becomes `&Dots` in Rust:
@@ -114,6 +148,8 @@ pub fn structured_dots(_dots: &Dots, ...) -> f64 {
     dots_typed.x as f64 + dots_typed.y
 }
 ```
+
+---
 
 ## Factors (Enums)
 

--- a/site/content/manual/adapter-cookbook.md
+++ b/site/content/manual/adapter-cookbook.md
@@ -427,5 +427,5 @@ unique_records <- records[!duplicated(hashes)]
 
 ## See Also
 
-- [ADAPTER_TRAITS.md](ADAPTER_TRAITS.md) - Pattern explanation and constraints
-- [SAFETY.md](SAFETY.md) - Thread safety for trait objects
+- [ADAPTER_TRAITS.md](../adapter-traits/) - Pattern explanation and constraints
+- [SAFETY.md](../safety/) - Thread safety for trait objects

--- a/site/content/manual/adapter-traits.md
+++ b/site/content/manual/adapter-traits.md
@@ -336,6 +336,6 @@ pub trait RIterator {
 
 ## See Also
 
-- [SAFETY.md](SAFETY.md) - Thread safety for trait dispatch
-- [ENTRYPOINT.md](ENTRYPOINT.md) - Trait ABI initialization requirements
+- [SAFETY.md](../safety/) - Thread safety for trait dispatch
+- [ENTRYPOINT.md](../entrypoint/) - Trait ABI initialization requirements
 - `miniextendr-api/src/trait_abi/` - Trait ABI implementation

--- a/site/content/manual/allocator.md
+++ b/site/content/manual/allocator.md
@@ -11,7 +11,7 @@ by R's memory manager.
 
 `RAllocator` routes every Rust heap allocation through R's `Rf_allocVector(RAWSXP, n)`,
 so Rust memory participates in R's garbage collection. Each allocation is
-GC-protected via the [preserve list](GC_PROTECT.md#preserve-list) and released
+GC-protected via the [preserve list](../gc-protect/#preserve-list) and released
 on dealloc.
 
 **Source:** `miniextendr-api/src/allocator.rs`
@@ -110,7 +110,7 @@ The allocator uses the **preserve list** (not the PROTECT stack) because:
 - Deallocations happen in arbitrary order (not LIFO)
 - The preserve list supports O(1) insert and any-order release
 
-See [GC Protection](GC_PROTECT.md) for the full picture of protection strategies.
+See [GC Protection](../gc-protect/) for the full picture of protection strategies.
 
 ## Example
 

--- a/site/content/manual/altrep-examples.md
+++ b/site/content/manual/altrep-examples.md
@@ -460,6 +460,6 @@ stopifnot(!is.na(max(x)))
 ---
 
 **See also**:
-- [ALTREP.md](ALTREP.md) - Complete API reference
+- [ALTREP.md](../altrep/) - Complete API reference
 - [Background reference implementations](../background/) - simplemmap, mutable, vectorwindow
 - [Test suite](../rpkg/tests/testthat/test-altrep*.R) - Examples in tests

--- a/site/content/manual/altrep-guards.md
+++ b/site/content/manual/altrep-guards.md
@@ -162,6 +162,6 @@ monomorphization time. The chosen mode has zero runtime cost.
 
 ## See Also
 
-- [ALTREP.md](ALTREP.md): full ALTREP guide
-- [ALTREP_QUICKREF.md](ALTREP_QUICKREF.md): quick reference checklist
-- [ERROR_HANDLING.md](ERROR_HANDLING.md): panic handling across FFI boundaries
+- [ALTREP.md](../altrep/): full ALTREP guide
+- [ALTREP_QUICKREF.md](../altrep-quickref/): quick reference checklist
+- [ERROR_HANDLING.md](../error-handling/): panic handling across FFI boundaries

--- a/site/content/manual/altrep-quickref.md
+++ b/site/content/manual/altrep-quickref.md
@@ -280,12 +280,12 @@ pub fn altrep_len(x: AltrepSexp) -> usize { x.len() }
 // altrep_len(c(1L, 2L)) ← error: not ALTREP
 ```
 
-Full guide: [Receiving ALTREP from R](ALTREP_SEXP.md)
+Full guide: [Receiving ALTREP from R](../altrep-sexp/)
 
 ## Further Reading
 
-- **Complete guide**: [ALTREP.md](ALTREP.md)
-- **Receiving ALTREP**: [ALTREP_SEXP.md](ALTREP_SEXP.md)
-- **Practical examples**: [ALTREP_EXAMPLES.md](ALTREP_EXAMPLES.md)
+- **Complete guide**: [ALTREP.md](../altrep/)
+- **Receiving ALTREP**: [ALTREP_SEXP.md](../altrep-sexp/)
+- **Practical examples**: [ALTREP_EXAMPLES.md](../altrep-examples/)
 - **Test suite**: [../rpkg/tests/testthat/test-altrep*.R](../rpkg/tests/testthat/)
 - **Reference**: [R Altrep.h](../background/r-source-tags-R-4-5-2/src/include/R_ext/Altrep.h)

--- a/site/content/manual/altrep-sexp.md
+++ b/site/content/manual/altrep-sexp.md
@@ -6,7 +6,7 @@ description = "How miniextendr handles ALTREP vectors when R passes them to Rust
 
 How miniextendr handles ALTREP vectors when R passes them to Rust functions.
 
-**See also**: [ALTREP.md](ALTREP.md) (creating ALTREP vectors), [ALTREP_QUICKREF.md](ALTREP_QUICKREF.md), [THREADS.md](THREADS.md)
+**See also**: [ALTREP.md](../altrep/) (creating ALTREP vectors), [ALTREP_QUICKREF.md](../altrep-quickref/), [THREADS.md](../threads/)
 
 ## The Problem
 

--- a/site/content/manual/altrep.md
+++ b/site/content/manual/altrep.md
@@ -7,9 +7,9 @@ description = "ALTREP (Alternative Representations) is R's system for creating c
 ALTREP (Alternative Representations) is R's system for creating custom vector implementations. miniextendr provides a powerful, safe abstraction for creating ALTREP vectors from Rust.
 
 **Additional Resources**:
-- **[Quick Reference](ALTREP_QUICKREF.md)** - One-page cheat sheet
-- **[Receiving ALTREP from R](ALTREP_SEXP.md)** - How `SEXP` and `AltrepSexp` parameters handle ALTREP input
-- **[Practical Examples](ALTREP_EXAMPLES.md)** - Real-world use cases
+- **[Quick Reference](../altrep-quickref/)** - One-page cheat sheet
+- **[Receiving ALTREP from R](../altrep-sexp/)** - How `SEXP` and `AltrepSexp` parameters handle ALTREP input
+- **[Practical Examples](../altrep-examples/)** - Real-world use cases
 - **[Test Suite](../rpkg/tests/testthat/test-altrep*.R)** - Working examples
 
 ## What is ALTREP?

--- a/site/content/manual/architecture.md
+++ b/site/content/manual/architecture.md
@@ -106,7 +106,7 @@ exists solely to satisfy R's build system requirement for at least one C file.
 
 For CRAN compatibility, all dependencies must be vendored:
 
-1. **Workspace crates** (miniextendr-api, miniextendr-macros, miniextendr-lint) and **crates.io dependencies** (proc-macro2, syn, quote): Both are populated by `cargo revendor` into `rpkg/vendor/`. See [VENDOR.md](VENDOR.md) for details.
+1. **Workspace crates** (miniextendr-api, miniextendr-macros, miniextendr-lint) and **crates.io dependencies** (proc-macro2, syn, quote): Both are populated by `cargo revendor` into `rpkg/vendor/`. See [VENDOR.md](../vendor/) for details.
 2. **Local crates** use flat paths (`vendor/miniextendr-api/`); **transitive registry crates** use versioned paths (`vendor/serde-1.0.210/`).
 
 ### Cross-package dispatch

--- a/site/content/manual/connections.md
+++ b/site/content/manual/connections.md
@@ -667,7 +667,7 @@ These are thin wrappers around `R_GetConnection`, `R_ReadConnection`, and `R_Wri
 
 ## See Also
 
-- [FEATURES.md](FEATURES.md) -- Feature flags reference (`connections`)
-- [THREADS.md](THREADS.md) -- Thread safety and the worker thread model
-- [ERROR_HANDLING.md](ERROR_HANDLING.md) -- Panic handling across the FFI boundary
+- [FEATURES.md](../features/) -- Feature flags reference (`connections`)
+- [THREADS.md](../threads/) -- Thread safety and the worker thread model
+- [ERROR_HANDLING.md](../error-handling/) -- Panic handling across the FFI boundary
 - Test fixtures: `rpkg/src/rust/connection_tests.rs`

--- a/site/content/manual/conversion-matrix.md
+++ b/site/content/manual/conversion-matrix.md
@@ -348,4 +348,4 @@ fn sum_all(x: f64, _dots: &Dots) -> f64 {
 }
 ```
 
-For typed dots validation, see [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md).
+For typed dots validation, see [DOTS_TYPED_LIST.md](../dots-typed-list/).

--- a/site/content/manual/developer-workflow.md
+++ b/site/content/manual/developer-workflow.md
@@ -147,7 +147,7 @@ R_LIBS=/tmp/R_lib just rcmdinstall
 
 ### Lint warnings
 
-Run [`just lint`](https://github.com/A2-ai/miniextendr/blob/main/justfile) to check source-level attributes for consistency. See [MACRO_ERRORS.md](MACRO_ERRORS.md) for interpreting lint output.
+Run [`just lint`](https://github.com/A2-ai/miniextendr/blob/main/justfile) to check source-level attributes for consistency. See [MACRO_ERRORS.md](../macro-errors/) for interpreting lint output.
 
 ### Transient test failures in parallel runs
 

--- a/site/content/manual/entrypoint.md
+++ b/site/content/manual/entrypoint.md
@@ -210,7 +210,7 @@ and Cargo.toml. The crate name must use underscores (not hyphens) for the
 
 ## See Also
 
-- [ARCHITECTURE.md](ARCHITECTURE.md): high-level crate and call flow overview
-- [MINIEXTENDR_ATTRIBUTE.md](MINIEXTENDR_ATTRIBUTE.md): complete `#[miniextendr]` reference
-- [R_BUILD_SYSTEM.md](R_BUILD_SYSTEM.md): how R builds packages with compiled code
-- [LINKING.md](LINKING.md): shared library linking strategy (libR discovery)
+- [ARCHITECTURE.md](../architecture/): high-level crate and call flow overview
+- [MINIEXTENDR_ATTRIBUTE.md](../miniextendr-attribute/): complete `#[miniextendr]` reference
+- [R_BUILD_SYSTEM.md](../r-build-system/): how R builds packages with compiled code
+- [LINKING.md](../linking/): shared library linking strategy (libR discovery)

--- a/site/content/manual/enums-and-factors.md
+++ b/site/content/manual/enums-and-factors.md
@@ -373,5 +373,5 @@ fn lookup<T: MatchArg>(choice: &str) -> Option<T> {
 
 ## See Also
 
-- [MINIEXTENDR_ATTRIBUTE.md](MINIEXTENDR_ATTRIBUTE.md): `#[miniextendr]` on enums
-- [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md): full type conversion reference
+- [MINIEXTENDR_ATTRIBUTE.md](../miniextendr-attribute/): `#[miniextendr]` on enums
+- [TYPE_CONVERSIONS.md](../type-conversions/): full type conversion reference

--- a/site/content/manual/environment-variables.md
+++ b/site/content/manual/environment-variables.md
@@ -66,10 +66,10 @@ MINIEXTENDR_LINT=0 cargo check --manifest-path=rpkg/src/rust/Cargo.toml
 | `MINIEXTENDR_ENCODING_DEBUG` | Print encoding snapshot at init (any value enables) | Not set |
 
 `MINIEXTENDR_BACKTRACE` is read at panic time, not at package load, so it can be toggled
-during a session without restarting R. See [Error Handling: Panic Hook and Backtraces](ERROR_HANDLING.md#panic-hook-and-backtraces).
+during a session without restarting R. See [Error Handling: Panic Hook and Backtraces](../error-handling/#panic-hook-and-backtraces).
 
 `MINIEXTENDR_ENCODING_DEBUG` is only useful when embedding R via `miniextendr-engine` or on platforms where non-API
-encoding symbols are exported. See [Encoding](ENCODING.md).
+encoding symbols are exported. See [Encoding](../encoding/).
 
 ## minirextendr (Scaffolding)
 

--- a/site/content/manual/error-handling.md
+++ b/site/content/manual/error-handling.md
@@ -918,19 +918,19 @@ pub fn risky() -> Result<(), String> {
 
 ## Known Limitations
 
-- **Spawned-thread panics** cannot be cleanly propagated through `extern "C-unwind"` boundaries. Convert thread errors to `Result` instead of using `resume_unwind`. See [GAPS.md](GAPS.md#56-thread-panic-propagation-limitation).
-- **Thread safety debug assertions** for SEXP access only run in debug builds. Checked FFI wrappers provide runtime thread checks in all build modes. See [GAPS.md](GAPS.md#55-thread-safety-debug-assertions).
+- **Spawned-thread panics** cannot be cleanly propagated through `extern "C-unwind"` boundaries. Convert thread errors to `Result` instead of using `resume_unwind`. See [GAPS.md](../gaps/#56-thread-panic-propagation-limitation).
+- **Thread safety debug assertions** for SEXP access only run in debug builds. Checked FFI wrappers provide runtime thread checks in all build modes. See [GAPS.md](../gaps/#55-thread-safety-debug-assertions).
 
-See [GAPS.md](GAPS.md) for the full catalog of known limitations.
+See [GAPS.md](../gaps/) for the full catalog of known limitations.
 
 ---
 
 ## See Also
 
-- [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md) -- Project-wide feature defaults
-- [MINIEXTENDR_ATTRIBUTE.md](MINIEXTENDR_ATTRIBUTE.md) -- Complete `#[miniextendr]` option reference
-- [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) -- `MINIEXTENDR_BACKTRACE` and other env vars
-- [THREADS.md](THREADS.md) -- Worker thread architecture and thread safety
-- [SAFETY.md](SAFETY.md) -- Safety invariants (R_UnwindProtect, GC protection)
-- [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md#error-cases) -- Type conversion error messages
-- [MACRO_ERRORS.md](MACRO_ERRORS.md) -- Proc-macro and lint error codes
+- [FEATURE_DEFAULTS.md](../feature-defaults/) -- Project-wide feature defaults
+- [MINIEXTENDR_ATTRIBUTE.md](../miniextendr-attribute/) -- Complete `#[miniextendr]` option reference
+- [ENVIRONMENT_VARIABLES.md](../environment-variables/) -- `MINIEXTENDR_BACKTRACE` and other env vars
+- [THREADS.md](../threads/) -- Worker thread architecture and thread safety
+- [SAFETY.md](../safety/) -- Safety invariants (R_UnwindProtect, GC protection)
+- [TYPE_CONVERSIONS.md](../type-conversions/#error-cases) -- Type conversion error messages
+- [MACRO_ERRORS.md](../macro-errors/) -- Proc-macro and lint error codes

--- a/site/content/manual/expression-eval.md
+++ b/site/content/manual/expression-eval.md
@@ -125,6 +125,6 @@ In `#[miniextendr]` functions, use these inside `unsafe(main_thread)` blocks or 
 
 ## See Also
 
-- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md#s4-helpers-module) -- S4 helpers built on RCall
-- [THREADS.md](THREADS.md) -- Main thread requirements
-- [GC_PROTECT.md](GC_PROTECT.md) -- Protecting returned SEXPs
+- [CLASS_SYSTEMS.md](../class-systems/#s4-helpers-module) -- S4 helpers built on RCall
+- [THREADS.md](../threads/) -- Main thread requirements
+- [GC_PROTECT.md](../gc-protect/) -- Protecting returned SEXPs

--- a/site/content/manual/externalptr.md
+++ b/site/content/manual/externalptr.md
@@ -255,7 +255,7 @@ The `TYPE_ID_CSTR` format (`crate@version::module::Type`) ensures:
 
 When wrapping a SEXP, `wrap_sexp()` compares the stored symbol pointer against the expected symbol pointer. A mismatch returns `None` (or `TypeMismatchError` from `wrap_sexp_with_error`).
 
-For cross-package trait dispatch, see [Trait ABI](TRAIT_ABI.md).
+For cross-package trait dispatch, see [Trait ABI](../trait-abi/).
 
 ## Type-Erased Pointers (ErasedExternalPtr)
 

--- a/site/content/manual/features.md
+++ b/site/content/manual/features.md
@@ -61,8 +61,12 @@ Only `default` features are enabled automatically.
 | `sha2` | SHA-256/SHA-512 hashing helpers | sha2 |
 | **Formatting** | | |
 | `tabled` | ASCII/Unicode table formatting | tabled |
+| **Arrow / DataFusion** | | |
+| `arrow` | Zero-copy R vector / data.frame to Apache Arrow array conversions | arrow-array, arrow-buffer, arrow-schema, arrow-select |
+| `datafusion` | SQL query engine on R data frames via DataFusion (implies `arrow`) | datafusion, tokio |
+| **Logging** | | |
+| `log` | Routes Rust `log` macros (`info!`, `warn!`, `error!`) to R console | log |
 | **Diagnostics** | | |
-| `materialization-tracking` | Logs ALTREP materializations for diagnostics | (none) |
 | `macro-coverage` | Macro expansion coverage module for auditing | (none) |
 
 ---
@@ -98,7 +102,7 @@ symbols may change between R versions and will cause `R CMD check` warnings.
 - `R_CStackStart`, `R_CStackLimit`, `R_CStackDir` -- stack checking controls
 - `scope_with_r()`, `spawn_with_r()`, `with_stack_checking_disabled()` -- thread safety utilities
 
-See [NONAPI.md](NONAPI.md) for the full tracking list.
+See [NONAPI.md](../nonapi/) for the full tracking list.
 
 ### `worker-thread`
 
@@ -129,7 +133,7 @@ Parallel iterators via the Rayon crate, with R-safe interop.
 - `with_r_matrix()` -- parallel matrix fill
 - `reduce()` -- parallel reductions returning R scalars
 
-See [RAYON.md](RAYON.md) for the full guide.
+See [RAYON.md](../rayon/) for the full guide.
 
 ### `connections`
 
@@ -147,7 +151,7 @@ this feature flag to make the instability opt-in.
 - `RConnectionIo` builder -- auto-wraps any `std::io` type with zero boilerplate
 - Helper functions: `get_connection()`, `read_connection()`, `write_connection()`
 
-See [CONNECTIONS.md](CONNECTIONS.md) for the full guide with examples.
+See [CONNECTIONS.md](../connections/) for the full guide with examples.
 
 ### `indicatif`
 
@@ -161,7 +165,7 @@ All output is a no-op when called off the R main thread.
 - `progress::RStream` -- stdout/stderr target selection
 - Convenience constructors: `term_like_stdout()`, `term_like_stderr()`, `term_like_*_with_hz()`
 
-See [PROGRESS.md](PROGRESS.md) for the full guide with examples.
+See [PROGRESS.md](../progress/) for the full guide with examples.
 
 ### `vctrs`
 
@@ -179,7 +183,7 @@ for defining custom vctrs-compatible classes.
 - `#[miniextendr(vctrs)]` impl blocks for methods
 - `coerce = "type"` attribute for `vec_ptype2`/`vec_cast` generation
 
-Requires the `vctrs` R package to be installed. See [VCTRS.md](VCTRS.md) for the full guide.
+Requires the `vctrs` R package to be installed. See [VCTRS.md](../vctrs/) for the full guide.
 
 ---
 
@@ -196,7 +200,7 @@ native R objects (named lists, atomic vectors, etc.) using serde's `Serialize` a
 - `AsSerialize<T>` wrapper for returning `Serialize` types from `#[miniextendr]` functions
 
 **Type mappings:** structs become named lists, `Vec<primitive>` becomes atomic vectors,
-`Option::None` becomes NA or NULL. See [SERDE_R.md](SERDE_R.md) for details.
+`Option::None` becomes NA or NULL. See [SERDE_R.md](../serde-r/) for details.
 
 ### `serde_json`
 
@@ -867,20 +871,56 @@ cat(format_scores(c("Alice", "Bob"), c(95, 87)))
 
 ---
 
-## Diagnostic Features
+## Arrow / DataFusion Features
 
-### `materialization-tracking`
+### `arrow`
 
-Logs every ALTREP `Dataptr` call, which is when R forces a lazy/compact vector to
-materialize into contiguous memory. Useful for diagnosing unexpected materializations
-that negate ALTREP performance benefits.
+Zero-copy conversions between R vectors/data.frames and Apache Arrow arrays/RecordBatch.
+Foundation for DataFusion and other Arrow-based tools.
 
-Zero-cost when disabled (no runtime overhead).
+**Supported types (zero-copy where R memory layout matches Arrow):**
+- Scalar arrays: `Float64Array`, `Int32Array`, `BooleanArray`, `StringArray`, etc.
+- `RecordBatch` -- round-trips R data.frames column by column
 
-**From R:**
-```r
-miniextendr:::altrep_materialization_count()
+See [ARROW.md](../arrow/) for the full guide.
+
+### `datafusion`
+
+SQL query engine on R data frames via Apache DataFusion. Depends on `arrow`.
+Provides `RSessionContext` for running SQL queries on R data frames.
+
+Uses Tokio internally (`current_thread` / `block_on`) -- NOT `rt-multi-thread`.
+
+**Provides:**
+- `RSessionContext` -- register R data frames as tables, execute SQL
+- `execute_sql()`, `collect_to_r()` helpers
+
+---
+
+## Logging Features
+
+### `log`
+
+Routes Rust `log` macros (`info!`, `warn!`, `error!`, `debug!`, `trace!`) to R's
+console output (`Rprintf`/`REprintf`). The logger is installed automatically during
+`package_init()` -- no setup needed beyond enabling the feature.
+
+```rust
+use log::{info, warn};
+
+#[miniextendr]
+pub fn process_data(n: i32) -> i32 {
+    info!("Processing {} rows", n);
+    if n > 10000 {
+        warn!("Large input -- this may be slow");
+    }
+    n * 2
+}
 ```
+
+---
+
+## Diagnostic Features
 
 ### `macro-coverage`
 
@@ -895,7 +935,7 @@ supported attribute combinations.
 These features set project-wide defaults for `#[miniextendr]` options, so you don't
 need to annotate every function. Individual items can opt out with `no_` prefixed keywords.
 
-See [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md) for the full guide with examples.
+See [FEATURE_DEFAULTS.md](../feature-defaults/) for the full guide with examples.
 
 | Feature | Effect | Opt-out |
 |---------|--------|---------|
@@ -957,21 +997,23 @@ Feature implications (automatically enabled):
 | `serde_json` | `serde` |
 | `rand_distr` | `rand` |
 | `indicatif` | `nonapi` |
+| `datafusion` | `arrow` |
+| `default-worker` | `worker-thread` |
 
 ---
 
 ## Known Limitations
 
-- **`connections` is experimental.** R reserves the right to change the connection ABI without backward compatibility. Always check `R_CONNECTIONS_VERSION`. See [GAPS.md](GAPS.md#41-r-connections-api-experimental).
-- **Feature-gated modules** require path-based module switching with `#[cfg]` on `mod` declarations. See [GAPS.md](GAPS.md#13-feature-gated-module-entries).
-- **vctrs cross-package export** and inheritance are not yet implemented. See [GAPS.md](GAPS.md) section 4.2.
+- **`connections` is experimental.** R reserves the right to change the connection ABI without backward compatibility. Always check `R_CONNECTIONS_VERSION`. See [GAPS.md](../gaps/#41-r-connections-api-experimental).
+- **Feature-gated modules** require path-based module switching with `#[cfg]` on `mod` declarations. See [GAPS.md](../gaps/#13-feature-gated-module-entries).
+- **vctrs cross-package export** and inheritance are not yet implemented. See [GAPS.md](../gaps/) section 4.2.
 
-See [GAPS.md](GAPS.md) for the full catalog of known limitations.
+See [GAPS.md](../gaps/) for the full catalog of known limitations.
 
 ---
 
 ## See Also
 
-- [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) -- How feature-gated types convert to/from R
-- [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md) -- Project-wide defaults via Cargo features
-- [THREADS.md](THREADS.md) -- Thread utilities enabled by the `nonapi` feature
+- [TYPE_CONVERSIONS.md](../type-conversions/) -- How feature-gated types convert to/from R
+- [FEATURE_DEFAULTS.md](../feature-defaults/) -- Project-wide defaults via Cargo features
+- [THREADS.md](../threads/) -- Thread utilities enabled by the `nonapi` feature

--- a/site/content/manual/ffi-guard.md
+++ b/site/content/manual/ffi-guard.md
@@ -244,7 +244,7 @@ All four panic-to-R-error sites call `panic_telemetry::fire()`:
 
 ## See Also
 
-- [Error Handling](ERROR_HANDLING.md) -- How panics, Result, and R errors interact
-- [ALTREP Guards](ALTREP_GUARDS.md) -- Per-type guard mode selection for ALTREP
-- [Threads](THREADS.md) -- Worker thread architecture
-- [Connections](CONNECTIONS.md) -- Custom R connections from Rust
+- [Error Handling](../error-handling/) -- How panics, Result, and R errors interact
+- [ALTREP Guards](../altrep-guards/) -- Per-type guard mode selection for ALTREP
+- [Threads](../threads/) -- Worker thread architecture
+- [Connections](../connections/) -- Custom R connections from Rust

--- a/site/content/manual/gaps.md
+++ b/site/content/manual/gaps.md
@@ -93,7 +93,7 @@ my_func <- function(x, ...) {
 }
 ```
 
-See [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md) for the full dots guide, including `typed_list!` validation.
+See [DOTS_TYPED_LIST.md](../dots-typed-list/) for the full dots guide, including `typed_list!` validation.
 
 ---
 
@@ -123,7 +123,7 @@ Create a stub for the disabled case:
 
 This pattern is used throughout the example package (`rpkg/`) (e.g., `rayon_tests.rs` / `rayon_tests_disabled.rs`) and is documented in CLAUDE.md.
 
-See [FEATURES.md](FEATURES.md) for the full feature flags reference.
+See [FEATURES.md](../features/) for the full feature flags reference.
 
 ---
 
@@ -178,7 +178,7 @@ pub fn modify_state(state: &mut MyState) {
 }
 ```
 
-See [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) for slice lifetime details and [SAFETY.md](SAFETY.md) for the full safety model.
+See [TYPE_CONVERSIONS.md](../type-conversions/) for slice lifetime details and [SAFETY.md](../safety/) for the full safety model.
 
 ---
 
@@ -200,7 +200,7 @@ let string_matrix: Vec<Vec<String>> = array.outer_iter()
 
 **Why:** R's STRSXP is a vector of CHARSXP pointers, not contiguous memory. Direct ndarray integration would require special handling because ndarray assumes a contiguous backing buffer.
 
-See [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) for supported matrix types and [FEATURES.md](FEATURES.md#ndarray) for the `ndarray` feature flag.
+See [TYPE_CONVERSIONS.md](../type-conversions/) for supported matrix types and [FEATURES.md](../features/#ndarray) for the `ndarray` feature flag.
 
 ---
 
@@ -368,7 +368,7 @@ data structures that don't exist here. **S7 is the recommended class system for 
 and generic dispatch. Fall back to S4 only when integrating with Bioconductor or other S4-based
 ecosystems.
 
-See [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) for the full class system comparison and decision flowchart.
+See [CLASS_SYSTEMS.md](../class-systems/) for the full class system comparison and decision flowchart.
 
 ---
 
@@ -410,7 +410,7 @@ if check_connections_version().is_ok() {
 }
 ```
 
-See [FEATURES.md](FEATURES.md#connections) for the `connections` feature flag.
+See [FEATURES.md](../features/#connections) for the `connections` feature flag.
 
 ---
 
@@ -456,7 +456,7 @@ pub fn fetch_data(url: String) -> String {
 For true async I/O needs, users should use R-level parallelism (mirai, callr) with
 miniextendr handling the per-request Rust work synchronously.
 
-See [THREADS.md](THREADS.md) for the worker thread model and [FEATURES.md](FEATURES.md#rayon) for parallel iteration via Rayon.
+See [THREADS.md](../threads/) for the worker thread model and [FEATURES.md](../features/#rayon) for parallel iteration via Rayon.
 
 ---
 
@@ -500,7 +500,7 @@ impl<T, R> TryCoerce<R> for T where T: Coerce<R> {
 }
 ```
 
-See [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md#coercion-system) for the user-facing coercion guide and [COERCE.md](COERCE.md) for the full coercion trait design.
+See [TYPE_CONVERSIONS.md](../type-conversions/#coercion-system) for the user-facing coercion guide and [COERCE.md](../coerce/) for the full coercion trait design.
 
 ---
 
@@ -538,7 +538,7 @@ let x: Option<i32> = None;
 let r: i32 = x.coerce();  // Returns NA_INTEGER
 ```
 
-See [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md#na-value-representation) for the full NA handling guide with examples for all types.
+See [TYPE_CONVERSIONS.md](../type-conversions/#na-value-representation) for the full NA handling guide with examples for all types.
 
 ---
 
@@ -574,7 +574,7 @@ unsafe fn charsxp_to_str(charsxp: SEXP) -> &'static str
 
 **Recommended pattern:** Use `OwnedProtect` or `ProtectScope` for RAII-based SEXP protection. Never store raw SEXPs in long-lived Rust structures without protection.
 
-See [GC_PROTECT.md](GC_PROTECT.md) for the full GC protection toolkit and [SAFETY.md](SAFETY.md) for safety invariants.
+See [GC_PROTECT.md](../gc-protect/) for the full GC protection toolkit and [SAFETY.md](../safety/) for safety invariants.
 
 ---
 
@@ -610,7 +610,7 @@ pub fn replace(&mut self, new: Self) {
 }
 ```
 
-See [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md#externalptr-semantics) for the ExternalPtr ownership model.
+See [TYPE_CONVERSIONS.md](../type-conversions/#externalptr-semantics) for the ExternalPtr ownership model.
 
 ---
 
@@ -633,7 +633,7 @@ fn assert_main_thread() { ... }
 
 **Recommended pattern:** Rely on the worker thread model for safe R API access. For explicit thread control, use `spawn_with_r()` or `StackCheckGuard`.
 
-See [THREADS.md](THREADS.md) for the thread safety model, [SAFETY.md](SAFETY.md) for invariants, and [ERROR_HANDLING.md](ERROR_HANDLING.md#thread-safety) for thread-related error patterns.
+See [THREADS.md](../threads/) for the thread safety model, [SAFETY.md](../safety/) for invariants, and [ERROR_HANDLING.md](../error-handling/#thread-safety) for thread-related error patterns.
 
 ---
 
@@ -682,7 +682,7 @@ pub fn safe_threaded_work() -> Result<i32, String> {
 
 **Tests:** See `test-errors-more.R` for skipped tests demonstrating this behavior.
 
-See [ERROR_HANDLING.md](ERROR_HANDLING.md) for the full error handling model and [THREADS.md](THREADS.md) for the worker thread architecture.
+See [ERROR_HANDLING.md](../error-handling/) for the full error handling model and [THREADS.md](../threads/) for the worker thread architecture.
 
 ---
 
@@ -739,11 +739,11 @@ no inline snapshot tests for generated R code.
 
 | Guide | Status |
 |-------|--------|
-| Getting Started | [docs/GETTING_STARTED.md](GETTING_STARTED.md) |
-| Choosing a Class System | [docs/CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) |
-| Type Conversions | [docs/TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) |
-| ALTREP Tutorial | [docs/ALTREP.md](ALTREP.md) |
-| Error Handling Best Practices | [docs/ERROR_HANDLING.md](ERROR_HANDLING.md) |
+| Getting Started | [docs/GETTING_STARTED.md](../getting-started/) |
+| Choosing a Class System | [docs/CLASS_SYSTEMS.md](../class-systems/) |
+| Type Conversions | [docs/TYPE_CONVERSIONS.md](../type-conversions/) |
+| ALTREP Tutorial | [docs/ALTREP.md](../altrep/) |
+| Error Handling Best Practices | [docs/ERROR_HANDLING.md](../error-handling/) |
 | Thread Safety Guide | Covered in Error Handling |
 | Building a Package from Scratch | Covered in Getting Started |
 
@@ -751,10 +751,10 @@ no inline snapshot tests for generated R code.
 
 | Topic | Status |
 |-------|--------|
-| Coercion precedence rules | [docs/TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) |
-| NA handling for each type | [docs/TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) |
-| SEXP lifetime rules | [docs/TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md) |
-| Feature flag effects | [docs/FEATURES.md](FEATURES.md) |
+| Coercion precedence rules | [docs/TYPE_CONVERSIONS.md](../type-conversions/) |
+| NA handling for each type | [docs/TYPE_CONVERSIONS.md](../type-conversions/) |
+| SEXP lifetime rules | [docs/TYPE_CONVERSIONS.md](../type-conversions/) |
+| Feature flag effects | [docs/FEATURES.md](../features/) |
 
 ### 7.3 Example Coverage
 

--- a/site/content/manual/getting-started.md
+++ b/site/content/manual/getting-started.md
@@ -214,7 +214,7 @@ c$current    # Active binding (no parens)
 impl Counter { ... }
 ```
 
-See [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) for detailed comparison.
+See [CLASS_SYSTEMS.md](../class-systems/) for detailed comparison.
 
 ---
 
@@ -416,10 +416,10 @@ describe_color(factor("Red", levels = c("Red", "Green", "Blue")))
 
 ## Next Steps
 
-- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) - Detailed class system comparison
-- [ALTREP.md](ALTREP.md) - Lazy/compact vectors
-- [THREADS.md](THREADS.md) - Threading and parallelism
-- [SAFETY.md](SAFETY.md) - Memory safety guarantees
+- [CLASS_SYSTEMS.md](../class-systems/) - Detailed class system comparison
+- [ALTREP.md](../altrep/) - Lazy/compact vectors
+- [THREADS.md](../threads/) - Threading and parallelism
+- [SAFETY.md](../safety/) - Memory safety guarantees
 
 ---
 
@@ -449,7 +449,7 @@ cd src/rust && cargo check
 
 ## Next Steps
 
-- [Documentation Index](README.md) -- Browse all available documentation
-- [Known Gaps & Limitations](GAPS.md) -- Important context on what's missing or limited
-- [Troubleshooting](TROUBLESHOOTING.md) -- Common issues and solutions
-- [Architecture Overview](ARCHITECTURE.md) -- How miniextendr works under the hood
+- [Documentation Index](../readme/) -- Browse all available documentation
+- [Known Gaps & Limitations](../gaps/) -- Important context on what's missing or limited
+- [Troubleshooting](../troubleshooting/) -- Common issues and solutions
+- [Architecture Overview](../architecture/) -- How miniextendr works under the hood

--- a/site/content/manual/lifecycle.md
+++ b/site/content/manual/lifecycle.md
@@ -103,5 +103,5 @@ Or in `Suggests` if lifecycle signals are optional.
 
 ## See Also
 
-- [FEATURES.md](FEATURES.md) -- Feature flags reference
-- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) -- How lifecycle interacts with class generators
+- [FEATURES.md](../features/) -- Feature flags reference
+- [CLASS_SYSTEMS.md](../class-systems/) -- How lifecycle interacts with class generators

--- a/site/content/manual/linking.md
+++ b/site/content/manual/linking.md
@@ -162,4 +162,4 @@ miniextendr always links dynamically to `libR`:
 ## See Also
 
 - [R Installation and Administration](https://cran.r-project.org/doc/manuals/r-release/R-admin.html)
-- [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front-ends-to-R)
+- [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front_002dends-to-R)

--- a/site/content/manual/miniextendr-attribute.md
+++ b/site/content/manual/miniextendr-attribute.md
@@ -118,7 +118,7 @@ pub fn parse_data(s: String) -> Result<i32, String> {
 | `rng` | Manage R's RNG state (`GetRNGstate`/`PutRNGstate`) |
 | `c_symbol = "..."` | Custom C function name |
 | `lifecycle = "..."` | Mark as deprecated/experimental/superseded |
-| `dots = typed_list!(...)` | Validate `...` arguments (see [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md)) |
+| `dots = typed_list!(...)` | Validate `...` arguments (see [DOTS_TYPED_LIST.md](../dots-typed-list/)) |
 
 ```rust
 #[miniextendr(check_interrupt, rng)]
@@ -618,12 +618,12 @@ appropriate derives internally. Both paths produce identical code.
 
 ## See Also
 
-- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md): all 6 class systems with examples
-- [S3_METHODS.md](S3_METHODS.md): detailed S3 print/format guide
-- [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md): dots and typed_list validation
-- [ALTREP.md](ALTREP.md): ALTREP deep dive
-- [DATAFRAME.md](DATAFRAME.md): DataFrame conversion (derive + serde + columnar)
-- [SERDE_R.md](SERDE_R.md): serde integration for direct Rust-R serialization
-- [ERROR_HANDLING.md](ERROR_HANDLING.md): error_in_r, unwrap_in_r, panic handling
-- [LIFECYCLE.md](LIFECYCLE.md): deprecation/experimental lifecycle attributes
-- [TRAIT_ABI.md](TRAIT_ABI.md): cross-package trait dispatch
+- [CLASS_SYSTEMS.md](../class-systems/): all 6 class systems with examples
+- [S3_METHODS.md](../s3-methods/): detailed S3 print/format guide
+- [DOTS_TYPED_LIST.md](../dots-typed-list/): dots and typed_list validation
+- [ALTREP.md](../altrep/): ALTREP deep dive
+- [DATAFRAME.md](../dataframe/): DataFrame conversion (derive + serde + columnar)
+- [SERDE_R.md](../serde-r/): serde integration for direct Rust-R serialization
+- [ERROR_HANDLING.md](../error-handling/): error_in_r, unwrap_in_r, panic handling
+- [LIFECYCLE.md](../lifecycle/): deprecation/experimental lifecycle attributes
+- [TRAIT_ABI.md](../trait-abi/): cross-package trait dispatch

--- a/site/content/manual/minirextendr.md
+++ b/site/content/manual/minirextendr.md
@@ -371,7 +371,7 @@ Cache location: `rappdirs::user_cache_dir("minirextendr")`.
 | **Inline compilation** | `rust_source`, `rust_function`, `rust_source_clean` |
 | **Cargo wrappers** | `cargo_add`, `cargo_rm`, `cargo_build`, `cargo_check`, `cargo_test`, `cargo_clippy`, `cargo_fmt`, `cargo_doc`, `cargo_search`, `cargo_deps`, `cargo_update`, `cargo_init`, `cargo_new` |
 | **Feature scaffolding** | `use_miniextendr`, `use_rayon`, `use_serde`, `use_vctrs`, `use_r6`, `use_s4`, `use_s7`, `use_feature_detection`, `update_feature_detection`, `use_vendor_lib` |
-| **Native R package FFI** | `use_native_package`, `check_native_package` (see [NATIVE_R_PACKAGES.md](NATIVE_R_PACKAGES.md)) |
+| **Native R package FFI** | `use_native_package`, `check_native_package` (see [NATIVE_R_PACKAGES.md](../native-r-packages/)) |
 | **Git hooks** | `use_miniextendr_git_hooks` (pre-commit + post-merge reminders) |
 | **Vendoring** | `vendor_miniextendr`, `vendor_crates_io`, `vendor_sync`, `miniextendr_vendor`, `miniextendr_available_versions` |
 | **Diagnostics** | `has_miniextendr`, `miniextendr_status`, `miniextendr_validate`, `miniextendr_doctor`, `miniextendr_check_rust` |

--- a/site/content/manual/native-pkg-cppflags.md
+++ b/site/content/manual/native-pkg-cppflags.md
@@ -75,9 +75,9 @@ PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 `$(CC) $(CPPFLAGS) $(CPICFLAGS) $(PKG_CPPFLAGS) ...`, adding our
 discovered include paths to the preprocessor search.
 
-See [R_BUILD_SYSTEM.md](R_BUILD_SYSTEM.md) for how `PKG_CPPFLAGS` fits
+See [R_BUILD_SYSTEM.md](../r-build-system/) for how `PKG_CPPFLAGS` fits
 into R's overall Makefile include chain, and
-[NATIVE_R_PACKAGES.md](NATIVE_R_PACKAGES.md) for the full recipe
+[NATIVE_R_PACKAGES.md](../native-r-packages/) for the full recipe
 (including the `OBJECTS → cargo rustc -C link-arg=` link step that
 makes the shim's symbols visible to the Rust crate).
 

--- a/site/content/manual/prefer-derives.md
+++ b/site/content/manual/prefer-derives.md
@@ -181,6 +181,6 @@ representations for the same type in different contexts.
 
 ## See Also
 
-- [MINIEXTENDR_ATTRIBUTE.md](MINIEXTENDR_ATTRIBUTE.md): `prefer` attribute reference
-- [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md): IntoR trait and conversion system
-- [DATAFRAME.md](DATAFRAME.md): DataFrame conversion patterns
+- [MINIEXTENDR_ATTRIBUTE.md](../miniextendr-attribute/): `prefer` attribute reference
+- [TYPE_CONVERSIONS.md](../type-conversions/): IntoR trait and conversion system
+- [DATAFRAME.md](../dataframe/): DataFrame conversion patterns

--- a/site/content/manual/progress.md
+++ b/site/content/manual/progress.md
@@ -165,7 +165,7 @@ operations that need R console access should use `unsafe(main_thread)` or run th
 bar update on the main thread. In practice, since indicatif batches draws, the simplest
 approach is to create the progress bar and call `pb.inc()` from your function directly.
 
-See [THREADS.md](THREADS.md) for details on the worker thread model.
+See [THREADS.md](../threads/) for details on the worker thread model.
 
 ## ANSI Cursor Support
 
@@ -268,6 +268,6 @@ pub fn parallel_progress() {
 
 ## See Also
 
-- [FEATURES.md](FEATURES.md) -- Feature flags reference (`indicatif`)
-- [THREADS.md](THREADS.md) -- Worker thread architecture and main thread safety
+- [FEATURES.md](../features/) -- Feature flags reference (`indicatif`)
+- [THREADS.md](../threads/) -- Worker thread architecture and main thread safety
 - [indicatif documentation](https://docs.rs/indicatif) -- Full indicatif API reference

--- a/site/content/manual/r-build-system.md
+++ b/site/content/manual/r-build-system.md
@@ -239,9 +239,9 @@ being set to its default value.
 
 ## See Also
 
-- [LINKING.md](LINKING.md): how miniextendr links to libR (engine vs package)
-- [ENTRYPOINT.md](ENTRYPOINT.md): the C entry point design
-- [VENDOR.md](VENDOR.md): dependency vendoring for CRAN
-- [TEMPLATES.md](TEMPLATES.md): how configure.ac templates work
+- [LINKING.md](../linking/): how miniextendr links to libR (engine vs package)
+- [ENTRYPOINT.md](../entrypoint/): the C entry point design
+- [VENDOR.md](../vendor/): dependency vendoring for CRAN
+- [TEMPLATES.md](../templates/): how configure.ac templates work
 - R sources: `share/make/shlib.mk`, `share/make/winshlib.mk`
 - R sources: `src/library/tools/R/install.R` (the `R CMD INSTALL` implementation)

--- a/site/content/manual/rarray.md
+++ b/site/content/manual/rarray.md
@@ -350,7 +350,7 @@ for row in 0..nrow {
 
 ## See Also
 
-- [Type Conversions](TYPE_CONVERSIONS.md) -- `TryFromSexp`/`IntoR` system
-- [`#[miniextendr]` Attribute](MINIEXTENDR_ATTRIBUTE.md) -- `unsafe(main_thread)` and other options
-- [Rayon Integration](RAYON.md) -- `with_r_matrix` and `new_r_matrix` for parallel matrix construction
-- [GC Protection](GC_PROTECT.md) -- Protecting allocated arrays from garbage collection
+- [Type Conversions](../type-conversions/) -- `TryFromSexp`/`IntoR` system
+- [`#[miniextendr]` Attribute](../miniextendr-attribute/) -- `unsafe(main_thread)` and other options
+- [Rayon Integration](../rayon/) -- `with_r_matrix` and `new_r_matrix` for parallel matrix construction
+- [GC Protection](../gc-protect/) -- Protecting allocated arrays from garbage collection

--- a/site/content/manual/rayon.md
+++ b/site/content/manual/rayon.md
@@ -637,6 +637,6 @@ eprintln!("Thread index: {:?}", perf::thread_index());
 
 ## See Also
 
-- [SAFETY.md](SAFETY.md): thread safety invariants
-- [ENTRYPOINT.md](ENTRYPOINT.md): worker initialization requirements
+- [SAFETY.md](../safety/): thread safety invariants
+- [ENTRYPOINT.md](../entrypoint/): worker initialization requirements
 - `miniextendr-bench/benches/rayon.rs`: performance benchmarks

--- a/site/content/manual/rng.md
+++ b/site/content/manual/rng.md
@@ -233,10 +233,10 @@ fn parallel_random(len: i32, seed: i64) -> SEXP {
 }
 ```
 
-See [Rayon](RAYON.md#rng-reproducibility) for full details on reproducible parallel RNG.
+See [Rayon](../rayon/#rng-reproducibility) for full details on reproducible parallel RNG.
 
 ## See Also
 
-- [Rayon Integration](RAYON.md) -- Parallel computation (including RNG reproducibility)
-- [`#[miniextendr]` Attribute](MINIEXTENDR_ATTRIBUTE.md) -- Complete attribute reference
-- [Threads](THREADS.md) -- Worker thread architecture
+- [Rayon Integration](../rayon/) -- Parallel computation (including RNG reproducibility)
+- [`#[miniextendr]` Attribute](../miniextendr-attribute/) -- Complete attribute reference
+- [Threads](../threads/) -- Worker thread architecture

--- a/site/content/manual/s3-methods.md
+++ b/site/content/manual/s3-methods.md
@@ -330,6 +330,6 @@ pub fn tbl_sum_my_tbl(x: SEXP, _dots: ...) -> Vec<String> { ... }
 
 ## See Also
 
-- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md): overview of all 6 class systems (env, R6, S3, S4, S7, vctrs)
-- [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md): using dots and typed_list validation
-- [VCTRS.md](VCTRS.md): vctrs-compatible S3 classes with `format` methods
+- [CLASS_SYSTEMS.md](../class-systems/): overview of all 6 class systems (env, R6, S3, S4, S7, vctrs)
+- [DOTS_TYPED_LIST.md](../dots-typed-list/): using dots and typed_list validation
+- [VCTRS.md](../vctrs/): vctrs-compatible S3 classes with `format` methods

--- a/site/content/manual/safety.md
+++ b/site/content/manual/safety.md
@@ -297,5 +297,5 @@ will cause all subsequent thread checks to be incorrect.
 ## Reporting Safety Issues
 
 If you discover a soundness issue in miniextendr, please report it via
-[GitHub Issues](https://github.com/miniextendr/miniextendr/issues) with the
+[GitHub Issues](https://github.com/A2-ai/miniextendr/issues) with the
 `[SAFETY]` tag.

--- a/site/content/manual/safety.md
+++ b/site/content/manual/safety.md
@@ -272,7 +272,7 @@ this happens via the `miniextendr_init!` macro, which generates
 miniextendr_api::miniextendr_init!(pkgname);
 ```
 
-See [ENTRYPOINT.md](ENTRYPOINT.md) for the full init sequence. `package_init()`:
+See [ENTRYPOINT.md](../entrypoint/) for the full init sequence. `package_init()`:
 1. Records `R_MAIN_THREAD_ID` for thread checks
 2. With `worker-thread` feature: spawns the worker thread and sets up channels
 3. Without `worker-thread`: only records the thread ID (no thread spawned)

--- a/site/content/manual/sparse-iterator-altrep.md
+++ b/site/content/manual/sparse-iterator-altrep.md
@@ -6,7 +6,7 @@ description = "Sparse iterator ALTREP vectors use Iterator::nth() to skip direct
 
 Sparse iterator ALTREP vectors use `Iterator::nth()` to skip directly to requested indices, caching only the elements that are actually accessed. This makes them ideal for large vectors where only a few elements are needed.
 
-**See also**: [ALTREP.md](ALTREP.md) for the full ALTREP system documentation, [ALTREP_QUICKREF.md](ALTREP_QUICKREF.md) for a quick reference.
+**See also**: [ALTREP.md](../altrep/) for the full ALTREP system documentation, [ALTREP_QUICKREF.md](../altrep-quickref/) for a quick reference.
 
 ---
 

--- a/site/content/manual/strict-mode.md
+++ b/site/content/manual/strict-mode.md
@@ -141,6 +141,6 @@ These panics are caught and converted to R errors.
 
 ## See Also
 
-- [MINIEXTENDR_ATTRIBUTE.md](MINIEXTENDR_ATTRIBUTE.md): `strict` attribute reference
-- [TYPE_CONVERSIONS.md](TYPE_CONVERSIONS.md): normal conversion behavior
-- [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md): project-wide feature flags
+- [MINIEXTENDR_ATTRIBUTE.md](../miniextendr-attribute/): `strict` attribute reference
+- [TYPE_CONVERSIONS.md](../type-conversions/): normal conversion behavior
+- [FEATURE_DEFAULTS.md](../feature-defaults/): project-wide feature flags

--- a/site/content/manual/threads.md
+++ b/site/content/manual/threads.md
@@ -253,7 +253,7 @@ For explicit ALTREP handling, use `AltrepSexp`, a `!Send + !Sync` wrapper
 that prevents un-materialized ALTREP vectors from reaching rayon or other
 worker threads at compile time.
 
-See [Receiving ALTREP from R](ALTREP_SEXP.md) for the full guide.
+See [Receiving ALTREP from R](../altrep-sexp/) for the full guide.
 
 ## Worker Shutdown
 
@@ -349,24 +349,24 @@ These are gated behind `feature = "nonapi"` and may break with R updates:
 | `R_CStackLimit` | Stack limit (set to `usize::MAX` to disable) |
 | `R_CStackDir` | Stack growth direction |
 
-See [NONAPI.md](NONAPI.md) for the full tracking document.
+See [NONAPI.md](../nonapi/) for the full tracking document.
 
 ## Known Limitations
 
-- **Async/await is not supported.** R's C API is single-threaded and synchronous; use blocking I/O on the worker thread or R-level parallelism (mirai, callr). See [GAPS.md](GAPS.md#43-asyncawait-support).
-- **Spawned-thread panics cannot be propagated** through `extern "C-unwind"` functions. Handle thread errors explicitly via `Result` rather than `resume_unwind`. See [GAPS.md](GAPS.md#56-thread-panic-propagation-limitation).
+- **Async/await is not supported.** R's C API is single-threaded and synchronous; use blocking I/O on the worker thread or R-level parallelism (mirai, callr). See [GAPS.md](../gaps/#43-asyncawait-support).
+- **Spawned-thread panics cannot be propagated** through `extern "C-unwind"` functions. Handle thread errors explicitly via `Result` rather than `resume_unwind`. See [GAPS.md](../gaps/#56-thread-panic-propagation-limitation).
 - **Debug-only SEXP thread assertions** mean release builds may not detect SEXP access from wrong threads. Checked FFI wrappers provide runtime checks in all build modes.
 
-See [GAPS.md](GAPS.md) for the full catalog of known limitations.
+See [GAPS.md](../gaps/) for the full catalog of known limitations.
 
 ---
 
 ## See Also
 
-- [SAFETY.md](SAFETY.md) -- Safety invariants and the worker thread model
-- [ERROR_HANDLING.md](ERROR_HANDLING.md) -- Panic handling and R error propagation
-- [FEATURES.md](FEATURES.md#nonapi) -- The `nonapi` feature flag for thread utilities
-- [RAYON.md](RAYON.md) -- Parallel iteration with Rayon
+- [SAFETY.md](../safety/) -- Safety invariants and the worker thread model
+- [ERROR_HANDLING.md](../error-handling/) -- Panic handling and R error propagation
+- [FEATURES.md](../features/#nonapi) -- The `nonapi` feature flag for thread utilities
+- [RAYON.md](../rayon/) -- Parallel iteration with Rayon
 
 ## References
 

--- a/site/content/manual/type-conversions.md
+++ b/site/content/manual/type-conversions.md
@@ -74,7 +74,7 @@ parameter types handle this transparently:
 | `SEXP` | Auto-materialized via `ensure_materialized` |
 | `AltrepSexp` | Accepted only if ALTREP, `!Send + !Sync` |
 
-See [Receiving ALTREP from R](ALTREP_SEXP.md) for details.
+See [Receiving ALTREP from R](../altrep-sexp/) for details.
 
 ---
 
@@ -617,15 +617,15 @@ pub fn double_in_place(mut x: Vec<f64>) -> Vec<f64> {
 - **String matrices** (`ndarray::Array<String, Ix2>`) are not directly convertible because R's STRSXP is not contiguous memory. Use `Vec<Vec<String>>` as an intermediary.
 - **SEXP slice lifetimes** use `'static` for convenience, but actual lifetime is tied to GC protection scope.
 
-See [GAPS.md](GAPS.md) for the full catalog of known limitations and workarounds.
+See [GAPS.md](../gaps/) for the full catalog of known limitations and workarounds.
 
 ---
 
 ## See Also
 
-- [COERCE.md](COERCE.md) -- Type coercion trait design
-- [AS_COERCE.md](AS_COERCE.md) -- `as.<class>()` coercion methods
-- [CONVERSION_MATRIX.md](CONVERSION_MATRIX.md) -- R type x Rust type behavior reference
-- [FEATURES.md](FEATURES.md) -- Feature-gated types (ndarray, nalgebra, uuid, time, etc.)
-- [GC_PROTECT.md](GC_PROTECT.md) -- RAII-based GC protection for SEXP lifetimes
-- [ERROR_HANDLING.md](ERROR_HANDLING.md#type-conversion-errors) -- Type conversion error messages
+- [COERCE.md](../coerce/) -- Type coercion trait design
+- [AS_COERCE.md](../as-coerce/) -- `as.<class>()` coercion methods
+- [CONVERSION_MATRIX.md](../conversion-matrix/) -- R type x Rust type behavior reference
+- [FEATURES.md](../features/) -- Feature-gated types (ndarray, nalgebra, uuid, time, etc.)
+- [GC_PROTECT.md](../gc-protect/) -- RAII-based GC protection for SEXP lifetimes
+- [ERROR_HANDLING.md](../error-handling/#type-conversion-errors) -- Type conversion error messages

--- a/site/content/manual/vendor.md
+++ b/site/content/manual/vendor.md
@@ -367,6 +367,6 @@ just r-cmd-check
 
 ## See Also
 
-- [R_BUILD_SYSTEM.md](R_BUILD_SYSTEM.md): how R builds packages with compiled code
-- [TEMPLATES.md](TEMPLATES.md): template system (configure.ac templates)
-- [SMOKE_TEST.md](SMOKE_TEST.md): phase A4 covers CRAN-like tarball validation
+- [R_BUILD_SYSTEM.md](../r-build-system/): how R builds packages with compiled code
+- [TEMPLATES.md](../templates/): template system (configure.ac templates)
+- [SMOKE_TEST.md](../smoke-test/): phase A4 covers CRAN-like tarball validation


### PR DESCRIPTION
## Summary

Ran `zola check` on the site after #294 merged; it flagged 2 broken external links unrelated to the RAYON.md fix. This PR fixes those plus two stale references in the archive, and documents the verification step in `site/CLAUDE.md`.

## What changed

- `docs/SAFETY.md`: `github.com/miniextendr/miniextendr/issues` → `github.com/A2-ai/miniextendr/issues` (wrong org, 404).
- `docs/LINKING.md`: CRAN R-exts anchor `#Linking-GUIs-and-other-front-ends-to-R` → `#Linking-GUIs-and-other-front_002dends-to-R`. Texinfo-generated HTML escapes hyphens in section names; the un-escaped form 404s on anchor.
- `docs/archive/ALTREP_PERFORMANCE_REPORT.md`: two more `miniextendr/miniextendr` → `A2-ai/miniextendr` fixes (archive page, not currently rendered, but fixing for consistency).
- `site/CLAUDE.md`: documents the `UPPERCASE.md` → `../kebab-case/` rewrite the docs-to-site generator does (added in #294), and `zola check` as the verification step after editing docs.

## Test plan

- [x] `bash scripts/docs-to-site.sh` regenerates cleanly (71 pages).
- [x] `cd site && zola check` passes with zero broken links (was 2 broken before).
