### PR TITLE
feat(rpkg): configure-time Cargo.lock shape drift detection

### DIFF
--- a/justfile
+++ b/justfile
@@ -697,6 +697,7 @@ templates-sources:
     rpkg/Makevars.in	rpkg/src/Makevars.in
     rpkg/Makevars.win	rpkg/src/Makevars.win
     rpkg/stub.c	rpkg/src/stub.c
+    rpkg/tools/lock-shape-check.R	rpkg/tools/lock-shape-check.R
     rpkg/win.def.in	rpkg/src/win.def.in
     # === Monorepo Template (monorepo/) ===
     # The embedded R package uses same sources as rpkg/ template
@@ -712,6 +713,7 @@ templates-sources:
     monorepo/rpkg/Makevars.in	rpkg/src/Makevars.in
     monorepo/rpkg/Makevars.win	rpkg/src/Makevars.win
     monorepo/rpkg/stub.c	rpkg/src/stub.c
+    monorepo/rpkg/tools/lock-shape-check.R	rpkg/tools/lock-shape-check.R
     monorepo/rpkg/win.def.in	rpkg/src/win.def.in
     EOF
 

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -438,7 +438,25 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
  SED="$SED"])
 
-dnl ---- 3) Cargo.lock compatibility ----
+dnl ---- 3) Cargo.lock shape check (tarball mode only) ----
+dnl In tarball mode, the lock must be in tarball-shape: no checksum = lines and
+dnl no path+... sources for framework crates. Drift is fatal at offline install
+dnl time; we catch it here before cargo starts building.
+dnl In source mode, cargo silently rewrites the lock; drift is tolerated.
+AC_CONFIG_COMMANDS([lock-shape-check],
+[
+  if test "$IS_TARBALL_INSTALL" = "true"; then
+    if "${R_HOME}/bin/Rscript" tools/lock-shape-check.R "tarball" "src/rust/Cargo.lock"; then
+      echo "configure: lock-shape OK"
+    else
+      AC_MSG_ERROR([Cargo.lock shape drift detected in tarball mode; see message above])
+    fi
+  fi
+],
+[IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
+ R_HOME="$R_HOME"])
+
+dnl ---- 4) Cargo.lock compatibility ----
 dnl Older cargo releases (<1.78) cannot read lockfile version 4. Regenerate
 dnl in-place if the toolchain on this machine can't read what's committed.
 AC_CONFIG_COMMANDS([cargo-lockfile-compat],
@@ -470,7 +488,7 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
 ],
 [CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED"])
 
-dnl ---- 4) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
+dnl ---- 5) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
 AC_CONFIG_COMMANDS([post-config],
 [
   dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/minirextendr/inst/templates/monorepo/rpkg/tools/lock-shape-check.R
+++ b/minirextendr/inst/templates/monorepo/rpkg/tools/lock-shape-check.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+# tools/lock-shape-check.R
+#
+# Asserts rpkg/src/rust/Cargo.lock is in tarball-shape when running in tarball
+# install mode. Invoked from configure.ac AC_CONFIG_COMMANDS([lock-shape-check]).
+#
+# In source mode, the lock is allowed to drift — cargo silently rewrites it
+# during `cargo build`. The pre-commit hook + lock-shape-check just-recipe
+# protect commits; this script only fires in tarball mode where drift is fatal.
+#
+# Usage: Rscript tools/lock-shape-check.R <mode> <lockfile>
+#   mode     : "tarball" | "source"
+#   lockfile : path to Cargo.lock
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+  message("usage: Rscript tools/lock-shape-check.R <mode> <lockfile>")
+  quit("no", status = 1)
+}
+mode     <- args[[1]]   # "tarball" | "source"
+lockfile <- args[[2]]   # path to Cargo.lock
+
+if (mode != "tarball") quit("no", status = 0)
+if (!file.exists(lockfile)) quit("no", status = 0)
+
+content <- readLines(lockfile, warn = FALSE)
+
+# Check 1: no path+... source entries for framework crates.
+# In tarball mode, framework crates must use git+https://github.com/A2-ai/miniextendr#<sha>
+# so that cargo's source-replacement can match them against the vendored layout.
+path_re <- "^source = \"path\\+"
+path_violations <- grep(path_re, content, value = TRUE)
+if (length(path_violations) > 0) {
+  message("configure: ERROR — Cargo.lock has source = \"path+...\" entries:")
+  for (v in path_violations) message("  ", v)
+  message("")
+  message("This lock is in source-shape, not tarball-shape. Tarball install requires")
+  message("  source = \"git+https://github.com/A2-ai/miniextendr#<sha>\"")
+  message("for miniextendr-{api,lint,macros} so cargo's source replacement matches")
+  message("the vendored layout.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+# Check 2: no checksum = lines.
+# Vendored crates ship with empty .cargo-checksum.json; cargo 1.95+ refuses to
+# verify registry checksums against vendored sources.
+# NOTE: this rule will be re-evaluated when item 2 of
+# plans/lockfile-mode-unification.md lands (cargo-revendor checksum recompute).
+sum_re <- "^checksum = "
+sum_count <- length(grep(sum_re, content))
+if (sum_count > 0) {
+  message(sprintf("configure: ERROR — Cargo.lock has %d checksum = line(s).", sum_count))
+  message("Vendored crates ship with empty .cargo-checksum.json; cargo offline install")
+  message("refuses to verify registry checksums against them.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+quit("no", status = 0)

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -438,7 +438,25 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
  SED="$SED"])
 
-dnl ---- 3) Cargo.lock compatibility ----
+dnl ---- 3) Cargo.lock shape check (tarball mode only) ----
+dnl In tarball mode, the lock must be in tarball-shape: no checksum = lines and
+dnl no path+... sources for framework crates. Drift is fatal at offline install
+dnl time; we catch it here before cargo starts building.
+dnl In source mode, cargo silently rewrites the lock; drift is tolerated.
+AC_CONFIG_COMMANDS([lock-shape-check],
+[
+  if test "$IS_TARBALL_INSTALL" = "true"; then
+    if "${R_HOME}/bin/Rscript" tools/lock-shape-check.R "tarball" "src/rust/Cargo.lock"; then
+      echo "configure: lock-shape OK"
+    else
+      AC_MSG_ERROR([Cargo.lock shape drift detected in tarball mode; see message above])
+    fi
+  fi
+],
+[IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
+ R_HOME="$R_HOME"])
+
+dnl ---- 4) Cargo.lock compatibility ----
 dnl Older cargo releases (<1.78) cannot read lockfile version 4. Regenerate
 dnl in-place if the toolchain on this machine can't read what's committed.
 AC_CONFIG_COMMANDS([cargo-lockfile-compat],
@@ -470,7 +488,7 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
 ],
 [CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED"])
 
-dnl ---- 4) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
+dnl ---- 5) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
 AC_CONFIG_COMMANDS([post-config],
 [
   dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/minirextendr/inst/templates/rpkg/tools/lock-shape-check.R
+++ b/minirextendr/inst/templates/rpkg/tools/lock-shape-check.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+# tools/lock-shape-check.R
+#
+# Asserts rpkg/src/rust/Cargo.lock is in tarball-shape when running in tarball
+# install mode. Invoked from configure.ac AC_CONFIG_COMMANDS([lock-shape-check]).
+#
+# In source mode, the lock is allowed to drift — cargo silently rewrites it
+# during `cargo build`. The pre-commit hook + lock-shape-check just-recipe
+# protect commits; this script only fires in tarball mode where drift is fatal.
+#
+# Usage: Rscript tools/lock-shape-check.R <mode> <lockfile>
+#   mode     : "tarball" | "source"
+#   lockfile : path to Cargo.lock
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+  message("usage: Rscript tools/lock-shape-check.R <mode> <lockfile>")
+  quit("no", status = 1)
+}
+mode     <- args[[1]]   # "tarball" | "source"
+lockfile <- args[[2]]   # path to Cargo.lock
+
+if (mode != "tarball") quit("no", status = 0)
+if (!file.exists(lockfile)) quit("no", status = 0)
+
+content <- readLines(lockfile, warn = FALSE)
+
+# Check 1: no path+... source entries for framework crates.
+# In tarball mode, framework crates must use git+https://github.com/A2-ai/miniextendr#<sha>
+# so that cargo's source-replacement can match them against the vendored layout.
+path_re <- "^source = \"path\\+"
+path_violations <- grep(path_re, content, value = TRUE)
+if (length(path_violations) > 0) {
+  message("configure: ERROR — Cargo.lock has source = \"path+...\" entries:")
+  for (v in path_violations) message("  ", v)
+  message("")
+  message("This lock is in source-shape, not tarball-shape. Tarball install requires")
+  message("  source = \"git+https://github.com/A2-ai/miniextendr#<sha>\"")
+  message("for miniextendr-{api,lint,macros} so cargo's source replacement matches")
+  message("the vendored layout.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+# Check 2: no checksum = lines.
+# Vendored crates ship with empty .cargo-checksum.json; cargo 1.95+ refuses to
+# verify registry checksums against vendored sources.
+# NOTE: this rule will be re-evaluated when item 2 of
+# plans/lockfile-mode-unification.md lands (cargo-revendor checksum recompute).
+sum_re <- "^checksum = "
+sum_count <- length(grep(sum_re, content))
+if (sum_count > 0) {
+  message(sprintf("configure: ERROR — Cargo.lock has %d checksum = line(s).", sum_count))
+  message("Vendored crates ship with empty .cargo-checksum.json; cargo offline install")
+  message("refuses to verify registry checksums against them.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+quit("no", status = 0)

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-04-29 17:09:49
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-29 17:09:49
+--- a/monorepo/rpkg/bootstrap.R	2026-05-06 12:28:51
++++ b/monorepo/rpkg/bootstrap.R	2026-05-06 12:28:51
 @@ -4,7 +4,8 @@
  #
  # Install-mode detection is automatic: if inst/vendor.tar.xz exists
@@ -14,8 +14,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-01 10:58:49
-+++ b/monorepo/rpkg/configure.ac	2026-05-01 10:59:05
+--- a/monorepo/rpkg/configure.ac	2026-05-06 12:30:46
++++ b/monorepo/rpkg/configure.ac	2026-05-06 12:31:14
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -181,14 +181,14 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -427,5 +458,5 @@
+@@ -445,5 +476,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -443,13 +474,22 @@
+@@ -461,13 +492,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -214,8 +214,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-01 10:58:49
-+++ b/rpkg/configure.ac	2026-05-01 10:58:57
+--- a/rpkg/configure.ac	2026-05-06 12:30:46
++++ b/rpkg/configure.ac	2026-05-06 12:31:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -381,14 +381,14 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -427,5 +458,5 @@
+@@ -445,5 +476,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -443,13 +474,22 @@
+@@ -461,13 +492,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2561,6 +2561,9 @@ ac_config_commands="$ac_config_commands unpack-vendor-tarball"
 ac_config_commands="$ac_config_commands cargo-config"
 
 
+ac_config_commands="$ac_config_commands lock-shape-check"
+
+
 ac_config_commands="$ac_config_commands cargo-lockfile-compat"
 
 
@@ -3231,6 +3234,8 @@ IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  VENDOR_OUT_CARGO="$VENDOR_OUT_CARGO"
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
  SED="$SED"
+IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
+ R_HOME="$R_HOME"
 CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED"
 ABS_RPKG_SRC="$abs_rpkg_src" CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG"
 
@@ -3246,6 +3251,7 @@ do
     "src/$PACKAGE_NAME-win.def") CONFIG_FILES="$CONFIG_FILES src/$PACKAGE_NAME-win.def:src/win.def.in" ;;
     "unpack-vendor-tarball") CONFIG_COMMANDS="$CONFIG_COMMANDS unpack-vendor-tarball" ;;
     "cargo-config") CONFIG_COMMANDS="$CONFIG_COMMANDS cargo-config" ;;
+    "lock-shape-check") CONFIG_COMMANDS="$CONFIG_COMMANDS lock-shape-check" ;;
     "cargo-lockfile-compat") CONFIG_COMMANDS="$CONFIG_COMMANDS cargo-lockfile-compat" ;;
     "post-config") CONFIG_COMMANDS="$CONFIG_COMMANDS post-config" ;;
 
@@ -3738,6 +3744,15 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
     echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+  fi
+ ;;
+    "lock-shape-check":C)
+  if test "$IS_TARBALL_INSTALL" = "true"; then
+    if "${R_HOME}/bin/Rscript" tools/lock-shape-check.R "tarball" "src/rust/Cargo.lock"; then
+      echo "configure: lock-shape OK"
+    else
+      as_fn_error $? "Cargo.lock shape drift detected in tarball mode; see message above" "$LINENO" 5
+    fi
   fi
  ;;
     "cargo-lockfile-compat":C)

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -407,7 +407,25 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
  SED="$SED"])
 
-dnl ---- 3) Cargo.lock compatibility ----
+dnl ---- 3) Cargo.lock shape check (tarball mode only) ----
+dnl In tarball mode, the lock must be in tarball-shape: no checksum = lines and
+dnl no path+... sources for framework crates. Drift is fatal at offline install
+dnl time; we catch it here before cargo starts building.
+dnl In source mode, cargo silently rewrites the lock; drift is tolerated.
+AC_CONFIG_COMMANDS([lock-shape-check],
+[
+  if test "$IS_TARBALL_INSTALL" = "true"; then
+    if "${R_HOME}/bin/Rscript" tools/lock-shape-check.R "tarball" "src/rust/Cargo.lock"; then
+      echo "configure: lock-shape OK"
+    else
+      AC_MSG_ERROR([Cargo.lock shape drift detected in tarball mode; see message above])
+    fi
+  fi
+],
+[IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
+ R_HOME="$R_HOME"])
+
+dnl ---- 4) Cargo.lock compatibility ----
 dnl Older cargo releases (<1.78) cannot read lockfile version 4. Regenerate
 dnl in-place if the toolchain on this machine can't read what's committed.
 AC_CONFIG_COMMANDS([cargo-lockfile-compat],
@@ -439,7 +457,7 @@ AC_CONFIG_COMMANDS([cargo-lockfile-compat],
 ],
 [CARGO_CMD="$CARGO_CMD" CARGO_OFFLINE_FLAG="$CARGO_OFFLINE_FLAG" SED="$SED"])
 
-dnl ---- 4) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
+dnl ---- 5) Ensure Cargo.lock exists; touch Cargo.toml to force rebuild ----
 AC_CONFIG_COMMANDS([post-config],
 [
   if test ! -f "src/rust/Cargo.lock"; then

--- a/rpkg/tools/lock-shape-check.R
+++ b/rpkg/tools/lock-shape-check.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+# tools/lock-shape-check.R
+#
+# Asserts rpkg/src/rust/Cargo.lock is in tarball-shape when running in tarball
+# install mode. Invoked from configure.ac AC_CONFIG_COMMANDS([lock-shape-check]).
+#
+# In source mode, the lock is allowed to drift — cargo silently rewrites it
+# during `cargo build`. The pre-commit hook + lock-shape-check just-recipe
+# protect commits; this script only fires in tarball mode where drift is fatal.
+#
+# Usage: Rscript tools/lock-shape-check.R <mode> <lockfile>
+#   mode     : "tarball" | "source"
+#   lockfile : path to Cargo.lock
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+  message("usage: Rscript tools/lock-shape-check.R <mode> <lockfile>")
+  quit("no", status = 1)
+}
+mode     <- args[[1]]   # "tarball" | "source"
+lockfile <- args[[2]]   # path to Cargo.lock
+
+if (mode != "tarball") quit("no", status = 0)
+if (!file.exists(lockfile)) quit("no", status = 0)
+
+content <- readLines(lockfile, warn = FALSE)
+
+# Check 1: no path+... source entries for framework crates.
+# In tarball mode, framework crates must use git+https://github.com/A2-ai/miniextendr#<sha>
+# so that cargo's source-replacement can match them against the vendored layout.
+path_re <- "^source = \"path\\+"
+path_violations <- grep(path_re, content, value = TRUE)
+if (length(path_violations) > 0) {
+  message("configure: ERROR — Cargo.lock has source = \"path+...\" entries:")
+  for (v in path_violations) message("  ", v)
+  message("")
+  message("This lock is in source-shape, not tarball-shape. Tarball install requires")
+  message("  source = \"git+https://github.com/A2-ai/miniextendr#<sha>\"")
+  message("for miniextendr-{api,lint,macros} so cargo's source replacement matches")
+  message("the vendored layout.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+# Check 2: no checksum = lines.
+# Vendored crates ship with empty .cargo-checksum.json; cargo 1.95+ refuses to
+# verify registry checksums against vendored sources.
+# NOTE: this rule will be re-evaluated when item 2 of
+# plans/lockfile-mode-unification.md lands (cargo-revendor checksum recompute).
+sum_re <- "^checksum = "
+sum_count <- length(grep(sum_re, content))
+if (sum_count > 0) {
+  message(sprintf("configure: ERROR — Cargo.lock has %d checksum = line(s).", sum_count))
+  message("Vendored crates ship with empty .cargo-checksum.json; cargo offline install")
+  message("refuses to verify registry checksums against them.")
+  message("")
+  message("Recovery: run `just vendor` (monorepo) or rebuild the package tarball.")
+  quit("no", status = 1)
+}
+
+quit("no", status = 0)


### PR DESCRIPTION
## Summary

Implements item 3 of [`plans/lockfile-mode-unification.md`](plans/lockfile-mode-unification.md).

- Adds `rpkg/tools/lock-shape-check.R`: a self-contained R script (no `minirextendr::*` calls) that validates `src/rust/Cargo.lock` is in tarball-shape when running in tarball install mode.
- Wires the check into `rpkg/configure.ac` as `AC_CONFIG_COMMANDS([lock-shape-check])` placed after the `cargo-config` block. Two violations are caught: `source = "path+..."` entries (framework crates must carry `git+https://...#<sha>` for source replacement) and `checksum = "..."` lines (vendored crates ship empty `.cargo-checksum.json`).
- In source mode the check is skipped entirely — cargo silently rewrites the lock, and the pre-commit hook / `just lock-shape-check` protect commits.
- Mirrors `lock-shape-check.R` and the `AC_CONFIG_COMMANDS` block into both template trees (`minirextendr/inst/templates/rpkg/` and `monorepo/rpkg/`). Adds `tools/lock-shape-check.R` to `templates-sources` in the justfile and regenerates `patches/templates.patch` via `just templates-approve`.
- Regenerates `rpkg/configure` via `autoconf`.

**Note on checksum rule:** The `checksum = "..."` check will be re-evaluated when item 2 of the unification plan (cargo-revendor checksum recompute) lands. At that point `cargo-revendor` will write valid checksums and the committed lock can retain them; this script will be updated to match.

## Test plan

- [x] **Positive (source mode, clean lock):** `cd rpkg && bash ./configure` — succeeds, `lock-shape-check` block runs and exits silently (skipped in source mode).
- [x] **Positive (tarball mode, clean lock):** `touch inst/vendor.tar.xz && bash ./configure` — succeeds, prints `configure: lock-shape OK`.
- [x] **Negative (tarball mode, `path+` entry):** with fake tarball present, appended `source = "path+file:///..."` to lock → configure fails with clear error message pointing at the violation and recovery hint.
- [x] **Negative (source mode, `path+` entry):** same lock edit but no tarball → configure succeeds (rule doesn't apply in source mode).
- [x] `just templates-check` passes.
- [x] `just templates-approve` re-ran and `patches/templates.patch` committed.

**Note on checksum negative test:** The pre-existing `unpack-vendor-tarball` block already strips `checksum = "..."` lines with `sed` before the shape check runs, so the checksum path is currently covered by that existing fix-up rather than by a configure error. The shape check's checksum rule serves as defense-in-depth for any case where a checksum line survives to that point.