### PR TITLE
fix(macros): vctrs protocol-method R wrappers accept ... for S3 dispatch (#418)

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl/tests.rs
+++ b/miniextendr-macros/src/miniextendr_impl/tests.rs
@@ -828,13 +828,16 @@ fn vctrs_protocol_method_override() {
 
     // format_currency method should be generated as format.Currency, not format_currency.Currency
     assert!(wrapper.contains("#' @method format Currency"));
-    assert!(wrapper.contains("format.Currency <- function(amounts)"));
+    // Protocol methods get a trailing `...` so `format(x, nsmall = 2)` doesn't error
+    // with "unused argument (nsmall = 2)" when R dispatches to format.Currency.
+    assert!(wrapper.contains("format.Currency <- function(amounts, ...)"));
 
     // Should NOT create a new S3 generic for "format" (it's a base R function)
     assert!(!wrapper.contains("format <- function(x, ...) UseMethod(\"format\")"));
 
-    // symbol static helper should be generated as regular function currency_symbol(amounts)
+    // symbol static helper (non-protocol) should keep fixed formals — no trailing `...`
     assert!(wrapper.contains("currency_symbol <- function(amounts)"));
+    assert!(!wrapper.contains("currency_symbol <- function(amounts, ...)"));
 }
 // endregion
 

--- a/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
@@ -348,7 +348,15 @@ pub fn generate_vctrs_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.extend(method_doc.build());
         }
 
-        lines.push(format!("{} <- function({}) {{", fn_name, ctx.params));
+        // Protocol methods accept `...` so `format(x, nsmall = 2)` and similar
+        // S3 dispatch calls with extra arguments don't error with "unused argument".
+        // The `...` is silently dropped; the underlying Rust function has a fixed signature.
+        let formals = if is_protocol {
+            format!("{}, ...", ctx.params)
+        } else {
+            ctx.params.to_string()
+        };
+        lines.push(format!("{} <- function({}) {{", fn_name, formals));
 
         // Inject r_entry
         if let Some(ref entry) = ctx.method.method_attrs.r_entry {

--- a/plans/issue-418-vctrs-protocol-dotdotdot.md
+++ b/plans/issue-418-vctrs-protocol-dotdotdot.md
@@ -1,0 +1,46 @@
+# Issue #418 — vctrs protocol-method R wrappers should accept `...`
+
+## Decision: Option 3 from the issue (explicit drop)
+
+Generate the protocol-method R wrapper as:
+
+    format.Currency <- function(amounts, ...) {
+      .val <- .Call(C_Currency__format_currency, .call = match.call(), amounts)
+      ...
+    }
+
+Trailing `...` accepts (and discards) extra args, making the method compatible
+with `format(x, nsmall = 2)`-style invocation. The underlying `.Call` ignores
+`...` since the Rust function has a fixed signature.
+
+## Implementation
+
+`miniextendr-macros/src/miniextendr_impl/vctrs_class.rs`, in the static-method
+codegen branch (around line 310-348 added by #414's rectification):
+
+When `is_protocol = true` (the static method is annotated with
+`#[miniextendr(vctrs(<protocol>))]`), append `, ...` to the R formals.
+Only protocol methods get `...` — regular static helpers keep their
+existing fixed-formals shape.
+
+## Tests
+
+- Update the snapshot test `vctrs_protocol_method_override` in
+  `tests.rs` so the assertion is
+  `assert!(wrapper.contains("format.Currency <- function(amounts, ...)"))`.
+- Add a snapshot assertion that a *non*-protocol static helper still emits
+  without `, ...` (`assert!(wrapper.contains("currency_symbol <- function(amounts)"))`).
+
+## Acceptance
+
+- [ ] Existing snapshots updated and `cargo test -p miniextendr-macros` passes.
+- [ ] Generated `format.Currency` has `function(amounts, ...)`.
+- [ ] Non-protocol static helpers unchanged.
+- [ ] `just check && just clippy` clean.
+
+## Out of scope
+
+- Passing `...` *into* the Rust call — Rust has fixed signatures; would require
+  variadic arg support.
+- Other vctrs protocols (cast, ptype2, etc.) — same pattern applies but only
+  `format` is currently exercised; extend if other protocols add fixtures.


### PR DESCRIPTION
## Summary

- Appends `, ...` to the R formals of protocol-method wrappers generated by `#[miniextendr(vctrs(<protocol>))]` on static methods in `#[miniextendr(vctrs(...))] impl` blocks.
- Non-protocol static helpers keep their existing fixed-formals shape (no change).
- `...` is silently dropped — the underlying Rust function has a fixed signature.

## Problem

When `format.Currency <- function(amounts)` is dispatched via `format(x, nsmall = 2)`, R errors with "unused argument (nsmall = 2)". This is a standard S3 dispatch pattern — all format methods must accept `...`.

## Fix

In `vctrs_class.rs`, the static-method codegen now emits:

```r
format.Currency <- function(amounts, ...) {
  .val <- .Call(C_Currency__format_currency, .call = match.call(), amounts)
  ...
}
```

## Tests

- Updated `vctrs_protocol_method_override` assertion: expects `function(amounts, ...)`.
- Added negative assertion: `currency_symbol <- function(amounts, ...)` must NOT appear (non-protocol helpers keep fixed formals).
- All 289 `miniextendr-macros` tests pass.

## Dependency on PR #414

This branch is based on `fix/issue-248-vctrs-self-ctor-rejected` (PR #414), which introduced the `is_protocol` branch for static-method codegen. The commit `650c4338` from PR #414 is the direct parent. When #414 merges to main, this branch should be rebased onto main before merging.

## Test plan

- [x] `cargo test -p miniextendr-macros` — 289 passed.
- [x] `just check` — clean.
- [x] `just clippy` — clean.
- [ ] After #414 merges: rebase onto main, re-run tests, then merge.

Closes #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)