### PR TITLE
feat(macros): emit @prop tag for non-constructor S7 properties (roxygen2 8.0.0)

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -395,7 +395,26 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
         // @prop tags for impl-block S7 properties (getter/setter pairs).
         // These appear in the class-level @rdname page via roxygen2's @prop tag.
+        //
+        // Properties that ARE constructor formals are already documented above via
+        // @param and must NOT also receive @prop — roxygen2 8.0.0 treats @param /
+        // @prop as disjoint sets (constructor formals → @param; getter/setter-only
+        // props → @prop). Collect the constructor-formal names and skip them here.
+        let constructor_param_names: std::collections::HashSet<String> =
+            if let Some(ctx) = parsed_impl.constructor_context() {
+                ctx.params
+                    .split(", ")
+                    .filter(|p| !p.is_empty())
+                    .map(|p| p.split('=').next().unwrap_or(p).trim().to_string())
+                    .filter(|n| n != ".ptr" && n != "...")
+                    .collect()
+            } else {
+                std::collections::HashSet::new()
+            };
         for prop in properties.values() {
+            if constructor_param_names.contains(&prop.name) {
+                continue; // already documented as @param above
+            }
             let doc = prop.doc.as_deref().unwrap_or("(undocumented property)");
             lines.push(format!("#' @prop {} {}", prop.name, doc));
         }

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_prop_tags_with_defaults_and_varargs.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_prop_tags_with_defaults_and_varargs.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1963
 expression: generate_s7_r_wrapper(&parsed)
 ---
 #' @title WithDefaults S7 Class
@@ -12,7 +13,6 @@ expression: generate_s7_r_wrapper(&parsed)
 #' @param scale (undocumented)
 #' @param mode (undocumented)
 #' @param .ptr Internal pointer (used by static methods, not for direct use).
-#' @prop name (undocumented property)
 WithDefaults <- S7::new_class("WithDefaults",
   properties = list(
     .ptr = S7::class_any,


### PR DESCRIPTION
## Summary

- Teach the S7 codegen in `miniextendr-macros` to emit `#' @prop <name> <description>` for properties defined via getter/setter/validator that are NOT constructor formals
- Constructor formals keep `@param` (existing behaviour); only non-constructor props gain `@prop`
- Description is sourced from getter doc comments (falls back to setter, validator, then `(undocumented)`)
- Add fixture `S7Sensor` covering one ctor param + one getter-only prop + one getter+setter prop
- Existing S7 fixtures with non-constructor props (`S7Range`, `S7Config`, `S7PropOuter`) gain the new `\section{Additional properties}` Rd block automatically

## Generated artefacts

`rpkg/man/S7Sensor.Rd`:

```
\section{Additional properties}{
\describe{
\item{\code{@label}}{A human-readable label for this sensor. Can be updated...}
\item{\code{@reading}}{The most recent sensor reading in raw units. ...}
}}
```

`rpkg/R/miniextendr-wrappers.R` shows:

```r
#' @param device_id Character identifier for the sensor device.
#' @prop label A human-readable label for this sensor. Can be updated...
#' @prop reading The most recent sensor reading in raw units. ...
S7Sensor <- S7::new_class("S7Sensor", ...)
```

## Test plan

- [x] `cargo test -p miniextendr-macros snapshot_s7` — 3 passed
- [x] `just devtools-document` regenerates `S7Sensor.Rd` and the three pre-existing S7 fixtures with non-constructor props
- [x] No churn in NAMESPACE or DESCRIPTION
- [ ] CI (clippy_default + clippy_all + R CMD check)

## Context

Part of the roxygen2 8.0.0 adoption sweep — see plan PR #375 (`plans/roxygen2-8-adoption.md`). Companion PRs:

- #376 — DESCRIPTION migration (PR A)
- (PR C — R6 `@field name NULL` opt-out — pending)

Out-of-scope follow-ups tracked in: #369, #370, #371, #372, #373, #374

## Notes

Reference link: https://opensource.posit.co/blog/2026-05-01_roxygen2-8-0-0/

🤖 Generated with [Claude Code](https://claude.com/claude-code)