### PR TITLE
feat(cargo-revendor): auto-read [patch."git+url"] from .cargo/config.toml (#338)

### DIFF
--- a/cargo-revendor/README.md
+++ b/cargo-revendor/README.md
@@ -172,6 +172,37 @@ same for every invocation; flags toggle individual steps on or off.
 | `--output <DIR>` | Vendor directory (default `vendor`). Relative paths resolve from CWD, not the manifest dir. |
 | `--source-root <DIR>` | Workspace root containing path dependencies. Auto-detected from metadata when omitted. Set explicitly when bootstrapping a frozen tree on a fresh clone. |
 
+### Reading `.cargo/config.toml` patch tables
+
+`--source-root` is optional when the manifest's workspace already carries a
+`.cargo/config.toml` with `[patch."git+<url>"]` (or `[patch."https://<url>"]`)
+entries that redirect git dependencies to local paths.
+
+cargo-revendor searches for `.cargo/config.toml` starting from the manifest
+directory and walking up the filesystem tree — the same search order cargo
+itself uses. `$HOME/.cargo/config.toml` is also checked as a final fallback.
+For each file found it reads every `[patch."<url>"]` table and extracts entries
+with a `path = "..."` key, resolving relative paths against the directory
+containing the `.cargo/` folder. The resulting `LocalPackage` list is merged
+with any packages found via `--source-root` (explicit `--source-root` wins when
+both list the same crate name, so old scripts with an explicit flag continue to
+work unchanged).
+
+**Typical miniextendr monorepo layout:**
+
+```
+repo-root/
+  .cargo/config.toml          ← [patch."git+https://github.com/…"] entries
+  miniextendr-api/             ← local override for the git dep
+  miniextendr-macros/
+  rpkg/src/rust/Cargo.toml     ← the --manifest-path target
+```
+
+With this layout, `cargo revendor --manifest-path rpkg/src/rust/Cargo.toml`
+discovers the `.cargo/config.toml` two directories above the manifest,
+reads the patch entries, and vendors `miniextendr-api` and `miniextendr-macros`
+from their on-disk locations. No `--source-root` flag is required.
+
 ### Trimming
 
 These flags strip code that is not needed at build time. Stripping exists
@@ -347,7 +378,9 @@ path deps on a fresh clone.
 
 Wraps `cargo_metadata::MetadataCommand`. Exposes `LocalPackage` (a thin
 record of name, version, path, manifest path), `discover_workspace_members`
-for source-root walks, `partition_packages` for the local-vs-external
+for source-root walks, `discover_from_patch_config` for reading
+`[patch."<url>"]` entries from `.cargo/config.toml` files found along the
+cargo config search path, `partition_packages` for the local-vs-external
 split, and `check_duplicate_sources`, which mirrors upstream cargo's check
 that two git sources cannot resolve to the same name+version pair.
 

--- a/cargo-revendor/src/cache.rs
+++ b/cargo-revendor/src/cache.rs
@@ -288,11 +288,7 @@ fn collect_crate_files(crate_path: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
     Ok(out)
 }
 
-fn walk_dir(
-    dir: &Path,
-    root: &Path,
-    out: &mut BTreeMap<String, Vec<u8>>,
-) -> Result<()> {
+fn walk_dir(dir: &Path, root: &Path, out: &mut BTreeMap<String, Vec<u8>>) -> Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -401,7 +397,11 @@ mod tests {
         assert!(is_cached(&lockfile, &sync, &vendor, &locals).unwrap());
 
         // Bump the sync manifest; cache should invalidate.
-        std::fs::write(&sync_manifest, "[package]\nname = \"syncpkg\"\nversion = \"0.2.0\"").unwrap();
+        std::fs::write(
+            &sync_manifest,
+            "[package]\nname = \"syncpkg\"\nversion = \"0.2.0\"",
+        )
+        .unwrap();
         assert!(
             !is_cached(&lockfile, &sync, &vendor, &locals).unwrap(),
             "cache should invalidate when a --sync manifest changes"
@@ -444,11 +444,7 @@ mod tests {
         for (input, expected) in cases {
             let mut h = Fnv64::new();
             h.update(input);
-            assert_eq!(
-                h.finish(),
-                *expected,
-                "FNV-1a mismatch for {input:?}"
-            );
+            assert_eq!(h.finish(), *expected, "FNV-1a mismatch for {input:?}");
         }
     }
 

--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -91,7 +91,16 @@ struct Cli {
     output: PathBuf,
 
     /// Root of the monorepo/workspace containing path dependencies.
-    /// If not set, auto-detected from workspace metadata.
+    ///
+    /// When omitted, cargo-revendor auto-detects local path overrides from
+    /// `[patch."<url>"]` tables in `.cargo/config.toml` files found by
+    /// walking up from the manifest directory. For a typical miniextendr
+    /// monorepo (where `configure` writes those patch entries), passing this
+    /// flag is no longer necessary.
+    ///
+    /// Pass explicitly for cross-monorepo scenarios where the workspace root
+    /// is not covered by any `.cargo/config.toml` patch table, or to override
+    /// a patch entry detected from config.
     #[arg(long)]
     source_root: Option<PathBuf>,
 
@@ -286,32 +295,22 @@ fn validate_flag_compatibility(cli: &Cli, mode: Mode, output: &std::path::Path) 
                 );
             }
             if cli.source_marker {
-                anyhow::bail!(
-                    "--external-only is incompatible with --source-marker"
-                );
+                anyhow::bail!("--external-only is incompatible with --source-marker");
             }
             if cli.blank_md {
-                anyhow::bail!(
-                    "--external-only is incompatible with --blank-md"
-                );
+                anyhow::bail!("--external-only is incompatible with --blank-md");
             }
             if cli.strict_freeze {
-                anyhow::bail!(
-                    "--external-only is incompatible with --strict-freeze"
-                );
+                anyhow::bail!("--external-only is incompatible with --strict-freeze");
             }
         }
         Mode::LocalOnly => {
             // These flags require a complete vendor/ tree (external + local).
             // Allow them only when externals were previously vendored.
-            let needs_externals = cli.freeze
-                || cli.compress.is_some()
-                || cli.source_marker
-                || cli.blank_md;
+            let needs_externals =
+                cli.freeze || cli.compress.is_some() || cli.source_marker || cli.blank_md;
             if needs_externals {
-                let externals_present = output
-                    .join(cache::CACHE_FILE_EXTERNAL)
-                    .exists();
+                let externals_present = output.join(cache::CACHE_FILE_EXTERNAL).exists();
                 if !externals_present {
                     anyhow::bail!(
                         "--local-only with --freeze/--compress/--source-marker/--blank-md \
@@ -341,13 +340,11 @@ fn merge_copy_vendor(staging: &std::path::Path, output: &std::path::Path) -> Res
         let dst = output.join(&name);
         if dst.exists() {
             if dst.is_dir() {
-                std::fs::remove_dir_all(&dst).with_context(|| {
-                    format!("failed to remove existing {}", dst.display())
-                })?;
+                std::fs::remove_dir_all(&dst)
+                    .with_context(|| format!("failed to remove existing {}", dst.display()))?;
             } else {
-                std::fs::remove_file(&dst).with_context(|| {
-                    format!("failed to remove existing {}", dst.display())
-                })?;
+                std::fs::remove_file(&dst)
+                    .with_context(|| format!("failed to remove existing {}", dst.display()))?;
             }
         }
         std::fs::rename(entry.path(), &dst)
@@ -453,7 +450,8 @@ fn run_full(
     let versioned_dirs = !cli.flat_dirs;
 
     // Step 1a: Pre-seed `vendor/<name>-<version>/` for each workspace member
-    // when `--source-root` is set (dev-monorepo configure path).
+    // when `--source-root` is set (dev-monorepo configure path) OR when
+    // `.cargo/config.toml` nearby contains `[patch."<git-url>"]` path entries.
     //
     // Why: the target manifest ships in vendor-frozen state with `path =
     // "../../vendor/<crate>-<ver>/"` in `[dependencies]`. Those aren't
@@ -474,6 +472,24 @@ fn run_full(
     } else {
         Vec::new()
     };
+
+    // Auto-detect local path overrides from [patch."git+url"] tables in
+    // .cargo/config.toml files found by walking up from the manifest dir.
+    // Explicit --source-root takes precedence: on conflict by crate name, the
+    // --source-root entry is kept and the config.toml entry is dropped.
+    let patch_config_members = metadata::discover_from_patch_config(manifest_path)
+        .context("failed to read [patch] entries from .cargo/config.toml")?;
+
+    // Merge: source_root (explicit) wins, then patch_config entries fill in
+    // anything not already covered.
+    let source_root_members = merge_packages(&source_root_members, &patch_config_members);
+
+    if v.debug() && !patch_config_members.is_empty() {
+        eprintln!(
+            "  Auto-detected {} local crate(s) from .cargo/config.toml [patch] tables",
+            patch_config_members.len()
+        );
+    }
 
     if !source_root_members.is_empty() {
         bootstrap_vendor_from_source_root(output, &source_root_members, v)?;
@@ -497,8 +513,8 @@ fn run_full(
     let (mut local_pkgs, _external_pkgs) =
         metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
 
-    // Fall back to heuristic workspace-root detection only if `--source-root`
-    // wasn't explicitly provided.
+    // Fall back to heuristic workspace-root detection only if neither
+    // --source-root nor patch config entries were provided.
     let all_workspace_members = if !source_root_members.is_empty() {
         source_root_members
     } else if let Some(first_local) = local_pkgs.first() {
@@ -512,7 +528,9 @@ fn run_full(
     // (e.g., [source.vendored-sources] directory = "vendor"), cargo metadata
     // resolves local workspace crate paths to the vendor directory instead of the
     // real workspace source. Detect this and replace with the real workspace path.
-    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.to_path_buf());
+    let canonical_output = output
+        .canonicalize()
+        .unwrap_or_else(|_| output.to_path_buf());
     for pkg in &mut local_pkgs {
         let canonical_pkg = pkg.path.canonicalize().unwrap_or_else(|_| pkg.path.clone());
         if canonical_pkg.starts_with(&canonical_output) {
@@ -768,6 +786,11 @@ fn run_external_only(
         Vec::new()
     };
 
+    // Auto-detect additional local path overrides from [patch."git+url"] tables.
+    let patch_config_members = metadata::discover_from_patch_config(manifest_path)
+        .context("failed to read [patch] entries from .cargo/config.toml")?;
+    let source_root_members = merge_packages(&source_root_members, &patch_config_members);
+
     // Seed stubs for ALL source-root members first so cargo metadata can
     // resolve any frozen path = "../../vendor/<name>" entries in Cargo.toml.
     // After metadata, we know the actual local_pkgs subset; the extra stubs
@@ -780,8 +803,7 @@ fn run_external_only(
     // Step 1b: Load metadata; derive local and patch package lists.
     let meta = metadata::load_metadata(manifest_path)?;
     metadata::check_duplicate_sources(&meta)?;
-    let (local_pkgs, _) =
-        metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
+    let (local_pkgs, _) = metadata::partition_packages(&meta, manifest_path, &source_root_members)?;
 
     let all_workspace_members = if !source_root_members.is_empty() {
         source_root_members
@@ -795,7 +817,10 @@ fn run_external_only(
     let patch_pkgs = merge_packages(&local_pkgs, &all_workspace_members);
 
     if v.info() {
-        eprintln!("cargo-revendor: --external-only: skipping {} local crates", local_pkgs.len());
+        eprintln!(
+            "cargo-revendor: --external-only: skipping {} local crates",
+            local_pkgs.len()
+        );
     }
 
     // Step 3: Run `cargo vendor` for external deps only
@@ -835,29 +860,21 @@ fn run_external_only(
         eprintln!("  Merged external deps into {}", output.display());
     }
 
-    // Step 8.5: Remove bootstrap stubs for non-dep workspace members.
+    // Step 8.5: Remove ALL bootstrap stubs from output.
     // bootstrap_vendor_from_source_root seeds ALL workspace members so that
-    // cargo metadata can resolve frozen path deps. After metadata resolution
-    // we know which subset are actual deps (local_pkgs). Non-dep members
-    // (e.g. bench/cli/engine siblings) are only ever stubs and must not
-    // appear in the external-only output.
-    let non_dep_members: Vec<_> = patch_pkgs
-        .iter()
-        .filter(|p| !local_pkgs.iter().any(|l| l.name == p.name))
-        .collect();
-    for pkg in &non_dep_members {
-        for dir_name in &[
-            pkg.name.clone(),
-            format!("{}-{}", pkg.name, pkg.version),
-        ] {
+    // cargo metadata can resolve frozen path deps. In --external-only mode,
+    // local crates (both non-dep workspace members AND actual local deps like
+    // `myhelper = { path = "../myhelper" }`) must be removed from output so
+    // only external crates remain.
+    for pkg in &patch_pkgs {
+        for dir_name in &[pkg.name.clone(), format!("{}-{}", pkg.name, pkg.version)] {
             let p = output.join(dir_name);
             if p.is_dir() {
                 if v.debug() {
-                    eprintln!("  --external-only: removing non-dep stub {dir_name} from output");
+                    eprintln!("  --external-only: removing local stub {dir_name} from output");
                 }
-                std::fs::remove_dir_all(&p).with_context(|| {
-                    format!("failed to remove non-dep stub {}", p.display())
-                })?;
+                std::fs::remove_dir_all(&p)
+                    .with_context(|| format!("failed to remove local stub {}", p.display()))?;
             }
         }
     }
@@ -910,6 +927,11 @@ fn run_local_only(
         Vec::new()
     };
 
+    // Auto-detect additional local path overrides from [patch."git+url"] tables.
+    let patch_config_members = metadata::discover_from_patch_config(manifest_path)
+        .context("failed to read [patch] entries from .cargo/config.toml")?;
+    let source_root_members = merge_packages(&source_root_members, &patch_config_members);
+
     // Step 0: Cache check using source_root paths — skip bootstrap + metadata
     // on a hit to avoid unnecessary I/O.
     if !cli.force && !source_root_members.is_empty() {
@@ -944,7 +966,9 @@ fn run_local_only(
     };
 
     // Fix vendor-dir-resolved paths (same logic as run_full)
-    let canonical_output = output.canonicalize().unwrap_or_else(|_| output.to_path_buf());
+    let canonical_output = output
+        .canonicalize()
+        .unwrap_or_else(|_| output.to_path_buf());
     for pkg in &mut local_pkgs {
         let canonical_pkg = pkg.path.canonicalize().unwrap_or_else(|_| pkg.path.clone());
         if canonical_pkg.starts_with(&canonical_output)
@@ -1030,7 +1054,11 @@ fn run_local_only(
     // Step 8: Merge into output (only overwrite dirs present in staging)
     merge_copy_vendor(&vendor_staging, output)?;
     if v.info() {
-        eprintln!("  Merged {} local crate(s) into {}", packaged.len(), output.display());
+        eprintln!(
+            "  Merged {} local crate(s) into {}",
+            packaged.len(),
+            output.display()
+        );
     }
 
     // Step 8.5: Remove bootstrap stubs for non-dep workspace members.
@@ -1041,18 +1069,14 @@ fn run_local_only(
         .filter(|p| !local_pkgs.iter().any(|l| l.name == p.name))
         .collect();
     for pkg in &non_dep_members {
-        for dir_name in &[
-            pkg.name.clone(),
-            format!("{}-{}", pkg.name, pkg.version),
-        ] {
+        for dir_name in &[pkg.name.clone(), format!("{}-{}", pkg.name, pkg.version)] {
             let p = output.join(dir_name);
             if p.is_dir() {
                 if v.debug() {
                     eprintln!("  --local-only: removing non-dep stub {dir_name} from output");
                 }
-                std::fs::remove_dir_all(&p).with_context(|| {
-                    format!("failed to remove non-dep stub {}", p.display())
-                })?;
+                std::fs::remove_dir_all(&p)
+                    .with_context(|| format!("failed to remove non-dep stub {}", p.display()))?;
             }
         }
     }
@@ -1101,8 +1125,7 @@ fn remove_flat_dirs(
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
         let is_local = local_pkgs.iter().any(|p| {
-            name_str.as_ref() == p.name
-                || name_str.as_ref() == format!("{}-{}", p.name, p.version)
+            name_str.as_ref() == p.name || name_str.as_ref() == format!("{}-{}", p.name, p.version)
         });
         if is_local {
             if v.debug() {
@@ -1137,9 +1160,7 @@ fn resolve_manifest_path(user_path: Option<&std::path::Path>) -> Result<PathBuf>
     }
     // Running from inside the Rust crate itself (has Cargo.toml + src/lib.rs or src/main.rs).
     let in_crate = cwd.join("Cargo.toml");
-    if in_crate.exists()
-        && (cwd.join("src/lib.rs").exists() || cwd.join("src/main.rs").exists())
-    {
+    if in_crate.exists() && (cwd.join("src/lib.rs").exists() || cwd.join("src/main.rs").exists()) {
         return in_crate.canonicalize().context("manifest not found");
     }
     // Subdirectory layout: R package in a subdir (e.g. dvs-rpkg/src/rust/Cargo.toml).
@@ -1188,7 +1209,10 @@ fn run_verify(
     v: Verbosity,
 ) -> Result<()> {
     if v.info() {
-        eprintln!("cargo-revendor: verifying Cargo.lock ↔ {}", vendor_dir.display());
+        eprintln!(
+            "cargo-revendor: verifying Cargo.lock ↔ {}",
+            vendor_dir.display()
+        );
     }
     verify::verify_lock_matches_vendor(lockfile, vendor_dir)?;
     if v.info() {
@@ -1379,7 +1403,10 @@ mod tests {
         let mut cli = base_cli();
         cli.freeze = true;
         let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
-        assert!(err.to_string().contains("--external-only is incompatible with --freeze"));
+        assert!(
+            err.to_string()
+                .contains("--external-only is incompatible with --freeze")
+        );
     }
 
     #[test]
@@ -1388,7 +1415,10 @@ mod tests {
         let mut cli = base_cli();
         cli.compress = Some(std::path::PathBuf::from("vendor.tar.xz"));
         let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
-        assert!(err.to_string().contains("--external-only is incompatible with --compress"));
+        assert!(
+            err.to_string()
+                .contains("--external-only is incompatible with --compress")
+        );
     }
 
     #[test]
@@ -1397,7 +1427,10 @@ mod tests {
         let mut cli = base_cli();
         cli.source_marker = true;
         let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
-        assert!(err.to_string().contains("--external-only is incompatible with --source-marker"));
+        assert!(
+            err.to_string()
+                .contains("--external-only is incompatible with --source-marker")
+        );
     }
 
     #[test]
@@ -1406,7 +1439,10 @@ mod tests {
         let mut cli = base_cli();
         cli.blank_md = true;
         let err = validate_flag_compatibility(&cli, Mode::ExternalOnly, &output).unwrap_err();
-        assert!(err.to_string().contains("--external-only is incompatible with --blank-md"));
+        assert!(
+            err.to_string()
+                .contains("--external-only is incompatible with --blank-md")
+        );
     }
 
     #[test]

--- a/cargo-revendor/src/manifest_guard.rs
+++ b/cargo-revendor/src/manifest_guard.rs
@@ -131,7 +131,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("does-not-exist.toml");
         let result = ManifestGuard::snapshot(&path);
-        assert!(result.is_err(), "expected snapshot of missing file to error");
+        assert!(
+            result.is_err(),
+            "expected snapshot of missing file to error"
+        );
     }
 
     #[test]

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -416,21 +416,84 @@ fn cargo_config_search_paths(manifest_path: &Path) -> Vec<PathBuf> {
     paths
 }
 
-/// Read `[package] version = "..."` from a `Cargo.toml`.
+/// Read `[package] version` from a `Cargo.toml`, resolving `version.workspace = true`
+/// by walking up to the nearest workspace-root manifest's `[workspace.package]`.
 fn read_package_version(manifest: &Path) -> Result<String> {
     let content = std::fs::read_to_string(manifest)
         .with_context(|| format!("failed to read {}", manifest.display()))?;
     let doc: toml_edit::DocumentMut = content
         .parse()
         .with_context(|| format!("failed to parse TOML in {}", manifest.display()))?;
-    let version = doc
+    let version_item = doc
         .get("package")
         .and_then(|p| p.as_table())
         .and_then(|t| t.get("version"))
-        .and_then(|v| v.as_str())
-        .with_context(|| format!("no `[package] version` found in {}", manifest.display()))?
-        .to_string();
-    Ok(version)
+        .with_context(|| format!("no `[package] version` found in {}", manifest.display()))?;
+
+    if let Some(s) = version_item.as_str() {
+        return Ok(s.to_string());
+    }
+
+    // `version.workspace = true` — either inline (`version = { workspace = true }`)
+    // or dotted-key form (`version.workspace = true`, parsed as a sub-table).
+    let inherits_workspace = version_item
+        .as_inline_table()
+        .and_then(|t| t.get("workspace"))
+        .and_then(|v| v.as_bool())
+        == Some(true)
+        || version_item
+            .as_table()
+            .and_then(|t| t.get("workspace"))
+            .and_then(|v| v.as_bool())
+            == Some(true);
+
+    if inherits_workspace {
+        return read_workspace_package_version(manifest);
+    }
+
+    anyhow::bail!(
+        "could not resolve `[package] version` in {} (not a string and not workspace-inherited)",
+        manifest.display()
+    )
+}
+
+/// Walk up from `manifest`'s parent looking for the workspace-root `Cargo.toml`,
+/// then read `[workspace.package].version`.
+fn read_workspace_package_version(manifest: &Path) -> Result<String> {
+    let start = manifest
+        .parent()
+        .with_context(|| format!("manifest {} has no parent", manifest.display()))?;
+    let mut dir: Option<&Path> = start.parent();
+    while let Some(d) = dir {
+        let candidate = d.join("Cargo.toml");
+        if candidate.exists() {
+            let content = std::fs::read_to_string(&candidate)
+                .with_context(|| format!("failed to read {}", candidate.display()))?;
+            if let Ok(doc) = content.parse::<toml_edit::DocumentMut>()
+                && let Some(ws) = doc.get("workspace").and_then(|v| v.as_table())
+            {
+                if let Some(version) = ws
+                    .get("package")
+                    .and_then(|p| p.as_table())
+                    .and_then(|t| t.get("version"))
+                    .and_then(|v| v.as_str())
+                {
+                    return Ok(version.to_string());
+                }
+                anyhow::bail!(
+                    "workspace at {} has no `[workspace.package] version`; \
+                     crate {} declares `version.workspace = true`",
+                    candidate.display(),
+                    manifest.display()
+                );
+            }
+        }
+        dir = d.parent();
+    }
+    anyhow::bail!(
+        "no workspace `Cargo.toml` found above {}; cannot resolve `version.workspace = true`",
+        manifest.display()
+    )
 }
 
 /// Cross-platform home directory. Tries `$HOME` (Unix), `$USERPROFILE` (Windows).
@@ -629,6 +692,86 @@ mod tests {
         let overrides = vec![local_pkg("miniextendr-api", "1.0.0")];
         let result = resolve_git_override("serde", "1.0.0", &overrides).unwrap();
         assert!(result.is_none());
+    }
+
+    // endregion
+
+    // region: read_package_version tests
+
+    #[test]
+    fn read_package_version_string_literal() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            "[package]\nname = \"foo\"\nversion = \"1.2.3\"\n",
+        )
+        .unwrap();
+        assert_eq!(read_package_version(&manifest).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_package_version_workspace_inheritance_inline() {
+        // Workspace root with [workspace.package] version, member declares
+        // `version = { workspace = true }` (inline-table form).
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"member\"]\n\
+             [workspace.package]\nversion = \"4.5.6\"\n",
+        )
+        .unwrap();
+        let member = dir.path().join("member");
+        std::fs::create_dir(&member).unwrap();
+        let manifest = member.join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            "[package]\nname = \"bar\"\nversion = { workspace = true }\n",
+        )
+        .unwrap();
+        assert_eq!(read_package_version(&manifest).unwrap(), "4.5.6");
+    }
+
+    #[test]
+    fn read_package_version_workspace_inheritance_dotted() {
+        // Same as above but using the dotted-key form
+        // (`version.workspace = true`), which is the canonical style used by
+        // the miniextendr workspace and most cargo workspaces in the wild.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"member\"]\n\
+             [workspace.package]\nversion = \"7.8.9\"\n",
+        )
+        .unwrap();
+        let member = dir.path().join("member");
+        std::fs::create_dir(&member).unwrap();
+        let manifest = member.join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            "[package]\nname = \"bar\"\nversion.workspace = true\n",
+        )
+        .unwrap();
+        assert_eq!(read_package_version(&manifest).unwrap(), "7.8.9");
+    }
+
+    #[test]
+    fn read_package_version_workspace_missing_root_errors() {
+        // Member declares `version.workspace = true` but no ancestor
+        // Cargo.toml has [workspace] — bail with a clear error.
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = dir.path().join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            "[package]\nname = \"bar\"\nversion.workspace = true\n",
+        )
+        .unwrap();
+        let err = read_package_version(&manifest).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("no workspace `Cargo.toml` found above"),
+            "unexpected error message: {err}"
+        );
     }
 
     // endregion

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -227,9 +227,7 @@ pub fn check_duplicate_sources(meta: &Metadata) -> Result<()> {
 /// Each triple is `(name, version, source)` where `None` source means a
 /// local path dep (skipped — workspace semantics prevent in-workspace
 /// duplicates of the same name+version).
-fn check_duplicate_sources_impl(
-    pkgs: &[(String, String, Option<String>)],
-) -> Result<()> {
+fn check_duplicate_sources_impl(pkgs: &[(String, String, Option<String>)]) -> Result<()> {
     use std::collections::BTreeMap;
 
     let mut seen: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -263,6 +261,185 @@ fn check_duplicate_sources_impl(
     Ok(())
 }
 
+/// Discover local package overrides from `[patch."<url>"]` tables in
+/// `.cargo/config.toml`.
+///
+/// Cargo's config search order walks up from the manifest directory, checking
+/// `<dir>/.cargo/config.toml` at each level, then falls back to
+/// `$HOME/.cargo/config.toml`. This function mirrors that walk.
+///
+/// For each `[patch."<url>"]` table (the URL may have or lack the `git+`
+/// scheme prefix — both forms are accepted), entries of the form
+/// `<crate-name> = { path = "<path>" }` are collected. The `path` is resolved
+/// relative to the config file that declares it. For each entry, the target
+/// crate's `Cargo.toml` is read to extract the version, and a `LocalPackage`
+/// is returned.
+///
+/// Entries where the `path` does not contain a readable `Cargo.toml` are
+/// silently skipped (the dep may not exist yet on this machine).
+///
+/// On TOML parse errors in a config file, returns an error with the file path
+/// and position so the caller can report it loudly.
+pub fn discover_from_patch_config(manifest_path: &Path) -> Result<Vec<LocalPackage>> {
+    let config_files = cargo_config_search_paths(manifest_path);
+    let mut results: Vec<LocalPackage> = Vec::new();
+    // Track by crate name: first config file (closest to manifest) wins.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for config_path in &config_files {
+        if !config_path.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?;
+
+        let doc: toml_edit::DocumentMut = content
+            .parse()
+            .with_context(|| format!("failed to parse TOML in {}", config_path.display()))?;
+
+        // .cargo/config.toml lives in `<config_dir>/.cargo/config.toml`; the
+        // paths declared inside it resolve relative to `<config_dir>`.
+        let config_dir = config_path
+            .parent() // .cargo/
+            .and_then(|p| p.parent()) // <config_dir>
+            .unwrap_or(config_path.parent().unwrap_or(config_path));
+
+        // Walk every top-level table key that looks like `patch."<url>"`.
+        let Some(patch_tbl) = doc.get("patch").and_then(|v| v.as_table()) else {
+            continue;
+        };
+
+        for (_url_key, url_entries) in patch_tbl.iter() {
+            let Some(entries) = url_entries.as_table() else {
+                continue;
+            };
+            for (crate_name, crate_spec) in entries.iter() {
+                if seen.contains(crate_name) {
+                    continue; // earlier config file already provided this entry
+                }
+
+                // Extract the `path` field from either an inline table
+                // (`{ path = "..." }`) or a regular table (`[patch.url.name]`).
+                let path_val = crate_spec
+                    .as_inline_table()
+                    .and_then(|t| t.get("path"))
+                    .and_then(|v| v.as_str())
+                    .or_else(|| {
+                        crate_spec
+                            .as_table()
+                            .and_then(|t| t.get("path"))
+                            .and_then(|v| v.as_str())
+                    });
+
+                let Some(path_val) = path_val else {
+                    continue; // not a path-dep override
+                };
+
+                let crate_path = if Path::new(path_val).is_absolute() {
+                    PathBuf::from(path_val)
+                } else {
+                    config_dir.join(path_val)
+                };
+
+                let crate_manifest = crate_path.join("Cargo.toml");
+                if !crate_manifest.exists() {
+                    continue; // path doesn't resolve on this machine — skip
+                }
+
+                // Read the version from the crate's own Cargo.toml.
+                let version = read_package_version(&crate_manifest).with_context(|| {
+                    format!(
+                        "failed to read version from {} (patch entry for `{crate_name}` in {})",
+                        crate_manifest.display(),
+                        config_path.display()
+                    )
+                })?;
+
+                let canonical = crate_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| crate_path.clone());
+
+                seen.insert(crate_name.to_string());
+                results.push(LocalPackage {
+                    name: crate_name.to_string(),
+                    version,
+                    path: canonical.clone(),
+                    manifest_path: canonical.join("Cargo.toml"),
+                });
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Return the cargo config search path for a given manifest path, in
+/// priority order (highest priority first). Mirrors cargo's own search:
+/// starting from the manifest's directory, walk up the filesystem checking
+/// `<dir>/.cargo/config.toml` (and legacy `<dir>/.cargo/config`) at each
+/// level, stopping at a filesystem root. `$HOME/.cargo/config.toml` is
+/// appended last.
+fn cargo_config_search_paths(manifest_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Walk from manifest dir upward.
+    let mut dir = manifest_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    loop {
+        let cargo_dir = dir.join(".cargo");
+        // Prefer config.toml; fall back to legacy `config`.
+        let toml_path = cargo_dir.join("config.toml");
+        let plain_path = cargo_dir.join("config");
+        if toml_path.exists() {
+            paths.push(toml_path);
+        } else if plain_path.exists() {
+            paths.push(plain_path);
+        }
+
+        // Stop at filesystem root.
+        if !dir.pop() {
+            break;
+        }
+    }
+
+    // $HOME/.cargo/config.toml as the global fallback.
+    if let Some(home) = home_dir() {
+        let global = home.join(".cargo").join("config.toml");
+        if global.exists() && !paths.contains(&global) {
+            paths.push(global);
+        }
+    }
+
+    paths
+}
+
+/// Read `[package] version = "..."` from a `Cargo.toml`.
+fn read_package_version(manifest: &Path) -> Result<String> {
+    let content = std::fs::read_to_string(manifest)
+        .with_context(|| format!("failed to read {}", manifest.display()))?;
+    let doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse TOML in {}", manifest.display()))?;
+    let version = doc
+        .get("package")
+        .and_then(|p| p.as_table())
+        .and_then(|t| t.get("version"))
+        .and_then(|v| v.as_str())
+        .with_context(|| format!("no `[package] version` found in {}", manifest.display()))?
+        .to_string();
+    Ok(version)
+}
+
+/// Cross-platform home directory. Tries `$HOME` (Unix), `$USERPROFILE` (Windows).
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
 /// Recursively collect all dependency package IDs
 fn collect_deps(
     resolve: &cargo_metadata::Resolve,
@@ -284,7 +461,11 @@ mod tests {
     use super::*;
 
     fn pkg(name: &str, version: &str, source: Option<&str>) -> (String, String, Option<String>) {
-        (name.to_string(), version.to_string(), source.map(String::from))
+        (
+            name.to_string(),
+            version.to_string(),
+            source.map(String::from),
+        )
     }
 
     fn local_pkg(name: &str, version: &str) -> LocalPackage {
@@ -349,10 +530,7 @@ mod tests {
         // source: None = local path dep. Two local deps with the same
         // (name, version) would be a workspace-level problem, detected
         // elsewhere. Don't double-report here.
-        let pkgs = vec![
-            pkg("local", "0.1.0", None),
-            pkg("local", "0.1.0", None),
-        ];
+        let pkgs = vec![pkg("local", "0.1.0", None), pkg("local", "0.1.0", None)];
         check_duplicate_sources_impl(&pkgs).unwrap();
     }
 
@@ -363,7 +541,11 @@ mod tests {
         // should error — upstream cargo does.
         let pkgs = vec![
             pkg("serde", "1.0.0", Some("registry+https://crates.io")),
-            pkg("serde", "1.0.0", Some("git+https://github.com/serde-rs/serde")),
+            pkg(
+                "serde",
+                "1.0.0",
+                Some("git+https://github.com/serde-rs/serde"),
+            ),
         ];
         let err = check_duplicate_sources_impl(&pkgs).unwrap_err();
         assert!(err.to_string().contains("serde v1.0.0"));
@@ -378,7 +560,10 @@ mod tests {
         // Dep is not in overrides — should stay external.
         let overrides = vec![local_pkg("miniextendr-api", "0.5.0")];
         let result = resolve_git_override("serde", "1.0.0", &overrides).unwrap();
-        assert!(result.is_none(), "unrelated dep should not match any override");
+        assert!(
+            result.is_none(),
+            "unrelated dep should not match any override"
+        );
     }
 
     #[test]
@@ -408,9 +593,18 @@ mod tests {
         let overrides = vec![local_pkg("miniextendr-api", "0.6.0")];
         let err = resolve_git_override("miniextendr-api", "0.5.0", &overrides).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("miniextendr-api"), "error should name the crate");
-        assert!(msg.contains("0.5.0"), "error should mention the git version");
-        assert!(msg.contains("0.6.0"), "error should mention the local version");
+        assert!(
+            msg.contains("miniextendr-api"),
+            "error should name the crate"
+        );
+        assert!(
+            msg.contains("0.5.0"),
+            "error should mention the git version"
+        );
+        assert!(
+            msg.contains("0.6.0"),
+            "error should mention the local version"
+        );
     }
 
     #[test]

--- a/cargo-revendor/src/package.rs
+++ b/cargo-revendor/src/package.rs
@@ -49,8 +49,7 @@ pub fn package_local_crates(
         // Snapshot both the inner crate manifest and the workspace manifest.
         // The guards restore both on drop (scope exits at the end of this
         // iteration, or earlier via `?` / panic unwind).
-        let _inner_guard =
-            crate::manifest_guard::ManifestGuard::snapshot(&pkg.manifest_path)?;
+        let _inner_guard = crate::manifest_guard::ManifestGuard::snapshot(&pkg.manifest_path)?;
         let _ws_guard = crate::manifest_guard::ManifestGuard::snapshot(&ws_manifest)?;
 
         // Temporarily rewrite Cargo.toml to add version = "*" to path-only deps

--- a/cargo-revendor/src/strip.rs
+++ b/cargo-revendor/src/strip.rs
@@ -334,6 +334,7 @@ const STRIPABLE_TOP_DIRS: &[&str] = &["tests", "benches", "examples", "bin"];
 ///   2. composed-path macros — scan all string literals in the macro's
 ///      argument span (handles `concat!(...)`) for `<...>tests/`, `benches/`,
 ///      `examples/`, `bin/` substrings and preserve those dirs.
+///
 /// Paths escaping the crate root or referencing files outside it are ignored.
 fn scan_referenced_top_dirs(crate_dir: &Path) -> Vec<String> {
     let crate_root = match crate_dir.canonicalize() {
@@ -365,15 +366,13 @@ fn scan_referenced_top_dirs(crate_dir: &Path) -> Vec<String> {
         for literal in extract_include_arg_literals(&content) {
             // (1) Literal-path resolution: works for `include_str!("...")`.
             let resolved = parent.join(&literal);
-            if let Ok(canon) = resolved.canonicalize() {
-                if let Ok(rel) = canon.strip_prefix(&crate_root) {
-                    if let Some(first) = rel.components().next() {
-                        if let Some(s) = first.as_os_str().to_str() {
-                            top_dirs.insert(s.to_string());
-                            continue;
-                        }
-                    }
-                }
+            if let Ok(canon) = resolved.canonicalize()
+                && let Ok(rel) = canon.strip_prefix(&crate_root)
+                && let Some(first) = rel.components().next()
+                && let Some(s) = first.as_os_str().to_str()
+            {
+                top_dirs.insert(s.to_string());
+                continue;
             }
             // (2) Substring sniff: catches `concat!("../benches/...", x, ".rs")`
             //     where the literal alone doesn't resolve to a real file.
@@ -713,11 +712,20 @@ default = []
         strip_crate_dir(&crate_dir, &StripConfig::all(), Verbosity(0)).unwrap();
 
         let result = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
-        assert!(!result.contains("[dev-dependencies]"), "dev-deps should be removed");
-        assert!(!result.contains("criterion"), "criterion ref should be gone");
+        assert!(
+            !result.contains("[dev-dependencies]"),
+            "dev-deps should be removed"
+        );
+        assert!(
+            !result.contains("criterion"),
+            "criterion ref should be gone"
+        );
         assert!(result.contains("serde"), "regular dep preserved");
         assert!(result.contains("default = []"), "default feature preserved");
-        assert!(result.contains("real_blackbox"), "feature key still present but pruned");
+        assert!(
+            result.contains("real_blackbox"),
+            "feature key still present but pruned"
+        );
     }
 
     #[test]
@@ -877,12 +885,20 @@ default = []
         strip_crate_dir(&crate_dir, &StripConfig::toml_only(), Verbosity(0)).unwrap();
 
         // Source-related dirs preserved (the whole point of --strip-toml-sections)
-        assert!(crate_dir.join("benches/formats/static_size.rs").exists(),
-            "benches/ must survive — referenced by include_str! in some crates");
+        assert!(
+            crate_dir.join("benches/formats/static_size.rs").exists(),
+            "benches/ must survive — referenced by include_str! in some crates"
+        );
         assert!(crate_dir.join("tests").exists(), "tests/ must survive");
-        assert!(crate_dir.join("examples").exists(), "examples/ must survive");
+        assert!(
+            crate_dir.join("examples").exists(),
+            "examples/ must survive"
+        );
         // Always-safe base dirs still go
-        assert!(!crate_dir.join(".github").exists(), ".github/ should still be stripped");
+        assert!(
+            !crate_dir.join(".github").exists(),
+            ".github/ should still be stripped"
+        );
         // TOML surgery still happens
         let manifest = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
         assert!(!manifest.contains("[dev-dependencies]"));

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -24,7 +24,10 @@ pub fn run_cargo_vendor(
     if v.info() {
         eprintln!("  Running cargo vendor...");
         if !sync_manifests.is_empty() {
-            eprintln!("    syncing {} additional manifest(s)", sync_manifests.len());
+            eprintln!(
+                "    syncing {} additional manifest(s)",
+                sync_manifests.len()
+            );
             for m in sync_manifests {
                 eprintln!("      --sync {}", m.display());
             }
@@ -1037,7 +1040,12 @@ fn rewrite_dep_to_vendor(dep: &mut toml_edit::Item, name: &str, vendor_rel: &str
 /// - Falls back to flat `<name>` if only the flat dir exists.
 ///
 /// With `versioned_dirs = false`: always returns `<name>`.
-fn vendor_dir_name_for_pkg(vendor_dir: &Path, name: &str, version: &str, versioned_dirs: bool) -> String {
+fn vendor_dir_name_for_pkg(
+    vendor_dir: &Path,
+    name: &str,
+    version: &str,
+    versioned_dirs: bool,
+) -> String {
     if versioned_dirs {
         if !version.is_empty() {
             let versioned = format!("{}-{}", name, version);
@@ -1504,8 +1512,15 @@ external = { git = "https://example.com/ext" }
         let vendor = dir.path().join("vendor");
         std::fs::create_dir_all(&vendor).unwrap();
 
-        let err = freeze_manifest(&manifest, &vendor, &[], false, /* strict */ true, Verbosity(0))
-            .unwrap_err();
+        let err = freeze_manifest(
+            &manifest,
+            &vendor,
+            &[],
+            false,
+            /* strict */ true,
+            Verbosity(0),
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("--strict-freeze") && msg.contains("external"),
@@ -1535,8 +1550,15 @@ external = { git = "https://example.com/ext" }
         let vendor = dir.path().join("vendor");
         std::fs::create_dir_all(&vendor).unwrap();
 
-        freeze_manifest(&manifest, &vendor, &[], false, /* strict */ false, Verbosity(0))
-            .unwrap();
+        freeze_manifest(
+            &manifest,
+            &vendor,
+            &[],
+            false,
+            /* strict */ false,
+            Verbosity(0),
+        )
+        .unwrap();
     }
 
     // endregion
@@ -1584,7 +1606,12 @@ version = "0.1.0"
     fn freeze_manifest_patch_crates_io_is_alphabetical() {
         let dir = tempfile::tempdir().unwrap();
         let vendor = dir.path().join("vendor");
-        for name in ["miniextendr-api", "miniextendr-macros", "miniextendr-lint", "miniextendr-macros-core"] {
+        for name in [
+            "miniextendr-api",
+            "miniextendr-macros",
+            "miniextendr-lint",
+            "miniextendr-macros-core",
+        ] {
             std::fs::create_dir_all(vendor.join(name)).unwrap();
         }
         let manifest = dir.path().join("Cargo.toml");
@@ -1613,7 +1640,11 @@ miniextendr-macros-core = { path = "/tmp/mc" }
         let lint = result.find("miniextendr-lint =").unwrap();
         let macros = result.find("miniextendr-macros =").unwrap();
         let macros_core = result.find("miniextendr-macros-core =").unwrap();
-        assert!(api < lint && lint < macros && macros < macros_core, "patch.crates-io entries not alphabetical: {}", result);
+        assert!(
+            api < lint && lint < macros && macros < macros_core,
+            "patch.crates-io entries not alphabetical: {}",
+            result
+        );
     }
 
     #[test]
@@ -1709,7 +1740,10 @@ dependencies = [
         strip_lockfile_inplace(&lockfile, 0).unwrap();
 
         let result = std::fs::read_to_string(&lockfile).unwrap();
-        assert!(result.ends_with('\n'), "trailing newline should be preserved");
+        assert!(
+            result.ends_with('\n'),
+            "trailing newline should be preserved"
+        );
         assert!(!result.contains("checksum = "));
     }
 

--- a/cargo-revendor/src/verify.rs
+++ b/cargo-revendor/src/verify.rs
@@ -150,10 +150,7 @@ pub fn verify_lock_matches_vendor(lockfile: &Path, vendor_dir: &Path) -> Result<
         }
     }
     if !mismatched.is_empty() {
-        msg.push_str(&format!(
-            "\n  Version mismatches ({}):\n",
-            mismatched.len()
-        ));
+        msg.push_str(&format!("\n  Version mismatches ({}):\n", mismatched.len()));
         for (name, locked, vendored) in mismatched.iter().take(20) {
             msg.push_str(&format!(
                 "    - {}: Cargo.lock says {}, vendor/ says {}\n",
@@ -161,10 +158,7 @@ pub fn verify_lock_matches_vendor(lockfile: &Path, vendor_dir: &Path) -> Result<
             ));
         }
         if mismatched.len() > 20 {
-            msg.push_str(&format!(
-                "    ... and {} more\n",
-                mismatched.len() - 20
-            ));
+            msg.push_str(&format!("    ... and {} more\n", mismatched.len() - 20));
         }
     }
     msg.push_str(
@@ -292,10 +286,13 @@ fn collect_file_hashes(root: &Path) -> Result<BTreeMap<String, u64>> {
             .unwrap_or(entry.path())
             .to_string_lossy()
             .into_owned();
-        // cache.rs writes `.revendor-cache` at the top of vendor/ AFTER the
-        // tarball is compressed, so it's never in the tarball by design —
-        // skip it to avoid a perpetual false-positive diff.
-        if rel == ".revendor-cache" {
+        // cache.rs writes `.revendor-cache*` files at the top of vendor/ AFTER
+        // the tarball is compressed, so they're never in the tarball by design —
+        // skip them to avoid perpetual false-positive diffs.
+        if rel == ".revendor-cache"
+            || rel == ".revendor-cache-external"
+            || rel == ".revendor-cache-local"
+        {
             continue;
         }
         let bytes = std::fs::read(entry.path())?;

--- a/cargo-revendor/tests/common/mod.rs
+++ b/cargo-revendor/tests/common/mod.rs
@@ -297,14 +297,11 @@ pub fn vendor_has(vendor: &Path, name: &str) -> bool {
     std::fs::read_dir(vendor)
         .ok()
         .map(|entries| {
-            entries
-                .flatten()
-                .filter(|e| e.path().is_dir())
-                .any(|e| {
-                    e.file_name()
-                        .to_str()
-                        .is_some_and(|n| n.starts_with(&prefix))
-                })
+            entries.flatten().filter(|e| e.path().is_dir()).any(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with(&prefix))
+            })
         })
         .unwrap_or(false)
 }

--- a/cargo-revendor/tests/edge_cases_diagnostics.rs
+++ b/cargo-revendor/tests/edge_cases_diagnostics.rs
@@ -10,9 +10,7 @@
 
 mod common;
 
-use common::{
-    create_simple_crate, create_workspace, read_vendor_toml, revendor_cmd, vendor_has,
-};
+use common::{create_simple_crate, create_workspace, read_vendor_toml, revendor_cmd, vendor_has};
 
 // region: Edge cases (E1-E5)
 
@@ -371,7 +369,10 @@ cfg-if = "1"
         .success();
 
     let marker = vendor.join(".vendor-source");
-    assert!(marker.exists(), "--source-marker should write .vendor-source");
+    assert!(
+        marker.exists(),
+        "--source-marker should write .vendor-source"
+    );
     let body = std::fs::read_to_string(&marker).unwrap();
     let body = body.trim();
     assert_eq!(

--- a/cargo-revendor/tests/git_deps.rs
+++ b/cargo-revendor/tests/git_deps.rs
@@ -255,11 +255,7 @@ publish = false
 "#,
     )
     .unwrap();
-    std::fs::write(
-        work_root.join("unused/src/lib.rs"),
-        "pub fn unused() {}\n",
-    )
-    .unwrap();
+    std::fs::write(work_root.join("unused/src/lib.rs"), "pub fn unused() {}\n").unwrap();
 
     common::git_init(&work_root);
 
@@ -419,4 +415,3 @@ path = "src/lib.rs"
         "vendored crate should be the patched local, got:\n{toml}"
     );
 }
-

--- a/cargo-revendor/tests/integration.rs
+++ b/cargo-revendor/tests/integration.rs
@@ -212,36 +212,52 @@ path = "lib.rs"
 #[test]
 #[ignore] // network
 fn patch_cratesio_pattern() {
+    // Use a crate name that is guaranteed not to exist on crates.io so the
+    // version from the local workspace (0.1.0) never conflicts with a
+    // registry resolution.
+    //
+    // The [patch.crates-io] must be placed in the workspace root manifest,
+    // not in a member manifest — cargo ignores member-level [patch] in
+    // workspace context.
+    let crate_name = "zzz-cargo-revendor-test-fixture-mylib";
     let proj = create_workspace(
-        r#"[workspace]
-members = ["rpkg", "mylib"]
-"#,
+        &format!(
+            r#"[workspace]
+members = ["rpkg", "{crate_name}"]
+resolver = "2"
+
+[patch.crates-io]
+{crate_name} = {{ path = "{crate_name}" }}
+"#
+        ),
         &[
             (
                 "rpkg",
-                r#"[package]
+                &format!(
+                    r#"[package]
 name = "rpkg"
 version = "0.1.0"
 edition = "2021"
 [lib]
 path = "lib.rs"
 [dependencies]
-mylib = { version = "*" }
+{crate_name} = {{ version = "0.1.0" }}
 cfg-if = "1"
-[patch.crates-io]
-mylib = { path = "../mylib" }
-"#,
+"#
+                ),
                 "pub fn go() {}",
             ),
             (
-                "mylib",
-                r#"[package]
-name = "mylib"
+                crate_name,
+                &format!(
+                    r#"[package]
+name = "{crate_name}"
 version = "0.1.0"
 edition = "2021"
 [lib]
 path = "lib.rs"
-"#,
+"#
+                ),
                 "pub fn lib_fn() {}",
             ),
         ],
@@ -261,7 +277,7 @@ path = "lib.rs"
         .assert()
         .success();
 
-    assert_vendor_has(&vendor, "mylib");
+    assert_vendor_has(&vendor, crate_name);
     assert_vendor_has(&vendor, "cfg-if");
 }
 
@@ -272,22 +288,26 @@ path = "lib.rs"
 #[test]
 #[ignore] // network
 fn monorepo_nested_rpkg() {
+    // Use a crate name that doesn't exist on crates.io to avoid version
+    // conflicts between the local workspace copy and the registry.
+    let crate_name = "zzz-cargo-revendor-test-fixture-mylib";
     let proj = create_monorepo(
-        r#"[workspace]
-members = ["mylib"]
-"#,
+        &format!("[workspace]\nmembers = [\"{crate_name}\"]\n"),
         &[(
-            "mylib",
-            r#"[package]
-name = "mylib"
+            crate_name,
+            &format!(
+                r#"[package]
+name = "{crate_name}"
 version = "0.1.0"
 edition = "2021"
 [lib]
 path = "lib.rs"
-"#,
+"#
+            ),
             "pub fn lib_fn() {}",
         )],
-        r#"[package]
+        &format!(
+            r#"[package]
 name = "mypkg"
 version = "0.1.0"
 edition = "2021"
@@ -295,11 +315,12 @@ edition = "2021"
 [lib]
 path = "lib.rs"
 [dependencies]
-mylib = { version = "*" }
+{crate_name} = {{ version = "0.1.0" }}
 cfg-if = "1"
 [patch.crates-io]
-mylib = { path = "../../../mylib" }
-"#,
+{crate_name} = {{ path = "../../../{crate_name}" }}
+"#
+        ),
         "pub fn go() {}",
     );
     let vendor = proj.root().join("vendor");
@@ -320,7 +341,7 @@ mylib = { path = "../../../mylib" }
         .assert()
         .success();
 
-    assert_vendor_has(&vendor, "mylib");
+    assert_vendor_has(&vendor, crate_name);
     assert_vendor_has(&vendor, "cfg-if");
 }
 

--- a/cargo-revendor/tests/patch_from_config.rs
+++ b/cargo-revendor/tests/patch_from_config.rs
@@ -1,0 +1,407 @@
+//! Integration tests for auto-reading `[patch."<url>"]` from `.cargo/config.toml`.
+//!
+//! These tests exercise the feature described in plans/lockfile-mode-unification.md
+//! item 1: cargo-revendor reads `[patch."<url>"] crate = { path = "..." }` entries
+//! from `.cargo/config.toml` and vendors the patched local source *without* the
+//! caller passing `--source-root`.
+//!
+//! All tests are gated behind `#[ignore]` because they invoke `cargo vendor`
+//! (which may touch the registry for a full dep-graph resolve even with pure-git
+//! or pure-path deps). Run with `cargo test -p cargo-revendor -- --ignored`.
+
+mod common;
+
+use common::{assert_vendor_has, create_local_git_crate, git_init, revendor_cmd, vendor_dir_for};
+use std::path::Path;
+
+/// Build a small workspace with one member and write a `.cargo/config.toml`
+/// that patches the given git URL to point at the workspace member.
+///
+/// Layout:
+///   root/
+///     Cargo.toml          ← workspace root: resolver = "2", member = ["lib"]
+///     lib/
+///       Cargo.toml        ← the local crate being patched in
+///       src/lib.rs        ← contains MARKER so we can assert the version
+///     pkg/
+///       Cargo.toml        ← the crate that depends on the git source
+///       lib.rs
+///     .cargo/config.toml  ← [patch."git_url"] lib = { path = "lib" }
+fn build_patch_workspace(
+    git_url: &str,
+    crate_name: &str,
+    crate_version: &str,
+    marker: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Workspace root
+    std::fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["lib", "pkg"]
+resolver = "2"
+"#,
+    )
+    .unwrap();
+
+    // Local lib crate (the one that overrides the git source)
+    std::fs::create_dir_all(root.join("lib/src")).unwrap();
+    std::fs::write(
+        root.join("lib/Cargo.toml"),
+        format!(
+            r#"[package]
+name = "{crate_name}"
+version = "{crate_version}"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("lib/src/lib.rs"),
+        format!("// PATCH_MARKER: {marker}\npub fn patched() -> &'static str {{ \"{marker}\" }}\n"),
+    )
+    .unwrap();
+
+    // The rpkg-style crate that depends on the git source
+    std::fs::create_dir_all(root.join("pkg")).unwrap();
+    std::fs::write(
+        root.join("pkg/Cargo.toml"),
+        format!(
+            r#"[package]
+name = "test-pkg"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+{crate_name} = {{ git = "{git_url}" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("pkg/lib.rs"),
+        format!(
+            "pub use {lib}::patched;\n",
+            lib = crate_name.replace('-', "_")
+        ),
+    )
+    .unwrap();
+
+    // .cargo/config.toml at workspace root with the [patch] override
+    std::fs::create_dir_all(root.join(".cargo")).unwrap();
+    std::fs::write(
+        root.join(".cargo/config.toml"),
+        format!(
+            "[patch.\"{}\"]\n{crate_name} = {{ path = \"lib\" }}\n",
+            git_url
+        ),
+    )
+    .unwrap();
+
+    git_init(&root);
+
+    let manifest = root.join("pkg/Cargo.toml");
+    (dir, manifest)
+}
+
+/// **P1** — basic: `.cargo/config.toml` with `[patch."file://..."]` and a
+/// `path = "..."` entry. cargo-revendor should pick up the local override
+/// *without* `--source-root`, and the vendored copy should contain the
+/// patched source.
+#[test]
+#[ignore] // invokes cargo vendor
+fn patch_from_config_basic() {
+    // Bare git repo as the "upstream" we are going to override.
+    let git_upstream = create_local_git_crate(
+        "upstream-lib",
+        r#"[package]
+name = "upstream-lib"
+version = "0.1.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn upstream() -> u32 { 1 }\npub fn patched() -> &'static str { \"GIT\" }\n",
+    );
+
+    let (_work, manifest) = build_patch_workspace(
+        &git_upstream.url(),
+        "upstream-lib",
+        "0.1.0",
+        "LOCAL_EDIT_123",
+    );
+    let vendor = manifest.parent().unwrap().join("vendor");
+
+    revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&vendor)
+        // No --source-root — auto-detection from .cargo/config.toml must do it.
+        .assert()
+        .success();
+
+    assert_vendor_has(&vendor, "upstream-lib");
+
+    // The vendored copy must be the patched LOCAL version, not the git snapshot.
+    let crate_dir = vendor_dir_for(&vendor, "upstream-lib", None);
+    let lib_rs = std::fs::read_to_string(crate_dir.join("src/lib.rs"))
+        .expect("src/lib.rs not found in vendored upstream-lib");
+    assert!(
+        lib_rs.contains("LOCAL_EDIT_123"),
+        "vendored upstream-lib should contain the local override, got:\n{lib_rs}"
+    );
+}
+
+/// **P2** — config.toml placed one level above the manifest dir (ancestor
+/// directory). cargo-revendor should walk up and find it.
+#[test]
+#[ignore] // invokes cargo vendor
+fn patch_from_config_in_ancestor_dir() {
+    let git_upstream = create_local_git_crate(
+        "ancestor-lib",
+        r#"[package]
+name = "ancestor-lib"
+version = "0.2.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn ancestor() {}\npub fn patched() -> &'static str { \"GIT\" }\n",
+    );
+
+    let (_work, manifest) = build_patch_workspace(
+        &git_upstream.url(),
+        "ancestor-lib",
+        "0.2.0",
+        "ANCESTOR_OVERRIDE",
+    );
+
+    // The .cargo/config.toml is already written at the workspace root level
+    // (one level above pkg/Cargo.toml), so this test exercises the ancestor
+    // walk without any extra setup.
+    let vendor = manifest.parent().unwrap().join("vendor");
+
+    revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&vendor)
+        .assert()
+        .success();
+
+    assert_vendor_has(&vendor, "ancestor-lib");
+    let crate_dir = vendor_dir_for(&vendor, "ancestor-lib", None);
+    let lib_rs = std::fs::read_to_string(crate_dir.join("src/lib.rs"))
+        .expect("src/lib.rs not found in vendored ancestor-lib");
+    assert!(
+        lib_rs.contains("ANCESTOR_OVERRIDE"),
+        "vendored ancestor-lib should contain the ancestor-level override, got:\n{lib_rs}"
+    );
+}
+
+/// **P3** — explicit `--source-root` wins over a `.cargo/config.toml` entry
+/// for the same crate. Verifies the "explicit beats inferred" rule.
+#[test]
+#[ignore] // invokes cargo vendor
+fn source_root_wins_over_patch_config() {
+    let git_upstream = create_local_git_crate(
+        "conflict-lib",
+        r#"[package]
+name = "conflict-lib"
+version = "0.3.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn conflict() {}\npub fn patched() -> &'static str { \"GIT\" }\n",
+    );
+
+    let git_url = git_upstream.url();
+
+    // Two competing workspaces:
+    // - from_config_ws: what .cargo/config.toml points at (marker = FROM_CONFIG)
+    // - source_root_ws: what --source-root discovers (marker = FROM_SOURCE_ROOT)
+
+    let config_ws = tempfile::TempDir::new().unwrap();
+    let config_root = config_ws.path().to_path_buf();
+    build_lib_workspace(&config_root, "conflict-lib", "0.3.0", "FROM_CONFIG");
+    git_init(&config_root);
+
+    let sr_ws = tempfile::TempDir::new().unwrap();
+    let sr_root = sr_ws.path().to_path_buf();
+    build_lib_workspace(&sr_root, "conflict-lib", "0.3.0", "FROM_SOURCE_ROOT");
+    git_init(&sr_root);
+
+    // Project that depends on the git source; .cargo/config.toml points at config_ws.
+    let proj_dir = tempfile::TempDir::new().unwrap();
+    let proj_root = proj_dir.path().to_path_buf();
+    std::fs::create_dir_all(proj_root.join(".cargo")).unwrap();
+    std::fs::write(
+        proj_root.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "proj"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+conflict-lib = {{ git = "{git_url}" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(proj_root.join("lib.rs"), "pub use conflict_lib::patched;\n").unwrap();
+    std::fs::write(
+        proj_root.join(".cargo/config.toml"),
+        format!(
+            "[patch.\"{}\"]\nconflict-lib = {{ path = \"{}\" }}\n",
+            git_url,
+            config_root.join("conflict-lib").display()
+        ),
+    )
+    .unwrap();
+    git_init(&proj_root);
+
+    let vendor = proj_root.join("vendor");
+    revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(proj_root.join("Cargo.toml"))
+        .arg("--output")
+        .arg(&vendor)
+        .arg("--source-root")
+        .arg(&sr_root) // explicit; should win over config.toml entry
+        .assert()
+        .success();
+
+    assert_vendor_has(&vendor, "conflict-lib");
+    let crate_dir = vendor_dir_for(&vendor, "conflict-lib", None);
+    let lib_rs = std::fs::read_to_string(crate_dir.join("src/lib.rs"))
+        .expect("src/lib.rs not found in vendored conflict-lib");
+    // The --source-root entry should win.
+    assert!(
+        lib_rs.contains("FROM_SOURCE_ROOT"),
+        "vendored conflict-lib should come from --source-root, got:\n{lib_rs}"
+    );
+    assert!(
+        !lib_rs.contains("FROM_CONFIG"),
+        "vendored conflict-lib should NOT come from config.toml patch, got:\n{lib_rs}"
+    );
+}
+
+/// **P4** — no `.cargo/config.toml` present: behavior is unchanged from the
+/// pre-patch-detection baseline. Should succeed without any local crate
+/// pre-seeding (the dep is a pure git dep with no local override).
+#[test]
+#[ignore] // invokes cargo vendor
+fn no_config_toml_behaves_as_before() {
+    let git_upstream = create_local_git_crate(
+        "no-config-lib",
+        r#"[package]
+name = "no-config-lib"
+version = "0.4.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn no_config() {}\n",
+    );
+
+    let work = tempfile::TempDir::new().unwrap();
+    let root = work.path().join("project");
+    let git_url = git_upstream.url();
+
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "test-proj"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+no-config-lib = {{ git = "{git_url}" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(root.join("lib.rs"), "pub use no_config_lib::no_config;\n").unwrap();
+    git_init(&root);
+    // No .cargo/config.toml written.
+
+    let vendor = root.join("vendor");
+    revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .arg("--output")
+        .arg(&vendor)
+        .assert()
+        .success();
+
+    // The git dep from the bare local repo should still be vendored.
+    assert_vendor_has(&vendor, "no-config-lib");
+    let crate_dir = vendor_dir_for(&vendor, "no-config-lib", None);
+    let lib_rs = std::fs::read_to_string(crate_dir.join("src/lib.rs"))
+        .expect("src/lib.rs not found in vendored no-config-lib");
+    assert!(
+        lib_rs.contains("no_config"),
+        "vendored no-config-lib should have original content, got:\n{lib_rs}"
+    );
+}
+
+// Helper: build a workspace with a single `conflict-lib` member (no pkg subdir),
+// used for the `--source-root` test where the source root IS the workspace.
+fn build_lib_workspace(root: &Path, crate_name: &str, version: &str, marker: &str) {
+    std::fs::write(
+        root.join("Cargo.toml"),
+        format!("[workspace]\nmembers = [\"{crate_name}\"]\nresolver = \"2\"\n"),
+    )
+    .unwrap();
+    std::fs::create_dir_all(root.join(format!("{crate_name}/src"))).unwrap();
+    std::fs::write(
+        root.join(format!("{crate_name}/Cargo.toml")),
+        format!(
+            r#"[package]
+name = "{crate_name}"
+version = "{version}"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        root.join(format!("{crate_name}/src/lib.rs")),
+        format!("// MARKER: {marker}\npub fn patched() -> &'static str {{ \"{marker}\" }}\n"),
+    )
+    .unwrap();
+}

--- a/cargo-revendor/tests/phase_modes.rs
+++ b/cargo-revendor/tests/phase_modes.rs
@@ -127,7 +127,9 @@ path = "lib.rs"
         ])
         .assert()
         .failure()
-        .stderr(predicates::str::contains(".revendor-cache-external not found"));
+        .stderr(predicates::str::contains(
+            ".revendor-cache-external not found",
+        ));
 }
 
 /// --external-only and --local-only are mutually exclusive (clap enforces this).
@@ -234,11 +236,7 @@ path = "lib.rs"
     let has_cfg_if = std::fs::read_dir(&vendor)
         .unwrap()
         .flatten()
-        .any(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("cfg-if-")
-        });
+        .any(|e| e.file_name().to_string_lossy().starts_with("cfg-if-"));
     assert!(has_cfg_if, "cfg-if versioned dir should be in vendor/");
 
     // myhelper (local) must NOT be present (we skipped local packaging).
@@ -309,10 +307,7 @@ path = "lib.rs"
         .find(|e| e.file_name().to_string_lossy().starts_with("cfg-if-"))
         .expect("cfg-if should be vendored")
         .path();
-    let before_mtime = std::fs::metadata(&cfg_if_dir)
-        .unwrap()
-        .modified()
-        .unwrap();
+    let before_mtime = std::fs::metadata(&cfg_if_dir).unwrap().modified().unwrap();
 
     // Step 2: local-only
     revendor_cmd()
@@ -336,10 +331,7 @@ path = "lib.rs"
     );
 
     // cfg-if versioned dir must be untouched.
-    let after_mtime = std::fs::metadata(&cfg_if_dir)
-        .unwrap()
-        .modified()
-        .unwrap();
+    let after_mtime = std::fs::metadata(&cfg_if_dir).unwrap().modified().unwrap();
     assert_eq!(
         before_mtime, after_mtime,
         "cfg-if-* mtime should be unchanged after --local-only"

--- a/cargo-revendor/tests/verify_freeze_compress.rs
+++ b/cargo-revendor/tests/verify_freeze_compress.rs
@@ -12,7 +12,7 @@
 mod common;
 
 use common::{
-    create_simple_crate, diff_trees, extract_tarball, revendor_cmd, vendor_dir_for, TreeDiff,
+    TreeDiff, create_simple_crate, diff_trees, extract_tarball, revendor_cmd, vendor_dir_for,
 };
 
 // region: --verify end-to-end (V1-V5)
@@ -167,11 +167,13 @@ fn verify_ignores_revendor_cache_byproduct() {
         .assert()
         .success();
 
-    // The cache file MUST exist after a vendor run, otherwise this test is
-    // a tautology.
+    // At least one cache file MUST exist after a vendor run, otherwise this
+    // test is a tautology.
     assert!(
-        vendor.join(".revendor-cache").exists(),
-        "expected vendor/.revendor-cache to be written after vendor run"
+        vendor.join(".revendor-cache").exists()
+            || vendor.join(".revendor-cache-external").exists()
+            || vendor.join(".revendor-cache-local").exists(),
+        "expected at least one vendor/.revendor-cache* file to be written after vendor run"
     );
 
     revendor_cmd()
@@ -454,11 +456,15 @@ fn compress_roundtrip_matches_vendor() {
         .expect("tarball should have a top-level dir");
 
     let mut diffs = diff_trees(&vendor, &extracted_root);
-    // Filter out `.revendor-cache` — written after compress by design.
-    diffs.retain(|d| !matches!(d,
-        TreeDiff::OnlyInA(p) | TreeDiff::OnlyInB(p) | TreeDiff::ContentDiff(p)
-            if p == ".revendor-cache"
-    ));
+    // Filter out `.revendor-cache*` files — written after compress by design.
+    diffs.retain(|d| {
+        !matches!(d,
+            TreeDiff::OnlyInA(p) | TreeDiff::OnlyInB(p) | TreeDiff::ContentDiff(p)
+                if p == ".revendor-cache"
+                    || p == ".revendor-cache-external"
+                    || p == ".revendor-cache-local"
+        )
+    });
     assert!(
         diffs.is_empty(),
         "vendor/ and tarball should match bit-for-bit (modulo .revendor-cache), diffs:\n{diffs:#?}"

--- a/justfile
+++ b/justfile
@@ -408,14 +408,15 @@ vendor:
     if [[ -f "$cargo_cfg.tmp_just_vendor" ]]; then
       mv "$cargo_cfg.tmp_just_vendor" "$cargo_cfg"
     fi
-    # `--source-root .` makes cargo-revendor copy miniextendr-{api,lint,macros}
-    # from this workspace checkout instead of fetching them from the git URL
+    # cargo-revendor auto-reads [patch."git+url"] from .cargo/config.toml
+    # (written by `configure` in dev-monorepo mode) to copy miniextendr-{api,
+    # lint,macros} from this workspace checkout instead of fetching the git URL
     # pinned in Cargo.lock. PRs that edit a workspace crate alongside rpkg get
     # their edits reflected in vendor/ and inst/vendor.tar.xz, so
     # `vendor-sync-check` passes and the offline tarball ships the PR's code.
+    # `--source-root` is no longer needed here (kept as CLI flag for back-compat).
     cargo revendor \
       --manifest-path rpkg/src/rust/Cargo.toml \
-      --source-root . \
       --output rpkg/vendor \
       --compress rpkg/inst/vendor.tar.xz \
       --blank-md \


### PR DESCRIPTION
## Summary

- Adds `discover_from_patch_config` in `metadata.rs` — walks the cargo config search path (manifest dir → ancestors → `$HOME/.cargo`), parses every `[patch."<url>"]` table, extracts `path = "..."` entries, and resolves the local crate name + version from the target `Cargo.toml`.
- Integrates into all three run modes (`run_full`, `run_external_only`, `run_local_only`) in `main.rs`. Explicit `--source-root` wins over auto-detected patches (`merge_packages` first-seen rule), so no existing invocations break.
- Drops `--source-root .` from the `just vendor` recipe in `justfile` — the monorepo's `rpkg/src/rust/.cargo/config.toml` `[patch."git+url"]` entries are now discovered automatically.
- Adds `cargo-revendor/tests/patch_from_config.rs` with 4 integration tests covering: basic auto-detection, config in ancestor directory, `--source-root` precedence, and no-config fallback.
- Fixes a pre-existing bug in `run_external_only` where cleanup only removed non-dep workspace members from `vendor/`, leaving local-dep stubs behind.
- Updates `verify.rs` and `verify_freeze_compress.rs` to recognise `.revendor-cache-external` / `.revendor-cache-local` alongside the original `.revendor-cache` byproduct files.
- Fixes pre-existing clippy warnings in `strip.rs` (collapsible nested if-lets, doc list continuation indentation).
- Documents the new auto-detection behaviour in `cargo-revendor/README.md` under a new "Reading `.cargo/config.toml` patch tables" section.

Closes #338. Unblocks #337. Implements Item 1 of `plans/lockfile-mode-unification.md`.

## Test plan

- [ ] `cargo test --manifest-path cargo-revendor/Cargo.toml -- --include-ignored` — all 154 tests pass
- [ ] `cargo clippy --manifest-path cargo-revendor/Cargo.toml --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --manifest-path cargo-revendor/Cargo.toml -- --check` — clean
- [ ] `just vendor` in the monorepo root runs without `--source-root` and picks up workspace siblings correctly (manual smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)