### PR TITLE
feat(minirextendr): pre-commit hook blocks source-shape Cargo.lock

### DIFF
--- a/minirextendr/R/git-hooks.R
+++ b/minirextendr/R/git-hooks.R
@@ -13,7 +13,9 @@ miniextendr_hook_marker <- "miniextendr_pre_commit\\(\\)|miniextendr_post_merge\
 #'
 #' - **pre-commit**: Checks `cargo fmt`, blocks on stale `configure` script
 #'   or stale NAMESPACE (when `*-wrappers.R` changed without `devtools::document()`),
-#'   notes when `inst/vendor.tar.xz` may need updating
+#'   blocks on source-shape `src/rust/Cargo.lock` (recommends
+#'   [miniextendr_repair_lock()]), notes when `inst/vendor.tar.xz` may need
+#'   updating
 #' - **post-merge**: Reminds you to reconfigure after pulling changes to
 #'   build files (configure.ac, Makevars.in, Cargo.toml, Rust sources)
 #'

--- a/minirextendr/inst/hooks/pre-commit
+++ b/minirextendr/inst/hooks/pre-commit
@@ -91,6 +91,36 @@ miniextendr_pre_commit() {
         fi
     fi
 
+    # ── Cargo.lock shape ─────────────────────────────────────────────────────
+    # The committed src/rust/Cargo.lock must be in tarball-shape:
+    #   - no `checksum = "..."` lines (vendored crates ship empty
+    #     .cargo-checksum.json; offline install would refuse to verify)
+    #   - no `source = "path+..."` entries for framework crates (cargo's
+    #     source-replacement matches against the lockfile by source URL;
+    #     path+ would not survive shipping the tarball)
+    # See: https://a2-ai.github.io/miniextendr/manual/cargo-lock-shape/
+    STAGED_LOCK=$(echo "$STAGED" | grep -E "^${PREFIX}src/rust/Cargo\.lock$" || true)
+    if [ -n "$STAGED_LOCK" ]; then
+        LOCK_PATH="${RPKG_DIR}/src/rust/Cargo.lock"
+        if [ -f "$LOCK_PATH" ]; then
+            BAD_PATH=$(grep -c '^source = "path+' "$LOCK_PATH" || true)
+            BAD_SUMS=$(grep -c '^checksum = ' "$LOCK_PATH" || true)
+            if [ "${BAD_PATH:-0}" -gt 0 ] || [ "${BAD_SUMS:-0}" -gt 0 ]; then
+                echo "BLOCKED: src/rust/Cargo.lock is in source-shape, not tarball-shape."
+                if [ "${BAD_PATH:-0}" -gt 0 ]; then
+                    echo "  ${BAD_PATH} source = \"path+...\" entries for framework crates."
+                fi
+                if [ "${BAD_SUMS:-0}" -gt 0 ]; then
+                    echo "  ${BAD_SUMS} checksum = \"...\" lines."
+                fi
+                echo ""
+                echo "  Recovery (R):  miniextendr_repair_lock()"
+                echo "  Or full vendor refresh: miniextendr_vendor()"
+                return 1
+            fi
+        fi
+    fi
+
     echo "pre-commit: all miniextendr checks passed."
 }
 

--- a/minirextendr/tests/testthat/test-git-hooks-lock-shape.R
+++ b/minirextendr/tests/testthat/test-git-hooks-lock-shape.R
@@ -12,14 +12,20 @@ run_hook_in_repo <- function(repo, staged) {
     system2("git", c("config", "user.email", "test@example.com"))
     system2("git", c("config", "user.name", "Test"))
     system2("git", c("add", staged), stdout = FALSE, stderr = FALSE)
-    system2("bash", hook_path, stdout = TRUE, stderr = TRUE)
+    # Hook returns non-zero on intentional block; suppress R's warning for
+    # that case so testthat doesn't flag every blocked-commit case.
+    suppressWarnings(system2("bash", hook_path, stdout = TRUE, stderr = TRUE))
   })
 }
 
 # Build a fake R-package layout: DESCRIPTION + src/rust/Cargo.toml +
 # src/rust/Cargo.lock with the requested content.
+# NOTE: must use plain tempfile + dir.create so the dir survives past this
+# helper's frame (withr::local_tempdir defaults scope cleanup here, deleting
+# the dir before the test uses it).
 make_lock_repo <- function(lock_lines) {
-  repo <- withr::local_tempdir(pattern = "lock-shape-hook-")
+  repo <- tempfile("lock-shape-hook-")
+  dir.create(repo)
   writeLines("Package: testpkg\nVersion: 0.1.0\n", file.path(repo, "DESCRIPTION"))
   rust <- file.path(repo, "src", "rust")
   dir.create(rust, recursive = TRUE)
@@ -45,6 +51,7 @@ test_that("pre-commit hook accepts a tarball-shape Cargo.lock", {
     'version = "0.1.0"',
     'source = "git+https://github.com/A2-ai/miniextendr#abc123"'
   ))
+  on.exit(unlink(repo, recursive = TRUE), add = TRUE)
 
   out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
   status <- attr(out, "status")
@@ -63,6 +70,7 @@ test_that("pre-commit hook blocks a path+ source entry", {
     'version = "0.1.0"',
     'source = "path+file:///home/dev/miniextendr/miniextendr-api"'
   ))
+  on.exit(unlink(repo, recursive = TRUE), add = TRUE)
 
   out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
   status <- attr(out, "status")
@@ -85,6 +93,7 @@ test_that("pre-commit hook blocks a checksum line", {
     'source = "registry+https://github.com/rust-lang/crates.io-index"',
     'checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3b3e0b4b63760b6d924afb5"'
   ))
+  on.exit(unlink(repo, recursive = TRUE), add = TRUE)
 
   out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
   status <- attr(out, "status")
@@ -106,6 +115,7 @@ test_that("pre-commit hook does not check Cargo.lock when it is not staged", {
     'version = "0.1.0"',
     'source = "path+file:///home/dev/miniextendr/miniextendr-api"'
   ))
+  on.exit(unlink(repo, recursive = TRUE), add = TRUE)
   # Stage DESCRIPTION instead, leaving Cargo.lock unstaged.
   out <- run_hook_in_repo(repo, "DESCRIPTION")
   status <- attr(out, "status")

--- a/minirextendr/tests/testthat/test-git-hooks-lock-shape.R
+++ b/minirextendr/tests/testthat/test-git-hooks-lock-shape.R
@@ -1,0 +1,114 @@
+# Tests for the Cargo.lock-shape check in inst/hooks/pre-commit.
+
+# Run the bundled pre-commit hook against a fake repo + staged file set.
+# Returns the system2 exit status. The hook reads its staged-file list from
+# `git diff --cached --name-only --diff-filter=ACM`, so we shell out to a
+# real `git` in a tempdir.
+run_hook_in_repo <- function(repo, staged) {
+  hook_path <- system.file("hooks", "pre-commit", package = "minirextendr", mustWork = TRUE)
+  withr::with_dir(repo, {
+    system2("git", c("init", "-q"))
+    # Quiet identity so commits don't fail in CI sandboxes.
+    system2("git", c("config", "user.email", "test@example.com"))
+    system2("git", c("config", "user.name", "Test"))
+    system2("git", c("add", staged), stdout = FALSE, stderr = FALSE)
+    system2("bash", hook_path, stdout = TRUE, stderr = TRUE)
+  })
+}
+
+# Build a fake R-package layout: DESCRIPTION + src/rust/Cargo.toml +
+# src/rust/Cargo.lock with the requested content.
+make_lock_repo <- function(lock_lines) {
+  repo <- withr::local_tempdir(pattern = "lock-shape-hook-")
+  writeLines("Package: testpkg\nVersion: 0.1.0\n", file.path(repo, "DESCRIPTION"))
+  rust <- file.path(repo, "src", "rust")
+  dir.create(rust, recursive = TRUE)
+  writeLines(c(
+    '[package]', 'name = "testpkg"', 'version = "0.1.0"', 'edition = "2021"'
+  ), file.path(rust, "Cargo.toml"))
+  writeLines(lock_lines, file.path(rust, "Cargo.lock"))
+  repo
+}
+
+skip_if_no_git_or_bash <- function() {
+  if (Sys.which("git") == "") testthat::skip("git not available")
+  if (Sys.which("bash") == "") testthat::skip("bash not available")
+}
+
+test_that("pre-commit hook accepts a tarball-shape Cargo.lock", {
+  skip_if_no_git_or_bash()
+  repo <- make_lock_repo(c(
+    'version = 3',
+    '',
+    '[[package]]',
+    'name = "miniextendr-api"',
+    'version = "0.1.0"',
+    'source = "git+https://github.com/A2-ai/miniextendr#abc123"'
+  ))
+
+  out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
+  status <- attr(out, "status")
+  # Hook returns 0 (and prints "all miniextendr checks passed.") on success.
+  expect_true(is.null(status) || status == 0L,
+              info = paste(out, collapse = "\n"))
+})
+
+test_that("pre-commit hook blocks a path+ source entry", {
+  skip_if_no_git_or_bash()
+  repo <- make_lock_repo(c(
+    'version = 3',
+    '',
+    '[[package]]',
+    'name = "miniextendr-api"',
+    'version = "0.1.0"',
+    'source = "path+file:///home/dev/miniextendr/miniextendr-api"'
+  ))
+
+  out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
+  status <- attr(out, "status")
+  expect_true(!is.null(status) && status == 1L,
+              info = paste(out, collapse = "\n"))
+  expect_true(any(grepl("source-shape|path\\+", out)),
+              info = paste(out, collapse = "\n"))
+  expect_true(any(grepl("miniextendr_repair_lock", out)),
+              info = paste(out, collapse = "\n"))
+})
+
+test_that("pre-commit hook blocks a checksum line", {
+  skip_if_no_git_or_bash()
+  repo <- make_lock_repo(c(
+    'version = 3',
+    '',
+    '[[package]]',
+    'name = "libc"',
+    'version = "0.2.150"',
+    'source = "registry+https://github.com/rust-lang/crates.io-index"',
+    'checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3b3e0b4b63760b6d924afb5"'
+  ))
+
+  out <- run_hook_in_repo(repo, "src/rust/Cargo.lock")
+  status <- attr(out, "status")
+  expect_true(!is.null(status) && status == 1L,
+              info = paste(out, collapse = "\n"))
+  expect_true(any(grepl("checksum", out)),
+              info = paste(out, collapse = "\n"))
+})
+
+test_that("pre-commit hook does not check Cargo.lock when it is not staged", {
+  skip_if_no_git_or_bash()
+  # Lock has path+ but is not staged — hook should pass (it inspects only
+  # what's in the diff).
+  repo <- make_lock_repo(c(
+    'version = 3',
+    '',
+    '[[package]]',
+    'name = "miniextendr-api"',
+    'version = "0.1.0"',
+    'source = "path+file:///home/dev/miniextendr/miniextendr-api"'
+  ))
+  # Stage DESCRIPTION instead, leaving Cargo.lock unstaged.
+  out <- run_hook_in_repo(repo, "DESCRIPTION")
+  status <- attr(out, "status")
+  expect_true(is.null(status) || status == 0L,
+              info = paste(out, collapse = "\n"))
+})

--- a/minirextendr/vignettes/getting-started.Rmd
+++ b/minirextendr/vignettes/getting-started.Rmd
@@ -259,6 +259,22 @@ miniextendr_repair_lock()
 Sub-second; lock-only. Use `miniextendr_vendor()` only when you also need a
 fresh `inst/vendor.tar.xz` (i.e., before `R CMD build` for CRAN submission).
 
+### Block source-shape commits with the pre-commit hook
+
+`use_miniextendr_git_hooks()` installs a pre-commit hook that, among
+other checks, blocks any commit staging `src/rust/Cargo.lock` when the
+file has drifted into source-shape (`path+...` source entries or
+`checksum = ` lines). The hook prints the recovery command:
+
+```{r}
+# Run once per checkout
+use_miniextendr_git_hooks()
+```
+
+After installation, if you accidentally `git add src/rust/Cargo.lock`
+after a `devtools::install()` rewrote it, the hook stops the commit and
+points you at `miniextendr_repair_lock()`.
+
 ### Upgrading
 
 ```{r}


### PR DESCRIPTION
## Summary

Implements item 6 of [`plans/lockfile-mode-unification.md`](https://github.com/A2-ai/miniextendr/blob/main/plans/lockfile-mode-unification.md).

Extends the bundled `inst/hooks/pre-commit` (installed via `use_miniextendr_git_hooks()`) with a `src/rust/Cargo.lock` shape check. When the lock is staged and contains:

- `source = "path+..."` entries (framework crates resolved through the dev `[patch."git+url"]` override), or
- `checksum = "..."` lines (registry hashes that won't verify against the empty `.cargo-checksum.json` files vendored crates ship with)

the commit is blocked with the exact counts and a recovery hint pointing at `miniextendr_repair_lock()` (or `miniextendr_vendor()`).

## Why fold into `use_miniextendr_git_hooks()` rather than add `use_miniextendr_lock_hook()`

The plan calls out a separate function. Adding one would duplicate `use_miniextendr_git_hooks()` since the hook fragment now carries the lock-shape check alongside the existing cargo-fmt / configure / NAMESPACE / vendor-tarball checks. Folded in instead, with the docstring updated.

## Tests

`test-git-hooks-lock-shape.R` — 4 cases run the bundled hook script against fake repos via `system2`:

- tarball-shape lock → hook exits 0
- staged `path+` entry → hook exits 1, mentions `miniextendr_repair_lock`
- staged `checksum =` line → hook exits 1, mentions `checksum`
- lock with drift but not staged → hook exits 0 (hook only inspects staged files)

`skip_if_no_git_or_bash()` for sandboxes.

## Related

- Builds on PR #406 (item 5: `miniextendr_repair_lock()`)
- Note: when item 2 lands (cargo-revendor recompute `.cargo-checksum.json`), the checksum-line rule will be relaxed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)