### PR TITLE
polish: post-#354 R6MethodAttrs ergonomics

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -1142,25 +1142,25 @@ impl ParsedMethod {
             if attrs.r6.active {
                 return Err(syn::Error::new(
                     attrs.r6.active_span.unwrap_or(span),
-                    "#[r6(active)] is only valid for R6 class systems",
+                    "`active` is only valid for R6 class systems",
                 ));
             }
             if attrs.r6.private {
                 return Err(syn::Error::new(
                     attrs.r6.private_span.unwrap_or(span),
-                    "#[r6(private)] is only valid for R6 class systems",
+                    "`private` is only valid for R6 class systems",
                 ));
             }
             if attrs.r6.finalize {
                 return Err(syn::Error::new(
                     attrs.r6.finalize_span.unwrap_or(span),
-                    "#[r6(finalize)] is only valid for R6 class systems",
+                    "`finalize` is only valid for R6 class systems",
                 ));
             }
             if attrs.r6.deep_clone {
                 return Err(syn::Error::new(
                     attrs.r6.deep_clone_span.unwrap_or(span),
-                    "#[r6(deep_clone)] is only valid for R6 class systems",
+                    "`deep_clone` is only valid for R6 class systems",
                 ));
             }
         }
@@ -1209,6 +1209,7 @@ impl ParsedMethod {
     /// - `#[miniextendr(s7(ignore, constructor, generic = "..."))]`
     /// - etc.
     fn parse_method_attrs(attrs: &[syn::Attribute]) -> syn::Result<MethodAttrs> {
+        use syn::spanned::Spanned;
         let mut method_attrs = MethodAttrs::default();
         // Use Option<bool> for fields that support feature defaults.
         let mut worker: Option<bool> = None;
@@ -1239,15 +1240,12 @@ impl ParsedMethod {
                         } else if inner.path.is_ident("constructor") {
                             method_attrs.constructor = true;
                         } else if inner.path.is_ident("finalize") {
-                            use syn::spanned::Spanned;
                             method_attrs.r6.finalize = true;
                             method_attrs.r6.finalize_span = Some(inner.path.span());
                         } else if inner.path.is_ident("private") {
-                            use syn::spanned::Spanned;
                             method_attrs.r6.private = true;
                             method_attrs.r6.private_span = Some(inner.path.span());
                         } else if inner.path.is_ident("active") {
-                            use syn::spanned::Spanned;
                             method_attrs.r6.active = true;
                             method_attrs.r6.active_span = Some(inner.path.span());
                         } else if inner.path.is_ident("setter") {
@@ -1330,7 +1328,6 @@ impl ParsedMethod {
                             let value: syn::LitStr = inner.input.parse()?;
                             method_attrs.s7.convert_to = Some(value.value());
                         } else if inner.path.is_ident("deep_clone") {
-                            use syn::spanned::Spanned;
                             method_attrs.r6.deep_clone = true;
                             method_attrs.r6.deep_clone_span = Some(inner.path.span());
                         } else if inner.path.is_ident("r_name") {
@@ -1398,7 +1395,6 @@ impl ParsedMethod {
                     })?;
                 } else if meta.path.is_ident("defaults") {
                     // Capture span for error reporting
-                    use syn::spanned::Spanned;
                     method_attrs.defaults_span = Some(meta.path.span());
                     // Parse defaults(param = "value", param2 = "value2", ...)
                     meta.parse_nested_meta(|inner| {
@@ -1416,7 +1412,6 @@ impl ParsedMethod {
                     })?;
                 } else if meta.path.is_ident("match_arg") {
                     // `match_arg(param1, param2, ...)` — scalar match_arg params.
-                    use syn::spanned::Spanned;
                     method_attrs.match_arg_span.get_or_insert(meta.path.span());
                     meta.parse_nested_meta(|inner| {
                         let name = inner
@@ -1434,7 +1429,6 @@ impl ParsedMethod {
                 } else if meta.path.is_ident("match_arg_several_ok") {
                     // `match_arg_several_ok(param1, param2, ...)` — match_arg + several_ok,
                     // for Vec/slice/array/Box<[_]>-typed parameters.
-                    use syn::spanned::Spanned;
                     method_attrs.match_arg_span.get_or_insert(meta.path.span());
                     meta.parse_nested_meta(|inner| {
                         let name = inner
@@ -1449,7 +1443,6 @@ impl ParsedMethod {
                     })?;
                 } else if meta.path.is_ident("choices") {
                     // `choices(param = "a, b, c", param2 = "x, y")` — explicit string choice lists.
-                    use syn::spanned::Spanned;
                     method_attrs.match_arg_span.get_or_insert(meta.path.span());
                     meta.parse_nested_meta(|inner| {
                         let name = inner
@@ -1465,7 +1458,6 @@ impl ParsedMethod {
                     })?;
                 } else if meta.path.is_ident("choices_several_ok") {
                     // `choices_several_ok(param = "a, b, c")` — choices + several_ok.
-                    use syn::spanned::Spanned;
                     method_attrs.match_arg_span.get_or_insert(meta.path.span());
                     meta.parse_nested_meta(|inner| {
                         let name = inner
@@ -1515,7 +1507,6 @@ impl ParsedMethod {
                     error_in_r = Some(false);
                 } else if meta.path.is_ident("as") {
                     // Parse as = "data.frame", as = "list", etc.
-                    use syn::spanned::Spanned;
                     method_attrs.as_coercion_span = Some(meta.path.span());
                     let _: syn::Token![=] = meta.input.parse()?;
                     let value: syn::LitStr = meta.input.parse()?;

--- a/miniextendr-macros/tests/ui/impl_r6_active_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_active_wrong_system.stderr
@@ -1,4 +1,4 @@
-error: #[r6(active)] is only valid for R6 class systems
+error: `active` is only valid for R6 class systems
   --> tests/ui/impl_r6_active_wrong_system.rs:10:22
    |
 10 |     #[miniextendr(r6(active))]

--- a/miniextendr-macros/tests/ui/impl_r6_active_wrong_system_s3.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_active_wrong_system_s3.rs
@@ -1,0 +1,17 @@
+//! Test: active marker on s3 class system should fail.
+//! Exercises a non-env wrapper to confirm the validator message is wrapper-agnostic.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(s3)]
+impl Foo {
+    #[miniextendr(s3(active))]
+    fn value(&self) -> i32 {
+        0
+    }
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_active_wrong_system_s3.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_active_wrong_system_s3.stderr
@@ -1,0 +1,5 @@
+error: `active` is only valid for R6 class systems
+  --> tests/ui/impl_r6_active_wrong_system_s3.rs:11:22
+   |
+11 |     #[miniextendr(s3(active))]
+   |                      ^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system.stderr
@@ -1,4 +1,4 @@
-error: #[r6(deep_clone)] is only valid for R6 class systems
+error: `deep_clone` is only valid for R6 class systems
   --> tests/ui/impl_r6_deep_clone_wrong_system.rs:10:23
    |
 10 |     #[miniextendr(env(deep_clone))]

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system_s7.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system_s7.rs
@@ -1,0 +1,15 @@
+//! Test: deep_clone marker on s7 class system should fail.
+//! Exercises a non-env wrapper to confirm the validator message is wrapper-agnostic.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(s7)]
+impl Foo {
+    #[miniextendr(s7(deep_clone))]
+    fn clone_fields(&self, _name: String, _value: miniextendr_api::Robj) {}
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system_s7.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_deep_clone_wrong_system_s7.stderr
@@ -1,0 +1,5 @@
+error: `deep_clone` is only valid for R6 class systems
+  --> tests/ui/impl_r6_deep_clone_wrong_system_s7.rs:11:22
+   |
+11 |     #[miniextendr(s7(deep_clone))]
+   |                      ^^^^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system.stderr
@@ -1,4 +1,4 @@
-error: #[r6(finalize)] is only valid for R6 class systems
+error: `finalize` is only valid for R6 class systems
   --> tests/ui/impl_r6_finalize_wrong_system.rs:10:23
    |
 10 |     #[miniextendr(env(finalize))]

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system_s4.rs
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system_s4.rs
@@ -1,0 +1,15 @@
+//! Test: finalize marker on s4 class system should fail.
+//! Exercises a non-env wrapper to confirm the validator message is wrapper-agnostic.
+
+use miniextendr_macros::miniextendr;
+
+#[derive(miniextendr_api::ExternalPtr)]
+struct Foo;
+
+#[miniextendr(s4)]
+impl Foo {
+    #[miniextendr(s4(finalize))]
+    fn destroy(self) {}
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system_s4.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_finalize_wrong_system_s4.stderr
@@ -1,0 +1,5 @@
+error: `finalize` is only valid for R6 class systems
+  --> tests/ui/impl_r6_finalize_wrong_system_s4.rs:11:22
+   |
+11 |     #[miniextendr(s4(finalize))]
+   |                      ^^^^^^^^

--- a/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
+++ b/miniextendr-macros/tests/ui/impl_r6_private_wrong_system.stderr
@@ -1,4 +1,4 @@
-error: #[r6(private)] is only valid for R6 class systems
+error: `private` is only valid for R6 class systems
   --> tests/ui/impl_r6_private_wrong_system.rs:10:23
    |
 10 |     #[miniextendr(env(private))]


### PR DESCRIPTION
## Summary

Post-merge polish for PR #354 (R6MethodAttrs migration). Four items from the `plans/post-354-r6methodattrs-polish.md` checklist:

- **Item 1**: Drop `#[r6(...)]` prefix from all four R6-only validator diagnostics — the old wording was misleading when the user wrote `env(active)` not `r6(active)`. New messages: `` `active` is only valid for R6 class systems `` etc. The marker token is already underlined in the span, so no context is lost.
- **Item 2**: Hoist six per-arm `use syn::spanned::Spanned;` copies in `parse_method_attrs` into a single `use` at the top of the function body.
- **Item 3**: Skipped — the `R6MethodAttrs` struct fields are already clearly laid out; comment-header regrouping would add churn without clarity gain.
- **Item 4**: Three new compile-fail UI tests exercise R6-only markers on non-`env` wrappers (`s3(active)`, `s4(finalize)`, `s7(deep_clone)`), confirming the validator message is wrapper-agnostic.

All four updated `.stderr` snapshots refreshed via `TRYBUILD=overwrite`. Both `clippy_default` and `clippy_all` feature-set passes are clean.

## Test plan

- [x] `cargo test -p miniextendr-macros --test ui` passes (all 4 existing + 3 new tests)
- [x] `just check` clean
- [x] `just clippy` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --locked --features rayon,...,default-r6,default-worker -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)