### PR TITLE
fix(rpkg,minirextendr): cd into rust/ before invoking cargo

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -79,6 +79,7 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	LINK_ARGS=""; \
 	for obj in $(OBJECTS); do LINK_ARGS="$$LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \
 	if [ -n "$(CARGO_BUILD_TARGET)" ]; then TARGET_OPT="--target $(CARGO_BUILD_TARGET)"; fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS) $$LINK_ARGS" \
 	$(CARGO) $(RUST_TOOLCHAIN) build $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \
@@ -117,6 +118,7 @@ $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
 	if [ "$(CDYLIB_EXT)" = "dll" ]; then \
 	  CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=-static-libgcc -C link-arg=$(ABS_RPKG_SRC_CARGO)/cdylib-exports.def -C link-arg=-Wl,--no-gc-sections"; \
 	fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS)" \
 	$(CARGO) $(RUST_TOOLCHAIN) rustc $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -79,6 +79,7 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	LINK_ARGS=""; \
 	for obj in $(OBJECTS); do LINK_ARGS="$$LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \
 	if [ -n "$(CARGO_BUILD_TARGET)" ]; then TARGET_OPT="--target $(CARGO_BUILD_TARGET)"; fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS) $$LINK_ARGS" \
 	$(CARGO) $(RUST_TOOLCHAIN) build $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \
@@ -117,6 +118,7 @@ $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
 	if [ "$(CDYLIB_EXT)" = "dll" ]; then \
 	  CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=-static-libgcc -C link-arg=$(ABS_RPKG_SRC_CARGO)/cdylib-exports.def -C link-arg=-Wl,--no-gc-sections"; \
 	fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS)" \
 	$(CARGO) $(RUST_TOOLCHAIN) rustc $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-04-28 15:02:17
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
+--- a/monorepo/rpkg/bootstrap.R	2026-04-29 17:09:49
++++ b/monorepo/rpkg/bootstrap.R	2026-04-29 17:09:49
 @@ -4,7 +4,8 @@
  #
  # Install-mode detection is automatic: if inst/vendor.tar.xz exists
@@ -14,8 +14,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-04-28 10:42:41
-+++ b/monorepo/rpkg/configure.ac	2026-04-28 10:42:41
+--- a/monorepo/rpkg/configure.ac	2026-04-29 17:09:49
++++ b/monorepo/rpkg/configure.ac	2026-04-29 17:09:49
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -214,8 +214,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-04-28 10:42:41
-+++ b/rpkg/configure.ac	2026-04-28 10:42:41
+--- a/rpkg/configure.ac	2026-04-29 17:09:49
++++ b/rpkg/configure.ac	2026-04-29 17:09:49
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -79,6 +79,7 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	LINK_ARGS=""; \
 	for obj in $(OBJECTS); do LINK_ARGS="$$LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \
 	if [ -n "$(CARGO_BUILD_TARGET)" ]; then TARGET_OPT="--target $(CARGO_BUILD_TARGET)"; fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS) $$LINK_ARGS" \
 	$(CARGO) $(RUST_TOOLCHAIN) build $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \
@@ -117,6 +118,7 @@ $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
 	if [ "$(CDYLIB_EXT)" = "dll" ]; then \
 	  CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=-static-libgcc -C link-arg=$(ABS_RPKG_SRC_CARGO)/cdylib-exports.def -C link-arg=-Wl,--no-gc-sections"; \
 	fi; \
+	cd "$(ABS_RPKG_SRCDIR)/rust"; \
 	RUSTFLAGS="$(ENV_RUSTFLAGS)" \
 	$(CARGO) $(RUST_TOOLCHAIN) rustc $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $$TARGET_OPT \
 	  --lib --profile $(CARGO_PROFILE) \


### PR DESCRIPTION
## Summary

R CMD INSTALL runs `make` from `src/`, but cargo only walks up from the current working directory when discovering `.cargo/config.toml` — it does **not** walk up from `--manifest-path`. So the source-replacement config that `configure` writes at `src/rust/.cargo/config.toml` during tarball installs was never read, and `cargo build --offline` fell back to fetching git deps from the network and failed.

This was masked locally and in CI because the cargo cache (`~/.cargo/git/`) usually had `miniextendr` fetched already, so the offline mode found things in the per-user cache. Reproduces deterministically with empty `CARGO_HOME` + `CARGO_NET_OFFLINE=1`:

```
error: failed to get `miniextendr-api` as a dependency of package `dvs-rpkg`
Caused by: failed to load source for dependency `miniextendr-api`
Caused by: unable to update https://github.com/A2-ai/miniextendr#<sha>
Caused by: can't checkout from 'https://github.com/A2-ai/miniextendr': you are in the offline mode (--offline)
```

The fix adds `cd "$(ABS_RPKG_SRCDIR)/rust"` before each cargo invocation in both the staticlib and cdylib recipes. All paths passed to cargo (`--manifest-path`, `--target-dir`, link-args) are already absolute, so the cwd switch only affects config discovery.

Mirrored in `minirextendr/inst/templates/rpkg/Makevars.in` so freshly scaffolded packages get the fix too.

## Test plan

- [ ] `R CMD INSTALL <built-tarball>` with `CARGO_NET_OFFLINE=1` and an empty `CARGO_HOME` succeeds
- [ ] `just rcmdinstall` still green for the rpkg in this repo
- [ ] cross-package tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)