### PR TITLE
fix(cargo-revendor): seed git-source workspace crates from --source-root

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -300,7 +300,8 @@ fn main() -> Result<()> {
     // the vendored contents depend on dep-graph iteration order.
     metadata::check_duplicate_sources(&meta)?;
 
-    let (mut local_pkgs, _external_pkgs) = metadata::partition_packages(&meta, &manifest_path)?;
+    let (mut local_pkgs, _external_pkgs) =
+        metadata::partition_packages(&meta, &manifest_path, &source_root_members)?;
 
     // Fall back to heuristic workspace-root detection only if `--source-root`
     // wasn't explicitly provided.

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -287,6 +287,17 @@ mod tests {
         (name.to_string(), version.to_string(), source.map(String::from))
     }
 
+    fn local_pkg(name: &str, version: &str) -> LocalPackage {
+        LocalPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            path: PathBuf::from("/workspace").join(name),
+            manifest_path: PathBuf::from("/workspace").join(name).join("Cargo.toml"),
+        }
+    }
+
+    // region: check_duplicate_sources tests
+
     #[test]
     fn no_duplicates_passes() {
         let pkgs = vec![
@@ -357,4 +368,74 @@ mod tests {
         let err = check_duplicate_sources_impl(&pkgs).unwrap_err();
         assert!(err.to_string().contains("serde v1.0.0"));
     }
+
+    // endregion
+
+    // region: resolve_git_override tests
+
+    #[test]
+    fn git_override_no_match_returns_none() {
+        // Dep is not in overrides — should stay external.
+        let overrides = vec![local_pkg("miniextendr-api", "0.5.0")];
+        let result = resolve_git_override("serde", "1.0.0", &overrides).unwrap();
+        assert!(result.is_none(), "unrelated dep should not match any override");
+    }
+
+    #[test]
+    fn git_override_empty_list_returns_none() {
+        let result = resolve_git_override("miniextendr-api", "0.5.0", &[]).unwrap();
+        assert!(result.is_none(), "empty override list should never match");
+    }
+
+    #[test]
+    fn git_override_name_and_version_match_returns_pkg() {
+        let overrides = vec![
+            local_pkg("miniextendr-api", "0.5.0"),
+            local_pkg("miniextendr-macros", "0.5.0"),
+        ];
+        let result = resolve_git_override("miniextendr-api", "0.5.0", &overrides)
+            .unwrap()
+            .expect("should match");
+        assert_eq!(result.name, "miniextendr-api");
+        assert_eq!(result.version, "0.5.0");
+    }
+
+    #[test]
+    fn git_override_name_match_version_mismatch_errors() {
+        // Git dep is pinned to 0.5.0 but local checkout is on 0.6.0.
+        // Silently vendoring would produce a build that doesn't match
+        // the lockfile — cargo-revendor must refuse.
+        let overrides = vec![local_pkg("miniextendr-api", "0.6.0")];
+        let err = resolve_git_override("miniextendr-api", "0.5.0", &overrides).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("miniextendr-api"), "error should name the crate");
+        assert!(msg.contains("0.5.0"), "error should mention the git version");
+        assert!(msg.contains("0.6.0"), "error should mention the local version");
+    }
+
+    #[test]
+    fn git_override_picks_first_name_match() {
+        // Degenerate case: two entries with the same name but different versions.
+        // Only the first match is considered; version check applies to it.
+        let overrides = vec![
+            local_pkg("miniextendr-api", "0.5.0"),
+            local_pkg("miniextendr-api", "0.6.0"),
+        ];
+        // Matches first entry — version must equal the git dep's version.
+        let result = resolve_git_override("miniextendr-api", "0.5.0", &overrides)
+            .unwrap()
+            .expect("should match first entry");
+        assert_eq!(result.version, "0.5.0");
+    }
+
+    #[test]
+    fn git_override_unrelated_crate_same_version_not_matched() {
+        // A dep named "serde" shouldn't match an override for "miniextendr-api"
+        // even if versions happen to be equal.
+        let overrides = vec![local_pkg("miniextendr-api", "1.0.0")];
+        let result = resolve_git_override("serde", "1.0.0", &overrides).unwrap();
+        assert!(result.is_none());
+    }
+
+    // endregion
 }

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -76,6 +76,12 @@ pub fn discover_workspace_members(workspace_root: &Path) -> Result<Vec<LocalPack
 /// where `--source-root` points at the workspace containing the git dep).
 /// Any git dep whose name matches an entry in `git_overrides` is treated as
 /// local and vendored from the local path rather than fetched from git.
+/// Pass `&[]` when `--source-root` is not in use.
+///
+/// Returns an error if a git dep matches a `git_overrides` entry by name but
+/// the resolved git version differs from the local version — a version mismatch
+/// means the local checkout is not the same code the lockfile pinned, and
+/// silently vendoring the wrong source would produce broken builds.
 pub fn partition_packages(
     meta: &Metadata,
     target_manifest: &Path,
@@ -145,15 +151,44 @@ pub fn partition_packages(
             // sets source = "git+...", but --source-root can point at the local
             // checkout. Without this override, cargo-revendor would fetch from
             // github instead of using the local edit.
-            if let Some(override_pkg) = git_overrides.iter().find(|o| o.name == pkg.name) {
-                local.push(override_pkg.clone());
-            } else {
-                external.push(pkg.name.clone());
+            match resolve_git_override(&pkg.name, &pkg.version.to_string(), git_overrides)? {
+                Some(override_pkg) => local.push(override_pkg.clone()),
+                None => external.push(pkg.name.clone()),
             }
         }
     }
 
     Ok((local, external))
+}
+
+/// Look up a git dep in the override list, checking that versions match.
+///
+/// Returns `Ok(Some(pkg))` when the git dep is overridden by a local source-root
+/// member of the same name **and** the same version. Returns `Ok(None)` when no
+/// override exists (dep should be treated as external). Returns `Err` when a
+/// name match is found but the versions differ — this indicates the local
+/// checkout is not the same code the lockfile pinned, which would produce a
+/// broken vendor tree.
+fn resolve_git_override<'a>(
+    name: &str,
+    git_version: &str,
+    overrides: &'a [LocalPackage],
+) -> Result<Option<&'a LocalPackage>> {
+    let Some(candidate) = overrides.iter().find(|o| o.name == name) else {
+        return Ok(None);
+    };
+
+    if candidate.version != git_version {
+        bail!(
+            "git dep `{name}` resolves to v{git_version} in Cargo.lock \
+             but the local source-root has v{local} — versions must match \
+             for `--source-root` override to be safe. \
+             Update the local crate or pin the git dep to a matching revision.",
+            local = candidate.version,
+        );
+    }
+
+    Ok(Some(candidate))
 }
 
 /// Error out when two different sources resolve to the same (name, version).

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -70,9 +70,16 @@ pub fn discover_workspace_members(workspace_root: &Path) -> Result<Vec<LocalPack
 /// Local packages are those whose source is a local path and whose
 /// manifest is NOT inside the target package's src/rust directory
 /// (i.e., they're workspace siblings, not the package itself).
+///
+/// `git_overrides` allows callers to reclassify git-sourced deps as local
+/// when the same crate is available in a local source root (e.g., a monorepo
+/// where `--source-root` points at the workspace containing the git dep).
+/// Any git dep whose name matches an entry in `git_overrides` is treated as
+/// local and vendored from the local path rather than fetched from git.
 pub fn partition_packages(
     meta: &Metadata,
     target_manifest: &Path,
+    git_overrides: &[LocalPackage],
 ) -> Result<(Vec<LocalPackage>, Vec<String>)> {
     let target_dir = target_manifest
         .parent()
@@ -133,7 +140,16 @@ pub fn partition_packages(
                 manifest_path: pkg.manifest_path.clone().into(),
             });
         } else if pkg.source.is_some() {
-            external.push(pkg.name.clone());
+            // Reclassify git deps that are available in the local source root.
+            // With git-dep declarations (git = "https://..."), cargo metadata
+            // sets source = "git+...", but --source-root can point at the local
+            // checkout. Without this override, cargo-revendor would fetch from
+            // github instead of using the local edit.
+            if let Some(override_pkg) = git_overrides.iter().find(|o| o.name == pkg.name) {
+                local.push(override_pkg.clone());
+            } else {
+                external.push(pkg.name.clone());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`partition_packages` classified packages as local only when `pkg.source.is_none()` (path deps). After PR #320, `miniextendr-{api,lint,macros}` are declared as `git = "..."` deps — so `source.is_some()` → treated as external → fetched from github instead of the local checkout even when `--source-root .` is set.

**Fix**: pass `source_root_members` into `partition_packages` as `git_overrides`. Any git dep whose name matches a source-root workspace member is reclassified as local and vendored from the local path instead of fetched from github.

This means a PR that edits `miniextendr-api/src/lib.rs` alongside `rpkg/` now ships a vendor tarball built from the PR's local state, not github HEAD.

## Test plan

- [x] `just revendor-test` → 57/57 pass
- [x] Reproduce: `echo "// marker" >> miniextendr-api/src/lib.rs && just vendor && grep marker rpkg/vendor/miniextendr-api/src/lib.rs` now finds the marker (previously it didn't)

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
