### PR TITLE
chore: just fmt

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -548,11 +548,7 @@ pub fn write_r_wrappers_to_file(path: &str) {
         let rotated = if entry.preferred_default.is_empty() {
             choices_str
         } else {
-            rotate_choices_for_default(
-                &choices_str,
-                entry.preferred_default,
-                entry.placeholder,
-            )
+            rotate_choices_for_default(&choices_str, entry.preferred_default, entry.placeholder)
         };
         let replacement = format!("c({rotated})");
         content = content.replace(entry.placeholder, &replacement);

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -997,8 +997,7 @@ pub fn miniextendr(
             Some(raw) => crate::match_arg_keys::extract_match_arg_default(raw),
             None => String::new(),
         };
-        let placeholder =
-            crate::match_arg_keys::choices_placeholder(&c_ident.to_string(), &r_name);
+        let placeholder = crate::match_arg_keys::choices_placeholder(&c_ident.to_string(), &r_name);
         merged_defaults.insert(r_name.clone(), placeholder.clone());
         match_arg_placeholders.push((placeholder, match_arg_param.clone(), preferred));
     }

--- a/rpkg/src/rust/condition_tests.rs
+++ b/rpkg/src/rust/condition_tests.rs
@@ -7,9 +7,7 @@ use miniextendr_api::miniextendr;
 
 /// @export
 #[miniextendr]
-pub fn test_condition_parse_int(
-    s: &str,
-) -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
+pub fn test_condition_parse_int(s: &str) -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
     s.parse::<i32>().map_err(RErrorAdapter)
 }
 

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -117,7 +117,6 @@ mod adapter_traits_tests;
 mod aho_corasick_adapter_tests;
 mod altrep_condition_tests;
 mod altrep_sexp_tests;
-mod call_attribution_demo;
 #[cfg(feature = "arrow")]
 mod arrow_adapter_tests;
 #[cfg(feature = "arrow")]
@@ -135,6 +134,7 @@ mod borsh_adapter_tests;
 mod box_slice_tests;
 #[cfg(feature = "bytes")]
 mod bytes_adapter_tests;
+mod call_attribution_demo;
 mod class_system_matrix;
 mod coerce_tests;
 mod collect_tests;

--- a/rpkg/src/rust/match_arg_tests.rs
+++ b/rpkg/src/rust/match_arg_tests.rs
@@ -294,9 +294,7 @@ pub fn match_arg_multi_mode_array(
 /// @export
 #[cfg(feature = "log")]
 #[miniextendr_api::miniextendr(internal)]
-pub fn match_arg_log_level(
-    #[miniextendr(match_arg)] level: log::LevelFilter,
-) -> String {
+pub fn match_arg_log_level(#[miniextendr(match_arg)] level: log::LevelFilter) -> String {
     format!("{level:?}").to_lowercase()
 }
 // endregion


### PR DESCRIPTION
Pre-existing fmt drift on `main` (toolchain updated its line-breaking rules since the last `just fmt` commit `4cf0713d`).

Touches 5 files, all pure whitespace/line-collapse rewrites by `cargo fmt`:
- `rpkg/src/rust/lib.rs` — reorder `mod call_attribution_demo;` to alphabetical
- `rpkg/src/rust/condition_tests.rs` — collapse multi-line `fn` signature
- `rpkg/src/rust/match_arg_tests.rs` — collapse multi-line `fn` signature
- `miniextendr-api/src/registry.rs` — collapse multi-line call
- `miniextendr-macros/src/lib.rs` — collapse multi-line let binding

No `Cargo.lock`, no generated files, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)