### PR TITLE
refactor(macros): finish migrating R6 booleans into R6MethodAttrs

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -461,12 +461,19 @@ pub struct R6MethodAttrs {
     /// Mark as private method (`#[miniextendr(r6(private))]`).
     /// Also inferred from non-`pub` Rust visibility.
     pub private: bool,
+    /// Span of the `r6(private)` marker — points the validator's diagnostic
+    /// at the offending marker rather than the method ident.
+    pub private_span: Option<proc_macro2::Span>,
     /// Mark as finalizer (`#[miniextendr(r6(finalize))]`).
     /// Also inferred when the method consumes `self` and does not return `Self`.
     pub finalize: bool,
+    /// Span of the `r6(finalize)` marker — see `private_span`.
+    pub finalize_span: Option<proc_macro2::Span>,
     /// Mark as R6 deep-clone handler (`#[miniextendr(r6(deep_clone))]`).
     /// This method is wired into `private$deep_clone` in the R6Class definition.
     pub deep_clone: bool,
+    /// Span of the `r6(deep_clone)` marker — see `private_span`.
+    pub deep_clone_span: Option<proc_macro2::Span>,
 }
 
 /// S7-specific per-method markers, separated from [`MethodAttrs`] so the S7
@@ -1140,19 +1147,19 @@ impl ParsedMethod {
             }
             if attrs.r6.private {
                 return Err(syn::Error::new(
-                    span,
+                    attrs.r6.private_span.unwrap_or(span),
                     "#[r6(private)] is only valid for R6 class systems",
                 ));
             }
             if attrs.r6.finalize {
                 return Err(syn::Error::new(
-                    span,
+                    attrs.r6.finalize_span.unwrap_or(span),
                     "#[r6(finalize)] is only valid for R6 class systems",
                 ));
             }
             if attrs.r6.deep_clone {
                 return Err(syn::Error::new(
-                    span,
+                    attrs.r6.deep_clone_span.unwrap_or(span),
                     "#[r6(deep_clone)] is only valid for R6 class systems",
                 ));
             }
@@ -1232,9 +1239,13 @@ impl ParsedMethod {
                         } else if inner.path.is_ident("constructor") {
                             method_attrs.constructor = true;
                         } else if inner.path.is_ident("finalize") {
+                            use syn::spanned::Spanned;
                             method_attrs.r6.finalize = true;
+                            method_attrs.r6.finalize_span = Some(inner.path.span());
                         } else if inner.path.is_ident("private") {
+                            use syn::spanned::Spanned;
                             method_attrs.r6.private = true;
+                            method_attrs.r6.private_span = Some(inner.path.span());
                         } else if inner.path.is_ident("active") {
                             use syn::spanned::Spanned;
                             method_attrs.r6.active = true;
@@ -1319,7 +1330,9 @@ impl ParsedMethod {
                             let value: syn::LitStr = inner.input.parse()?;
                             method_attrs.s7.convert_to = Some(value.value());
                         } else if inner.path.is_ident("deep_clone") {
+                            use syn::spanned::Spanned;
                             method_attrs.r6.deep_clone = true;
+                            method_attrs.r6.deep_clone_span = Some(inner.path.span());
                         } else if inner.path.is_ident("r_name") {
                             let _: syn::Token![=] = inner.input.parse()?;
                             let value: syn::LitStr = inner.input.parse()?;

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -444,18 +444,29 @@ pub struct ParsedMethod {
 /// R6-specific per-method markers, separated from [`MethodAttrs`] so the
 /// `r6` parser branch and R6 class generator own a self-contained bag.
 ///
-/// The older `active` / `private` / `finalize` / `deep_clone` bool fields
-/// also drive R6 output but remain on `MethodAttrs` because they're read by
-/// cross-cutting accessor methods (`ParsedMethod::is_active` etc.).
+/// All R6 boolean flags live here.  Using any of these markers under a
+/// non-R6 class system (`#[miniextendr(s3)]`, `s4`, `s7`, `env`) is a
+/// compile-time error caught by [`ParsedMethod::validate_method_attrs`].
 #[derive(Debug, Default)]
 pub struct R6MethodAttrs {
+    /// Mark as active binding getter (`#[miniextendr(r6(active))]`).
+    pub active: bool,
+    /// Span of the `r6(active)` marker — used for error reporting when the
+    /// marker is misused in a non-R6 class generator.
+    pub active_span: Option<proc_macro2::Span>,
     /// R6 active-binding *setter* (paired with an `active` getter by `prop`).
     pub setter: bool,
     /// R6 active-binding property name (defaults to the method name).
     pub prop: Option<String>,
-    /// Span of the `r6(active)` marker — used for error reporting when the
-    /// marker is misused in a non-R6 class generator.
-    pub active_span: Option<proc_macro2::Span>,
+    /// Mark as private method (`#[miniextendr(r6(private))]`).
+    /// Also inferred from non-`pub` Rust visibility.
+    pub private: bool,
+    /// Mark as finalizer (`#[miniextendr(r6(finalize))]`).
+    /// Also inferred when the method consumes `self` and does not return `Self`.
+    pub finalize: bool,
+    /// Mark as R6 deep-clone handler (`#[miniextendr(r6(deep_clone))]`).
+    /// This method is wired into `private$deep_clone` in the R6Class definition.
+    pub deep_clone: bool,
 }
 
 /// S7-specific per-method markers, separated from [`MethodAttrs`] so the S7
@@ -504,16 +515,9 @@ pub struct MethodAttrs {
     pub ignore: bool,
     /// Mark as constructor
     pub constructor: bool,
-    /// Mark as finalizer (R6)
-    pub finalize: bool,
-    /// Mark as private (R6)
-    pub private: bool,
-    /// Mark as active binding getter (R6)
-    pub active: bool,
-    /// R6-specific method markers (active-binding setter / prop / active_span).
-    /// The cross-cutting R6 booleans (`active`, `private`, `finalize`,
-    /// `deep_clone`) stay on `MethodAttrs` because `ParsedMethod`'s accessor
-    /// methods (`is_active`, `is_private`, `is_finalizer`) read them directly.
+    /// R6-specific method markers. All R6 boolean flags live here.
+    /// Only consumed by the R6 class generator and R6-aware accessor methods
+    /// (`ParsedMethod::is_active`, `is_private`, `is_finalizer`).
     pub r6: R6MethodAttrs,
     /// Generate as `as.<class>()` S3 method (e.g., "data.frame", "list", "character").
     ///
@@ -616,11 +620,6 @@ pub struct MethodAttrs {
     /// }
     /// ```
     pub lifecycle: Option<crate::lifecycle::LifecycleSpec>,
-    /// Mark as R6 deep_clone method.
-    ///
-    /// Use `#[miniextendr(r6(deep_clone))]` to mark a method as the R6 deep clone handler.
-    /// This method will be wired into `private$deep_clone` in the R6Class definition.
-    pub deep_clone: bool,
     /// vctrs protocol method override.
     ///
     /// Use `#[miniextendr(vctrs(format))]` to mark a method as implementing a vctrs
@@ -1131,12 +1130,32 @@ impl ParsedMethod {
         class_system: ClassSystem,
         span: proc_macro2::Span,
     ) -> syn::Result<()> {
-        // #[...(active)] is only meaningful for R6
-        if attrs.active && class_system != ClassSystem::R6 {
-            return Err(syn::Error::new(
-                attrs.r6.active_span.unwrap_or(span),
-                "#[r6(active)] is only valid for R6 class systems",
-            ));
+        // R6-only boolean markers must not appear under any other class system.
+        if class_system != ClassSystem::R6 {
+            if attrs.r6.active {
+                return Err(syn::Error::new(
+                    attrs.r6.active_span.unwrap_or(span),
+                    "#[r6(active)] is only valid for R6 class systems",
+                ));
+            }
+            if attrs.r6.private {
+                return Err(syn::Error::new(
+                    span,
+                    "#[r6(private)] is only valid for R6 class systems",
+                ));
+            }
+            if attrs.r6.finalize {
+                return Err(syn::Error::new(
+                    span,
+                    "#[r6(finalize)] is only valid for R6 class systems",
+                ));
+            }
+            if attrs.r6.deep_clone {
+                return Err(syn::Error::new(
+                    span,
+                    "#[r6(deep_clone)] is only valid for R6 class systems",
+                ));
+            }
         }
 
         // convert_from and convert_to are mutually exclusive on the same method
@@ -1213,12 +1232,12 @@ impl ParsedMethod {
                         } else if inner.path.is_ident("constructor") {
                             method_attrs.constructor = true;
                         } else if inner.path.is_ident("finalize") {
-                            method_attrs.finalize = true;
+                            method_attrs.r6.finalize = true;
                         } else if inner.path.is_ident("private") {
-                            method_attrs.private = true;
+                            method_attrs.r6.private = true;
                         } else if inner.path.is_ident("active") {
                             use syn::spanned::Spanned;
-                            method_attrs.active = true;
+                            method_attrs.r6.active = true;
                             method_attrs.r6.active_span = Some(inner.path.span());
                         } else if inner.path.is_ident("setter") {
                             // Active binding setter: works for both R6 and S7
@@ -1300,7 +1319,7 @@ impl ParsedMethod {
                             let value: syn::LitStr = inner.input.parse()?;
                             method_attrs.s7.convert_to = Some(value.value());
                         } else if inner.path.is_ident("deep_clone") {
-                            method_attrs.deep_clone = true;
+                            method_attrs.r6.deep_clone = true;
                         } else if inner.path.is_ident("r_name") {
                             let _: syn::Token![=] = inner.input.parse()?;
                             let value: syn::LitStr = inner.input.parse()?;
@@ -1924,7 +1943,7 @@ impl ParsedMethod {
                     if p.path.segments.last().map(|s| s.ident == "Self").unwrap_or(false)));
 
             // Allow if: constructor (returns Self) or explicitly marked as finalize
-            let is_allowed = returns_self || method_attrs.constructor || method_attrs.finalize;
+            let is_allowed = returns_self || method_attrs.constructor || method_attrs.r6.finalize;
 
             if !is_allowed {
                 return Err(syn::Error::new(
@@ -1967,7 +1986,7 @@ impl ParsedMethod {
     /// Inferred from Rust visibility: anything not `pub` is private.
     pub fn is_private(&self) -> bool {
         // Explicit attribute takes precedence
-        if self.method_attrs.private {
+        if self.method_attrs.r6.private {
             return true;
         }
         // Infer from visibility: anything not `pub` is private
@@ -1984,13 +2003,13 @@ impl ParsedMethod {
     /// Returns true if this is likely a finalizer.
     /// Inferred from: consumes self (by value) + doesn't return Self.
     pub fn is_finalizer(&self) -> bool {
-        self.method_attrs.finalize || (self.env == ReceiverKind::Value && !self.returns_self())
+        self.method_attrs.r6.finalize || (self.env == ReceiverKind::Value && !self.returns_self())
     }
 
     /// Returns true if this method should be an R6 active binding.
     /// Active bindings provide property-like access (obj$name instead of obj$name()).
     pub fn is_active(&self) -> bool {
-        self.method_attrs.active
+        self.method_attrs.r6.active
     }
 
     /// R-facing method name.

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -382,7 +382,7 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
     if let Some(dc_method) = parsed_impl
         .methods
         .iter()
-        .find(|m| m.method_attrs.deep_clone && m.should_include())
+        .find(|m| m.method_attrs.r6.deep_clone && m.should_include())
     {
         let c_ident = dc_method
             .c_wrapper_ident(type_ident, parsed_impl.label())

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.rs
@@ -1,0 +1,14 @@
+//! Test: #[r6(deep_clone)] on non-R6 class system should fail.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(env)]
+impl Foo {
+    #[miniextendr(env(deep_clone))]
+    fn clone_fields(&self, _name: String, _value: miniextendr_api::Robj) {}
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
@@ -1,5 +1,5 @@
 error: #[r6(deep_clone)] is only valid for R6 class systems
-  --> tests/ui/impl_r6_deep_clone_wrong_system.rs:11:8
+  --> tests/ui/impl_r6_deep_clone_wrong_system.rs:10:23
    |
-11 |     fn clone_fields(&self, _name: String, _value: miniextendr_api::Robj) {}
-   |        ^^^^^^^^^^^^
+10 |     #[miniextendr(env(deep_clone))]
+   |                       ^^^^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
@@ -1,0 +1,5 @@
+error: #[r6(deep_clone)] is only valid for R6 class systems
+  --> tests/ui/impl_r6_deep_clone_wrong_system.rs:11:8
+   |
+11 |     fn clone_fields(&self, _name: String, _value: miniextendr_api::Robj) {}
+   |        ^^^^^^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.rs
@@ -1,0 +1,14 @@
+//! Test: #[r6(finalize)] on non-R6 class system should fail.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(env)]
+impl Foo {
+    #[miniextendr(env(finalize))]
+    fn destroy(self) {}
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
@@ -1,5 +1,5 @@
 error: #[r6(finalize)] is only valid for R6 class systems
-  --> tests/ui/impl_r6_finalize_wrong_system.rs:11:8
+  --> tests/ui/impl_r6_finalize_wrong_system.rs:10:23
    |
-11 |     fn destroy(self) {}
-   |        ^^^^^^^
+10 |     #[miniextendr(env(finalize))]
+   |                       ^^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
@@ -1,0 +1,5 @@
+error: #[r6(finalize)] is only valid for R6 class systems
+  --> tests/ui/impl_r6_finalize_wrong_system.rs:11:8
+   |
+11 |     fn destroy(self) {}
+   |        ^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.rs
@@ -1,0 +1,16 @@
+//! Test: #[r6(private)] on non-R6 class system should fail.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(env)]
+impl Foo {
+    #[miniextendr(env(private))]
+    fn value(&self) -> i32 {
+        0
+    }
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
@@ -1,5 +1,5 @@
 error: #[r6(private)] is only valid for R6 class systems
-  --> tests/ui/impl_r6_private_wrong_system.rs:11:8
+  --> tests/ui/impl_r6_private_wrong_system.rs:10:23
    |
-11 |     fn value(&self) -> i32 {
-   |        ^^^^^
+10 |     #[miniextendr(env(private))]
+   |                       ^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
@@ -1,0 +1,5 @@
+error: #[r6(private)] is only valid for R6 class systems
+  --> tests/ui/impl_r6_private_wrong_system.rs:11:8
+   |
+11 |     fn value(&self) -> i32 {
+   |        ^^^^^

--- a/plans/macros-refactor.md
+++ b/plans/macros-refactor.md
@@ -35,17 +35,21 @@ Tracks 20 refactor items from the review of `miniextendr-macros` and
 ### Data shapes
 17. [#16] Collapse five per-param fields on `MiniextendrFunctionParsed` into a
     single `HashMap<String, ParamAttrs>`.
-18. [#20] Split `MethodAttrs` per class system — partial:
+18. [#20] Split `MethodAttrs` per class system — complete (closes #244):
     - Per-param fields (`per_param_match_arg`/`_several_ok`/`_choices`)
       collapsed into a single `HashMap<String, ParamAttrs>`.
     - S7-specific fields (13) moved into `S7MethodAttrs` sub-struct
       (`method_attrs.s7.*`).
-    - R6-prefixed fields (`r6_setter`, `r6_prop`, `active_span`) moved into
-      `R6MethodAttrs` sub-struct (`method_attrs.r6.*`).
-    - Remaining R6 booleans (`active`/`private`/`finalize`/`deep_clone`) and
-      S3/S4-related fields stay at the top level because they're read through
-      cross-cutting accessors (`is_active`, `is_private`, `is_finalizer`) or
-      are shared between class systems (`generic`, `class`, `as_coercion`).
+    - All R6-specific fields moved into `R6MethodAttrs` sub-struct
+      (`method_attrs.r6.*`): `setter`, `prop`, `active_span` (existing),
+      plus `active`, `private`, `finalize`, `deep_clone` (from this PR).
+    - `ParsedMethod::is_active`, `is_private`, `is_finalizer` now read
+      from `method_attrs.r6.*`.
+    - Compile-time validation in `validate_method_attrs` rejects
+      `r6(active)`, `r6(private)`, `r6(finalize)`, `r6(deep_clone)` under
+      non-R6 class systems (S3/S4/S7/Env/Vctrs) with a helpful error.
+    - Shared cross-class fields (`generic`, `class`, `as_coercion`) remain
+      at the top level of `MethodAttrs`.
 
 ### Crate structure
 19. [#18] Absorb `miniextendr-macros-core` into `miniextendr-macros`; drop the


### PR DESCRIPTION
## Summary

Closes #244. Completes the partial `#20` item from the macros refactor sweep (`plans/macros-refactor.md`).

The four R6-semantic booleans that were left at the top level of `MethodAttrs` after the 2026-04-18 refactor are now moved into `R6MethodAttrs`:

- `MethodAttrs.active` → `MethodAttrs.r6.active`
- `MethodAttrs.private` → `MethodAttrs.r6.private`
- `MethodAttrs.finalize` → `MethodAttrs.r6.finalize`
- `MethodAttrs.deep_clone` → `MethodAttrs.r6.deep_clone`

The `ParsedMethod::is_active()`, `is_private()`, and `is_finalizer()` accessors now read from `method_attrs.r6.*`. All parse sites and the `r6_class.rs` generator are updated accordingly.

**Compile-time validation** (issue item 4): `validate_method_attrs` now rejects `r6(active)`, `r6(private)`, `r6(finalize)`, and `r6(deep_clone)` when used under a non-R6 class system (S3/S4/S7/Env/Vctrs) with a clear error message. Previously only `active` was caught; the other three silently no-op'd. Three new UI tests cover the new diagnostics.

## Changes

- `miniextendr-macros/src/miniextendr_impl.rs`: Move fields, update parse sites, accessors, and validation
- `miniextendr-macros/src/miniextendr_impl/r6_class.rs`: Update `deep_clone` field access
- `miniextendr-macros/tests/ui/impl_r6_{private,finalize,deep_clone}_wrong_system.{rs,stderr}`: New compile-fail UI tests
- `plans/macros-refactor.md`: Mark item #20 as fully complete (20/20 done)

## Test plan

- [ ] `cargo test --workspace --locked` — 665 passed
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [ ] Full-features clippy (CI `clippy_all` equivalent) — clean
- [ ] `cargo test --test ui` — all compile-fail tests pass including 3 new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)