### PR TITLE
feat(lint): MXL110 — flag R reserved words as parameter names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ Build-time static analysis (runs via `build.rs` during `cargo build`/`check`). D
 - **MXL009**: multiple impl blocks missing distinct labels → add `#[miniextendr(label = "...")]`
 - **MXL010**: duplicate labels
 - **MXL106**: non-`pub` function that would get `@export` → make `pub` or add `#[miniextendr(noexport)]`
+- **MXL110**: parameter name is an R reserved word → codegen will break
 - **MXL203**: redundant `internal` + `noexport`
 - **MXL300**: direct `Rf_error`/`Rf_errorcall` → replace with `panic!()` (framework converts to R error)
 - **MXL301**: `_unchecked` FFI outside known-safe contexts

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -122,6 +122,11 @@ pub struct FileData {
     pub rf_error_calls: Vec<(String, usize)>,
     /// Lines containing `ffi::*_unchecked()` calls: (function_name, line_number).
     pub ffi_unchecked_calls: Vec<(String, usize)>,
+
+    // R reserved-word parameter names
+    /// Maps fn/method name → list of (param_name, line) for params that are R reserved words.
+    /// Key for free functions is the function name; for impl methods it is `"TypeName::method_name"`.
+    pub fn_param_names: HashMap<String, Vec<(String, usize)>>,
 }
 // endregion
 
@@ -369,6 +374,30 @@ fn parse_file(path: &Path) -> Result<FileData, String> {
     Ok(data)
 }
 
+/// Extract named parameter names (and their 1-based line numbers) from a function signature.
+///
+/// Skips `self` / `&self` / `&mut self` receiver parameters. Skips unnamed (`_`) parameters.
+fn extract_param_names(sig: &syn::Signature) -> Vec<(String, usize)> {
+    let mut params = Vec::new();
+    for input in &sig.inputs {
+        if let syn::FnArg::Typed(pat_type) = input
+            && let syn::Pat::Ident(pat_ident) = &*pat_type.pat
+        {
+            let name = pat_ident.ident.to_string();
+            // Skip `_` (bare anonymous). Named `_foo` patterns are kept because
+            // the proc-macro forwards the name verbatim (stripping only the leading
+            // underscore in some codegen paths), so they can still collide with R
+            // reserved words.
+            if name == "_" {
+                continue;
+            }
+            let line = pat_ident.ident.span().start().line;
+            params.push((name, line));
+        }
+    }
+    params
+}
+
 /// Recursively collect all lint-relevant information from parsed items.
 fn collect_items_recursive(items: &[Item], data: &mut FileData) {
     for item in items {
@@ -394,7 +423,13 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                 // Track doc-comment roxygen tags
                 let doc_tags = extract_roxygen_tags(&item_fn.attrs);
                 if !doc_tags.is_empty() {
-                    data.fn_doc_tags.insert(name, doc_tags);
+                    data.fn_doc_tags.insert(name.clone(), doc_tags);
+                }
+
+                // Track parameter names for R reserved-word check (MXL110)
+                let params = extract_param_names(&item_fn.sig);
+                if !params.is_empty() {
+                    data.fn_param_names.insert(name, params);
                 }
             }
             Item::Struct(item_struct) => {
@@ -475,9 +510,21 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                                 // Track export control
                                 if impl_attrs.internal || impl_attrs.noexport {
                                     data.export_control.insert(
-                                        type_name,
+                                        type_name.clone(),
                                         (impl_attrs.internal, impl_attrs.noexport, line),
                                     );
+                                }
+                            }
+
+                            // Track parameter names for all methods in the impl block (MXL110)
+                            for impl_item in &item_impl.items {
+                                if let syn::ImplItem::Fn(method) = impl_item {
+                                    let method_name = method.sig.ident.to_string();
+                                    let key = format!("{}::{}", type_name, method_name);
+                                    let params = extract_param_names(&method.sig);
+                                    if !params.is_empty() {
+                                        data.fn_param_names.insert(key, params);
+                                    }
                                 }
                             }
                         }

--- a/miniextendr-lint/src/lint_code.rs
+++ b/miniextendr-lint/src/lint_code.rs
@@ -21,6 +21,8 @@ pub enum LintCode {
     // region: P0: High Impact
     /// Registered top-level function is not `pub`.
     MXL106,
+    /// Parameter name is an R reserved word; codegen will produce invalid R syntax.
+    MXL110,
     // endregion
 
     // region: P1: Important
@@ -50,6 +52,9 @@ impl LintCode {
         match self {
             // Source-side checks are errors (CI-blocking).
             Self::MXL008 | Self::MXL009 | Self::MXL010 => Severity::Error,
+
+            // Codegen-breaking: reserved words produce syntactically invalid R wrappers.
+            Self::MXL110 => Severity::Error,
 
             // Everything else is a warning.
             Self::MXL106 | Self::MXL203 | Self::MXL300 | Self::MXL301 => Severity::Warning,

--- a/miniextendr-lint/src/rules.rs
+++ b/miniextendr-lint/src/rules.rs
@@ -8,6 +8,7 @@ pub mod export_attrs;
 pub mod ffi_unchecked;
 pub mod fn_visibility;
 pub mod impl_validation;
+pub mod r_reserved_params;
 pub mod rf_error;
 
 use crate::crate_index::CrateIndex;
@@ -25,6 +26,9 @@ pub fn run_all_rules(index: &CrateIndex) -> Vec<Diagnostic> {
 
     // Per-file: export attr redundancy (MXL203)
     export_attrs::check(index, &mut diagnostics);
+
+    // Per-file: R reserved words as parameter names (MXL110)
+    r_reserved_params::check(index, &mut diagnostics);
 
     // Per-file: direct Rf_error/Rf_errorcall usage (MXL300)
     rf_error::check(index, &mut diagnostics);

--- a/miniextendr-lint/src/rules/r_reserved_params.rs
+++ b/miniextendr-lint/src/rules/r_reserved_params.rs
@@ -1,0 +1,58 @@
+//! R reserved-word parameter name check.
+//!
+//! - MXL110: A `#[miniextendr]` function or method has a parameter whose name
+//!   is an R reserved word. The proc macro forwards parameter names verbatim
+//!   into the generated R wrapper, so the wrapper will be syntactically invalid.
+
+use crate::crate_index::CrateIndex;
+use crate::diagnostic::Diagnostic;
+use crate::lint_code::LintCode;
+
+/// R reserved words from `?Reserved`.
+///
+/// Strictly reserved only — does not include quasi-reserved (`T`, `F`, `c`, `t`, `q`)
+/// to avoid false positives.
+const R_RESERVED: &[&str] = &[
+    "if",
+    "else",
+    "repeat",
+    "while",
+    "function",
+    "for",
+    "in",
+    "next",
+    "break",
+    "TRUE",
+    "FALSE",
+    "NULL",
+    "Inf",
+    "NaN",
+    "NA",
+    "NA_integer_",
+    "NA_real_",
+    "NA_complex_",
+    "NA_character_",
+];
+
+pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
+    for (path, data) in &index.file_data {
+        for (fn_name, params) in &data.fn_param_names {
+            for (param, line) in params {
+                if R_RESERVED.contains(&param.as_str()) {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            LintCode::MXL110,
+                            path,
+                            *line,
+                            format!(
+                                "parameter `{param}` of `{fn_name}` is an R reserved word; \
+                                 the generated R wrapper will be syntactically invalid",
+                            ),
+                        )
+                        .with_help("rename the parameter (e.g., `n_chunks` instead of `repeat`)"),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -341,3 +341,83 @@ fn mxl301_ffi_unchecked_usage() {
         report.diagnostics
     );
 }
+
+#[test]
+fn mxl110_r_reserved_word_as_param() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        pub fn bad(repeat: i32) -> i32 { repeat }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL110"),
+        "expected MXL110 error for R reserved word `repeat` as param, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl110_good_param_name_no_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        pub fn good(n: i32) -> i32 { n }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        !report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL110"),
+        "expected no MXL110 for ordinary param name, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl110_r_reserved_word_as_method_param() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(r6)]
+        impl Foo {
+            pub fn n(&self, repeat: i32) -> i32 { repeat }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL110"),
+        "expected MXL110 error for R reserved word `repeat` as method param, got: {:?}",
+        report.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary

Closes #386.

The proc macro forwards `#[miniextendr]` parameter names verbatim into the generated R wrapper. Using an R reserved word (e.g. `repeat`, `if`, `for`, `while`, `TRUE`, `NULL`, …) as a Rust parameter name silently compiles with `cargo build` but produces a syntax error in the R wrapper, which only surfaces several minutes later during `devtools::document()`.

This PR adds lint rule **MXL110** (severity: `Error`) that detects this at `cargo build` time via `miniextendr-lint`'s `build.rs`.

### Changes

- `miniextendr-lint/src/crate_index.rs` — new `FileData::fn_param_names` field; `extract_param_names` helper; parameter collection for `#[miniextendr]` free functions and all methods in `#[miniextendr]` impl blocks.
- `miniextendr-lint/src/rules/r_reserved_params.rs` — new rule module; checks `R_RESERVED` blocklist against collected param names.
- `miniextendr-lint/src/lint_code.rs` — `MXL110` variant, severity `Error`.
- `miniextendr-lint/src/rules.rs` — module declaration + invocation in `run_all_rules`.
- `miniextendr-lint/tests/tests.rs` — three new tests (positive free-fn case, negative safe-name case, positive impl-method case).
- `CLAUDE.md` — MXL110 entry in the miniextendr-lint section.

### Rule output on a contrived fixture

```
[MXL110] src/lib.rs:3: parameter `repeat` of `condition_error_long_message` is an R reserved word; the generated R wrapper will be syntactically invalid Help: rename the parameter (e.g., `n_chunks` instead of `repeat`)
```

### Verified

- `just lint` → `miniextendr-lint: no issues found` (no false positives on rpkg)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` → clean
- `cargo clippy --workspace --all-targets --locked --features rayon,rand,...,default-worker -- -D warnings` → clean
- `just test` → all tests pass (15 lint tests, 293 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)