### PR TITLE
chore: declare R (>= 4.4) for cross-package DESCRIPTIONs (#411)

### DIFF
--- a/plans/issue-411-cross-package-r44.md
+++ b/plans/issue-411-cross-package-r44.md
@@ -1,0 +1,17 @@
+# Issue #411 — declare R (>= 4.4) for cross-package DESCRIPTIONs
+
+## Fix
+Add `Depends: R (>= 4.4)` to:
+- `tests/cross-package/consumer.pkg/DESCRIPTION`
+- `tests/cross-package/producer.pkg/DESCRIPTION`
+
+Insert between `Version:` and `Authors@R:`, matching the placement used in
+`rpkg/DESCRIPTION` (set by PR #410).
+
+## Verify
+- `grep '%||%' tests/cross-package/{consumer,producer}.pkg/R/*.R` confirms the
+  operator is still in use.
+- `just cross-check` clean (no new NOTEs/WARNINGs).
+
+## Out of scope
+- `minirextendr/inst/templates/` — no DESCRIPTION files yet.

--- a/tests/cross-package/consumer.pkg/DESCRIPTION
+++ b/tests/cross-package/consumer.pkg/DESCRIPTION
@@ -2,6 +2,7 @@ Package: consumer.pkg
 Type: Package
 Title: Cross-Package Trait Dispatch Consumer Example
 Version: 0.1.0
+Depends: R (>= 4.4)
 Authors@R: c(
     person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", role = c("aut", "cre")),
     person("A2-AI", role = c("cph", "fnd"))

--- a/tests/cross-package/producer.pkg/DESCRIPTION
+++ b/tests/cross-package/producer.pkg/DESCRIPTION
@@ -2,6 +2,7 @@ Package: producer.pkg
 Type: Package
 Title: Cross-Package Trait Dispatch Producer Example
 Version: 0.1.0
+Depends: R (>= 4.4)
 Authors@R: c(
     person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", role = c("aut", "cre")),
     person("A2-AI", role = c("cph", "fnd"))


### PR DESCRIPTION
## Summary

- Adds `Depends: R (>= 4.4)` to `tests/cross-package/consumer.pkg/DESCRIPTION`
- Adds `Depends: R (>= 4.4)` to `tests/cross-package/producer.pkg/DESCRIPTION`
- Writes plan file `plans/issue-411-cross-package-r44.md`

Both cross-package fixture packages use `%||%` (null-coalescing operator, available since R 4.4) in their generated wrappers — introduced as a follow-up to PRs #410/#384 — but neither DESCRIPTION declared the minimum R version. This closes the gap, matching the placement already used in `rpkg/DESCRIPTION`.

## Test plan

- [x] `grep '%||%' tests/cross-package/{consumer,producer}.pkg/R/*.R` — confirmed in both wrappers before this change
- [ ] `just cross-check` — requires compilation; skipped in this sandbox environment (compilation blocked). CI will verify.

Closes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)