### PR TITLE
feat(cargo-revendor): --external-only / --local-only phase modes

### DIFF
--- a/cargo-revendor/src/cache.rs
+++ b/cargo-revendor/src/cache.rs
@@ -7,12 +7,20 @@
 //!
 //! Hashing the lockfile alone misses pure source-file edits to workspace
 //! crates (see issue #150), which leaves a stale `vendor/` copy on disk.
+//!
+//! Phase-mode caches (#290): `.revendor-cache-external` hashes only external
+//! inputs (Cargo.lock + Cargo.toml + sync manifests); written by
+//! `--external-only` and checked to gate `--local-only` flag compatibility.
+//! `.revendor-cache-local` hashes only local crate source trees; written by
+//! `--local-only`. Full mode writes all three cache files.
 
 use anyhow::Result;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-const CACHE_FILE: &str = ".revendor-cache";
+pub const CACHE_FILE: &str = ".revendor-cache";
+pub const CACHE_FILE_EXTERNAL: &str = ".revendor-cache-external";
+pub const CACHE_FILE_LOCAL: &str = ".revendor-cache-local";
 
 /// Check whether `vendor_dir` is up to date relative to `lockfile` plus the
 /// source trees of `local_crate_paths`, plus any additional manifests
@@ -47,6 +55,58 @@ pub fn save_cache(
     std::fs::write(&cache_path, &hash)?;
     Ok(())
 }
+
+// region: phase-mode caches (#290)
+
+/// Check whether the external deps are up to date relative to `lockfile` and
+/// sync manifests. Ignores local crate source trees — pure source edits don't
+/// change external deps.
+pub fn is_cached_external(
+    lockfile: &Path,
+    sync_manifests: &[PathBuf],
+    vendor_dir: &Path,
+) -> Result<bool> {
+    let cache_path = vendor_dir.join(CACHE_FILE_EXTERNAL);
+    if !cache_path.exists() || !vendor_dir.exists() {
+        return Ok(false);
+    }
+    let current = compute_hash_external(lockfile, sync_manifests)?;
+    let cached = std::fs::read_to_string(&cache_path)?;
+    Ok(current.trim() == cached.trim())
+}
+
+/// Check whether the local crates are up to date relative to their source
+/// trees. Ignores Cargo.lock / sync manifests — lockfile changes don't affect
+/// the local crate packaging output.
+pub fn is_cached_local(vendor_dir: &Path, local_crate_paths: &[PathBuf]) -> Result<bool> {
+    let cache_path = vendor_dir.join(CACHE_FILE_LOCAL);
+    if !cache_path.exists() || !vendor_dir.exists() {
+        return Ok(false);
+    }
+    let current = compute_hash_local(local_crate_paths)?;
+    let cached = std::fs::read_to_string(&cache_path)?;
+    Ok(current.trim() == cached.trim())
+}
+
+/// Save the external-only cache file.
+pub fn save_cache_external(
+    lockfile: &Path,
+    sync_manifests: &[PathBuf],
+    vendor_dir: &Path,
+) -> Result<()> {
+    let hash = compute_hash_external(lockfile, sync_manifests)?;
+    std::fs::write(vendor_dir.join(CACHE_FILE_EXTERNAL), &hash)?;
+    Ok(())
+}
+
+/// Save the local-only cache file.
+pub fn save_cache_local(vendor_dir: &Path, local_crate_paths: &[PathBuf]) -> Result<()> {
+    let hash = compute_hash_local(local_crate_paths)?;
+    std::fs::write(vendor_dir.join(CACHE_FILE_LOCAL), &hash)?;
+    Ok(())
+}
+
+// endregion
 
 /// FNV-1a 64-bit streaming hasher.
 ///
@@ -136,6 +196,60 @@ fn compute_hash(
 
     // Hash each local crate's source tree in a deterministic order so the
     // cache key is stable across runs.
+    for crate_path in local_crate_paths {
+        let entries = collect_crate_files(crate_path)?;
+        for (rel, bytes) in entries {
+            hasher.update(rel.as_bytes());
+            hasher.update(b":");
+            hasher.update(&bytes);
+            hasher.update(b"|");
+        }
+    }
+
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+/// Compute a hash covering only the external inputs: `Cargo.lock`, the sibling
+/// `Cargo.toml`, and each `--sync` manifest's Cargo.toml + Cargo.lock pair.
+/// Local crate source trees are excluded — external deps don't change when
+/// workspace crate sources change.
+fn compute_hash_external(lockfile: &Path, sync_manifests: &[PathBuf]) -> Result<String> {
+    let mut hasher = Fnv64::new();
+
+    if lockfile.exists() {
+        hasher.update(&std::fs::read(lockfile)?);
+    }
+    hasher.update(b"|");
+
+    let manifest = lockfile.with_file_name("Cargo.toml");
+    if manifest.exists() {
+        hasher.update(&std::fs::read(&manifest)?);
+    }
+    hasher.update(b"|");
+
+    let mut sorted_sync: Vec<&PathBuf> = sync_manifests.iter().collect();
+    sorted_sync.sort();
+    for sync_manifest in sorted_sync {
+        if sync_manifest.exists() {
+            hasher.update(&std::fs::read(sync_manifest)?);
+        }
+        hasher.update(b"|");
+        let sync_lock = sync_manifest.with_file_name("Cargo.lock");
+        if sync_lock.exists() {
+            hasher.update(&std::fs::read(&sync_lock)?);
+        }
+        hasher.update(b"|");
+    }
+
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+/// Compute a hash covering only the local crate source trees. Cargo.lock and
+/// sync manifests are excluded — they don't influence the packaged output of
+/// local workspace crates.
+fn compute_hash_local(local_crate_paths: &[PathBuf]) -> Result<String> {
+    let mut hasher = Fnv64::new();
+
     for crate_path in local_crate_paths {
         let entries = collect_crate_files(crate_path)?;
         for (rel, bytes) in entries {
@@ -382,4 +496,76 @@ mod tests {
             "swapped --sync order should still hit the cache"
         );
     }
+
+    // region: phase-mode cache tests (#290)
+
+    #[test]
+    fn external_cache_ignores_local_source_edits() {
+        // Editing a local crate's source file must NOT invalidate the external
+        // cache — external deps don't change when workspace source changes.
+        let (tmp, lockfile, vendor) = setup();
+        let crate_path = tmp.path().join("libx");
+
+        save_cache_external(&lockfile, &[], &vendor).unwrap();
+        assert!(is_cached_external(&lockfile, &[], &vendor).unwrap());
+
+        // Edit the local crate source
+        std::fs::write(crate_path.join("src/lib.rs"), "// v2 changed").unwrap();
+
+        assert!(
+            is_cached_external(&lockfile, &[], &vendor).unwrap(),
+            "external cache should remain valid when only local crate source changes"
+        );
+    }
+
+    #[test]
+    fn local_cache_ignores_lockfile_change() {
+        // Changing Cargo.lock must NOT invalidate the local cache — the
+        // packaged output of local workspace crates doesn't depend on the lock.
+        let (tmp, lockfile, vendor) = setup();
+        let crate_path = tmp.path().join("libx");
+        let locals = vec![crate_path];
+
+        save_cache_local(&vendor, &locals).unwrap();
+        assert!(is_cached_local(&vendor, &locals).unwrap());
+
+        // Bump the lockfile
+        std::fs::write(&lockfile, "version = 4").unwrap();
+
+        assert!(
+            is_cached_local(&vendor, &locals).unwrap(),
+            "local cache should remain valid when only Cargo.lock changes"
+        );
+    }
+
+    #[test]
+    fn external_cache_invalidates_on_lockfile_change() {
+        let (_tmp, lockfile, vendor) = setup();
+
+        save_cache_external(&lockfile, &[], &vendor).unwrap();
+        assert!(is_cached_external(&lockfile, &[], &vendor).unwrap());
+
+        std::fs::write(&lockfile, "version = 99").unwrap();
+
+        assert!(
+            !is_cached_external(&lockfile, &[], &vendor).unwrap(),
+            "external cache should invalidate when Cargo.lock changes"
+        );
+    }
+
+    #[test]
+    fn external_cache_miss_when_file_absent() {
+        let (_tmp, lockfile, vendor) = setup();
+        // Never saved — must be a miss.
+        assert!(!is_cached_external(&lockfile, &[], &vendor).unwrap());
+    }
+
+    #[test]
+    fn local_cache_miss_when_file_absent() {
+        let (tmp, _lockfile, vendor) = setup();
+        let locals = vec![tmp.path().join("libx")];
+        assert!(!is_cached_local(&vendor, &locals).unwrap());
+    }
+
+    // endregion
 }

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -738,7 +738,8 @@ fn run_external_only(
     // Step 1b: Load metadata; derive local and patch package lists.
     let meta = metadata::load_metadata(manifest_path)?;
     metadata::check_duplicate_sources(&meta)?;
-    let (local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
+    let (local_pkgs, _) =
+        metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
 
     let all_workspace_members = if !source_root_members.is_empty() {
         source_root_members
@@ -859,7 +860,8 @@ fn run_local_only(
     // Step 1b: Load metadata + partition.
     let meta = metadata::load_metadata(manifest_path)?;
     metadata::check_duplicate_sources(&meta)?;
-    let (mut local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
+    let (mut local_pkgs, _) =
+        metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
 
     let all_workspace_members = if !source_root_members.is_empty() {
         source_root_members

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -398,9 +398,7 @@ fn main() -> Result<()> {
         Mode::ExternalOnly => {
             run_external_only(&cli, &manifest_path, &output, &lockfile, &sync_manifests, v)
         }
-        Mode::LocalOnly => {
-            run_local_only(&cli, &manifest_path, &output, &lockfile, &sync_manifests, v)
-        }
+        Mode::LocalOnly => run_local_only(&cli, &manifest_path, &output, v),
     }
 }
 
@@ -722,18 +720,36 @@ fn run_external_only(
         return Ok(());
     }
 
-    // Step 1b: Load metadata (no bootstrap needed — we don't package local crates)
+    // Step 1a: Bootstrap-seed from source_root so `cargo metadata` can resolve
+    // frozen path deps (`path = "../../vendor/<name>/"`) on a fresh clone.
+    // Same logic as run_full / run_local_only — seeds are stubs to unblock
+    // metadata; remove_flat_dirs cleans them from staging after cargo vendor.
+    let source_root_members = if let Some(ref source_root) = cli.source_root {
+        metadata::discover_workspace_members(source_root)?
+    } else {
+        Vec::new()
+    };
+
+    if !source_root_members.is_empty() {
+        bootstrap_vendor_from_source_root(output, &source_root_members, v)?;
+        vendor::rewrite_local_path_deps(output, &source_root_members, v)?;
+    }
+
+    // Step 1b: Load metadata; derive local and patch package lists.
     let meta = metadata::load_metadata(manifest_path)?;
     metadata::check_duplicate_sources(&meta)?;
     let (local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
 
-    let patch_pkgs = if let Some(first_local) = local_pkgs.first() {
+    let all_workspace_members = if !source_root_members.is_empty() {
+        source_root_members
+    } else if let Some(first_local) = local_pkgs.first() {
         let ws_root = find_workspace_root(&first_local.path)?;
-        let all_ws = metadata::discover_workspace_members(&ws_root)?;
-        merge_packages(&local_pkgs, &all_ws)
+        metadata::discover_workspace_members(&ws_root)?
     } else {
-        local_pkgs.clone()
+        Vec::new()
     };
+
+    let patch_pkgs = merge_packages(&local_pkgs, &all_workspace_members);
 
     if v.info() {
         eprintln!("cargo-revendor: --external-only: skipping {} local crates", local_pkgs.len());
@@ -811,34 +827,36 @@ fn run_local_only(
     cli: &Cli,
     manifest_path: &std::path::Path,
     output: &std::path::Path,
-    lockfile: &std::path::Path,
-    sync_manifests: &[std::path::PathBuf],
     v: Verbosity,
 ) -> Result<()> {
-    // Step 0: Cache check — skip if local crate sources are unchanged
-    let source_root_members_for_cache: Vec<std::path::PathBuf> = if let Some(ref sr) = cli.source_root {
-        metadata::discover_workspace_members(sr)?
-            .into_iter()
-            .map(|p| p.path)
-            .collect()
-    } else {
-        Vec::new()
-    };
-
     // Step 1a: Bootstrap-seed from source_root so metadata can resolve frozen
-    // path deps (same logic as run_full).
+    // path deps (same logic as run_full). Discover source_root_members once and
+    // reuse for bootstrap seeding, all_workspace_members, and the cache key.
     let source_root_members = if let Some(ref source_root) = cli.source_root {
         metadata::discover_workspace_members(source_root)?
     } else {
         Vec::new()
     };
 
+    // Step 0: Cache check using source_root paths — skip bootstrap + metadata
+    // on a hit to avoid unnecessary I/O.
+    if !cli.force && !source_root_members.is_empty() {
+        let source_root_paths: Vec<std::path::PathBuf> =
+            source_root_members.iter().map(|p| p.path.clone()).collect();
+        if cache::is_cached_local(output, &source_root_paths)? {
+            if v.info() {
+                eprintln!("cargo-revendor: local vendor/ is up to date (inputs unchanged)");
+            }
+            return Ok(());
+        }
+    }
+
     if !source_root_members.is_empty() {
         bootstrap_vendor_from_source_root(output, &source_root_members, v)?;
         vendor::rewrite_local_path_deps(output, &source_root_members, v)?;
     }
 
-    // Step 1b: Load metadata + partition with git_overrides = source_root_members
+    // Step 1b: Load metadata + partition.
     let meta = metadata::load_metadata(manifest_path)?;
     metadata::check_duplicate_sources(&meta)?;
     let (mut local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
@@ -874,15 +892,16 @@ fn run_local_only(
 
     let patch_pkgs = merge_packages(&local_pkgs, &all_workspace_members);
 
-    let local_crate_paths: Vec<std::path::PathBuf> = local_pkgs.iter().map(|p| p.path.clone()).collect();
+    let local_crate_paths: Vec<std::path::PathBuf> =
+        local_pkgs.iter().map(|p| p.path.clone()).collect();
 
-    // Cache check now that we have actual local_crate_paths
-    let cache_paths = if source_root_members_for_cache.is_empty() {
-        local_crate_paths.clone()
-    } else {
-        source_root_members_for_cache
-    };
-    if !cli.force && cache::is_cached_local(output, &cache_paths)? {
+    // Step 0 (fallback): when --source-root was not provided, the cache check
+    // can only happen after metadata (we need local_crate_paths). When
+    // --source-root was provided, the early cache check above already handled it.
+    if !cli.force
+        && cli.source_root.is_none()
+        && cache::is_cached_local(output, &local_crate_paths)?
+    {
         if v.info() {
             eprintln!("cargo-revendor: local vendor/ is up to date (inputs unchanged)");
         }
@@ -951,11 +970,12 @@ fn run_local_only(
         eprintln!("{}", config_toml);
     }
 
-    // Step 14: Save local cache. Also refresh the full cache if sync_manifests
-    // are available (so full-mode cache checks still work after local-only runs).
-    cache::save_cache_local(output, &cache_paths)?;
-    // Keep the legacy full cache in sync when we have enough info.
-    cache::save_cache(lockfile, sync_manifests, output, &cache_paths)?;
+    // Step 14: Save local cache.
+    // Do NOT update the legacy full cache (.revendor-cache) here — after a
+    // --local-only run we haven't re-processed external deps, so writing the
+    // full cache with local-only paths would produce a false hit in a subsequent
+    // full-mode run if external deps change before then.
+    cache::save_cache_local(output, &local_crate_paths)?;
 
     if v.info() {
         eprintln!(

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -176,6 +176,32 @@ struct Cli {
     /// flat vendor paths.
     #[arg(long)]
     flat_dirs: bool,
+
+    /// Vendor external (crates.io/git) dependencies only.
+    /// Writes vendor/<name>-<version>/ dirs; never touches local crate dirs.
+    /// Incompatible with --freeze, --compress, --source-marker, --blank-md,
+    /// and --strict-freeze.
+    #[arg(long, conflicts_with = "local_only")]
+    external_only: bool,
+
+    /// Vendor local workspace crates only.
+    /// Writes vendor/<name>/ (flat) dirs; never touches external dirs.
+    /// Requires externals to already be on disk (checked via
+    /// .revendor-cache-external) when --freeze, --compress, --source-marker,
+    /// or --blank-md are also given.
+    #[arg(long, conflicts_with = "external_only")]
+    local_only: bool,
+}
+
+/// Which phase(s) of vendoring to perform.
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    /// Full vendor pass (default): external deps + local crates.
+    Full,
+    /// External deps only (crates.io/git). Skips local crate packaging.
+    ExternalOnly,
+    /// Local workspace crates only. Skips `cargo vendor` for external deps.
+    LocalOnly,
 }
 
 impl Cli {
@@ -197,6 +223,108 @@ impl Cli {
     }
 }
 
+/// Validate that the selected phase mode is compatible with the other flags.
+///
+/// - `ExternalOnly` may not be combined with flags that require local crates to
+///   already be in vendor/ (freeze, compress, source-marker, blank-md,
+///   strict-freeze).
+/// - `LocalOnly` may only be combined with those flags if externals have
+///   already been vendored (`.revendor-cache-external` present in output).
+fn validate_flag_compatibility(cli: &Cli, mode: Mode, output: &std::path::Path) -> Result<()> {
+    match mode {
+        Mode::Full => {}
+        Mode::ExternalOnly => {
+            if cli.freeze {
+                anyhow::bail!(
+                    "--external-only is incompatible with --freeze: \
+                     freeze rewrites the manifest and regenerates Cargo.lock, \
+                     which requires local crates to already be in vendor/"
+                );
+            }
+            if cli.compress.is_some() {
+                anyhow::bail!(
+                    "--external-only is incompatible with --compress: \
+                     the tarball would be missing local crates"
+                );
+            }
+            if cli.source_marker {
+                anyhow::bail!(
+                    "--external-only is incompatible with --source-marker"
+                );
+            }
+            if cli.blank_md {
+                anyhow::bail!(
+                    "--external-only is incompatible with --blank-md"
+                );
+            }
+            if cli.strict_freeze {
+                anyhow::bail!(
+                    "--external-only is incompatible with --strict-freeze"
+                );
+            }
+        }
+        Mode::LocalOnly => {
+            // These flags require a complete vendor/ tree (external + local).
+            // Allow them only when externals were previously vendored.
+            let needs_externals = cli.freeze
+                || cli.compress.is_some()
+                || cli.source_marker
+                || cli.blank_md;
+            if needs_externals {
+                let externals_present = output
+                    .join(cache::CACHE_FILE_EXTERNAL)
+                    .exists();
+                if !externals_present {
+                    anyhow::bail!(
+                        "--local-only with --freeze/--compress/--source-marker/--blank-md \
+                         requires externals to already be vendored \
+                         (run --external-only first; .revendor-cache-external not found in {})",
+                        output.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Merge the contents of `staging` into `output`, replacing only the dirs that
+/// are present in `staging`. Dirs already in `output` but absent from `staging`
+/// are left untouched — this is how phase modes avoid clobbering the other
+/// phase's dirs.
+fn merge_copy_vendor(staging: &std::path::Path, output: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(output)
+        .with_context(|| format!("failed to create {}", output.display()))?;
+    for entry in std::fs::read_dir(staging)
+        .with_context(|| format!("failed to read staging dir {}", staging.display()))?
+    {
+        let entry = entry?;
+        let name = entry.file_name();
+        let dst = output.join(&name);
+        if dst.exists() {
+            if dst.is_dir() {
+                std::fs::remove_dir_all(&dst).with_context(|| {
+                    format!("failed to remove existing {}", dst.display())
+                })?;
+            } else {
+                std::fs::remove_file(&dst).with_context(|| {
+                    format!("failed to remove existing {}", dst.display())
+                })?;
+            }
+        }
+        std::fs::rename(entry.path(), &dst)
+            .or_else(|_| copy_dir_recursive(&entry.path(), &dst))
+            .with_context(|| {
+                format!(
+                    "failed to move {} to {}",
+                    entry.path().display(),
+                    dst.display()
+                )
+            })?;
+    }
+    Ok(())
+}
+
 /// JSON output structure
 #[derive(serde::Serialize)]
 struct JsonOutput {
@@ -211,8 +339,6 @@ struct JsonOutput {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let v = cli.verbosity();
-    // versioned_dirs is default-on; only disable when --flat-dirs is passed
-    let versioned_dirs = !cli.flat_dirs;
 
     let manifest_path = resolve_manifest_path(cli.manifest_path.as_deref())?;
 
@@ -232,8 +358,7 @@ fn main() -> Result<()> {
 
     let lockfile = manifest_path.with_file_name("Cargo.lock");
 
-    // Canonicalize each --sync manifest path once. Used by both the verify
-    // shortcut above and the vendor flow below (plus cache hashing).
+    // Canonicalize each --sync manifest path once.
     let sync_manifests: Vec<std::path::PathBuf> = cli
         .sync
         .iter()
@@ -257,6 +382,39 @@ fn main() -> Result<()> {
             v,
         );
     }
+
+    let mode = if cli.external_only {
+        Mode::ExternalOnly
+    } else if cli.local_only {
+        Mode::LocalOnly
+    } else {
+        Mode::Full
+    };
+
+    validate_flag_compatibility(&cli, mode, &output)?;
+
+    match mode {
+        Mode::Full => run_full(&cli, &manifest_path, &output, &lockfile, &sync_manifests, v),
+        Mode::ExternalOnly => {
+            run_external_only(&cli, &manifest_path, &output, &lockfile, &sync_manifests, v)
+        }
+        Mode::LocalOnly => {
+            run_local_only(&cli, &manifest_path, &output, &lockfile, &sync_manifests, v)
+        }
+    }
+}
+
+/// Full vendor pass: external deps + local workspace crates (existing behavior).
+fn run_full(
+    cli: &Cli,
+    manifest_path: &std::path::Path,
+    output: &std::path::Path,
+    lockfile: &std::path::Path,
+    sync_manifests: &[std::path::PathBuf],
+    v: Verbosity,
+) -> Result<()> {
+    // versioned_dirs is default-on; only disable when --flat-dirs is passed
+    let versioned_dirs = !cli.flat_dirs;
 
     // Step 1a: Pre-seed `vendor/<name>-<version>/` for each workspace member
     // when `--source-root` is set (dev-monorepo configure path).
@@ -282,17 +440,17 @@ fn main() -> Result<()> {
     };
 
     if !source_root_members.is_empty() {
-        bootstrap_vendor_from_source_root(&output, &source_root_members, v)?;
+        bootstrap_vendor_from_source_root(output, &source_root_members, v)?;
         // After seeding, each workspace member's Cargo.toml still has its
         // ORIGINAL inter-workspace `path = "../other-crate"` deps, which
         // resolve relative to the NEW vendor location and go nowhere.
         // Rewrite them to sibling vendor dirs (flat `../<name>`) so
         // cargo metadata can walk the dep graph.
-        vendor::rewrite_local_path_deps(&output, &source_root_members, v)?;
+        vendor::rewrite_local_path_deps(output, &source_root_members, v)?;
     }
 
     // Step 1b: Load cargo metadata to discover dependencies.
-    let meta = metadata::load_metadata(&manifest_path)?;
+    let meta = metadata::load_metadata(manifest_path)?;
 
     // Mirror upstream cargo's duplicate-source check: error out if two
     // different git sources resolve to the same crate name+version. Without
@@ -318,7 +476,7 @@ fn main() -> Result<()> {
     // (e.g., [source.vendored-sources] directory = "vendor"), cargo metadata
     // resolves local workspace crate paths to the vendor directory instead of the
     // real workspace source. Detect this and replace with the real workspace path.
-    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.clone());
+    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.to_path_buf());
     for pkg in &mut local_pkgs {
         let canonical_pkg = pkg.path.canonicalize().unwrap_or_else(|_| pkg.path.clone());
         if canonical_pkg.starts_with(&canonical_output) {
@@ -365,12 +523,12 @@ fn main() -> Result<()> {
         local_pkgs.iter().map(|p| p.path.clone()).collect();
 
     // Step 0: Check cache — skip if all inputs are unchanged
-    if !cli.force && cache::is_cached(&lockfile, &sync_manifests, &output, &local_crate_paths)? {
+    if !cli.force && cache::is_cached(lockfile, sync_manifests, output, &local_crate_paths)? {
         if v.info() {
             eprintln!("cargo-revendor: vendor/ is up to date (inputs unchanged)");
         }
         if cli.json {
-            let count = std::fs::read_dir(&output)
+            let count = std::fs::read_dir(output)
                 .map(|d| {
                     d.filter_map(|e| e.ok())
                         .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
@@ -397,7 +555,7 @@ fn main() -> Result<()> {
     let packaged = package::package_local_crates(
         &local_pkgs,
         &patch_pkgs,
-        &manifest_path,
+        manifest_path,
         staging.path(),
         cli.allow_dirty,
         v,
@@ -405,10 +563,10 @@ fn main() -> Result<()> {
 
     // Step 3: Run `cargo vendor` for external deps
     vendor::run_cargo_vendor(
-        &manifest_path,
+        manifest_path,
         &vendor_staging,
         &patch_pkgs,
-        &sync_manifests,
+        sync_manifests,
         versioned_dirs,
         v,
     )?;
@@ -444,17 +602,17 @@ fn main() -> Result<()> {
     // Step 7: Clear checksums
     vendor::clear_checksums(&vendor_staging)?;
 
-    // Step 8: Move to final output directory
+    // Step 8: Move to final output directory (full mode: fast replace)
     if output.exists() {
-        std::fs::remove_dir_all(&output)
+        std::fs::remove_dir_all(output)
             .with_context(|| format!("failed to remove existing {}", output.display()))?;
     }
-    std::fs::rename(&vendor_staging, &output)
-        .or_else(|_| copy_dir_recursive(&vendor_staging, &output))
+    std::fs::rename(&vendor_staging, output)
+        .or_else(|_| copy_dir_recursive(&vendor_staging, output))
         .with_context(|| format!("failed to move vendor to {}", output.display()))?;
 
     // Step 9: Generate .cargo/config.toml for source replacement
-    let config_toml = vendor::generate_cargo_config(&manifest_path, &output, &local_pkgs)?;
+    let config_toml = vendor::generate_cargo_config(manifest_path, output, &local_pkgs)?;
     if v.info() {
         eprintln!("  Generated .cargo/config.toml for source replacement");
     }
@@ -463,13 +621,13 @@ fn main() -> Result<()> {
     }
 
     // Step 10: Strip checksums from Cargo.lock (vendored crates have empty checksums)
-    vendor::strip_lock_checksums(&lockfile, &output, v)?;
+    vendor::strip_lock_checksums(lockfile, output, v)?;
 
     // When --compress is given, the canonical Cargo.lock also needs stripped
     // checksums — cargo --offline refuses to build against vendored sources
     // if the lockfile still contains registry checksums.
     if cli.compress.is_some() && !cli.freeze {
-        vendor::strip_lockfile_inplace(&lockfile, v.0)?;
+        vendor::strip_lockfile_inplace(lockfile, v.0)?;
     }
 
     // Step 11: Write source marker
@@ -488,14 +646,14 @@ fn main() -> Result<()> {
     // Step 12: Freeze — rewrite manifest so all sources resolve from vendor/
     if cli.freeze {
         vendor::freeze_manifest(
-            &manifest_path,
-            &output,
+            manifest_path,
+            output,
             &local_pkgs,
             versioned_dirs,
             cli.strict_freeze,
             v,
         )?;
-        vendor::regenerate_lockfile(&manifest_path, &output, v)?;
+        vendor::regenerate_lockfile(manifest_path, output, v)?;
     }
 
     // Step 13: Compress to tarball (relative paths resolve from CWD)
@@ -505,14 +663,16 @@ fn main() -> Result<()> {
         } else {
             std::env::current_dir()?.join(tarball_path)
         };
-        vendor::compress_vendor(&output, &tarball, cli.blank_md, v)?;
+        vendor::compress_vendor(output, &tarball, cli.blank_md, v)?;
     }
 
-    // Step 14: Save cache
-    cache::save_cache(&lockfile, &sync_manifests, &output, &local_crate_paths)?;
+    // Step 14: Save cache (all three files for full mode)
+    cache::save_cache(lockfile, sync_manifests, output, &local_crate_paths)?;
+    cache::save_cache_external(lockfile, sync_manifests, output)?;
+    cache::save_cache_local(output, &local_crate_paths)?;
 
     // Count total crates
-    let total = std::fs::read_dir(&output)
+    let total = std::fs::read_dir(output)
         .map(|d| {
             d.filter_map(|e| e.ok())
                 .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
@@ -539,6 +699,297 @@ fn main() -> Result<()> {
         );
     }
 
+    Ok(())
+}
+
+/// External-only vendor pass: runs `cargo vendor` for crates.io/git deps,
+/// never touches local workspace crate dirs.
+fn run_external_only(
+    cli: &Cli,
+    manifest_path: &std::path::Path,
+    output: &std::path::Path,
+    lockfile: &std::path::Path,
+    sync_manifests: &[std::path::PathBuf],
+    v: Verbosity,
+) -> Result<()> {
+    let versioned_dirs = !cli.flat_dirs;
+
+    // Step 0: Cache check — skip if external inputs are unchanged
+    if !cli.force && cache::is_cached_external(lockfile, sync_manifests, output)? {
+        if v.info() {
+            eprintln!("cargo-revendor: external vendor/ is up to date (inputs unchanged)");
+        }
+        return Ok(());
+    }
+
+    // Step 1b: Load metadata (no bootstrap needed — we don't package local crates)
+    let meta = metadata::load_metadata(manifest_path)?;
+    metadata::check_duplicate_sources(&meta)?;
+    let (local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
+
+    let patch_pkgs = if let Some(first_local) = local_pkgs.first() {
+        let ws_root = find_workspace_root(&first_local.path)?;
+        let all_ws = metadata::discover_workspace_members(&ws_root)?;
+        merge_packages(&local_pkgs, &all_ws)
+    } else {
+        local_pkgs.clone()
+    };
+
+    if v.info() {
+        eprintln!("cargo-revendor: --external-only: skipping {} local crates", local_pkgs.len());
+    }
+
+    // Step 3: Run `cargo vendor` for external deps only
+    let staging = tempfile::tempdir().context("failed to create staging dir")?;
+    let vendor_staging = staging.path().join("vendor");
+
+    vendor::run_cargo_vendor(
+        manifest_path,
+        &vendor_staging,
+        &patch_pkgs,
+        sync_manifests,
+        versioned_dirs,
+        v,
+    )?;
+
+    // Remove any flat (local-crate-style) dirs that cargo vendor may have
+    // placed in staging for path deps. External-only must not touch flat dirs.
+    remove_flat_dirs(&vendor_staging, &local_pkgs, v)?;
+
+    // Step 5: Strip directories (opt-in)
+    let strip_cfg = cli.strip_config();
+    if strip_cfg.any() {
+        strip::strip_vendor_dir(&vendor_staging, &strip_cfg, v)?;
+    }
+
+    // Step 5.5: Strip relative path deps from all vendored external crates
+    vendor::strip_vendor_path_deps(&vendor_staging, v)?;
+
+    // Step 7: Clear checksums
+    vendor::clear_checksums(&vendor_staging)?;
+
+    // Step 8: Merge into output (only overwrite dirs present in staging)
+    merge_copy_vendor(&vendor_staging, output)?;
+    if v.info() {
+        eprintln!("  Merged external deps into {}", output.display());
+    }
+
+    // Step 9: Generate .cargo/config.toml (rescans all of output, so local
+    // dirs already present are included)
+    let config_toml = vendor::generate_cargo_config(manifest_path, output, &local_pkgs)?;
+    if v.info() {
+        eprintln!("  Generated .cargo/config.toml for source replacement");
+    }
+    if v.debug() {
+        eprintln!("{}", config_toml);
+    }
+
+    // Step 14: Save external cache
+    cache::save_cache_external(lockfile, sync_manifests, output)?;
+
+    if v.info() {
+        let total = std::fs::read_dir(output)
+            .map(|d| {
+                d.filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                    .count()
+            })
+            .unwrap_or(0);
+        eprintln!(
+            "cargo-revendor: --external-only: wrote {} crate dirs to {}",
+            total,
+            output.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Local-only vendor pass: packages workspace crates and writes them to
+/// vendor/, never touching external crate dirs.
+fn run_local_only(
+    cli: &Cli,
+    manifest_path: &std::path::Path,
+    output: &std::path::Path,
+    lockfile: &std::path::Path,
+    sync_manifests: &[std::path::PathBuf],
+    v: Verbosity,
+) -> Result<()> {
+    // Step 0: Cache check — skip if local crate sources are unchanged
+    let source_root_members_for_cache: Vec<std::path::PathBuf> = if let Some(ref sr) = cli.source_root {
+        metadata::discover_workspace_members(sr)?
+            .into_iter()
+            .map(|p| p.path)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // Step 1a: Bootstrap-seed from source_root so metadata can resolve frozen
+    // path deps (same logic as run_full).
+    let source_root_members = if let Some(ref source_root) = cli.source_root {
+        metadata::discover_workspace_members(source_root)?
+    } else {
+        Vec::new()
+    };
+
+    if !source_root_members.is_empty() {
+        bootstrap_vendor_from_source_root(output, &source_root_members, v)?;
+        vendor::rewrite_local_path_deps(output, &source_root_members, v)?;
+    }
+
+    // Step 1b: Load metadata + partition with git_overrides = source_root_members
+    let meta = metadata::load_metadata(manifest_path)?;
+    metadata::check_duplicate_sources(&meta)?;
+    let (mut local_pkgs, _) = metadata::partition_packages(&meta, manifest_path)?;
+
+    let all_workspace_members = if !source_root_members.is_empty() {
+        source_root_members
+    } else if let Some(first_local) = local_pkgs.first() {
+        let ws_root = find_workspace_root(&first_local.path)?;
+        metadata::discover_workspace_members(&ws_root)?
+    } else {
+        Vec::new()
+    };
+
+    // Fix vendor-dir-resolved paths (same logic as run_full)
+    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.to_path_buf());
+    for pkg in &mut local_pkgs {
+        let canonical_pkg = pkg.path.canonicalize().unwrap_or_else(|_| pkg.path.clone());
+        if canonical_pkg.starts_with(&canonical_output)
+            && let Some(ws_pkg) = all_workspace_members.iter().find(|ws| ws.name == pkg.name)
+        {
+            if v.debug() {
+                eprintln!(
+                    "  Fixed {}: {} -> {}",
+                    pkg.name,
+                    pkg.path.display(),
+                    ws_pkg.path.display()
+                );
+            }
+            pkg.path = ws_pkg.path.clone();
+            pkg.manifest_path = ws_pkg.manifest_path.clone();
+        }
+    }
+
+    let patch_pkgs = merge_packages(&local_pkgs, &all_workspace_members);
+
+    let local_crate_paths: Vec<std::path::PathBuf> = local_pkgs.iter().map(|p| p.path.clone()).collect();
+
+    // Cache check now that we have actual local_crate_paths
+    let cache_paths = if source_root_members_for_cache.is_empty() {
+        local_crate_paths.clone()
+    } else {
+        source_root_members_for_cache
+    };
+    if !cli.force && cache::is_cached_local(output, &cache_paths)? {
+        if v.info() {
+            eprintln!("cargo-revendor: local vendor/ is up to date (inputs unchanged)");
+        }
+        return Ok(());
+    }
+
+    if v.info() {
+        eprintln!("  Local packages to vendor: {}", local_pkgs.len());
+        for pkg in &local_pkgs {
+            eprintln!(
+                "    - {} v{} ({})",
+                pkg.name,
+                pkg.version,
+                pkg.path.display()
+            );
+        }
+    }
+
+    // Step 2: Package local crates via `cargo package`
+    let staging = tempfile::tempdir().context("failed to create staging dir")?;
+    let vendor_staging = staging.path().join("vendor");
+
+    let packaged = package::package_local_crates(
+        &local_pkgs,
+        &patch_pkgs,
+        manifest_path,
+        staging.path(),
+        cli.allow_dirty,
+        v,
+    )?;
+
+    // Step 4: Extract packaged local crates into vendor staging
+    for (pkg_name, crate_path) in &packaged {
+        let pkg_version = local_pkgs
+            .iter()
+            .find(|p| &p.name == pkg_name)
+            .map(|p| p.version.as_str());
+        vendor::extract_crate_archive(crate_path, &vendor_staging, pkg_name, pkg_version, v)?;
+    }
+
+    // Step 5: Strip directories (opt-in)
+    let strip_cfg = cli.strip_config();
+    if strip_cfg.any() {
+        strip::strip_vendor_dir(&vendor_staging, &strip_cfg, v)?;
+    }
+
+    // Step 6: Rewrite inter-crate path deps for local crates
+    vendor::rewrite_local_path_deps(&vendor_staging, &local_pkgs, v)?;
+
+    // Step 7: Clear checksums
+    vendor::clear_checksums(&vendor_staging)?;
+
+    // Step 8: Merge into output (only overwrite dirs present in staging)
+    merge_copy_vendor(&vendor_staging, output)?;
+    if v.info() {
+        eprintln!("  Merged {} local crate(s) into {}", packaged.len(), output.display());
+    }
+
+    // Step 9: Generate .cargo/config.toml (rescans all of output, so external
+    // dirs already present are included)
+    let config_toml = vendor::generate_cargo_config(manifest_path, output, &local_pkgs)?;
+    if v.info() {
+        eprintln!("  Generated .cargo/config.toml for source replacement");
+    }
+    if v.debug() {
+        eprintln!("{}", config_toml);
+    }
+
+    // Step 14: Save local cache. Also refresh the full cache if sync_manifests
+    // are available (so full-mode cache checks still work after local-only runs).
+    cache::save_cache_local(output, &cache_paths)?;
+    // Keep the legacy full cache in sync when we have enough info.
+    cache::save_cache(lockfile, sync_manifests, output, &cache_paths)?;
+
+    if v.info() {
+        eprintln!(
+            "cargo-revendor: --local-only: wrote {} local crate(s) to {}",
+            packaged.len(),
+            output.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Remove flat (no-dash) dirs from `staging` that correspond to local
+/// packages. `cargo vendor` may place path deps directly in staging; those
+/// would clobber real local-crate entries on the next `--local-only` run.
+fn remove_flat_dirs(
+    staging: &std::path::Path,
+    local_pkgs: &[metadata::LocalPackage],
+    v: Verbosity,
+) -> Result<()> {
+    for entry in std::fs::read_dir(staging)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Flat dir: doesn't contain a '-' that looks like a version separator,
+        // or matches a known local package name exactly.
+        let is_flat = local_pkgs.iter().any(|p| p.name == name_str.as_ref());
+        if is_flat {
+            if v.debug() {
+                eprintln!("  --external-only: removing local placeholder {name_str} from staging");
+            }
+            std::fs::remove_dir_all(entry.path())?;
+        }
+    }
     Ok(())
 }
 
@@ -778,3 +1229,114 @@ fn bootstrap_vendor_from_source_root(
     }
     Ok(())
 }
+
+// region: unit tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a minimal Cli with all flags at their defaults. We parse with a
+    /// dummy manifest path so clap doesn't run auto-discovery.
+    fn base_cli() -> Cli {
+        Cli::parse_from(["cargo-revendor", "revendor", "--manifest-path", "/dev/null"])
+    }
+
+    fn tmp_output() -> (TempDir, std::path::PathBuf) {
+        let d = TempDir::new().unwrap();
+        let p = d.path().join("vendor");
+        std::fs::create_dir_all(&p).unwrap();
+        (d, p)
+    }
+
+    // region: validate_flag_compatibility
+
+    #[test]
+    fn validate_external_only_freeze_errors() {
+        let (_d, output) = tmp_output();
+        let mut cli = base_cli();
+        cli.freeze = true;
+        let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
+        assert!(err.to_string().contains("--external-only is incompatible with --freeze"));
+    }
+
+    #[test]
+    fn validate_external_only_compress_errors() {
+        let (_d, output) = tmp_output();
+        let mut cli = base_cli();
+        cli.compress = Some(std::path::PathBuf::from("vendor.tar.xz"));
+        let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
+        assert!(err.to_string().contains("--external-only is incompatible with --compress"));
+    }
+
+    #[test]
+    fn validate_external_only_source_marker_errors() {
+        let (_d, output) = tmp_output();
+        let mut cli = base_cli();
+        cli.source_marker = true;
+        let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
+        assert!(err.to_string().contains("--external-only is incompatible with --source-marker"));
+    }
+
+    #[test]
+    fn validate_external_only_blank_md_errors() {
+        let (_d, output) = tmp_output();
+        let mut cli = base_cli();
+        cli.blank_md = true;
+        let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
+        assert!(err.to_string().contains("--external-only is incompatible with --blank-md"));
+    }
+
+    #[test]
+    fn validate_local_only_compress_without_externals_errors() {
+        let (_d, output) = tmp_output();
+        // No .revendor-cache-external present → should fail
+        let mut cli = base_cli();
+        cli.compress = Some(std::path::PathBuf::from("vendor.tar.xz"));
+        let err = validate_flag_compatibility(&cli, Mode::LocalOnly, &output).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--local-only with --freeze/--compress"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains(".revendor-cache-external not found"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_local_only_compress_with_externals_ok() {
+        let (_d, output) = tmp_output();
+        // Write the sentinel file — externals were previously vendored.
+        std::fs::write(output.join(cache::CACHE_FILE_EXTERNAL), "abcd1234").unwrap();
+        let mut cli = base_cli();
+        cli.compress = Some(std::path::PathBuf::from("vendor.tar.xz"));
+        validate_flag_compatibility(&cli, Mode::LocalOnly, &output).unwrap();
+    }
+
+    #[test]
+    fn validate_full_mode_accepts_all_flags() {
+        let (_d, output) = tmp_output();
+        // Full mode should never error in validate_flag_compatibility.
+        let mut cli = base_cli();
+        cli.freeze = true;
+        cli.compress = Some(std::path::PathBuf::from("v.tar.xz"));
+        cli.source_marker = true;
+        cli.blank_md = true;
+        validate_flag_compatibility(&cli, Mode::Full, &output).unwrap();
+    }
+
+    #[test]
+    fn validate_local_only_no_flags_always_ok() {
+        let (_d, output) = tmp_output();
+        // No externals present, but also no flags that require them.
+        let cli = base_cli();
+        validate_flag_compatibility(&cli, Mode::LocalOnly, &output).unwrap();
+    }
+
+    // endregion
+}
+
+// endregion

--- a/cargo-revendor/tests/phase_modes.rs
+++ b/cargo-revendor/tests/phase_modes.rs
@@ -11,9 +11,7 @@ mod common;
 
 use common::{create_workspace, git_init, revendor_cmd};
 
-// =============================================================================
-// Flag compatibility (offline — no cargo vendor invoked)
-// =============================================================================
+// region: flag compatibility (offline — no cargo vendor invoked)
 
 /// --external-only --freeze must exit non-zero with a clear error.
 #[test]
@@ -157,9 +155,9 @@ path = "lib.rs"
         .failure();
 }
 
-// =============================================================================
-// Phase mode vendoring (network required)
-// =============================================================================
+// endregion
+
+// region: phase mode vendoring (network required)
 
 /// --external-only produces versioned dirs and writes .revendor-cache-external.
 #[test]
@@ -558,3 +556,5 @@ cfg-if = "1"
         ".revendor-cache-external should not be rewritten on a cache hit"
     );
 }
+
+// endregion

--- a/cargo-revendor/tests/phase_modes.rs
+++ b/cargo-revendor/tests/phase_modes.rs
@@ -1,0 +1,560 @@
+//! Integration tests for --external-only / --local-only phase modes (#290).
+//!
+//! Tests marked `#[ignore]` require network access or a full cargo/rustc
+//! toolchain for vendoring. Offline tests (flag compatibility) run without
+//! any network or package-compilation.
+//!
+//! Run all tests including ignored ones:
+//!   cargo test -p cargo-revendor -- --ignored
+
+mod common;
+
+use common::{create_workspace, git_init, revendor_cmd};
+
+// =============================================================================
+// Flag compatibility (offline — no cargo vendor invoked)
+// =============================================================================
+
+/// --external-only --freeze must exit non-zero with a clear error.
+#[test]
+fn flag_compat_external_only_freeze_exits_nonzero() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["mypkg"]
+"#,
+        &[(
+            "mypkg",
+            r#"[package]
+name = "mypkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+            "pub fn hello() {}",
+        )],
+    );
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("mypkg/Cargo.toml").to_str().unwrap(),
+            "--external-only",
+            "--freeze",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--external-only is incompatible with --freeze",
+        ));
+}
+
+/// --external-only --compress must exit non-zero.
+#[test]
+fn flag_compat_external_only_compress_exits_nonzero() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["mypkg"]
+"#,
+        &[(
+            "mypkg",
+            r#"[package]
+name = "mypkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+            "pub fn hello() {}",
+        )],
+    );
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("mypkg/Cargo.toml").to_str().unwrap(),
+            "--external-only",
+            "--compress",
+            "vendor.tar.xz",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--external-only is incompatible with --compress",
+        ));
+}
+
+/// --local-only --compress without a prior --external-only run must exit non-zero.
+#[test]
+fn flag_compat_local_only_compress_without_externals_exits_nonzero() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["mypkg"]
+"#,
+        &[(
+            "mypkg",
+            r#"[package]
+name = "mypkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+            "pub fn hello() {}",
+        )],
+    );
+
+    // Vendor dir is empty (no .revendor-cache-external) — should fail.
+    let vendor = proj.root().join("vendor");
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("mypkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--local-only",
+            "--compress",
+            "vendor.tar.xz",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(".revendor-cache-external not found"));
+}
+
+/// --external-only and --local-only are mutually exclusive (clap enforces this).
+#[test]
+fn flag_compat_external_and_local_only_are_exclusive() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["mypkg"]
+"#,
+        &[(
+            "mypkg",
+            r#"[package]
+name = "mypkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+            "pub fn hello() {}",
+        )],
+    );
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("mypkg/Cargo.toml").to_str().unwrap(),
+            "--external-only",
+            "--local-only",
+        ])
+        .assert()
+        .failure();
+}
+
+// =============================================================================
+// Phase mode vendoring (network required)
+// =============================================================================
+
+/// --external-only produces versioned dirs and writes .revendor-cache-external.
+#[test]
+#[ignore] // network
+fn external_only_produces_versioned_dirs_and_cache_file() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["rpkg", "myhelper"]
+"#,
+        &[
+            (
+                "rpkg",
+                r#"[package]
+name = "rpkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+[dependencies]
+myhelper = { path = "../myhelper" }
+cfg-if = "1"
+"#,
+                "pub fn go() {}",
+            ),
+            (
+                "myhelper",
+                r#"[package]
+name = "myhelper"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+                "pub fn help() {}",
+            ),
+        ],
+    );
+    let vendor = proj.root().join("vendor");
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--source-root",
+            proj.root().to_str().unwrap(),
+            "--external-only",
+        ])
+        .assert()
+        .success();
+
+    // External cache file must exist.
+    assert!(
+        vendor.join(".revendor-cache-external").exists(),
+        ".revendor-cache-external should be written by --external-only"
+    );
+
+    // Local-only cache file must NOT exist (we didn't run --local-only).
+    assert!(
+        !vendor.join(".revendor-cache-local").exists(),
+        ".revendor-cache-local should not exist after --external-only"
+    );
+
+    // cfg-if (external) must be present as a versioned dir.
+    let has_cfg_if = std::fs::read_dir(&vendor)
+        .unwrap()
+        .flatten()
+        .any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with("cfg-if-")
+        });
+    assert!(has_cfg_if, "cfg-if versioned dir should be in vendor/");
+
+    // myhelper (local) must NOT be present (we skipped local packaging).
+    assert!(
+        !common::vendor_has(&vendor, "myhelper"),
+        "myhelper (local) should not be in vendor/ after --external-only"
+    );
+}
+
+/// --local-only after --external-only: only flat dirs appear; versioned dirs
+/// are untouched.
+#[test]
+#[ignore] // network
+fn local_only_after_external_only_does_not_clobber_versioned_dirs() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["rpkg", "myhelper"]
+"#,
+        &[
+            (
+                "rpkg",
+                r#"[package]
+name = "rpkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+[dependencies]
+myhelper = { path = "../myhelper" }
+cfg-if = "1"
+"#,
+                "pub fn go() {}",
+            ),
+            (
+                "myhelper",
+                r#"[package]
+name = "myhelper"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+                "pub fn help() {}",
+            ),
+        ],
+    );
+    let vendor = proj.root().join("vendor");
+
+    // Step 1: external-only
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--source-root",
+            proj.root().to_str().unwrap(),
+            "--external-only",
+        ])
+        .assert()
+        .success();
+
+    // Record mtime of a versioned dir to verify it's untouched later.
+    let cfg_if_dir = std::fs::read_dir(&vendor)
+        .unwrap()
+        .flatten()
+        .find(|e| e.file_name().to_string_lossy().starts_with("cfg-if-"))
+        .expect("cfg-if should be vendored")
+        .path();
+    let before_mtime = std::fs::metadata(&cfg_if_dir)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Step 2: local-only
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--source-root",
+            proj.root().to_str().unwrap(),
+            "--local-only",
+        ])
+        .assert()
+        .success();
+
+    // myhelper (local) must now be present.
+    assert!(
+        common::vendor_has(&vendor, "myhelper"),
+        "myhelper should be vendored after --local-only"
+    );
+
+    // cfg-if versioned dir must be untouched.
+    let after_mtime = std::fs::metadata(&cfg_if_dir)
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert_eq!(
+        before_mtime, after_mtime,
+        "cfg-if-* mtime should be unchanged after --local-only"
+    );
+
+    // .revendor-cache-local must now exist.
+    assert!(
+        vendor.join(".revendor-cache-local").exists(),
+        ".revendor-cache-local should be written after --local-only"
+    );
+}
+
+/// After --external-only then --local-only, the vendor/ tree should equal
+/// what a full run produces.
+#[test]
+#[ignore] // network
+fn phase_modes_compose_to_full() {
+    // Project A: two-phase run
+    let proj_a = create_workspace(
+        r#"[workspace]
+members = ["rpkg", "myhelper"]
+"#,
+        &[
+            (
+                "rpkg",
+                r#"[package]
+name = "rpkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+[dependencies]
+myhelper = { path = "../myhelper" }
+cfg-if = "1"
+"#,
+                "pub fn go() {}",
+            ),
+            (
+                "myhelper",
+                r#"[package]
+name = "myhelper"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+                "pub fn help() {}",
+            ),
+        ],
+    );
+    let vendor_a = proj_a.root().join("vendor");
+    git_init(proj_a.root());
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj_a.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor_a.to_str().unwrap(),
+            "--source-root",
+            proj_a.root().to_str().unwrap(),
+            "--external-only",
+        ])
+        .assert()
+        .success();
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj_a.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor_a.to_str().unwrap(),
+            "--source-root",
+            proj_a.root().to_str().unwrap(),
+            "--local-only",
+        ])
+        .assert()
+        .success();
+
+    // Project B: full run (same manifest)
+    let proj_b = create_workspace(
+        r#"[workspace]
+members = ["rpkg", "myhelper"]
+"#,
+        &[
+            (
+                "rpkg",
+                r#"[package]
+name = "rpkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+[dependencies]
+myhelper = { path = "../myhelper" }
+cfg-if = "1"
+"#,
+                "pub fn go() {}",
+            ),
+            (
+                "myhelper",
+                r#"[package]
+name = "myhelper"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+"#,
+                "pub fn help() {}",
+            ),
+        ],
+    );
+    let vendor_b = proj_b.root().join("vendor");
+    git_init(proj_b.root());
+
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            proj_b.root().join("rpkg/Cargo.toml").to_str().unwrap(),
+            "--output",
+            vendor_b.to_str().unwrap(),
+            "--source-root",
+            proj_b.root().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Compare the Cargo.toml of each crate (content, not mtime).
+    let dirs_a: std::collections::BTreeSet<String> = std::fs::read_dir(&vendor_a)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| !n.starts_with('.'))
+        .collect();
+
+    let dirs_b: std::collections::BTreeSet<String> = std::fs::read_dir(&vendor_b)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| !n.starts_with('.'))
+        .collect();
+
+    let only_in_a: Vec<_> = dirs_a.difference(&dirs_b).collect();
+    let only_in_b: Vec<_> = dirs_b.difference(&dirs_a).collect();
+
+    assert!(
+        only_in_a.is_empty() && only_in_b.is_empty(),
+        "phase-composed vendor/ differs from full vendor/:\n  only in A: {only_in_a:?}\n  only in B: {only_in_b:?}"
+    );
+}
+
+/// A second --external-only run with unchanged lockfile should be a cache hit.
+#[test]
+#[ignore] // network
+fn external_cache_hit_skips_cargo_vendor() {
+    let proj = create_workspace(
+        r#"[workspace]
+members = ["mypkg"]
+"#,
+        &[(
+            "mypkg",
+            r#"[package]
+name = "mypkg"
+version = "0.1.0"
+edition = "2021"
+[lib]
+path = "lib.rs"
+[dependencies]
+cfg-if = "1"
+"#,
+            "pub fn hello() {}",
+        )],
+    );
+    let vendor = proj.root().join("vendor");
+    let manifest = proj.root().join("mypkg/Cargo.toml");
+
+    // First run
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            manifest.to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--external-only",
+        ])
+        .assert()
+        .success();
+
+    // Record mtime of the cache file.
+    let cache_mtime = std::fs::metadata(vendor.join(".revendor-cache-external"))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Second run — should be a no-op (cache hit)
+    revendor_cmd()
+        .args([
+            "revendor",
+            "--manifest-path",
+            manifest.to_str().unwrap(),
+            "--output",
+            vendor.to_str().unwrap(),
+            "--external-only",
+        ])
+        .assert()
+        .success();
+
+    // Cache file mtime must not change — nothing was written.
+    let cache_mtime2 = std::fs::metadata(vendor.join(".revendor-cache-external"))
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert_eq!(
+        cache_mtime, cache_mtime2,
+        ".revendor-cache-external should not be rewritten on a cache hit"
+    );
+}


### PR DESCRIPTION
## Summary

Decouples cargo-revendor's two vendoring concerns into independent phase modes so CI can cache the expensive external layer on a `Cargo.lock` key while the local workspace layer stays a cheap always-run step.

**New flags:**
- `--external-only` — vendors crates.io/git deps only; writes `vendor/<name>-<version>/`; never touches local crate dirs
- `--local-only` — packages and extracts local workspace crates only; writes `vendor/<name>/` (flat); never touches external dirs

**CI usage:**
```yaml
- uses: actions/cache@v4
  with:
    path: vendor/
    key: revendor-${{ hashFiles('**/Cargo.lock') }}
- run: cargo revendor --external-only --strip-all   # cache hit → no-op
- run: cargo revendor --local-only                  # always cheap
```

**Changes:**
- `main.rs`: `Mode` enum, `--external-only`/`--local-only` CLI flags, `validate_flag_compatibility`, `merge_copy_vendor`, three `run_*` functions
- `cache.rs`: `is_cached_external`, `is_cached_local`, `save_cache_external`, `save_cache_local` with separate hash inputs
- `tests/phase_modes.rs`: new test file (4 offline + 4 `#[ignore]` network tests)

Full mode behavior is unchanged; it also writes both new cache files going forward.

## Test plan

- [x] `just revendor-test` → 70 tests pass (57 pre-existing + 13 new)
- [x] `--external-only --freeze` exits non-zero with clear message
- [x] `--local-only --compress` without externals on disk exits non-zero
- [x] Zero clippy warnings

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
