### PR TITLE
fix(cargo-revendor): preserve dirs/features that real source needs

### DIFF
--- a/cargo-revendor/src/strip.rs
+++ b/cargo-revendor/src/strip.rs
@@ -111,8 +111,25 @@ fn strip_crate_dir(crate_dir: &Path, config: &StripConfig, v: Verbosity) -> Resu
     let crate_name = crate_dir.file_name().unwrap().to_string_lossy().to_string();
     let mut stripped = Vec::new();
 
+    // Some crates reference files in `tests/`/`benches/`/`examples/` from
+    // regular library source via `include_str!()`/`include_bytes!()`/`include!()`.
+    // Stripping those dirs breaks `cargo build --offline` post-vendor (winnow
+    // ships `include_str!("../examples/css/parser.rs")` in `src/lib.rs`).
+    // Scan the crate up front and skip stripping any top-level dir that's
+    // referenced this way.
+    let referenced_top_dirs = scan_referenced_top_dirs(crate_dir);
+
     // Remove configured directories
     for dir_name in config.dirs_to_strip() {
+        if referenced_top_dirs.iter().any(|d| d == dir_name) {
+            if v.debug() {
+                eprintln!(
+                    "  Preserving {}/{} — referenced by include_str!/include_bytes!/include!",
+                    crate_name, dir_name
+                );
+            }
+            continue;
+        }
         let dir_path = crate_dir.join(dir_name);
         if dir_path.exists() {
             std::fs::remove_dir_all(&dir_path).with_context(|| {
@@ -141,13 +158,23 @@ fn strip_crate_dir(crate_dir: &Path, config: &StripConfig, v: Verbosity) -> Resu
 
     // Clean TOML sections that reference stripped directories.
     // Before stripping, collect the dep names being removed from
-    // [dev-dependencies] so we can prune dangling [features] refs.
+    // [dev-dependencies] so we can prune dangling [features] refs — but
+    // subtract names that also live in [dependencies] / [build-dependencies],
+    // because those entries survive the strip and the feature ref points at
+    // them, not at the dev-only copy. (The `time` crate ships `time-macros`
+    // in both tables and `[features] formatting = ["time-macros?/formatting"]`
+    // would otherwise be silently dropped.)
     let cargo_toml = crate_dir.join("Cargo.toml");
     if cargo_toml.exists() {
         let sections = config.toml_sections_to_strip();
         if !sections.is_empty() {
             let removed_deps = if sections.iter().any(|s| s.starts_with("[dev-dependencies")) {
-                collect_dep_names(&cargo_toml, "dev-dependencies")?
+                let dev = collect_dep_names(&cargo_toml, "dev-dependencies")?;
+                let kept_deps = collect_dep_names(&cargo_toml, "dependencies")?;
+                let kept_build = collect_dep_names(&cargo_toml, "build-dependencies")?;
+                dev.into_iter()
+                    .filter(|d| !kept_deps.contains(d) && !kept_build.contains(d))
+                    .collect()
             } else {
                 Vec::new()
             };
@@ -192,6 +219,12 @@ fn prune_dangling_features_inplace(cargo_toml: &Path, removed_deps: &[String]) -
 /// referencing `"<dep>/..."`, `"<dep>?/..."`, or exactly `"<dep>"` for a
 /// removed dep becomes a dangling reference that breaks every consumer.
 ///
+/// Exact-match items (`"<dep>"`) are only pruned when no `[features]` entry
+/// of the same name exists in this crate. Otherwise the string refers to the
+/// crate's own feature, not the dep — e.g. toml ships
+/// `default = ["std", "serde", "parse", "display"]` where `"serde"` is the
+/// feature key, not the dev-dep.
+///
 /// If a feature's array becomes empty after pruning, it is kept as `[]`
 /// (a valid, harmless feature flag). Non-referencing features are unchanged.
 pub fn prune_dangling_feature_refs(content: &str, removed_deps: &[String]) -> String {
@@ -203,6 +236,14 @@ pub fn prune_dangling_feature_refs(content: &str, removed_deps: &[String]) -> St
         Ok(d) => d,
         Err(_) => return content.to_string(),
     };
+
+    // Snapshot defined feature names so we don't strip exact-match items that
+    // refer to a feature rather than the removed dep.
+    let feature_keys: std::collections::BTreeSet<String> = doc
+        .get("features")
+        .and_then(|v| v.as_table_like())
+        .map(|tbl| tbl.iter().map(|(k, _)| k.to_string()).collect())
+        .unwrap_or_default();
 
     let Some(features) = doc.get_mut("features").and_then(|v| v.as_table_mut()) else {
         return content.to_string();
@@ -220,8 +261,8 @@ pub fn prune_dangling_feature_refs(content: &str, removed_deps: &[String]) -> St
                 None => return true, // keep non-string items unchanged
             };
             !removed_deps.iter().any(|dep| {
-                // Exact match: "dep"
-                s == dep
+                // Exact match: "dep" — only when not also a feature name.
+                (s == dep && !feature_keys.contains(s))
                     // Dep-feature ref: "dep/feature" or "dep?/feature"
                     || s.starts_with(&format!("{}/", dep))
                     || s.starts_with(&format!("{}?/", dep))
@@ -276,6 +317,193 @@ fn strip_toml_sections(cargo_toml: &Path, sections_to_strip: &[&str]) -> Result<
     std::fs::write(cargo_toml, output_lines.join("\n"))?;
     Ok(())
 }
+
+// region: include macro scanner
+
+/// Stripable top-level directories whose names we recognize in path literals
+/// even when the file isn't (yet) on disk — needed when the include path is
+/// composed via `concat!()` (e.g. zerocopy:
+/// `include_str!(concat!("../benches/formats/", $format, ".rs"))`).
+const STRIPABLE_TOP_DIRS: &[&str] = &["tests", "benches", "examples", "bin"];
+
+/// Walk every `.rs` file under `crate_dir` and collect the top-level directory
+/// names referenced by `include_str!`/`include_bytes!`/`include!` macros.
+/// Two layers of detection:
+///   1. literal-path macros — resolve relative to the source file (matching
+///      rustc) and read the first component under the crate root.
+///   2. composed-path macros — scan all string literals in the macro's
+///      argument span (handles `concat!(...)`) for `<...>tests/`, `benches/`,
+///      `examples/`, `bin/` substrings and preserve those dirs.
+/// Paths escaping the crate root or referencing files outside it are ignored.
+fn scan_referenced_top_dirs(crate_dir: &Path) -> Vec<String> {
+    let crate_root = match crate_dir.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let mut top_dirs: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for entry in walkdir::WalkDir::new(crate_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let parent = match path.parent() {
+            Some(p) => p,
+            None => continue,
+        };
+        for literal in extract_include_arg_literals(&content) {
+            // (1) Literal-path resolution: works for `include_str!("...")`.
+            let resolved = parent.join(&literal);
+            if let Ok(canon) = resolved.canonicalize() {
+                if let Ok(rel) = canon.strip_prefix(&crate_root) {
+                    if let Some(first) = rel.components().next() {
+                        if let Some(s) = first.as_os_str().to_str() {
+                            top_dirs.insert(s.to_string());
+                            continue;
+                        }
+                    }
+                }
+            }
+            // (2) Substring sniff: catches `concat!("../benches/...", x, ".rs")`
+            //     where the literal alone doesn't resolve to a real file.
+            for dir in STRIPABLE_TOP_DIRS {
+                let needle = format!("/{}/", dir);
+                if literal.contains(&needle) || literal.starts_with(&format!("{}/", dir)) {
+                    top_dirs.insert((*dir).to_string());
+                }
+            }
+        }
+    }
+    top_dirs.into_iter().collect()
+}
+
+/// Pull every string literal that appears inside the argument list of an
+/// `include_str!`, `include_bytes!`, or `include!` macro invocation. Argument
+/// spans are matched with balanced-paren tracking so nested macro calls
+/// (e.g. `concat!(...)`) are scanned through, not skipped.
+fn extract_include_arg_literals(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = content.as_bytes();
+    for macro_name in ["include_str!", "include_bytes!", "include!"] {
+        let needle = macro_name.as_bytes();
+        let mut search = 0usize;
+        while search + needle.len() <= bytes.len() {
+            let Some(idx) = find_subslice(&bytes[search..], needle) else {
+                break;
+            };
+            let mut i = search + idx + needle.len();
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i >= bytes.len() || bytes[i] != b'(' {
+                search += idx + 1;
+                continue;
+            }
+            // Find matching close paren, tracking nested parens and strings.
+            let arg_start = i + 1;
+            let arg_end = match find_matching_close_paren(bytes, i) {
+                Some(end) => end,
+                None => break,
+            };
+            // Extract every string literal in [arg_start, arg_end).
+            extract_string_literals(&content[arg_start..arg_end], &mut out);
+            search = arg_end + 1;
+        }
+    }
+    out
+}
+
+/// Given byte index `open` pointing at `b'('`, return the index of the
+/// matching `b')'`, or None if unbalanced. Skips parens inside `"..."`
+/// string literals and `'.'` char literals.
+fn find_matching_close_paren(bytes: &[u8], open: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[open], b'(');
+    let mut depth = 1i32;
+    let mut i = open + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                i += 1;
+            }
+            b'\'' => {
+                // Skip char literal: '\'', '\\', or 'X'. Lifetime markers
+                // ('a) lack a closing quote — bail out of skipping if we
+                // don't see one within a few chars.
+                let scan_end = std::cmp::min(bytes.len(), i + 5);
+                let close = bytes[i + 1..scan_end].iter().position(|&b| b == b'\'');
+                match close {
+                    Some(off) => i += 2 + off,
+                    None => i += 1,
+                }
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Append every `"..."` string literal in `s` to `out`, decoding common
+/// escapes. Raw strings (`r"..."`, `r#"..."#`) and char literals are skipped.
+fn extract_string_literals(s: &str, out: &mut Vec<String>) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            i += 1;
+            let lit_start = i;
+            while i < bytes.len() && bytes[i] != b'"' {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            if i >= bytes.len() {
+                break;
+            }
+            out.push(s[lit_start..i].replace("\\\"", "\"").replace("\\\\", "\\"));
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+// endregion
 
 #[cfg(test)]
 mod tests {
@@ -492,6 +720,93 @@ default = []
         assert!(result.contains("real_blackbox"), "feature key still present but pruned");
     }
 
+    #[test]
+    fn strip_keeps_default_feature_ref_when_name_collides_with_dev_dep() {
+        // Mirrors the `toml` crate footgun: `serde` is BOTH a [dev-dependencies]
+        // entry AND a [features] key. `default = ["std", "serde", ...]` refers
+        // to the feature, not the dev-dep, so the prune must not drop it.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("toml_like");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(crate_dir.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            r#"[package]
+name = "toml_like"
+version = "0.1.0"
+
+[dependencies]
+serde_core = { version = "1", optional = true }
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[features]
+default = ["std", "serde", "parse"]
+std = []
+parse = []
+serde = ["dep:serde_core"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join(".cargo-checksum.json"), "{\"files\":{}}").unwrap();
+
+        strip_crate_dir(&crate_dir, &StripConfig::all(), Verbosity(0)).unwrap();
+
+        let result = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+        assert!(!result.contains("[dev-dependencies]"));
+        // 'serde' in default list is the FEATURE, not the dev-dep — keep it.
+        assert!(
+            result.contains("\"serde\""),
+            "default's 'serde' (feature ref) must survive: {result}"
+        );
+        // The serde feature definition itself is intact.
+        assert!(result.contains("dep:serde_core"));
+    }
+
+    #[test]
+    fn strip_keeps_feature_refs_for_deps_in_both_dev_and_regular() {
+        // Mirrors the `time` crate: `time-macros` appears in BOTH
+        // `[dev-dependencies]` and `[dependencies]` (as optional). Stripping
+        // dev-dependencies must not prune `time-macros?/formatting` from
+        // `[features]`, because the optional dep entry is still there.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("time_like");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(crate_dir.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            r#"[package]
+name = "time_like"
+version = "0.1.0"
+
+[dependencies]
+time-macros = { version = "0.2", optional = true }
+
+[dev-dependencies]
+time-macros = "0.2"
+
+[features]
+formatting = ["time-macros?/formatting"]
+parsing    = ["time-macros?/parsing"]
+macros     = ["dep:time-macros"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join(".cargo-checksum.json"), "{\"files\":{}}").unwrap();
+
+        strip_crate_dir(&crate_dir, &StripConfig::all(), Verbosity(0)).unwrap();
+
+        let result = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+        assert!(!result.contains("[dev-dependencies]"));
+        assert!(
+            result.contains("time-macros?/formatting"),
+            "feature ref to optional dep must survive: {result}"
+        );
+        assert!(result.contains("time-macros?/parsing"));
+        assert!(result.contains("dep:time-macros"));
+    }
+
     // endregion
 
     // region: --strip-toml-sections (#330)
@@ -578,6 +893,117 @@ default = []
         // Regular content preserved
         assert!(manifest.contains("serde"));
         assert!(manifest.contains("default = []"));
+    }
+
+    // endregion
+
+    // region: include macro scanner tests
+
+    #[test]
+    fn extract_include_arg_literals_basic() {
+        let src = r#"
+            const A: &str = include_str!("../examples/css/parser.rs");
+            const B: &[u8] = include_bytes!( "data/blob.bin" );
+            include!("generated.rs");
+        "#;
+        let paths = extract_include_arg_literals(src);
+        assert!(paths.iter().any(|p| p == "../examples/css/parser.rs"));
+        assert!(paths.iter().any(|p| p == "data/blob.bin"));
+        assert!(paths.iter().any(|p| p == "generated.rs"));
+    }
+
+    #[test]
+    fn extract_include_arg_literals_through_concat() {
+        // zerocopy pattern: include_str!(concat!("../benches/formats/", x, ".rs"))
+        let src = r#"
+            #[doc = include_str!(concat!("../benches/formats/", $f, ".rs"))]
+            #[doc = include_str!(concat!("../benches/", $b))]
+        "#;
+        let paths = extract_include_arg_literals(src);
+        assert!(
+            paths.iter().any(|p| p == "../benches/formats/"),
+            "expected '../benches/formats/' literal: {:?}",
+            paths
+        );
+        assert!(paths.iter().any(|p| p == "../benches/"));
+        assert!(paths.iter().any(|p| p == ".rs"));
+    }
+
+    #[test]
+    fn strip_all_preserves_dirs_referenced_by_include_str() {
+        // Mirrors winnow's footgun: src/lib.rs has include_str!("../examples/...")
+        // The strip must not delete examples/ even with --strip-all.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("winnow_like");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("examples/css")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("benches")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("tests")).unwrap();
+        std::fs::write(crate_dir.join("examples/css/parser.rs"), "// example").unwrap();
+        std::fs::write(crate_dir.join("benches/bench.rs"), "// bench").unwrap();
+        std::fs::write(crate_dir.join("tests/test.rs"), "// test").unwrap();
+        std::fs::write(
+            crate_dir.join("src/lib.rs"),
+            r#"#![doc = include_str!("../examples/css/parser.rs")]"#,
+        )
+        .unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname = \"winnow_like\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join(".cargo-checksum.json"), "{\"files\":{}}").unwrap();
+
+        strip_crate_dir(&crate_dir, &StripConfig::all(), Verbosity(0)).unwrap();
+
+        // examples/ preserved because include_str! references it
+        assert!(
+            crate_dir.join("examples/css/parser.rs").exists(),
+            "examples/ must survive — referenced by include_str!"
+        );
+        // tests/ and benches/ have no incoming references → still stripped
+        assert!(!crate_dir.join("tests").exists());
+        assert!(!crate_dir.join("benches").exists());
+    }
+
+    #[test]
+    fn strip_all_preserves_dirs_referenced_via_concat() {
+        // Mirrors zerocopy's footgun:
+        //   include_str!(concat!("../benches/formats/", x, ".rs"))
+        // The literal alone doesn't resolve to a file, so substring detection
+        // on '/benches/' has to kick in for the dir to survive.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("zerocopy_like");
+        std::fs::create_dir_all(crate_dir.join("src/util")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("benches/formats")).unwrap();
+        std::fs::create_dir_all(crate_dir.join("examples")).unwrap();
+        std::fs::write(crate_dir.join("benches/formats/coco.rs"), "// bench").unwrap();
+        std::fs::write(crate_dir.join("examples/ex.rs"), "// example").unwrap();
+        std::fs::write(
+            crate_dir.join("src/util/macros.rs"),
+            r#"
+                #[doc = include_str!(concat!("../benches/formats/", $format, ".rs"))]
+                fn _hint() {}
+            "#,
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join("src/lib.rs"), "pub mod util;").unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname = \"zerocopy_like\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join(".cargo-checksum.json"), "{\"files\":{}}").unwrap();
+
+        strip_crate_dir(&crate_dir, &StripConfig::all(), Verbosity(0)).unwrap();
+
+        // benches/ preserved via concat-substring detection
+        assert!(
+            crate_dir.join("benches/formats/coco.rs").exists(),
+            "benches/ must survive — referenced via concat!() in include_str!"
+        );
+        // examples/ has no reference → still stripped
+        assert!(!crate_dir.join("examples").exists());
     }
 
     // endregion


### PR DESCRIPTION
## Summary

Three independent strip-correctness bugs surfaced by running `cargo-revendor --strip-all` over the deps of an R-package monorepo and then doing `R CMD INSTALL <tarball>` with empty `CARGO_HOME` and `CARGO_NET_OFFLINE=1`. The cache-warm path had been masking all of them.

### 1. Directories referenced by `include_str!`/`include_bytes!`/`include!` were deleted

`--strip-all` removed `tests/`, `benches/`, `examples/` unconditionally. But:
- `winnow` ships `#![doc = include_str!(\"../examples/css/parser.rs\")]` in `src/lib.rs` — failed with `couldn't read .../examples/css/parser.rs: No such file or directory`.
- `zerocopy` does the same with `include_str!(concat!(\"../benches/formats/\", \$f, \".rs\"))` — failed with 289 errors after `examples/` survived but `benches/` didn't.

Fix: walk every `.rs` file in a vendored crate before stripping, parse `include_*!` macro arg spans (with balanced-paren tracking through `concat!()`), and skip stripping any top-level dir that appears as a literal path or as a `/<dir>/` substring in those args. Detection is conservative — false positives only preserve extra files, false negatives delete needed ones.

### 2. `prune_dangling_features_inplace` wiped feature refs to dual-table deps

`time` ships `time-macros` in BOTH `[dependencies]` (optional) and `[dev-dependencies]`. After dev-deps were stripped, `prune_dangling_feature_refs` saw `time-macros` in `removed_deps` and dropped `\"time-macros?/formatting\"` from `[features]` — even though the optional dep entry was still there. Build then failed with `no `format_description` in the root` because `time-macros/formatting` was never activated.

Fix: subtract names that survive in `[dependencies]` / `[build-dependencies]` from the removed-deps list before passing it to the prune.

### 3. Exact-match prune treated feature names as dep names

`toml` ships `default = [\"std\", \"serde\", \"parse\", \"display\"]` where `\"serde\"` is a `[features]` key — and `serde` is also a `[dev-dependencies]` entry (`serde = { ..., features = [\"derive\"] }`). The prune treated the string `\"serde\"` as the removed dev-dep and dropped it from `default`, breaking every downstream that called `toml::from_str`.

Fix: snapshot defined feature names before pruning and only treat exact-match items as dep references when no same-named feature key exists.

## Tests

Six new tests in `strip.rs`:
- `extract_include_arg_literals_basic` — literal-path `include_str!`/`include_bytes!`/`include!`
- `extract_include_arg_literals_through_concat` — literals inside `concat!()`
- `strip_all_preserves_dirs_referenced_by_include_str` — winnow shape
- `strip_all_preserves_dirs_referenced_via_concat` — zerocopy shape
- `strip_keeps_default_feature_ref_when_name_collides_with_dev_dep` — toml shape
- `strip_keeps_feature_refs_for_deps_in_both_dev_and_regular` — time shape

All 27 strip tests pass (`cargo test strip`).

## Test plan

- [ ] CI green
- [ ] `just vendor` for the rpkg in this repo still produces a buildable tarball
- [ ] Verified end-to-end on dvs-rpkg (which exercises winnow + zerocopy + time + toml in its dep graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
