### PR TITLE
fix: replace Vec::set_len with vec![default; n] (closes #96)

### DIFF
--- a/miniextendr-api/src/optionals/rayon_bridge.rs
+++ b/miniextendr-api/src/optionals/rayon_bridge.rs
@@ -1174,7 +1174,7 @@ pub trait RParallelExtend<T: Send> {
 ///
 /// # Safety contract
 ///
-/// - Backing Vec must have `set_len(n)` called (elements uninitialized).
+/// - Backing Vec must have `len == n` (elements initialized — use `vec![default; n]`).
 /// - Every index in `0..n` must be written exactly once before the Vec is read.
 /// - No two threads may write to the same index.
 #[doc(hidden)]
@@ -1187,7 +1187,7 @@ unsafe impl<T: Send> Send for ColumnWriter<T> {}
 unsafe impl<T: Send> Sync for ColumnWriter<T> {}
 
 impl<T> ColumnWriter<T> {
-    /// Create a new writer for a Vec that has had `set_len(n)` called.
+    /// Create a new writer for a pre-initialized Vec (use `vec![default; n]`).
     ///
     /// # Safety
     /// Vec must have `len` already set. Caller must write all indices before reading.
@@ -1608,13 +1608,9 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::uninit_vec)]
     fn test_column_writer_parallel() {
         let n = 10_000;
-        let mut col: Vec<i32> = Vec::with_capacity(n);
-        unsafe {
-            col.set_len(n);
-        }
+        let mut col: Vec<i32> = vec![0; n];
         {
             let w = unsafe { ColumnWriter::new(&mut col) };
             (0..n)
@@ -1627,13 +1623,9 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::uninit_vec)]
     fn test_column_writer_string() {
         let n = 100;
-        let mut col: Vec<String> = Vec::with_capacity(n);
-        unsafe {
-            col.set_len(n);
-        }
+        let mut col: Vec<String> = vec![String::new(); n];
         {
             let w = unsafe { ColumnWriter::new(&mut col) };
             (0..n)
@@ -1645,13 +1637,9 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::uninit_vec)]
     fn test_column_writer_option() {
         let n = 100;
-        let mut col: Vec<Option<f64>> = Vec::with_capacity(n);
-        unsafe {
-            col.set_len(n);
-        }
+        let mut col: Vec<Option<f64>> = vec![None; n];
         {
             let w = unsafe { ColumnWriter::new(&mut col) };
             (0..n).into_par_iter().for_each(|i| unsafe {

--- a/miniextendr-macros/src/dataframe_derive.rs
+++ b/miniextendr-macros/src/dataframe_derive.rs
@@ -1093,28 +1093,25 @@ fn derive_struct_dataframe(
 
     // region: Generate from_rows_par (parallel scatter-write via ColumnWriter)
     let from_rows_par_method = if !flat_cols.is_empty() || !auto_expand_cols.is_empty() || has_tag {
-        // Column declarations: Vec::with_capacity(len) + set_len(len)
+        // Column declarations: vec![default; len]
         let mut par_col_decls = Vec::new();
         if has_tag {
             par_col_decls.push(quote! {
-                let mut _tag: Vec<String> = Vec::with_capacity(len);
-                unsafe { _tag.set_len(len); }
+                let mut _tag: Vec<String> = vec![String::new(); len];
             });
         }
         for fc in &flat_cols {
             let name = &fc.df_field;
             let ty = &fc.vec_elem_ty;
             par_col_decls.push(quote! {
-                let mut #name: Vec<#ty> = Vec::with_capacity(len);
-                unsafe { #name.set_len(len); }
+                let mut #name: Vec<#ty> = vec![<#ty as ::core::default::Default>::default(); len];
             });
         }
         for ac in &auto_expand_cols {
             let name = &ac.df_field;
             let cty = &ac.container_ty;
             par_col_decls.push(quote! {
-                let mut #name: Vec<#cty> = Vec::with_capacity(len);
-                unsafe { #name.set_len(len); }
+                let mut #name: Vec<#cty> = vec![<#cty as ::core::default::Default>::default(); len];
             });
         }
 

--- a/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
+++ b/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
@@ -750,24 +750,21 @@ pub(super) fn derive_enum_dataframe(
         let mut par_col_decls = Vec::new();
         if has_tag {
             par_col_decls.push(quote! {
-                let mut _tag: Vec<String> = Vec::with_capacity(len);
-                unsafe { _tag.set_len(len); }
+                let mut _tag: Vec<String> = vec![String::new(); len];
             });
         }
         for col in &columns {
             let name = &col.col_name;
             let ty = &col.ty;
             par_col_decls.push(quote! {
-                let mut #name: Vec<Option<#ty>> = Vec::with_capacity(len);
-                unsafe { #name.set_len(len); }
+                let mut #name: Vec<Option<#ty>> = vec![None; len];
             });
         }
         for ac in &auto_expand_cols {
             let name = &ac.df_field;
             let cty = &ac.container_ty;
             par_col_decls.push(quote! {
-                let mut #name: Vec<Option<#cty>> = Vec::with_capacity(len);
-                unsafe { #name.set_len(len); }
+                let mut #name: Vec<Option<#cty>> = vec![None; len];
             });
         }
 


### PR DESCRIPTION
## Summary

- Replaces the unsound `Vec::with_capacity(n)` + `unsafe { set_len(n) }` (`clippy::uninit_vec`) pattern at all five sites with safe initialized vectors
- Removes the `#[allow(clippy::uninit_vec)]` suppression attributes on the three test functions
- Updates `ColumnWriter` doc comments to reflect callers now provide initialized vecs

## Five sites fixed

| File | Pattern used |
|------|-------------|
| `miniextendr-macros/src/dataframe_derive.rs` | `vec![String::new(); len]` for tag col; `vec![<T as Default>::default(); len]` for generic cols |
| `miniextendr-macros/src/dataframe_derive/enum_expansion.rs` | `vec![String::new(); len]` for tag col; `vec![None; len]` for `Option<T>` cols |
| `miniextendr-api/src/optionals/rayon_bridge.rs` (`test_column_writer_parallel`) | `vec![0; n]` (`i32`) |
| `miniextendr-api/src/optionals/rayon_bridge.rs` (`test_column_writer_string`) | `vec![String::new(); n]` |
| `miniextendr-api/src/optionals/rayon_bridge.rs` (`test_column_writer_option`) | `vec![None; n]` (`Option<f64>`) |

closes #96

## Test plan

- [x] `just clippy` passes clean (no `-D warnings` failures)
- [x] CI-parity `cargo clippy --workspace --all-targets --locked --features rayon,...,default-worker -- -D warnings` passes
- [x] `just test` passes (all suites green, including `test_column_writer_*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)