### PR TITLE
fix(configure): remove redundant Cargo.lock checksum strip (closes #427)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -331,18 +331,12 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
     else
       echo "configure: tarball install — vendor/ already populated"
     fi
-    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
-    dnl Vendored sources carry no registry checksums, but Cargo.lock can
-    dnl re-acquire them after a cargo update, a fresh git checkout, or any
-    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
-    dnl verify checksums against a vendored-sources tree, producing errors like:
-    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
-    dnl          is listed in the existing lock file
-    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
-    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-    fi
+    dnl AUDIT-427: checksum strip removed. PR #408 rewrote cargo-revendor to
+    dnl preserve the original `package` field in each .cargo-checksum.json
+    dnl (matching the lockfile's `checksum = "..."` line). Cargo can therefore
+    dnl verify checksums end-to-end; stripping them discards a valid integrity
+    dnl check. See issue #427 and tools/lock-shape-check.R which explicitly
+    dnl documents that checksum lines are allowed in tarball-shape locks.
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -331,18 +331,12 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
     else
       echo "configure: tarball install — vendor/ already populated"
     fi
-    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
-    dnl Vendored sources carry no registry checksums, but Cargo.lock can
-    dnl re-acquire them after a cargo update, a fresh git checkout, or any
-    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
-    dnl verify checksums against a vendored-sources tree, producing errors like:
-    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
-    dnl          is listed in the existing lock file
-    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
-    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-    fi
+    dnl AUDIT-427: checksum strip removed. PR #408 rewrote cargo-revendor to
+    dnl preserve the original `package` field in each .cargo-checksum.json
+    dnl (matching the lockfile's `checksum = "..."` line). Cargo can therefore
+    dnl verify checksums end-to-end; stripping them discards a valid integrity
+    dnl check. See issue #427 and tools/lock-shape-check.R which explicitly
+    dnl documents that checksum lines are allowed in tarball-shape locks.
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-06 12:25:22
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-06 12:25:22
+--- a/monorepo/rpkg/bootstrap.R	2026-05-08 09:09:58
++++ b/monorepo/rpkg/bootstrap.R	2026-05-08 09:09:58
 @@ -4,7 +4,8 @@
  #
  # Install-mode detection is automatic: if inst/vendor.tar.xz exists
@@ -14,8 +14,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-06 14:43:23
-+++ b/monorepo/rpkg/configure.ac	2026-05-06 14:43:23
+--- a/monorepo/rpkg/configure.ac	2026-05-08 09:16:00
++++ b/monorepo/rpkg/configure.ac	2026-05-08 09:36:22
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -181,14 +181,14 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -454,5 +485,5 @@
+@@ -448,5 +479,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -470,13 +501,22 @@
+@@ -464,13 +495,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -214,8 +214,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-06 14:43:23
-+++ b/rpkg/configure.ac	2026-05-06 14:43:23
+--- a/rpkg/configure.ac	2026-05-08 09:16:00
++++ b/rpkg/configure.ac	2026-05-08 09:36:16
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -381,14 +381,14 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -454,5 +485,5 @@
+@@ -448,5 +479,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -470,13 +501,22 @@
+@@ -464,13 +495,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/plans/issue-427-checksum-strip-audit.md
+++ b/plans/issue-427-checksum-strip-audit.md
@@ -1,0 +1,67 @@
++++
+title = "Issue #427 — Audit the Cargo.lock checksum strip in tarball-mode configure"
++++
+
+# Audit the Cargo.lock checksum strip in tarball-mode configure
+
+Closes #427. Three `configure.ac` files strip `checksum = ` lines from
+`Cargo.lock` at tarball-install time. PR #408 rewrote `cargo-revendor` to
+preserve the original `package` hash in each `.cargo-checksum.json` (so
+`Cargo.lock`'s `checksum =` line still matches the vendored copy after
+CRAN-trim). The strip was necessary before #408 because the old behaviour
+wrote `{"files":{}}` (null package), leaving the lockfile with a checksum
+that cargo could not verify — producing the "checksum for X could not be
+calculated" error (see also #426 lockfile-mode-unification and #342 original
+checksum-strip rationale). With #408 in place the three possible outcomes are:
+(1) the strip is now redundant — checksums agree, build succeeds without it;
+(2) retaining checksums actively strengthens integrity — cargo now verifies
+lockfile vs `.cargo-checksum.json` end-to-end and that verification should
+be left intact; (3) the strip is still required — cargo still errors, meaning
+something in the tarball path nullifies the `package` field after #408.
+
+## Work items
+
+1. Run `just configure && just vendor && just r-cmd-build` on origin/main to
+   produce a clean CRAN-trimmed tarball whose vendor/ was created with the
+   post-#408 `cargo-revendor`. Confirm `Cargo.lock` inside the tarball still
+   has `checksum = ` lines (the strip fires in configure, not at vendor time).
+
+2. Unpack the built tarball into a scratch directory, patch its `configure.ac`
+   to skip the sed strip (wrap the `$SED -i.bak …` block in `if false; then
+   … fi`), regenerate `configure` with `autoconf`, then run
+   `R CMD check --as-cran` against the patched tarball. Capture all output.
+   Watch for "checksum for … could not be calculated" or "checksum for …
+   changed between lock files" cargo errors.
+
+3. Decide based on observed output:
+   - **Success, no checksum errors** → outcome (1)/(2): strip is redundant
+     (or actively harmful to integrity, since it discards a valid check).
+     Either way: remove the `$SED` block and its comment from all three
+     `configure.ac` files, regenerate each `configure`, run
+     `just templates-approve`, verify `just templates-check` clean.
+   - **cargo checksum error** → outcome (3): strip is still required.
+     Restore it, extend comment to mention #408 and why the strip persists,
+     update `docs/CARGO_LOCK_SHAPE.md` with the exact cargo error observed,
+     so the next person who tries to remove it has the empirical record.
+
+4. Regardless of outcome: verify `just r-cmd-check` (aliased `rcmdcheck`)
+   passes end-to-end in tarball mode. Commit plan + outcome change together.
+
+## Files to edit (outcome: strip is redundant)
+
+- `rpkg/configure.ac` — remove lines 303–314 (comment block + sed + rm bak)
+- `rpkg/configure` — regenerate via `autoconf` inside `rpkg/`
+- `minirextendr/inst/templates/rpkg/configure.ac` — remove same block (~334–344)
+- `minirextendr/inst/templates/monorepo/rpkg/configure.ac` — remove same block (~334–344)
+- `patches/templates.patch` — regenerate via `just templates-approve`
+
+## Files to edit (outcome: strip still needed)
+
+- `rpkg/configure.ac` — extend comment to explain #408 does not fully fix it
+- `docs/CARGO_LOCK_SHAPE.md` — add empirical error message + explanation
+
+## Acceptance
+
+- `just r-cmd-check` (tarball mode) passes with no cargo checksum errors.
+- `just templates-check` passes (no unexpected template drift).
+- All three `configure.ac` files are in sync (same decision applied everywhere).

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3684,11 +3684,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
     else
       echo "configure: tarball install — vendor/ already populated"
     fi
-                                    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-    fi
-  fi
+                          fi
  ;;
     "cargo-config":C)
   RPKG_CFG="src/rust/.cargo/config.toml"

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -300,18 +300,12 @@ AC_CONFIG_COMMANDS([unpack-vendor-tarball],
     else
       echo "configure: tarball install — vendor/ already populated"
     fi
-    dnl Strip checksum lines from Cargo.lock unconditionally in tarball mode.
-    dnl Vendored sources carry no registry checksums, but Cargo.lock can
-    dnl re-acquire them after a cargo update, a fresh git checkout, or any
-    dnl workspace edit that regenerates the lockfile. Cargo 1.95+ refuses to
-    dnl verify checksums against a vendored-sources tree, producing errors like:
-    dnl   error: checksum for `<crate>` could not be calculated, but a checksum
-    dnl          is listed in the existing lock file
-    dnl The sed invocation is idempotent (no-op when no checksum lines exist).
-    if test -f "$abs_rpkg_src/rust/Cargo.lock"; then
-      $SED -i.bak '/^checksum = /d' "$abs_rpkg_src/rust/Cargo.lock" && \
-        rm -f "$abs_rpkg_src/rust/Cargo.lock.bak"
-    fi
+    dnl AUDIT-427: checksum strip removed. PR #408 rewrote cargo-revendor to
+    dnl preserve the original `package` field in each .cargo-checksum.json
+    dnl (matching the lockfile's `checksum = "..."` line). Cargo can therefore
+    dnl verify checksums end-to-end; stripping them discards a valid integrity
+    dnl check. See issue #427 and tools/lock-shape-check.R which explicitly
+    dnl documents that checksum lines are allowed in tarball-shape locks.
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"


### PR DESCRIPTION
## Summary

- Three `configure.ac` files (rpkg + both minirextendr templates) ran a `sed -i '/^checksum = /d'` against `Cargo.lock` at tarball-install time. PR #408 made this strip redundant by recomputing valid `.cargo-checksum.json` files; this PR removes it.
- `tools/lock-shape-check.R` already documents (post-#408) that `checksum = "..."` lines are allowed in tarball-shape locks. The strip's existing comment block was stale (claimed `cargo 1.95+ refuses to verify checksums against vendored-sources`, no longer true).
- Aligns with CLAUDE.md principle: **\"`configure.ac` never mutates sources\"** — don't rewrite `Cargo.lock` during `./configure`.

## Test plan

- [x] `just r-cmd-check` (full tarball-mode path, R CMD check --as-cran on built tarball): passed, 0 errors. Output: `configure: lock-shape OK`, `checking Rust compilation ... OK`, `Running 'testthat.R' [26s/28s] OK`, no checksum-related cargo errors.
- [x] `just templates-check`: clean.
- [x] `Rscript rpkg/tools/lock-shape-check.R tarball rpkg/src/rust/Cargo.lock`: exit 0.

## Audit decision

Outcome **(1) redundant** per the issue's three-way test:

1. PR #408 `cargo-revendor` preserves the registry `package` field in `.cargo-checksum.json` end-to-end, so cargo verifies lockfile checksums against vendored sources successfully. The strip is now a no-op (when applied to a #408-shaped tarball) and removing it strengthens integrity (cargo verifies what would otherwise be discarded).
2. The pre-#408 cargo error `checksum for X could not be calculated` does not occur with current `cargo-revendor` output.

Plan + decision record committed to `plans/issue-427-checksum-strip-audit.md`.

## Pre-existing items found during audit (not in scope)

- #431 — undocumented `s3_*` condition helpers (R CMD check warns: 'missing documentation entries'). From PR #344.
- #432 — macOS clang 21+: `-Wfixed-enum-extension` unknown warning group in R's `Boolean.h`.
- One R CMD check NOTE: 'possible bashism in configure.ac line 340' — false positive, the cited line is a `dnl` comment containing the literal text `trap ... EXIT`. m4 strips `dnl` lines from output; the bashism check sees the source. Pre-existing, ignorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
