### PR TITLE
feat(cargo-revendor): --strip-toml-sections flag

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -99,6 +99,21 @@ struct Cli {
     #[arg(long)]
     strip_all: bool,
 
+    /// Strip TOML sections (`[[test]]`, `[[bench]]`, `[[example]]`,
+    /// `[[bin]]`, `[dev-dependencies]`) without deleting `tests/`,
+    /// `benches/`, or `examples/` directories.
+    ///
+    /// Some published crates reference files inside those directories
+    /// from regular library source via `include_str!()` (zerocopy is
+    /// one); deleting them breaks `cargo check --offline` post-vendor.
+    /// Use this flag instead of `--strip-all` when CRAN trim is the
+    /// goal but the dep graph contains such crates.
+    ///
+    /// Always-safe base directories (`.github`, `.circleci`, `ci`,
+    /// `target`) are still removed.
+    #[arg(long, conflicts_with_all = ["strip_all", "strip_tests", "strip_benches", "strip_examples", "strip_bins"])]
+    strip_toml_sections: bool,
+
     /// Output results as JSON
     #[arg(long)]
     json: bool,
@@ -210,7 +225,9 @@ impl Cli {
     }
 
     fn strip_config(&self) -> strip::StripConfig {
-        if self.strip_all {
+        if self.strip_toml_sections {
+            strip::StripConfig::toml_only()
+        } else if self.strip_all {
             strip::StripConfig::all()
         } else {
             strip::StripConfig {
@@ -218,6 +235,7 @@ impl Cli {
                 benches: self.strip_benches,
                 examples: self.strip_examples,
                 bins: self.strip_bins,
+                toml_only: false,
             }
         }
     }
@@ -457,7 +475,7 @@ fn run_full(
     metadata::check_duplicate_sources(&meta)?;
 
     let (mut local_pkgs, _external_pkgs) =
-        metadata::partition_packages(&meta, &manifest_path, &source_root_members)?;
+        metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
 
     // Fall back to heuristic workspace-root detection only if `--source-root`
     // wasn't explicitly provided.

--- a/cargo-revendor/src/strip.rs
+++ b/cargo-revendor/src/strip.rs
@@ -11,16 +11,36 @@ pub struct StripConfig {
     pub benches: bool,
     pub examples: bool,
     pub bins: bool,
+    /// Strip TOML sections only — leave source-related directories
+    /// (`tests/`, `benches/`, `examples/`) on disk. Crates such as
+    /// `zerocopy` reference files in those directories from regular
+    /// library source via `include_str!()`; deleting them breaks
+    /// `cargo check --offline` post-vendor. Always-safe base dirs
+    /// (`.github`, `.circleci`, `ci`, `target`) are still removed.
+    pub toml_only: bool,
 }
 
 impl StripConfig {
-    /// Strip everything
+    /// Strip everything (directories and TOML sections)
     pub fn all() -> Self {
         Self {
             tests: true,
             benches: true,
             examples: true,
             bins: true,
+            toml_only: false,
+        }
+    }
+
+    /// Strip TOML sections for all source-target categories without
+    /// deleting `tests/` / `benches/` / `examples/` directories. See #330.
+    pub fn toml_only() -> Self {
+        Self {
+            tests: true,
+            benches: true,
+            examples: true,
+            bins: true,
+            toml_only: true,
         }
     }
 
@@ -32,6 +52,9 @@ impl StripConfig {
     /// Get directory names to strip
     fn dirs_to_strip(&self) -> Vec<&'static str> {
         let mut dirs = vec![".github", ".circleci", "ci", "target"];
+        if self.toml_only {
+            return dirs;
+        }
         if self.tests {
             dirs.push("tests");
         }
@@ -467,6 +490,94 @@ default = []
         assert!(result.contains("serde"), "regular dep preserved");
         assert!(result.contains("default = []"), "default feature preserved");
         assert!(result.contains("real_blackbox"), "feature key still present but pruned");
+    }
+
+    // endregion
+
+    // region: --strip-toml-sections (#330)
+
+    #[test]
+    fn toml_only_dirs_to_strip_excludes_source_dirs() {
+        let cfg = StripConfig::toml_only();
+        let dirs = cfg.dirs_to_strip();
+        // Always-safe base dirs survive
+        assert!(dirs.contains(&".github"));
+        assert!(dirs.contains(&".circleci"));
+        assert!(dirs.contains(&"ci"));
+        assert!(dirs.contains(&"target"));
+        // Source-related dirs are NOT stripped (zerocopy include_str! safety)
+        assert!(!dirs.contains(&"tests"));
+        assert!(!dirs.contains(&"benches"));
+        assert!(!dirs.contains(&"examples"));
+    }
+
+    #[test]
+    fn toml_only_still_strips_toml_sections() {
+        let cfg = StripConfig::toml_only();
+        let sections = cfg.toml_sections_to_strip();
+        assert!(sections.contains(&"[[test]]"));
+        assert!(sections.contains(&"[[bench]]"));
+        assert!(sections.contains(&"[[example]]"));
+        assert!(sections.contains(&"[[bin]]"));
+        assert!(sections.contains(&"[dev-dependencies"));
+    }
+
+    #[test]
+    fn strip_crate_dir_toml_only_preserves_source_dirs() {
+        // Mirrors the zerocopy footgun: bench source files referenced by
+        // `include_str!()` from regular lib code must survive stripping.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("zerocopy_like");
+        std::fs::create_dir_all(crate_dir.join("benches/formats")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("tests")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("examples")).unwrap();
+        std::fs::create_dir_all(crate_dir.join(".github/workflows")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(crate_dir.join("benches/formats/static_size.rs"), "// bench").unwrap();
+        std::fs::write(crate_dir.join("src/lib.rs"), "").unwrap();
+        std::fs::write(crate_dir.join(".cargo-checksum.json"), "{\"files\":{}}").unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            r#"[package]
+name = "zerocopy_like"
+version = "0.1.0"
+
+[dependencies]
+serde = "1"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "static_size"
+harness = false
+
+[features]
+real_blackbox = ["criterion/real_blackbox"]
+default = []
+"#,
+        )
+        .unwrap();
+
+        strip_crate_dir(&crate_dir, &StripConfig::toml_only(), Verbosity(0)).unwrap();
+
+        // Source-related dirs preserved (the whole point of --strip-toml-sections)
+        assert!(crate_dir.join("benches/formats/static_size.rs").exists(),
+            "benches/ must survive — referenced by include_str! in some crates");
+        assert!(crate_dir.join("tests").exists(), "tests/ must survive");
+        assert!(crate_dir.join("examples").exists(), "examples/ must survive");
+        // Always-safe base dirs still go
+        assert!(!crate_dir.join(".github").exists(), ".github/ should still be stripped");
+        // TOML surgery still happens
+        let manifest = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+        assert!(!manifest.contains("[dev-dependencies]"));
+        assert!(!manifest.contains("[[bench]]"));
+        assert!(!manifest.contains("criterion"));
+        // Dangling [features] ref pruned
+        assert!(!manifest.contains("criterion/real_blackbox"));
+        // Regular content preserved
+        assert!(manifest.contains("serde"));
+        assert!(manifest.contains("default = []"));
     }
 
     // endregion

--- a/minirextendr/R/vendor.R
+++ b/minirextendr/R/vendor.R
@@ -42,7 +42,13 @@ vendor_crates_io <- function(path = ".") {
     args = c(
       "revendor",
       "--manifest-path", cargo_toml,
-      "--output", vendor_dir
+      "--output", vendor_dir,
+      # --strip-toml-sections strips [[test]] / [[bench]] / [[example]] /
+      # [[bin]] / [dev-dependencies] from each vendored Cargo.toml and
+      # prunes dangling [features] refs (see #330, #322), but leaves
+      # tests/, benches/, examples/ on disk so crates that
+      # include_str!() into those dirs (e.g. zerocopy) keep building.
+      "--strip-toml-sections"
     ),
     log_prefix = "cargo-revendor",
     wd = usethis::proj_get()
@@ -54,11 +60,11 @@ vendor_crates_io <- function(path = ".") {
   # rpkg/.Rbuildignore has matching patterns for .github/, ci/, dotfiles etc.
   # on the source tree, but .Rbuildignore does not filter inside the tarball —
   # this stripping is the only mechanism that cleans tarball contents.
-  # Does NOT strip tests/ or benches/ — some crates (e.g. zerocopy) use
-  # include_str!("../benches/...") in library source; deleting those dirs
-  # breaks compilation. Cargo.toml surgery (dev-deps, [[bench]], [[test]])
-  # is skipped for the same reason: cargo-revendor ties TOML surgery to
-  # directory deletion (#330).
+  # cargo-revendor's --strip-toml-sections (above) handles .github/, .circleci/,
+  # ci/, target/ and TOML surgery; this covers the rest (docs/, examples/,
+  # remaining dotfiles). tests/ and benches/ are intentionally preserved —
+  # some crates (e.g. zerocopy) use include_str!("../benches/...") in library
+  # source; deleting those dirs breaks compilation.
   strip_vendored_dir(vendor_dir)
 
   cli::cli_alert_success("Vendored to {.path {vendor_dir}}")

--- a/minirextendr/inst/templates/monorepo/justfile
+++ b/minirextendr/inst/templates/monorepo/justfile
@@ -121,7 +121,7 @@ vendor:
     cargo revendor \
       --manifest-path {{{rpkg_name}}}/src/rust/Cargo.toml \
       --output {{{rpkg_name}}}/vendor \
-      --strip-all \
+      --strip-toml-sections \
       --compress {{{rpkg_name}}}/inst/vendor.tar.xz \
       --blank-md \
       --source-marker \

--- a/minirextendr/inst/templates/rpkg/justfile
+++ b/minirextendr/inst/templates/rpkg/justfile
@@ -112,7 +112,7 @@ vendor:
     cargo revendor \
       --manifest-path src/rust/Cargo.toml \
       --output vendor \
-      --strip-all \
+      --strip-toml-sections \
       --compress inst/vendor.tar.xz \
       --blank-md \
       --source-marker \


### PR DESCRIPTION
## Summary

Closes #330.

Adds `--strip-toml-sections` to `cargo-revendor` for TOML surgery without deleting `tests/`, `benches/`, or `examples/` directories — and wires it into both `minirextendr::vendor_crates_io()` and the scaffolded template justfiles, so downstream packages with `zerocopy` (or any crate that does `include_str!()` into those dirs) don't get bitten by `--strip-all`.

## Why

`--strip-all` couples TOML section removal with directory deletion. Some published crates reference files inside `benches/` / `tests/` from regular library source via `include_str!()`. Concrete example flagged in #330: `zerocopy` uses `include_str!(\"../benches/formats/coco_static_size.rs\")` from `src/util/macros.rs`. With `--strip-all`, `cargo check --offline` post-vendor fails with \"No such file or directory.\"

`vendor_crates_io()` previously couldn't pass `--strip-all` for this reason and skipped TOML surgery entirely; the template justfile DID pass `--strip-all`, so any user package landing on zerocopy through a transitive dep would silently break. This PR fixes both.

## What changed

- **`cargo-revendor/src/strip.rs`**: new `StripConfig::toml_only` mode. `dirs_to_strip()` returns only the always-safe base dirs (`.github`, `.circleci`, `ci`, `target`) and skips the source-related ones. `[features]` pruning (#322) still runs.
- **`cargo-revendor/src/main.rs`**: new `--strip-toml-sections` flag, mutually exclusive with `--strip-all` and the per-target `--strip-tests/benches/examples/bins`.
- **`minirextendr/R/vendor.R`**: `vendor_crates_io()` now passes `--strip-toml-sections`. The R-side `strip_vendored_dir` continues handling the broader CRAN-trim it always did.
- **`minirextendr/inst/templates/{rpkg,monorepo}/justfile`**: scaffolded `vendor` recipe replaces `--strip-all` with `--strip-toml-sections`.
- **Drive-by**: pre-existing `clippy::needless_borrow` on `partition_packages(&meta, &manifest_path, ...)` fixed (Rust 1.95.0 made the lint stricter; CLAUDE.md \"fix warnings you see\").

## Test plan

- [x] `cargo test --manifest-path cargo-revendor/Cargo.toml` — 88 passed, 55 ignored
- [x] `cargo clippy --manifest-path cargo-revendor/Cargo.toml --all-targets --locked -- -D warnings` — clean
- [x] `just minirextendr-test` — `[ FAIL 0 | WARN 4 | SKIP 3 | PASS 375 ]` (with the new binary installed; smoke tests exercise the full path through `miniextendr_vendor()` → `cargo revendor --strip-toml-sections`)
- [x] `just templates-check` — passes
- [x] CLI mutual-exclusion verified: `cargo revendor --strip-toml-sections --strip-all` → \"the argument '--strip-toml-sections' cannot be used with '--strip-all'\"
- [x] New unit tests:
  - `toml_only_dirs_to_strip_excludes_source_dirs`
  - `toml_only_still_strips_toml_sections`
  - `strip_crate_dir_toml_only_preserves_source_dirs` (zerocopy-shaped fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)