### PR TITLE
feat: unwind-safe FFI trampoline and buffered cross-thread logging

### DIFF
--- a/justfile
+++ b/justfile
@@ -383,15 +383,14 @@ vendor:
     if [[ -f "$cargo_cfg.tmp_just_vendor" ]]; then
       mv "$cargo_cfg.tmp_just_vendor" "$cargo_cfg"
     fi
-    # NOTE: vendor/ content for miniextendr-{api,lint,macros} comes from the
-    # github URL pinned in Cargo.lock, NOT this checkout. A PR that edits a
-    # workspace crate alongside rpkg won't see those edits in the tarball
-    # because cargo-revendor follows the git source. cran-check therefore
-    # validates the published-main state, not the PR's. Tracked: see follow-up
-    # issue. Workaround for release: land workspace changes first, then run
-    # `just vendor` from main with the new commit hash present at github HEAD.
+    # `--source-root .` makes cargo-revendor copy miniextendr-{api,lint,macros}
+    # from this workspace checkout instead of fetching them from the git URL
+    # pinned in Cargo.lock. PRs that edit a workspace crate alongside rpkg get
+    # their edits reflected in vendor/ and inst/vendor.tar.xz, so
+    # `vendor-sync-check` passes and the offline tarball ships the PR's code.
     cargo revendor \
       --manifest-path rpkg/src/rust/Cargo.toml \
+      --source-root . \
       --output rpkg/vendor \
       --compress rpkg/inst/vendor.tar.xz \
       --blank-md \

--- a/miniextendr-api/src/optionals/log_impl.rs
+++ b/miniextendr-api/src/optionals/log_impl.rs
@@ -6,8 +6,16 @@
 //!
 //! # Thread safety
 //!
-//! The logger only outputs on R's main thread. Messages logged from other
-//! threads are silently dropped (R API calls are not thread-safe).
+//! The logger is safe to call from any thread. Records logged from non-main
+//! threads are buffered in a bounded MPSC queue (capacity 1024) and drained
+//! to R's console the next time the main thread passes through the FFI
+//! trampoline. Main-thread records drain the queue first, then render
+//! immediately.
+//!
+//! If the queue fills up, the oldest record is dropped and an overflow counter
+//! is incremented. The next call to `drain_log_queue()` from the main thread
+//! emits a single `WARN`-level message ("N log records dropped due to queue
+//! overflow") and resets the counter to 0.
 //!
 //! # Level mapping
 //!
@@ -18,6 +26,20 @@
 //! | `info!()`  | `Rprintf` (stdout/console) |
 //! | `debug!()` | `Rprintf` (stdout/console) |
 //! | `trace!()` | `Rprintf` (stdout/console) |
+//!
+//! # Default level
+//!
+//! `install_r_logger()` sets the max level to `Off`. Downstream packages must
+//! explicitly opt in by calling `set_log_level("info")` (or any other level).
+//! This prevents packages from unexpectedly producing console output when users
+//! do not expect it.
+//!
+//! # Drain at FFI exit
+//!
+//! The `drain_log_queue()` function is called automatically from the unwind
+//! protect trampoline (`unwind_protect.rs`) on every FFI exit path — normal
+//! return, Rust panic, and R longjmp. It is a no-op when not on the main
+//! thread.
 //!
 //! # Example
 //!
@@ -35,7 +57,104 @@
 pub use log;
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
+use std::collections::VecDeque;
+#[cfg(not(test))]
 use std::ffi::CString;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+/// Capacity of the cross-thread log queue.
+const QUEUE_CAPACITY: usize = 1024;
+
+/// Buffered records from non-main threads, pending drain on the next main-thread FFI exit.
+static QUEUE: OnceLock<Mutex<VecDeque<(Level, String)>>> = OnceLock::new();
+
+/// Number of records dropped due to queue overflow since the last drain.
+static DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+fn queue() -> &'static Mutex<VecDeque<(Level, String)>> {
+    QUEUE.get_or_init(|| Mutex::new(VecDeque::with_capacity(QUEUE_CAPACITY)))
+}
+
+// region: Test infrastructure (cfg(test) overrides)
+
+// In tests, `is_r_main_thread()` is overridden by a thread-local boolean so
+// individual tests can pretend to be on or off the main thread without
+// actually running R.
+#[cfg(test)]
+thread_local! {
+    static FAKE_IS_MAIN: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+}
+
+/// Whether the current thread is R's main thread.
+///
+/// In tests: returns the thread-local override when set; falls back to the real
+/// `worker::is_r_main_thread()` otherwise.
+#[cfg(not(test))]
+#[inline(always)]
+fn is_main() -> bool {
+    crate::worker::is_r_main_thread()
+}
+
+#[cfg(test)]
+fn is_main() -> bool {
+    FAKE_IS_MAIN
+        .with(|c| c.get())
+        .unwrap_or_else(crate::worker::is_r_main_thread)
+}
+
+/// Override the main-thread predicate for the duration of the current test.
+///
+/// Call with `None` to restore the real predicate.
+#[cfg(test)]
+pub(crate) fn set_fake_main_thread(v: Option<bool>) {
+    FAKE_IS_MAIN.with(|c| c.set(v));
+}
+
+// endregion
+
+// region: Render abstraction (cfg(test) indirection)
+
+/// Write a formatted log message to R's console.
+///
+/// In production: calls `Rprintf` (stdout) or `REprintf` (stderr) based on
+/// level. In tests: appends to a `Mutex<Vec<String>>` sink to avoid calling
+/// the R FFI.
+#[cfg(not(test))]
+fn render(level: Level, msg: &str) {
+    let line = format!("{msg}\n");
+    let Ok(cmsg) = CString::new(line) else {
+        return; // message contains null byte, skip
+    };
+    unsafe {
+        let fmt = c"%s".as_ptr();
+        match level {
+            Level::Error | Level::Warn => {
+                crate::ffi::REprintf_unchecked(fmt, cmsg.as_ptr());
+            }
+            Level::Info | Level::Debug | Level::Trace => {
+                crate::ffi::Rprintf_unchecked(fmt, cmsg.as_ptr());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) static TEST_SINK: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+#[cfg(test)]
+fn render(_level: Level, msg: &str) {
+    TEST_SINK.lock().unwrap().push(msg.to_string());
+}
+
+#[cfg(test)]
+pub(crate) fn take_rendered() -> Vec<String> {
+    std::mem::take(&mut *TEST_SINK.lock().unwrap())
+}
+
+// endregion
+
+// region: Logger implementation
 
 /// R-aware logger that routes to `Rprintf`/`REprintf`.
 struct RLogger;
@@ -50,37 +169,41 @@ impl Log for RLogger {
             return;
         }
 
-        // Only output on R's main thread — R API is not thread-safe.
-        if !crate::worker::is_r_main_thread() {
-            return;
-        }
+        // Format the message immediately — `record.args()` borrows `record`
+        // which cannot escape this function.
+        let msg = format!("{}", record.args());
 
-        let msg = format!("{}\n", record.args());
-        let Ok(cmsg) = CString::new(msg) else {
-            return; // message contains null byte, skip
-        };
-
-        unsafe {
-            let fmt = c"%s".as_ptr();
-            match record.level() {
-                Level::Error | Level::Warn => {
-                    crate::ffi::REprintf_unchecked(fmt, cmsg.as_ptr());
-                }
-                Level::Info | Level::Debug | Level::Trace => {
-                    crate::ffi::Rprintf_unchecked(fmt, cmsg.as_ptr());
-                }
+        if is_main() {
+            // On the main thread: drain any buffered worker records first,
+            // then render this record immediately.
+            drain_log_queue();
+            render(record.level(), &msg);
+        } else {
+            // On a worker thread: push to the bounded queue.
+            let mut q = queue().lock().unwrap();
+            if q.len() >= QUEUE_CAPACITY {
+                q.pop_front(); // drop oldest
+                DROPPED.fetch_add(1, Ordering::Relaxed);
             }
+            q.push_back((record.level(), msg));
         }
     }
 
     fn flush(&self) {
-        if crate::worker::is_r_main_thread() {
+        if is_main() {
+            drain_log_queue();
+            #[cfg(not(test))]
             unsafe {
                 crate::ffi::R_FlushConsole_unchecked();
             }
         }
+        // No-op on non-main threads: cannot call R API.
     }
 }
+
+// endregion
+
+// region: Public API
 
 /// Install the R console logger.
 ///
@@ -88,27 +211,315 @@ impl Log for RLogger {
 /// If a logger is already installed (by another package or the user),
 /// this is a no-op.
 ///
-/// Default level: `Info` (shows info, warn, error; hides debug, trace).
+/// Default level: `Off` (all output suppressed until the downstream package
+/// calls `set_log_level("info")` or similar).
 pub fn install_r_logger() {
     static LOGGER: RLogger = RLogger;
     // ok() — ignore AlreadySet error if another logger is installed
     log::set_logger(&LOGGER).ok();
-    log::set_max_level(LevelFilter::Info);
+    log::set_max_level(LevelFilter::Off);
 }
 
 /// Set the log level filter from a string.
 ///
-/// Valid levels: "error", "warn", "info", "debug", "trace", "off".
-/// Invalid strings default to "info".
+/// Valid levels: "error", "warn", "info", "debug", "trace", "off"
+/// (case-insensitive). Invalid strings default to `"info"`.
 pub fn set_log_level(level: &str) {
-    let filter = match level {
-        "error" => LevelFilter::Error,
-        "warn" => LevelFilter::Warn,
-        "info" => LevelFilter::Info,
-        "debug" => LevelFilter::Debug,
-        "trace" => LevelFilter::Trace,
-        "off" => LevelFilter::Off,
-        _ => LevelFilter::Info,
-    };
+    use std::str::FromStr;
+    let filter = LevelFilter::from_str(level).unwrap_or(LevelFilter::Info);
     log::set_max_level(filter);
 }
+
+/// Drain all buffered cross-thread log records to R's console.
+///
+/// Must be called from R's main thread — silently returns otherwise.
+/// Idempotent: if the queue is empty, this is a no-op.
+///
+/// If records were dropped due to queue overflow, a single `WARN`-level
+/// message ("N log records dropped due to queue overflow") is emitted first,
+/// and the overflow counter is reset to zero.
+///
+/// The FFI trampoline in `unwind_protect.rs` calls this automatically on every
+/// FFI exit path (normal return, Rust panic, and caught R longjmp). Direct
+/// callers are rare but supported (e.g. end-of-batch flush points).
+pub fn drain_log_queue() {
+    if !is_main() {
+        return;
+    }
+
+    // Emit overflow warning before the buffered records.
+    let dropped = DROPPED.swap(0, Ordering::Relaxed);
+    if dropped > 0 {
+        render(
+            Level::Warn,
+            &format!("{dropped} log records dropped due to queue overflow"),
+        );
+    }
+
+    // Drain and render all buffered records.
+    let records: Vec<(Level, String)> = {
+        let mut q = queue().lock().unwrap();
+        std::mem::take(&mut *q).into_iter().collect()
+    };
+    for (level, msg) in records {
+        render(level, &msg);
+    }
+}
+
+// endregion
+
+// region: Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    /// Serializes all tests in this module so they don't clobber the shared
+    /// global QUEUE, DROPPED, and TEST_SINK state.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Acquire the test serialization lock, recovering from a previous test
+    /// panic that left the lock poisoned.
+    fn acquire_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    // Convenience: install logger if not already installed, set level to Trace.
+    fn init_trace() {
+        install_r_logger();
+        set_log_level("trace");
+    }
+
+    // Clear the queue and reset dropped counter between tests.
+    fn reset_state() {
+        // Recover from poisoned mutex (prior test may have panicked holding the lock).
+        let mut q = queue().lock().unwrap_or_else(|e| e.into_inner());
+        q.clear();
+        drop(q);
+        DROPPED.store(0, Ordering::Relaxed);
+        take_rendered();
+        set_fake_main_thread(None);
+    }
+
+    // Enqueue a record as if from a worker thread (bypasses level filter).
+    fn enqueue(level: Level, msg: &str) {
+        let mut q = queue().lock().unwrap_or_else(|e| e.into_inner());
+        if q.len() >= QUEUE_CAPACITY {
+            q.pop_front();
+            DROPPED.fetch_add(1, Ordering::Relaxed);
+        }
+        q.push_back((level, msg.to_string()));
+    }
+
+    // -------------------------------------------------------------------------
+    // default_level_is_off
+    // -------------------------------------------------------------------------
+
+    /// After `install_r_logger`, the max level is Off so info!/error! produce
+    /// nothing (no queue entries, no rendered output).
+    #[test]
+    fn default_level_is_off() {
+        let _guard = acquire_test_lock();
+        reset_state();
+        install_r_logger(); // resets to Off
+        set_fake_main_thread(Some(true));
+
+        // These should be filtered out before reaching queue or render.
+        log::info!("should be suppressed");
+        log::error!("also suppressed");
+
+        assert_eq!(
+            queue().lock().unwrap_or_else(|e| e.into_inner()).len(),
+            0,
+            "queue must be empty"
+        );
+        assert!(take_rendered().is_empty(), "nothing should be rendered");
+    }
+
+    // -------------------------------------------------------------------------
+    // worker_buffering
+    // -------------------------------------------------------------------------
+
+    /// A record logged from a non-main thread lands in QUEUE and is not
+    /// rendered immediately.
+    #[test]
+    fn worker_buffering() {
+        let _guard = acquire_test_lock();
+        reset_state();
+        init_trace();
+
+        // Pretend we are NOT on the main thread.
+        set_fake_main_thread(Some(false));
+        log::info!("buffered from worker");
+
+        let q = queue().lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(q.len(), 1, "record must be in queue");
+        assert_eq!(q[0].1, "buffered from worker");
+        drop(q);
+
+        assert!(
+            take_rendered().is_empty(),
+            "worker records must not be rendered immediately"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // fifo_drain
+    // -------------------------------------------------------------------------
+
+    /// Records enqueued in order are drained in the same order (FIFO).
+    #[test]
+    fn fifo_drain() {
+        let _guard = acquire_test_lock();
+        reset_state();
+
+        // Enqueue directly (bypasses level/thread check).
+        for i in 0..5 {
+            enqueue(Level::Info, &format!("msg-{i}"));
+        }
+
+        // Drain on the "main thread".
+        set_fake_main_thread(Some(true));
+        drain_log_queue();
+
+        let rendered = take_rendered();
+        assert_eq!(rendered.len(), 5);
+        for (i, r) in rendered.iter().enumerate() {
+            assert_eq!(r, &format!("msg-{i}"), "FIFO order violated at index {i}");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // overflow_accounting
+    // -------------------------------------------------------------------------
+
+    /// Enqueueing capacity+50 records results in exactly 50 dropped and the
+    /// queue stays at QUEUE_CAPACITY.
+    #[test]
+    fn overflow_accounting() {
+        let _guard = acquire_test_lock();
+        reset_state();
+
+        let extra = 50usize;
+        for i in 0..(QUEUE_CAPACITY + extra) {
+            enqueue(Level::Info, &format!("msg-{i}"));
+        }
+
+        assert_eq!(
+            DROPPED.load(Ordering::Relaxed),
+            extra,
+            "expected {extra} dropped records"
+        );
+        assert_eq!(
+            queue().lock().unwrap_or_else(|e| e.into_inner()).len(),
+            QUEUE_CAPACITY,
+            "queue must be capped at {QUEUE_CAPACITY}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // overflow_warning_emitted_and_reset
+    // -------------------------------------------------------------------------
+
+    /// After overflow, the first drain emits a warning. A subsequent drain
+    /// does NOT re-emit it.
+    #[test]
+    fn overflow_warning_emitted_and_reset() {
+        let _guard = acquire_test_lock();
+        reset_state();
+
+        // Force overflow by enqueueing capacity+1 records.
+        for i in 0..=(QUEUE_CAPACITY) {
+            enqueue(Level::Info, &format!("msg-{i}"));
+        }
+
+        set_fake_main_thread(Some(true));
+
+        // First drain — overflow warning + QUEUE_CAPACITY records.
+        drain_log_queue();
+        let first = take_rendered();
+        assert!(
+            first
+                .iter()
+                .any(|m| m.contains("log records dropped due to queue overflow")),
+            "expected overflow warning in first drain; got: {first:?}"
+        );
+
+        // Second drain — nothing left, no overflow warning.
+        drain_log_queue();
+        let second = take_rendered();
+        assert!(
+            second.iter().all(|m| !m.contains("log records dropped")),
+            "unexpected overflow warning re-emitted in second drain; got: {second:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // drain_on_error_path
+    // -------------------------------------------------------------------------
+
+    /// A record buffered by a "worker" is visible in the rendered sink after
+    /// the drain that the trampoline would call on error exit.
+    ///
+    /// This test exercises the drain path directly, which is what the
+    /// `drain_log_queue_if_available()` call in `unwind_protect.rs` fires on
+    /// every FFI exit path (normal, panic, R longjmp).
+    #[test]
+    fn drain_on_error_path() {
+        let _guard = acquire_test_lock();
+        reset_state();
+
+        // Step 1: buffer a record as if from a worker thread.
+        enqueue(Level::Warn, "worker warning before error");
+
+        // Step 2: simulate trampoline error-path drain — called from main thread.
+        set_fake_main_thread(Some(true));
+        drain_log_queue();
+
+        // Step 3: the record must appear in the rendered sink.
+        let rendered = take_rendered();
+        assert!(
+            rendered
+                .iter()
+                .any(|m| m.contains("worker warning before error")),
+            "buffered record must be drained even on error path; got: {rendered:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // std::thread spawn buffering (real thread, no fake override)
+    // -------------------------------------------------------------------------
+
+    /// A record from a real `std::thread::spawn` thread is buffered (not
+    /// rendered), and appears after drain on the "main thread".
+    #[test]
+    fn real_thread_buffering() {
+        let _guard = acquire_test_lock();
+        reset_state();
+        init_trace();
+
+        // Spawn a thread that will NOT be the R main thread (R_MAIN_THREAD_ID
+        // is either unset or set to the test thread, neither matches the spawned
+        // thread ID).
+        let handle = thread::spawn(|| {
+            log::info!("from spawned thread");
+        });
+        handle.join().unwrap();
+
+        // The record must be in the queue (not rendered yet).
+        assert_eq!(queue().lock().unwrap_or_else(|e| e.into_inner()).len(), 1);
+        assert!(take_rendered().is_empty());
+
+        // Drain on the fake-main thread.
+        set_fake_main_thread(Some(true));
+        drain_log_queue();
+        let rendered = take_rendered();
+        assert!(
+            rendered.iter().any(|m| m.contains("from spawned thread")),
+            "got: {rendered:?}"
+        );
+    }
+}
+
+// endregion

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -6,6 +6,13 @@
 //! **Important**: R uses `longjmp` for error handling, which normally bypasses Rust destructors.
 //! Use this API to ensure cleanup happens even when R errors occur.
 //!
+//! ## Log drain
+//!
+//! Every call to `with_r_unwind_protect` (and its variants) drains the
+//! cross-thread log queue via [`drain_log_queue_if_available`] before
+//! returning or re-raising an R error. This ensures that records buffered by
+//! worker threads are flushed to R's console on every FFI exit — including
+//! error paths.
 use std::{
     any::Any,
     ffi::c_void,
@@ -84,11 +91,34 @@ pub(crate) unsafe fn panic_payload_to_r_error(
     }
 }
 
+// region: Log drain integration
+
+/// Drain the cross-thread log queue if the `log` feature is enabled.
+///
+/// This is called at every exit point of `run_r_unwind_protect` (normal
+/// return, Rust panic, and immediately before `R_ContinueUnwind`) so that
+/// worker-thread log records always reach R's console before the FFI call
+/// returns or re-raises an R error.
+///
+/// When the `log` feature is disabled this compiles to a no-op; there is
+/// no runtime overhead.
+#[inline]
+fn drain_log_queue_if_available() {
+    #[cfg(feature = "log")]
+    crate::optionals::log_impl::drain_log_queue();
+}
+
+// endregion
+
 /// Core R_UnwindProtect wrapper. Returns `Ok(result)` on success,
 /// `Err(payload)` on Rust panic, or diverges via `R_ContinueUnwind` on R longjmp.
 ///
 /// Handles: CallData boxing, trampoline, cleanup handler, continuation token,
 /// `Box::from_raw` reclamation on all non-diverging paths.
+///
+/// Drains the cross-thread log queue (when the `log` feature is enabled) at
+/// each exit point so worker-thread records reach R's console before the FFI
+/// boundary is crossed.
 fn run_r_unwind_protect<F, R>(f: F) -> Result<R, Box<dyn Any + Send>>
 where
     F: FnOnce() -> R,
@@ -155,13 +185,20 @@ where
                 // Check if trampoline caught a panic
                 if let Some(payload) = data.panic_payload.take() {
                     drop(data);
+                    // Drain worker-thread log records before returning the panic
+                    // payload to the caller (which will convert it to an R error).
+                    drain_log_queue_if_available();
                     Err(payload)
                 } else {
                     // Normal completion - return the result
-                    Ok(data
+                    let result = data
                         .result
                         .take()
-                        .expect("result not set after successful completion"))
+                        .expect("result not set after successful completion");
+                    drop(data);
+                    // Drain worker-thread log records on the normal success path.
+                    drain_log_queue_if_available();
+                    Ok(result)
                 }
             }
             Err(payload) => {
@@ -169,10 +206,14 @@ where
                 drop(data);
                 // Check if this was an R error or a Rust panic
                 if payload.downcast_ref::<RErrorMarker>().is_some() {
-                    // R error - continue R's unwind (diverges, never returns)
+                    // R error - drain log records before re-raising so worker
+                    // thread output is not lost even on error exits.
+                    drain_log_queue_if_available();
+                    // Continue R's unwind (diverges, never returns)
                     R_ContinueUnwind(token);
                 } else {
-                    // Rust panic
+                    // Rust panic — drain before returning the payload.
+                    drain_log_queue_if_available();
                     Err(payload)
                 }
             }

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "icu_normalizer",
@@ -1648,7 +1648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-api"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#b9cb6a8648e9d60cf04b1b2df9b017b4cc9c1fca"
+source = "git+https://github.com/A2-ai/miniextendr#58c8a51864af79fdf7f28ca7e93b828a11092b7b"
 dependencies = [
  "ahash 0.8.12",
  "aho-corasick",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-lint"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#b9cb6a8648e9d60cf04b1b2df9b017b4cc9c1fca"
+source = "git+https://github.com/A2-ai/miniextendr#58c8a51864af79fdf7f28ca7e93b828a11092b7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-macros"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#b9cb6a8648e9d60cf04b1b2df9b017b4cc9c1fca"
+source = "git+https://github.com/A2-ai/miniextendr#58c8a51864af79fdf7f28ca7e93b828a11092b7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-ident",
@@ -3358,3 +3358,27 @@ dependencies = [
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[patch.unused]]
+name = "miniextendr-api"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-bench"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-cli"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-engine"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-lint"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "miniextendr-macros"
+version = "0.1.0"

--- a/rpkg/tests/testthat/test-log.R
+++ b/rpkg/tests/testthat/test-log.R
@@ -1,31 +1,41 @@
-# Tests for log crate → R console routing
+# Tests for log crate → R console routing.
+#
+# install_r_logger() defaults to LevelFilter::Off — every test that expects
+# log output must opt in explicitly via test_log_set_level(). Each test
+# resets to "off" on exit so it doesn't leak into the next.
 
 test_that("log::info! outputs to R console", {
+  test_log_set_level("info")
+  on.exit(test_log_set_level("off"), add = TRUE)
   out <- capture.output(test_log_info("hello from rust"))
   expect_true(any(grepl("hello from rust", out)))
 })
 
 test_that("log::warn! outputs to R stderr", {
+  test_log_set_level("warn")
+  on.exit(test_log_set_level("off"), add = TRUE)
   # REprintf goes to stderr — capture via capture.output(type = "message")
   msg <- capture.output(test_log_warn("watch out"), type = "message")
   expect_true(any(grepl("watch out", msg)))
 })
 
 test_that("log::error! outputs to R stderr", {
+  test_log_set_level("error")
+  on.exit(test_log_set_level("off"), add = TRUE)
   msg <- capture.output(test_log_error("something broke"), type = "message")
   expect_true(any(grepl("something broke", msg)))
 })
 
 test_that("debug messages hidden at info level", {
   test_log_set_level("info")
+  on.exit(test_log_set_level("off"), add = TRUE)
   out <- capture.output(test_log_debug("hidden debug"))
   expect_false(any(grepl("hidden debug", out)))
 })
 
 test_that("debug messages visible at debug level", {
   test_log_set_level("debug")
+  on.exit(test_log_set_level("off"), add = TRUE)
   out <- capture.output(test_log_debug("visible debug"))
   expect_true(any(grepl("visible debug", out)))
-  # Reset to info
-  test_log_set_level("info")
 })


### PR DESCRIPTION
## Why

Three problems with the current design:

1. **Worker-thread logs silently dropped.** `RLogger::log` checked `is_r_main_thread()` and returned early for any non-main-thread caller. Packages using `#[miniextendr(worker)]` or `std::thread::spawn` lost all log output with no indication.

2. **FFI bodies can leak resources on `Rf_error`.** While miniextendr's generated wrappers have always used `with_r_unwind_protect` (which internally calls `R_UnwindProtect`), there was no guarantee that cross-thread buffered log records were flushed before R's longjmp resumed — so records from the current FFI call could disappear on error paths.

3. **Default log level `Info` is opinionated.** Packages that depend on miniextendr but don't intend to emit log output would start producing console noise as soon as they called `install_r_logger()`. Downstream packages should opt in explicitly.

## What

### Layer 1 — Drain at every FFI exit (`unwind_protect.rs`)

Added `drain_log_queue_if_available()` — a thin wrapper that calls `log_impl::drain_log_queue()` when the `log` feature is enabled (zero-cost no-op otherwise).

Called at **every exit point** of `run_r_unwind_protect`:
- Normal success path (before `Ok(result)` return)
- Rust panic path (before returning the panic payload to the caller)
- R-longjmp path (immediately before `R_ContinueUnwind(token)`)

`run_r_unwind_protect` is the shared inner function used by `with_r_unwind_protect`, `with_r_unwind_protect_error_in_r`, and `with_r_unwind_protect_sourced`, so every generated `extern "C-unwind"` wrapper is covered without touching the macro layer.

### Layer 2 — Bounded MPSC log queue (`log_impl.rs`)

- `static QUEUE: OnceLock<Mutex<VecDeque<(Level, String)>>>` — capacity 1024, lazy-initialized.
- `static DROPPED: AtomicUsize` — overflow counter.
- `RLogger::log`: formats message immediately (lifetime safety); if main thread, drains queue then renders; if worker thread, push-back with pop-front-on-full overflow.
- `pub fn drain_log_queue()`: main-thread-only, idempotent. Emits `WARN` overflow notice (once, then resets counter), then drains and renders all buffered records.
- `install_r_logger`: default level changed from `Info` → **`Off`**.
- `set_log_level`: rewritten to use `log::LevelFilter::from_str` (case-insensitive); fallback `Info` for invalid strings preserves prior behavior.

### Trampoline strategy: `R_UnwindProtect` (not `R_ToplevelExec`)

`R_ToplevelExec` runs a closure in a fresh top-level context: if an error occurs the entire closure is aborted and the caller receives a `FALSE` return — there is no mechanism to re-raise the original R condition, capture a continuation token, or resume the outer longjmp chain. It is suited for "try this and ignore failure" patterns, not for transparent error propagation.

`R_UnwindProtect` gives us a cleanup callback that fires mid-unwind with a continuation token (`R_MakeUnwindCont` / `R_ContinueUnwind`). We can run Rust destructors in the cleanup callback (via `panic_any(RErrorMarker)` + `catch_unwind`), then re-raise with `R_ContinueUnwind`, preserving the original R condition and the full call stack. This is the pattern used by extendr-api and is the only correct choice for a transparent trampoline.

The existing `run_r_unwind_protect` in `unwind_protect.rs` already implements this correctly. This PR adds the log-drain hook at its exit points rather than re-implementing the trampoline.

## Test plan

All tests are in `miniextendr-api/src/optionals/log_impl.rs` under `#[cfg(test)] mod tests`.

| Test | Intent |
|------|--------|
| `default_level_is_off` | After `install_r_logger()`, `info!`/`error!` produce zero queue entries and zero rendered output |
| `worker_buffering` | A record logged with `FAKE_IS_MAIN=false` lands in `QUEUE`, nothing rendered |
| `fifo_drain` | N records enqueued directly are drained in insertion order |
| `overflow_accounting` | capacity+50 enqueues → `DROPPED==50`, `queue.len()==1024` |
| `overflow_warning_emitted_and_reset` | First drain emits overflow warning; second drain does not re-emit |
| `drain_on_error_path` | Record buffered by "worker", then `drain_log_queue()` (simulating trampoline error exit) → record appears in rendered sink |
| `real_thread_buffering` | Real `std::thread::spawn` thread logs a record; verified in queue, then drained on fake-main thread |

Test infrastructure: `FAKE_IS_MAIN` thread-local, `TEST_SINK: Mutex<Vec<String>>` render indirection, `TEST_LOCK: Mutex<()>` to serialize tests sharing global queue state.

## Migration note

**Breaking behaviour change: default log level is now `Off`.**

Any downstream package that called `install_r_logger()` and relied on the previous `Info` default will go silent after upgrading. To restore the previous behaviour, add an explicit call:

```rust
// In package_init or equivalent:
miniextendr_api::optionals::log_impl::set_log_level("info");
```

`dvs-rpkg` is one known affected package (it calls `set_log_level` via R code, but its `install_r_logger()` call in `init.rs` previously relied on the `Info` default). A follow-up PR will migrate it.

## Out of scope / future work

- **Layer 3 — `WorkerPump`**: a dedicated pump that drains the queue from the main-thread event loop *between* `with_r_thread` callbacks during long worker operations. This would allow log output to appear before the worker job completes, rather than only at FFI exit. Tracked as future work; the current drain-at-exit design is a strictly correct subset.
- **`dvs-rpkg` migration**: updating the downstream consumer to call `set_log_level("info")` explicitly. Out of scope per the task specification.