### PR TITLE
chore(rpkg): declare R (>= 4.4) dependency for %||% (#384)

### DIFF
--- a/plans/issue-384-r-44-depends.md
+++ b/plans/issue-384-r-44-depends.md
@@ -1,0 +1,14 @@
+# Issue #384 — declare R (>= 4.4) for `%||%` in generated wrappers
+
+## Fix
+Add `Depends: R (>= 4.4)` to `rpkg/DESCRIPTION`. Convention: place it just after the `Type:` field or between `Title:` and `Authors@R:`, matching how other CRAN packages format it.
+
+## Audit
+Verify generated wrappers still use `%||%` (grep `rpkg/R/miniextendr-wrappers.R`). If `%||%` was removed in some recent refactor, this declaration becomes unnecessary — note it in the PR body.
+
+## Out of scope
+Other downstream packages (`tests/cross-package/*/DESCRIPTION`, `minirextendr/inst/templates/*/DESCRIPTION`) may also need `Depends: R (>= 4.4)`. Check whether they regenerate wrappers using `%||%`; if so, file a follow-up issue (don't expand this PR's scope).
+
+## Acceptance
+- `rpkg/DESCRIPTION` contains `Depends: R (>= 4.4)`.
+- `just r-cmd-build` and `just r-cmd-check` clean (or noted in PR body if not run).

--- a/rpkg/DESCRIPTION
+++ b/rpkg/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: miniextendr
 Title: Rust-R Interoperability Framework
 Version: 0.1.0
+Depends: R (>= 4.4)
 Authors@R:
     c(
         person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", role = c("aut", "cre")),


### PR DESCRIPTION
## Summary

- `rpkg/DESCRIPTION` had no minimum R version declared, but the generated `rpkg/R/miniextendr-wrappers.R` uses `%||%` (introduced in base R 4.4.0).
- Adds `Depends: R (>= 4.4)` after the `Version:` field, following standard CRAN placement convention.

## Plan

See `plans/issue-384-r-44-depends.md` for full audit plan.

## Audit findings

`%||%` is confirmed in use in `rpkg/R/miniextendr-wrappers.R` (line 18: `.call <- .val$call %||% .call_default`). The `Depends` declaration is necessary.

The cross-package test fixtures `tests/cross-package/consumer.pkg/R/consumer.pkg-wrappers.R` and `tests/cross-package/producer.pkg/R/producer.pkg-wrappers.R` also use `%||%` in their generated wrappers, but their `DESCRIPTION` files likewise lack an R minimum version. This is out of scope for this PR — tracked as a follow-up.

No template `DESCRIPTION` files were found under `minirextendr/inst/templates/` (none exist yet).

## Test plan

- [ ] `just r-cmd-build` — not run in this PR (compilation blocked in sandbox); CI will verify
- [ ] `just r-cmd-check` — not run in this PR; CI will verify
- [ ] Confirm `rpkg/DESCRIPTION` contains `Depends: R (>= 4.4)`

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)