### PR TITLE
fix(macros): @prop should not duplicate constructor formals (re-open of #377)

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -395,7 +395,26 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
         // @prop tags for impl-block S7 properties (getter/setter pairs).
         // These appear in the class-level @rdname page via roxygen2's @prop tag.
+        //
+        // Properties that ARE constructor formals are already documented above via
+        // @param and must NOT also receive @prop — roxygen2 8.0.0 treats @param /
+        // @prop as disjoint sets (constructor formals → @param; getter/setter-only
+        // props → @prop). Collect the constructor-formal names and skip them here.
+        let constructor_param_names: std::collections::HashSet<String> =
+            if let Some(ctx) = parsed_impl.constructor_context() {
+                ctx.params
+                    .split(", ")
+                    .filter(|p| !p.is_empty())
+                    .map(|p| p.split('=').next().unwrap_or(p).trim().to_string())
+                    .filter(|n| n != ".ptr" && n != "...")
+                    .collect()
+            } else {
+                std::collections::HashSet::new()
+            };
         for prop in properties.values() {
+            if constructor_param_names.contains(&prop.name) {
+                continue; // already documented as @param above
+            }
             let doc = prop.doc.as_deref().unwrap_or("(undocumented property)");
             lines.push(format!("#' @prop {} {}", prop.name, doc));
         }

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_prop_tags_with_defaults_and_varargs.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_prop_tags_with_defaults_and_varargs.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/miniextendr_impl/tests.rs
+assertion_line: 1963
 expression: generate_s7_r_wrapper(&parsed)
 ---
 #' @title WithDefaults S7 Class
@@ -12,7 +13,6 @@ expression: generate_s7_r_wrapper(&parsed)
 #' @param scale (undocumented)
 #' @param mode (undocumented)
 #' @param .ptr Internal pointer (used by static methods, not for direct use).
-#' @prop name (undocumented property)
 WithDefaults <- S7::new_class("WithDefaults",
   properties = list(
     .ptr = S7::class_any,


### PR DESCRIPTION
## Summary

Re-opens [PR #377](https://github.com/A2-ai/miniextendr/pull/377) (CGMossa) on a branch I own, since pushing the rebased version to the original `worktree-agent-*` branch was gated.

Single-commit rebase of CGMossa's `0d9be60` onto current main. Trivial conflict in `snapshot_s3_basic.snap` (only `assertion_line:` metadata; expression identical) was resolved with `--ours` (HEAD/main side).

## What this PR does

After PR #421 added `#' @prop` emission for S7 properties in the impl-block path, properties that are *also* constructor formals were being documented twice — once via `#' @param` (from the constructor) and again via `#' @prop`. roxygen2 8.0.0 treats `@param` and `@prop` as disjoint sets (constructor formals → `@param`; getter/setter-only properties → `@prop`), so the duplication broke rendered docs.

Fix: collect constructor-formal names into a `HashSet` and skip them in the `@prop` emission loop. Snapshot reflects the dedup.

```rust
let constructor_param_names: std::collections::HashSet<String> =
    if let Some(ctx) = parsed_impl.constructor_context() {
        ctx.params.split(", ")
            .filter(|p| !p.is_empty())
            .map(|p| p.split('=').next().unwrap_or(p).trim().to_string())
            .filter(|n| n != ".ptr" && n != "...")
            .collect()
    } else {
        std::collections::HashSet::new()
    };
for prop in properties.values() {
    if constructor_param_names.contains(&prop.name) {
        continue; // already documented as @param above
    }
    let doc = prop.doc.as_deref().unwrap_or("(undocumented property)");
    lines.push(format!("#' @prop {} {}", prop.name, doc));
}
```

## Authorship

Original work by **@CGMossa** (commit `0d9be60` on `worktree-agent-a3110054a5feef202`). Closing the original #377 in favour of this branch is fine; if @CGMossa prefers I'd happily transfer the rebased branch back. Co-authored attribution preserved.

## Test plan

- [x] Trivial `assertion_line:` snapshot conflict resolved (HEAD wins)
- [x] Diff vs main is exactly the parser change + the snapshot `@prop name` line removed
- [ ] CI green (after #444's vendor-cache-key fix lands, no chance of stale-cache regression)

## Context

Part of the roxygen2 8.0.0 sweep tracked under #422 / #375. Companion PRs: #442 (rv pin) merged, #444 (CI cache fix) in flight, #378 (R6 `@field NULL`) blocked on #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
