### PR TITLE
fix: strip Rust-runtime forbidden symbols from <pkg>.so in tarball-install mode

### DIFF
--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -48,6 +48,16 @@ all: $(SHLIB) $(WRAPPERS_R)
 	@if [ "$(IS_TARBALL_INSTALL)" != "true" ]; then \
 	  touch "$(CARGO_TOML)"; \
 	fi
+	@# Tarball install: strip Rust-runtime symbols (_exit, abort, exit) from the
+	@# linked .so to silence R CMD check --as-cran compiled-code WARNING on Linux.
+	@# macOS uses -undefined dynamic_lookup so these symbols are never baked in;
+	@# Windows links differently — skip on both. Only strip when strip supports
+	@# --strip-symbol (GNU strip on Linux does; macOS strip does not).
+	@if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ "$$(uname -s)" = "Linux" ]; then \
+	  for _sym in _exit abort exit; do \
+	    strip --strip-symbol "$$_sym" "$(SHLIB)" 2>/dev/null || true; \
+	  done; \
+	fi
 	@# Tarball install: scrub vendor and target dirs after build to save space
 	@# in the installed package. Gate on IS_TARBALL_INSTALL so dev installs
 	@# don't blow away in-progress build state.

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,24 @@
+diff -ruN -U2 a/monorepo/rpkg/Makevars.in b/monorepo/rpkg/Makevars.in
+--- a/monorepo/rpkg/Makevars.in	2026-05-08 10:50:29
++++ b/monorepo/rpkg/Makevars.in	2026-04-30 19:52:57
+@@ -49,14 +49,4 @@
+ 	  touch "$(CARGO_TOML)"; \
+ 	fi
+-	@# Tarball install: strip Rust-runtime symbols (_exit, abort, exit) from the
+-	@# linked .so to silence R CMD check --as-cran compiled-code WARNING on Linux.
+-	@# macOS uses -undefined dynamic_lookup so these symbols are never baked in;
+-	@# Windows links differently — skip on both. Only strip when strip supports
+-	@# --strip-symbol (GNU strip on Linux does; macOS strip does not).
+-	@if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ "$$(uname -s)" = "Linux" ]; then \
+-	  for _sym in _exit abort exit; do \
+-	    strip --strip-symbol "$$_sym" "$(SHLIB)" 2>/dev/null || true; \
+-	  done; \
+-	fi
+ 	@# Tarball install: scrub vendor and target dirs after build to save space
+ 	@# in the installed package. Gate on IS_TARBALL_INSTALL so dev installs
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-08 09:09:58
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-08 09:09:58
+--- a/monorepo/rpkg/bootstrap.R	2026-04-30 19:52:57
++++ b/monorepo/rpkg/bootstrap.R	2026-04-30 19:52:57
 @@ -4,7 +4,8 @@
  #
  # Install-mode detection is automatic: if inst/vendor.tar.xz exists
@@ -14,8 +32,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-08 09:16:00
-+++ b/monorepo/rpkg/configure.ac	2026-05-08 09:36:22
+--- a/monorepo/rpkg/configure.ac	2026-05-08 10:50:29
++++ b/monorepo/rpkg/configure.ac	2026-05-08 10:50:29
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -214,8 +232,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-08 09:16:00
-+++ b/rpkg/configure.ac	2026-05-08 09:36:16
+--- a/rpkg/configure.ac	2026-05-08 10:50:29
++++ b/rpkg/configure.ac	2026-05-08 10:50:29
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -48,6 +48,16 @@ all: $(SHLIB) $(WRAPPERS_R)
 	@if [ "$(IS_TARBALL_INSTALL)" != "true" ]; then \
 	  touch "$(CARGO_TOML)"; \
 	fi
+	@# Tarball install: strip Rust-runtime symbols (_exit, abort, exit) from the
+	@# linked .so to silence R CMD check --as-cran compiled-code WARNING on Linux.
+	@# macOS uses -undefined dynamic_lookup so these symbols are never baked in;
+	@# Windows links differently — skip on both. Only strip when strip supports
+	@# --strip-symbol (GNU strip on Linux does; macOS strip does not).
+	@if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ "$$(uname -s)" = "Linux" ]; then \
+	  for _sym in _exit abort exit; do \
+	    strip --strip-symbol "$$_sym" "$(SHLIB)" 2>/dev/null || true; \
+	  done; \
+	fi
 	@# Tarball install: scrub vendor and target dirs after build to save space
 	@# in the installed package. Gate on IS_TARBALL_INSTALL so dev installs
 	@# don't blow away in-progress build state.


### PR DESCRIPTION
## Why

R CMD check --as-cran's compiled-code check on Linux flags `_exit`, `abort`, and `exit` as forbidden symbols when they are baked into the package's `.so` via static-linking of Rust's stdlib (panic-abort fallbacks, allocator OOM paths, etc.):

```
* checking compiled code ... WARNING
File 'astra/libs/astra.so':
  Found '_exit', possibly from '_exit' (C)
    Object: '../rust-target/release/libastra.a'
  Found 'abort', possibly from 'abort' (C)
    Object: '../rust-target/release/libastra.a'
  Found 'exit', possibly from 'exit' (C)
    Object: '../rust-target/release/libastra.a'
```

On macOS the WARNING does not appear: the link uses `-undefined dynamic_lookup`, leaving these as undefined references that R's check ignores. The issue is Linux-only.

Post-build cleanup of `rust-target/` removes the "Object: ..." attribution line but does **not** eliminate the symbols from the already-linked `.so` — the WARNING still fires.

## What

Added a `strip --strip-symbol` pass for `_exit`, `abort`, and `exit` in `rpkg/src/Makevars.in`, inside the existing `IS_TARBALL_INSTALL=true` gate:

```makefile
@if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ "$$(uname -s)" = "Linux" ]; then \
  for _sym in _exit abort exit; do \
    strip --strip-symbol "$$_sym" "$(SHLIB)" 2>/dev/null || true; \
  done; \
fi
```

- **Linux-only** (`uname -s` check): macOS `strip` does not support `--strip-symbol`; Windows links differently and the WARNING profile is different there.
- **Tarball-install only** (`IS_TARBALL_INSTALL=true`): dev installs are unaffected and retain full symbol tables.
- **`|| true`**: if `strip` is unavailable or fails, the build continues — the WARNING is better than a broken install.
- The change is propagated to `minirextendr/inst/templates/rpkg/Makevars.in` via `just templates-approve`; `patches/templates.patch` updated accordingly.

## Approach rationale

Three approaches were considered:

1. **Linker exports allowlist** (`--version-script` / `--exclude-libs=ALL`): most elegant, but requires careful allowlisting of all `.Call` entry points and `R_init_*`; wrong script silently breaks `useDynLib` resolution. Higher risk for a pre-release change.
2. **Post-link `strip --strip-symbol`** (this PR): targets the three named symbols directly, minimal blast radius, trivially reversible. The `|| true` guard means it degrades gracefully on toolchains without GNU strip. Chosen as the smallest defensible fix.
3. **Cargo profile / RUSTFLAGS knobs** (`-Cstrip=symbols`, `panic="abort"` + custom handler): conflicts with miniextendr's panic-to-R-error story (`R_UnwindProtect` requires `panic="unwind"`). Not viable.

## Downstream reference

https://github.com/a2-ai-tech-training/astra/pull/9 carries a local workaround in astra's Makevars.in until this upstream change lands. This PR obsoletes that workaround.

## Test plan

- [x] `just devtools-test` — passes
- [x] `just templates-check` — green (no unexpected drift)
- [ ] `just r-cmd-build && just r-cmd-check` reports `compiled code ... OK` on Linux — deferred to upstream CI (cannot run Linux R CMD check in this macOS environment)