### PR TITLE
feat(lint): MXL111 — flag s4_-prefixed methods on #[miniextendr(s4)] impls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ Build-time static analysis (runs via `build.rs` during `cargo build`/`check`). D
 - **MXL010**: duplicate labels
 - **MXL106**: non-`pub` function that would get `@export` → make `pub` or add `#[miniextendr(noexport)]`
 - **MXL110**: parameter name is an R reserved word → codegen will break
+- **MXL111**: `s4_*` method name on `#[miniextendr(s4)]` impl — codegen auto-prepends, you'll get `s4_s4_*`
 - **MXL203**: redundant `internal` + `noexport`
 - **MXL300**: direct `Rf_error`/`Rf_errorcall` → replace with `panic!()` (framework converts to R error)
 - **MXL301**: `_unchecked` FFI outside known-safe contexts

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -113,6 +113,10 @@ pub struct FileData {
     /// (has_internal, has_noexport, line)
     pub export_control: HashMap<String, (bool, bool, usize)>,
 
+    // Impl method details for per-method lint rules
+    /// Methods per inherent impl type: type_name → Vec<(method_name, line, class_system)>.
+    pub impl_methods: HashMap<String, Vec<(String, usize, String)>>,
+
     // Doc-comment roxygen tags per function/impl name
     /// Known roxygen tags: "@noRd", "@export", "@keywords internal"
     pub fn_doc_tags: HashMap<String, Vec<String>>,
@@ -492,10 +496,10 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                                 }
                             } else {
                                 // Inherent impl
-                                data.inherent_impl_class_systems.insert(
-                                    type_name.clone(),
-                                    (impl_attrs.class_system.clone().unwrap_or_default(), line),
-                                );
+                                let class_system =
+                                    impl_attrs.class_system.clone().unwrap_or_default();
+                                data.inherent_impl_class_systems
+                                    .insert(type_name.clone(), (class_system.clone(), line));
                                 data.impl_blocks_per_type
                                     .entry(type_name.clone())
                                     .or_default()
@@ -506,6 +510,21 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                                     impl_attrs.label.clone(),
                                     line,
                                 ));
+
+                                // Collect method names for per-method rules (e.g. MXL111)
+                                let methods =
+                                    data.impl_methods.entry(type_name.clone()).or_default();
+                                for impl_item in &item_impl.items {
+                                    if let syn::ImplItem::Fn(method) = impl_item {
+                                        let method_name = method.sig.ident.to_string();
+                                        let method_line = method.sig.ident.span().start().line;
+                                        methods.push((
+                                            method_name,
+                                            method_line,
+                                            class_system.clone(),
+                                        ));
+                                    }
+                                }
 
                                 // Track export control
                                 if impl_attrs.internal || impl_attrs.noexport {

--- a/miniextendr-lint/src/lint_code.rs
+++ b/miniextendr-lint/src/lint_code.rs
@@ -23,6 +23,8 @@ pub enum LintCode {
     MXL106,
     /// Parameter name is an R reserved word; codegen will produce invalid R syntax.
     MXL110,
+    /// `s4_*` method name on `#[miniextendr(s4)]` impl — codegen auto-prepends `s4_`.
+    MXL111,
     // endregion
 
     // region: P1: Important
@@ -57,7 +59,9 @@ impl LintCode {
             Self::MXL110 => Severity::Error,
 
             // Everything else is a warning.
-            Self::MXL106 | Self::MXL203 | Self::MXL300 | Self::MXL301 => Severity::Warning,
+            Self::MXL106 | Self::MXL111 | Self::MXL203 | Self::MXL300 | Self::MXL301 => {
+                Severity::Warning
+            }
         }
     }
 }

--- a/miniextendr-lint/src/rules.rs
+++ b/miniextendr-lint/src/rules.rs
@@ -10,6 +10,7 @@ pub mod fn_visibility;
 pub mod impl_validation;
 pub mod r_reserved_params;
 pub mod rf_error;
+pub mod s4_method_prefix;
 
 use crate::crate_index::CrateIndex;
 use crate::diagnostic::Diagnostic;
@@ -35,6 +36,9 @@ pub fn run_all_rules(index: &CrateIndex) -> Vec<Diagnostic> {
 
     // Per-file: ffi::*_unchecked() usage (MXL301)
     ffi_unchecked::check(index, &mut diagnostics);
+
+    // Per-file: s4_* method name on #[miniextendr(s4)] impl (MXL111)
+    s4_method_prefix::check(index, &mut diagnostics);
 
     // Sort by path and line for deterministic output
     diagnostics.sort_by(|a, b| {

--- a/miniextendr-lint/src/rules/s4_method_prefix.rs
+++ b/miniextendr-lint/src/rules/s4_method_prefix.rs
@@ -1,0 +1,45 @@
+//! MXL111: `s4_*` method name on `#[miniextendr(s4)]` impl.
+//!
+//! S4 codegen auto-prepends `s4_` to every instance method name when generating
+//! the R generic. A Rust method named `s4_foo` on an `#[miniextendr(s4)]` impl
+//! produces an R generic `s4_s4_foo`, making it unreachable via the expected
+//! `s4_foo(obj, ...)` call.
+
+use crate::crate_index::CrateIndex;
+use crate::diagnostic::Diagnostic;
+use crate::lint_code::LintCode;
+
+pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
+    for (path, data) in &index.file_data {
+        for (impl_type, methods) in &data.impl_methods {
+            for (method_name, line, class_system) in methods {
+                if class_system != "s4" {
+                    continue;
+                }
+                // Constructors (`new`) are not auto-prefixed — they become the
+                // class constructor function, named after the type, not `s4_new`.
+                if method_name == "new" {
+                    continue;
+                }
+                if let Some(rest) = method_name.strip_prefix("s4_") {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            LintCode::MXL111,
+                            path,
+                            *line,
+                            format!(
+                                "method `{impl_type}::{method_name}` will produce R generic \
+                                 `s4_{method_name}` (s4 codegen auto-prepends `s4_`); \
+                                 rename to `{rest}` to avoid the double prefix",
+                            ),
+                        )
+                        .with_help(
+                            "the macro prepends `s4_` to every S4 method name; \
+                             keep the Rust method name unprefixed",
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -315,6 +315,116 @@ fn mxl300_rf_error_usage() {
 }
 
 #[test]
+fn mxl111_s4_prefixed_method_fires() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(s4)]
+        impl Foo {
+            pub fn s4_compute(&self) -> i32 { 0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL111"),
+        "expected MXL111 warning for s4_-prefixed method on s4 impl, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl111_no_fire_for_non_s4_impl() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(r6)]
+        impl Bar {
+            pub fn s4_compute(&self) -> i32 { 0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL111"),
+        "MXL111 must not fire on r6 impl with s4_-prefixed method, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl111_no_fire_for_standalone_fn() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        pub fn s4_helper() -> i32 { 0 }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL111"),
+        "MXL111 must not fire on standalone fn named s4_*, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl111_no_fire_for_s4_constructor() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(s4)]
+        impl Foo {
+            pub fn new() -> Self { Foo {} }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL111"),
+        "MXL111 must not fire on `new` constructor of s4 impl, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
 fn mxl301_ffi_unchecked_usage() {
     let dir = tempfile::tempdir().unwrap();
     let src_dir = dir.path().join("src");


### PR DESCRIPTION
## Summary

- Adds `MXL111`: detects Rust methods named `s4_*` on `#[miniextendr(s4)]` impl blocks, where S4 codegen auto-prepends `s4_` and produces an unreachable `s4_s4_*` R generic.
- Extends `FileData` with `impl_methods: HashMap<String, Vec<(String, usize, String)>>` populated during inherent-impl parsing.
- New rule module `miniextendr-lint/src/rules/s4_method_prefix.rs` — fires a `Warning` with a rename suggestion; skips `new` constructors (not auto-prefixed by S4 codegen) and non-S4 class systems.
- Documents MXL111 in `CLAUDE.md`.

Closes #387

## Example diagnostic

```
[MXL111] src/s4_demo.rs:5: method `Foo::s4_compute` will produce R generic `s4_s4_compute` (s4 codegen auto-prepends `s4_`); rename to `compute` to avoid the double prefix Help: the macro prepends `s4_` to every S4 method name; keep the Rust method name unprefixed
```

## Verification

- `cargo test -p miniextendr-lint` — 16 passed (4 new MXL111 tests)
- `just lint` — no MXL111 findings on rpkg (PR #385 already fixed the S4 fixtures)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo clippy --workspace --all-targets --locked --features rayon,...,default-worker -- -D warnings` — clean
- `just test` — all Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)