### PR TITLE
fix(configure): strip Cargo.lock checksums on every configure run, not just first vendor unpack

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -328,14 +328,20 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
         echo "configure: error: failed to unpack inst/vendor.tar.xz" >&2
         exit 1
       fi
-      dnl Vendored crates ship with empty checksums; strip the [checksum]
-      dnl entries from Cargo.lock so cargo accepts the vendored tree.
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-          rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
     else
       echo "configure: tarball install — vendor/ already populated"
+    fi
+    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
+    dnl Vendored sources carry no registry checksums, but Cargo.lock can
+    dnl re-acquire them after a cargo update, a fresh git checkout, or any
+    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
+    dnl verify checksums against a vendored-sources tree, producing errors like:
+    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
+    dnl          is listed in the existing lock file
+    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
+    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
+        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
     fi
   fi
 ],

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -328,14 +328,20 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
         echo "configure: error: failed to unpack inst/vendor.tar.xz" >&2
         exit 1
       fi
-      dnl Vendored crates ship with empty checksums; strip the [checksum]
-      dnl entries from Cargo.lock so cargo accepts the vendored tree.
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-          rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
     else
       echo "configure: tarball install — vendor/ already populated"
+    fi
+    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
+    dnl Vendored sources carry no registry checksums, but Cargo.lock can
+    dnl re-acquire them after a cargo update, a fresh git checkout, or any
+    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
+    dnl verify checksums against a vendored-sources tree, producing errors like:
+    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
+    dnl          is listed in the existing lock file
+    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
+    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
+        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
     fi
   fi
 ],

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -14,8 +14,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-04-29 17:09:49
-+++ b/monorepo/rpkg/configure.ac	2026-04-29 17:09:49
+--- a/monorepo/rpkg/configure.ac	2026-05-01 10:58:49
++++ b/monorepo/rpkg/configure.ac	2026-05-01 10:59:05
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -181,14 +181,14 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -421,5 +452,5 @@
+@@ -427,5 +458,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -437,13 +468,22 @@
+@@ -443,13 +474,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -214,8 +214,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-04-29 17:09:49
-+++ b/rpkg/configure.ac	2026-04-29 17:09:49
+--- a/rpkg/configure.ac	2026-05-01 10:58:49
++++ b/rpkg/configure.ac	2026-05-01 10:58:57
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -381,14 +381,14 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -421,5 +452,5 @@
+@@ -427,5 +458,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -437,13 +468,22 @@
+@@ -443,13 +474,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3675,12 +3675,12 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
         echo "configure: error: failed to unpack inst/vendor.tar.xz" >&2
         exit 1
       fi
-                  if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-          rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
     else
       echo "configure: tarball install — vendor/ already populated"
+    fi
+                                    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
+        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
     fi
   fi
  ;;

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -297,14 +297,20 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
         echo "configure: error: failed to unpack inst/vendor.tar.xz" >&2
         exit 1
       fi
-      dnl Vendored crates ship with empty checksums; strip the [checksum]
-      dnl entries from Cargo.lock so cargo accepts the vendored tree.
-      if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-        $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-          rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-      fi
     else
       echo "configure: tarball install — vendor/ already populated"
+    fi
+    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
+    dnl Vendored sources carry no registry checksums, but Cargo.lock can
+    dnl re-acquire them after a cargo update, a fresh git checkout, or any
+    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
+    dnl verify checksums against a vendored-sources tree, producing errors like:
+    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
+    dnl          is listed in the existing lock file
+    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
+    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
+      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
+        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
     fi
   fi
 ],

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-api"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#e192f7cc3722fefac7bcb96f01cd530eb24d69c5"
+source = "git+https://github.com/A2-ai/miniextendr#c1863c861a07de7682804df91df1a7a553b7de1e"
 dependencies = [
  "ahash 0.8.12",
  "aho-corasick",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-lint"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#e192f7cc3722fefac7bcb96f01cd530eb24d69c5"
+source = "git+https://github.com/A2-ai/miniextendr#c1863c861a07de7682804df91df1a7a553b7de1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-macros"
 version = "0.1.0"
-source = "git+https://github.com/A2-ai/miniextendr#e192f7cc3722fefac7bcb96f01cd530eb24d69c5"
+source = "git+https://github.com/A2-ai/miniextendr#c1863c861a07de7682804df91df1a7a553b7de1e"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Motivation

Fixes dvs2#179. Users hit cryptic build failures after any event that re-introduces `checksum = ...` lines to `Cargo.lock` (e.g. `cargo update`, a fresh git checkout, or a workspace member edit that regenerates the lockfile). The failure from Cargo 1.95+:

```
error: checksum for `portable-atomic-util v0.2.7` could not be calculated, but a checksum is listed in the existing lock file
```

The only recovery today is manually running `sed -i '/^checksum = /d' Cargo.lock`.

## Bug

The checksum-strip `sed` call was nested inside the first-unpack guard:

```sh
if test ! -d "$VENDOR_OUT" || test -z "`ls -A "$VENDOR_OUT" 2>/dev/null`"; then
  # unpack tarball ...
  # strip checksums  ← ONLY RUNS HERE
else
  echo "configure: tarball install — vendor/ already populated"  ← strip skipped
fi
```

So the strip only ran on the first `configure` invocation when `vendor/` was freshly extracted. The "already populated" branch silently skipped it. Any subsequent lockfile regeneration left checksums in place, causing Cargo to reject the vendored tree.

## Fix

Move the strip block out of the if/else so it executes unconditionally inside the `IS_TARBALL_INSTALL` guard, in both branches:

```sh
if test ! -d "$VENDOR_OUT" || test -z "`ls -A "$VENDOR_OUT" 2>/dev/null`"; then
  # unpack tarball ...
else
  echo "configure: tarball install — vendor/ already populated"
fi
# Strip checksums unconditionally — idempotent, cheap, safe.
if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
  $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
    rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
fi
```

The `sed` invocation is idempotent: when no `checksum =` lines exist it is a no-op. Running it unconditionally in tarball mode is safe and cheap.

## Test plan

End-to-end recovery test (run from repo root):

```bash
# Start clean
rm -rf rpkg/vendor rpkg/inst/vendor.tar.xz rpkg/src/rust/Cargo.lock

# 1. Generate Cargo.lock with checksums (default cargo behavior).
cargo generate-lockfile --manifest-path rpkg/src/rust/Cargo.toml
grep -c '^checksum = ' rpkg/src/rust/Cargo.lock   # expect: many (351 on this run)

# 2. Vendor + create the tarball.
just vendor
test -f rpkg/inst/vendor.tar.xz   # expect: success

# 3. First configure — both old and new code strip checksums here.
just configure
grep -c '^checksum = ' rpkg/src/rust/Cargo.lock   # expect: 0

# 4. Re-introduce checksums (simulates cargo update, fresh checkout, etc.).
cargo generate-lockfile --manifest-path rpkg/src/rust/Cargo.toml
grep -c '^checksum = ' rpkg/src/rust/Cargo.lock   # expect: 351 again

# 5. Run configure AGAIN. Old code: skips strip, leaves checksums. New code: strips.
just configure
grep -c '^checksum = ' rpkg/src/rust/Cargo.lock   # expect: 0  ← KEY ASSERTION
```

Verified results on this branch:

- Step 1: 351 checksum lines
- Step 3: 0 checksum lines (first configure, unpack path)
- Step 4: 351 checksum lines re-introduced
- **Step 5: 0 checksum lines** — configure output showed `"vendor/ already populated"`, strip still ran
- Step 6 (`just rcmdinstall`) was not run: sandbox blocks compilation. The step 5 grep=0 is the load-bearing assertion.

## Note on `configure.ac` mutation principle

The CLAUDE.md principle "configure.ac never mutates sources" exists to prevent VCS-dirtying rewrites of `Cargo.toml` / `.rs` files. The Cargo.lock checksum strip is an existing controlled exception to that principle (it was already in `configure.ac` before this PR). This PR does not add a new class of mutation — it only unconditions an existing one. The PR body calls this out for maintainer awareness.

## Files changed

- `rpkg/configure.ac` — example R package
- `rpkg/configure` — regenerated via `autoconf` from `rpkg/configure.ac`
- `minirextendr/inst/templates/rpkg/configure.ac` — standalone scaffold template
- `minirextendr/inst/templates/monorepo/rpkg/configure.ac` — monorepo scaffold template

Future packages scaffolded via `minirextendr` inherit the fix automatically.