### PR TITLE
ci: include workspace crate sources in vendor cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: rpkg/inst/vendor.tar.xz
-          key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'miniextendr-*/src/**', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml', 'rpkg/src/rust/**/*.rs') }}
 
       - name: Install cargo-revendor
         run: cargo install --path cargo-revendor
@@ -1003,7 +1003,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: rpkg/inst/vendor.tar.xz
-          key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'miniextendr-*/src/**', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml', 'rpkg/src/rust/**/*.rs') }}
 
       - name: Install cargo-revendor
         run: cargo install --path cargo-revendor


### PR DESCRIPTION
## Problem

CI vendor cache key (`hashFiles('Cargo.lock', '**/Cargo.toml', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml')`) doesn't include workspace crate `.rs` source. PRs that modify *only* crate source hit a stale cached `inst/vendor.tar.xz` produced from older source. The new code is silently discarded; the build compiles against vendor's old version; CI fails with errors that no longer match the PR's HEAD.

## Concrete example: PR #378

PR #378 added `noexport` / `internal` arms to `MethodAttrs` parsing in `miniextendr-macros/src/miniextendr_impl.rs:1695`. CI emitted the *pre-change* "unknown attribute; expected one of: env, r6, ... r_on_exit" error message — `noexport, internal` missing — because the vendored `miniextendr-macros` was a cached pre-PR version. The PR's source on `ffeb4d2` was correct; the build never saw it.

Symptoms in the install log:
- `configure: install mode = tarball install (offline, vendored)` on the *first* configure (cache restored stale tarball before `just vendor` ran)
- `cargo-revendor: Local packages to vendor: 0` (`.cargo/config.toml` was tarball-mode, so `[patch."git+url"]` redirection to local sibling crates wasn't applied)

## Fix

Extend `hashFiles` to also hash workspace crate sources:

```yaml
hashFiles(
  'Cargo.lock', '**/Cargo.toml',
  'miniextendr-*/src/**',
  'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml',
  'rpkg/src/rust/**/*.rs'
)
```

Applied to both cache-restoration sites (Linux R CMD check at line 394, Windows R CMD check at line 1006 — both keyed identically before this change).

## Test plan

- [x] CI runs on this PR (the cache key for this branch will be a fresh hash; it should rebuild vendor cleanly)
- [ ] After merge, rebase PR #378 onto main → CI re-runs → `MethodAttrs` parser hits the new arms → green
- [ ] Future workspace-only PRs no longer hit silent-stale-cache failures

## Why not drop the cache

Vendor regeneration takes ~50s. With ~3 R-version matrix jobs, that's 2.5 min/PR. Caching is worth keeping; the bug is the under-narrow key, not caching itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
