### PR TITLE
fix(macros): stabilise ALTREP reg fn + vtable static symbol names (#392 #393 #394)

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -29,8 +29,15 @@ pub static MX_R_WRAPPERS: [RWrapperEntry];
 /// ALTREP class registration functions, called once at package init.
 ///
 /// Each ALTREP struct or trait impl emits an entry.
+///
+/// The element type is `extern "C" fn()` so that each registration function
+/// can be declared `pub extern "C"` with `#[unsafe(no_mangle)]`, making it
+/// externally addressable from a separate compilation unit (e.g. a WASM
+/// codegen path). The functions are not `unsafe` — R-thread invariants are a
+/// module-level contract, not encoded in the type (same convention as the
+/// `extern "C-unwind" fn` entries in `MX_CALL_DEFS`).
 #[distributed_slice]
-pub static MX_ALTREP_REGISTRATIONS: [fn()];
+pub static MX_ALTREP_REGISTRATIONS: [extern "C" fn()];
 
 /// Trait dispatch entries for [`universal_query`].
 ///

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -60,15 +60,22 @@ pub(crate) fn generate_direct_altrep_registration(
         ident
     );
 
-    // For non-generic types, emit a distributed_slice ALTREP registration entry
+    // For non-generic types, emit a distributed_slice ALTREP registration entry.
+    //
+    // The function is `pub extern "C"` with `#[unsafe(no_mangle)]` so that a separate
+    // compilation unit (e.g. a WASM codegen path) can reference it by name via an
+    // `extern { fn __mx_altrep_reg_<Ident>(); }` declaration.
+    //
+    // The ident is used verbatim (no `.to_lowercase()`) to avoid case-collision footguns:
+    // `MyType` vs `MYType` would both produce the same symbol name if lowercased.
     let altrep_reg_entry = if generics.params.is_empty() {
-        let reg_fn_name =
-            quote::format_ident!("__mx_altrep_reg_{}", ident.to_string().to_lowercase());
+        let reg_fn_name = quote::format_ident!("__mx_altrep_reg_{}", ident);
         quote::quote! {
             #[::miniextendr_api::linkme::distributed_slice(::miniextendr_api::registry::MX_ALTREP_REGISTRATIONS)]
             #[linkme(crate = ::miniextendr_api::linkme)]
             #[doc(hidden)]
-            fn #reg_fn_name() {
+            #[unsafe(no_mangle)]
+            pub extern "C" fn #reg_fn_name() {
                 <#ident as ::miniextendr_api::altrep_registration::RegisterAltrep>::get_or_init_class();
             }
         }

--- a/miniextendr-macros/src/miniextendr_impl_trait.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait.rs
@@ -398,20 +398,60 @@ fn trait_method_body_lines(call_expr: &str, error_in_r: bool, indent: &str) -> V
 
 /// Convert a type to an uppercase identifier-safe name.
 ///
-/// Examples:
+/// For non-generic types, the name is simply the last path segment uppercased:
 /// - `MyType` → `MYTYPE`
-/// - `path::to::MyType` → `MYTYPE` (uses last segment)
-/// - `MyType<T>` → `MYTYPE` (strips generics)
+/// - `path::to::MyType` → `MYTYPE`
+///
+/// For generic types, a 16-character lowercase hex suffix derived from a stable
+/// FNV-1a-64 hash of the full canonical token stream is appended:
+/// - `MyType<u32>` → `MYTYPE_a1b2c3d4e5f60718`
+/// - `MyType<f64>` → `MYTYPE_0102030405060708` (different hash → no collision)
+///
+/// This prevents vtable static name collisions when the same base type is
+/// monomorphised with different generic arguments in the same crate.
+///
+/// **Hash stability:** FNV-1a-64 with a fixed seed (offset basis = 0xcbf29ce484222325)
+/// is deterministic across builds, rustc versions, and platforms.  We deliberately
+/// avoid `std::collections::hash_map::DefaultHasher` and `RandomState` because both
+/// are explicitly unspecified and can change across releases.
 fn type_to_uppercase_name(ty: &syn::Type) -> String {
+    /// FNV-1a 64-bit hash of a byte slice.
+    ///
+    /// Chosen for simplicity (≈10 lines, no new deps) and cross-build stability.
+    /// The FNV offset basis and prime are fixed constants defined in the FNV spec.
+    fn fnv1a_64(data: &[u8]) -> u64 {
+        const OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+        const PRIME: u64 = 0x00000100000001b3;
+        let mut h = OFFSET_BASIS;
+        for &b in data {
+            h ^= b as u64;
+            h = h.wrapping_mul(PRIME);
+        }
+        h
+    }
+
     match ty {
         syn::Type::Path(type_path) => {
-            // Use last segment, strip generics
-            type_path
-                .path
-                .segments
-                .last()
+            let last = type_path.path.segments.last();
+            let base = last
                 .map(|s| s.ident.to_string().to_uppercase())
-                .unwrap_or_else(|| "UNKNOWN".to_string())
+                .unwrap_or_else(|| "UNKNOWN".to_string());
+
+            // Only append a hash suffix when the type actually carries generic arguments
+            // (e.g. `MyType<u32>`). Plain `MyType` keeps the clean `MYTYPE` form.
+            let has_generics = last
+                .map(|s| !matches!(s.arguments, syn::PathArguments::None))
+                .unwrap_or(false);
+
+            if has_generics {
+                // Canonical token string of the *full* type (including all generic args)
+                // so that `MyType<u32>` and `MyType<f64>` produce distinct hashes.
+                let token_str = quote::quote!(#ty).to_string();
+                let hash = fnv1a_64(token_str.as_bytes());
+                format!("{}_{:016x}", base, hash)
+            } else {
+                base
+            }
         }
         _ => "UNKNOWN".to_string(),
     }
@@ -921,7 +961,8 @@ fn generate_tpie_invocation(
     quote::quote! {
         #[doc(hidden)]
         #[doc = #source_loc_doc]
-        static #vtable_static_name: #vtable_type_path =
+        #[unsafe(no_mangle)]
+        pub static #vtable_static_name: #vtable_type_path =
             #builder_path::<#concrete_type>();
 
         #crate_ident :: #macro_name !(#concrete_type, #trait_path, #class_system_ident, #no_rd_ident, #internal_ident, #noexport_ident);

--- a/miniextendr-macros/src/miniextendr_impl_trait/tests.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/tests.rs
@@ -11,6 +11,62 @@ fn test_type_to_uppercase_name() {
     assert_eq!(type_to_uppercase_name(&ty), "MYTYPE");
 }
 
+/// Regression test for #394: generic monomorphisations must not produce the same
+/// vtable static name.  Before the fix, both `MyType<u32>` and `MyType<f64>`
+/// resolved to `MYTYPE`, causing a silent collision (wrong vtable wins).
+#[test]
+fn test_type_to_uppercase_name_generic_distinct() {
+    let ty_u32: syn::Type = syn::parse_quote!(MyType<u32>);
+    let ty_f64: syn::Type = syn::parse_quote!(MyType<f64>);
+    let ty_plain: syn::Type = syn::parse_quote!(MyType);
+
+    let name_u32 = type_to_uppercase_name(&ty_u32);
+    let name_f64 = type_to_uppercase_name(&ty_f64);
+    let name_plain = type_to_uppercase_name(&ty_plain);
+
+    // Both generic names must start with the base ident
+    assert!(
+        name_u32.starts_with("MYTYPE_"),
+        "MyType<u32> should have a hash suffix, got: {name_u32}"
+    );
+    assert!(
+        name_f64.starts_with("MYTYPE_"),
+        "MyType<f64> should have a hash suffix, got: {name_f64}"
+    );
+
+    // The two monomorphisations must be distinct
+    assert_ne!(
+        name_u32, name_f64,
+        "MyType<u32> and MyType<f64> must produce distinct vtable names"
+    );
+
+    // Non-generic plain type must NOT get a hash suffix (clean name for simple cases)
+    assert_eq!(
+        name_plain, "MYTYPE",
+        "plain MyType should not have a hash suffix"
+    );
+
+    // Hash suffix must be 16 hex chars (FNV-1a-64 output)
+    let suffix_u32 = name_u32.strip_prefix("MYTYPE_").unwrap();
+    assert_eq!(
+        suffix_u32.len(),
+        16,
+        "hash suffix must be 16 hex chars, got: {suffix_u32}"
+    );
+    assert!(
+        suffix_u32.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash suffix must be lowercase hex, got: {suffix_u32}"
+    );
+
+    // Hashes must be deterministic: calling again must yield the same result
+    let ty_u32_again: syn::Type = syn::parse_quote!(MyType<u32>);
+    assert_eq!(
+        type_to_uppercase_name(&ty_u32_again),
+        name_u32,
+        "type_to_uppercase_name must be deterministic across calls"
+    );
+}
+
 /// Helper to build a simple TraitMethod for testing R wrapper generation.
 fn make_test_method(name: &str, has_self: bool) -> TraitMethod {
     let ident = format_ident!("{}", name);

--- a/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
@@ -223,10 +223,14 @@ pub(super) fn generate_vtable_static(
 
     // For generic traits (with type args like <i32>), generate concrete vtable shims
     // and inline vtable construction. For non-generic traits, use the builder function.
+    //
+    // Both paths emit the static as `pub` with `#[unsafe(no_mangle)]` so that a separate
+    // compilation unit (e.g. a WASM codegen path) can reference it by name.
     let vtable_static_tokens = if trait_type_args.is_empty() {
         // Non-generic: use the builder function generated at the trait definition site
         quote::quote! {
-            static #vtable_static_name: #vtable_type_path =
+            #[unsafe(no_mangle)]
+            pub static #vtable_static_name: #vtable_type_path =
                 #builder_path::<#concrete_type>();
         }
     } else {
@@ -252,7 +256,8 @@ pub(super) fn generate_vtable_static(
             .collect();
         quote::quote! {
             #concrete_shims
-            static #vtable_static_name: #vtable_type_path = #vtable_type_path {
+            #[unsafe(no_mangle)]
+            pub static #vtable_static_name: #vtable_type_path = #vtable_type_path {
                 #(#vtable_inits),*
             };
         }


### PR DESCRIPTION
Re-opening of #395 from a clean branch — same fix, but cut from `main` so the PR contains only the macro symbol-stability commit (no unrelated work bleed-in from `refactor/raise-condition-helper`). Also folds in the `unsafe`-on-fn-signature tightening that was in flight when #395 was reviewed.

## Summary

Three audit-confirmed cleanups in `miniextendr-macros` so symbols are addressable from a separate compilation unit. Prerequisite for the WASM registry-codegen port in #391.

### #392 — ALTREP register fn

`__mx_altrep_reg_<Ident>` now emitted as `#[unsafe(no_mangle)] pub extern "C" fn` (no `unsafe` modifier on the fn — the body has no unsafe ops, and R-thread invariants are a module-level contract, same convention as the `extern "C-unwind" fn` entries in `MX_CALL_DEFS`). The `MX_ALTREP_REGISTRATIONS` slice element type bumps from `[fn()]` to `[extern "C" fn()]` to match. Also drops `.to_lowercase()` on the ident (case collision footgun: `MyType` vs `MYType`). Single emission site.

### #393 — Vtable statics

`__VTABLE_{TRAIT}_FOR_{TYPE}` static gets `#[unsafe(no_mangle)]` + `pub` at all three emission paths (`generate_vtable_static`'s generic and non-generic branches in `vtable.rs`, plus `generate_tpie_invocation` in `miniextendr_impl_trait.rs`). `#[repr(C)]` was already on the `*VTable` struct definition — confirmed, no change needed.

### #394 — Generic monomorphisation hash

`type_to_uppercase_name` now appends a 16-char FNV-1a-64 hex suffix when the concrete type carries generic arguments. `MyType<u32>` and `MyType<f64>` produce distinct vtable static names; plain non-generic `MyType` keeps its clean `MYTYPE` form. Hand-rolled hash with fixed `OFFSET_BASIS` / `PRIME` constants from the FNV spec — deterministic across builds, rustc versions, and platforms (unlike `DefaultHasher` / `RandomState`). No new dependencies.

Regression test added covering: distinct hashes for distinct monomorphisations, no-suffix on plain types, suffix is 16 lowercase hex chars, repeated calls deterministic.

## Test plan

- [x] `cargo test -p miniextendr-macros` — passes incl. new regression test
- [x] `just check` — workspace clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default)
- [x] `cargo clippy --workspace --all-targets --locked --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,default-strict,default-coerce,default-r6,default-worker -- -D warnings` (clippy_all)
- [x] `just configure && just rcmdinstall && just devtools-document` — installs and documents cleanly

## Closes

- Closes #392
- Closes #393
- Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)