### PR TITLE
[codex] Declare R 4.4 dependency for generated wrappers

### DIFF
--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -184,7 +184,7 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
   # Create DESCRIPTION manually (not from template)
   desc_path <- usethis::proj_path(rpkg_name, "DESCRIPTION")
   desc_content <- sprintf(
-    "Package: %s\nTitle: What the Package Does (One Line, Title Case)\nVersion: 0.0.0.9000\nAuthors@R:\n    person(\"First\", \"Last\", , \"first.last@example.com\", role = c(\"aut\", \"cre\"))\nDescription: What the package does (one paragraph).\nLicense: MIT + file LICENSE\nEncoding: UTF-8\nRoxygen: list(markdown = TRUE)\nRoxygenNote: 7.3.2\nSystemRequirements: Rust (>= 1.85)\nConfig/build/bootstrap: TRUE\nConfig/build/never-clean: true\nConfig/build/extra-sources: src/rust/Cargo.lock\n",
+    "Package: %s\nTitle: What the Package Does (One Line, Title Case)\nVersion: 0.0.0.9000\nAuthors@R:\n    person(\"First\", \"Last\", , \"first.last@example.com\", role = c(\"aut\", \"cre\"))\nDescription: What the package does (one paragraph).\nLicense: MIT + file LICENSE\nDepends: R (>= 4.4)\nEncoding: UTF-8\nRoxygen: list(markdown = TRUE)\nRoxygenNote: 7.3.2\nSystemRequirements: Rust (>= 1.85)\nConfig/build/bootstrap: TRUE\nConfig/build/never-clean: true\nConfig/build/extra-sources: src/rust/Cargo.lock\n",
     data$package
   )
   writeLines(desc_content, desc_path)

--- a/minirextendr/R/rust-source.R
+++ b/minirextendr/R/rust-source.R
@@ -277,6 +277,7 @@ scaffold_inline_package <- function(code, hash, features, pkg_name, pkg_rs,
     "Version: 0.0.1\n",
     "Description: Auto-generated package for inline Rust compilation.\n",
     "License: MIT\n",
+    "Depends: R (>= 4.4)\n",
     "SystemRequirements: Rust (>= 1.85)\n",
     "Encoding: UTF-8\n",
     "Config/build/bootstrap: TRUE\n"

--- a/minirextendr/tests/testthat/test-rust-source.R
+++ b/minirextendr/tests/testthat/test-rust-source.R
@@ -144,6 +144,8 @@ pub fn add_one(x: i32) -> i32 { x + 1 }
   # Check DESCRIPTION content
   desc <- readLines(fs::path(pkg_dir, "DESCRIPTION"))
   expect_true(any(grepl(paste0("Package: ", pkg_name), desc)))
+  dcf <- read.dcf(fs::path(pkg_dir, "DESCRIPTION"))
+  expect_equal(unname(dcf[1, "Depends"]), "R (>= 4.4)")
 
   # Check NAMESPACE exports
   ns <- readLines(fs::path(pkg_dir, "NAMESPACE"))

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -182,6 +182,7 @@ local({
     tmp <- get_fixture()
 
     dcf <- read.dcf(file.path(tmp, "testpkg", "DESCRIPTION"))
+    expect_equal(unname(dcf[1, "Depends"]), "R (>= 4.4)")
     expect_equal(unname(dcf[1, "Config/build/bootstrap"]), "TRUE")
     expect_equal(unname(dcf[1, "Config/build/never-clean"]), "true")
     expect_equal(unname(dcf[1, "Config/build/extra-sources"]), "src/rust/Cargo.lock")
@@ -232,7 +233,9 @@ test_that("create_miniextendr_monorepo performs correct template substitution", 
   expect_true(any(grepl("my-pkg", readLines(file.path(tmp, "Cargo.toml")))))
   expect_true(any(grepl('name = "my-pkg"', readLines(file.path(tmp, "my-pkg", "Cargo.toml")))))
   expect_true(any(grepl("#\\[miniextendr\\]", readLines(file.path(tmp, "myPkg", "src", "rust", "lib.rs")))))
-  expect_true(any(grepl("Package: myPkg", readLines(file.path(tmp, "myPkg", "DESCRIPTION")))))
+  dcf <- read.dcf(file.path(tmp, "myPkg", "DESCRIPTION"))
+  expect_equal(unname(dcf[1, "Package"]), "myPkg")
+  expect_equal(unname(dcf[1, "Depends"]), "R (>= 4.4)")
 })
 
 # -----------------------------------------------------------------------------

--- a/rpkg/DESCRIPTION
+++ b/rpkg/DESCRIPTION
@@ -11,6 +11,7 @@ Description: Provides a framework for building R packages with Rust backends.
     macros, automatic type conversion, external pointers with GC protection,
     ALTREP support, and safe multi-threading via worker threads.
 License: MIT + file LICENSE
+Depends: R (>= 4.4)
 SystemRequirements: Cargo (Rust package manager), rustc >= 1.85.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/tests/cross-package/consumer.pkg/DESCRIPTION
+++ b/tests/cross-package/consumer.pkg/DESCRIPTION
@@ -11,6 +11,7 @@ Description: Demonstrates miniextendr's cross-package trait dispatch capabilitie
     with Counter implementations from any package (like producer.pkg), proving
     ABI compatibility via type tag matching and vtable dispatch.
 License: MIT + file LICENSE
+Depends: R (>= 4.4)
 Config/build/bootstrap: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/tests/cross-package/producer.pkg/DESCRIPTION
+++ b/tests/cross-package/producer.pkg/DESCRIPTION
@@ -11,6 +11,7 @@ Description: Demonstrates miniextendr's cross-package trait dispatch capabilitie
     here can be passed to consumer.pkg functions that operate on the Counter trait
     interface, proving ABI compatibility via type tag matching.
 License: MIT + file LICENSE
+Depends: R (>= 4.4)
 Config/build/bootstrap: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
## Summary

Closes #384.

- add `Depends: R (>= 4.4)` to generated-wrapper packages that ship in this repo
- add the same declaration to minirextendr scaffolding paths that create future generated-wrapper packages
- add regression assertions for generated DESCRIPTION files

## Why

Generated wrappers use base R's `%||%`, which is available from R 4.4.0. Packages containing those wrappers should declare that runtime floor explicitly.

## Validation

- DCF parse check for updated DESCRIPTION files
- `just minirextendr-test rust-source`
- `just minirextendr-test templates`

## Notes

I left `minirextendr/DESCRIPTION` unchanged because minirextendr defines its own `%||%` fallback rather than relying on base R's operator.