### PR TITLE
feat(macros): R6 active-binding noexport/internal opt-out (phase 1 of #378)

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -651,6 +651,14 @@ pub struct MethodAttrs {
     /// Short form: `#[miniextendr(r_on_exit = "close(con)")]`
     /// Long form: `#[miniextendr(r_on_exit(expr = "close(con)", add = false))]`
     pub r_on_exit: Option<crate::miniextendr_fn::ROnExit>,
+    /// Mark this method as internal: adds `@keywords internal`, suppresses export.
+    ///
+    /// For R6 active bindings this emits `#' @field name NULL` (roxygen2 8.0.0 opt-out).
+    pub internal: bool,
+    /// Suppress export for this method without adding `@keywords internal`.
+    ///
+    /// For R6 active bindings this emits `#' @field name NULL` (roxygen2 8.0.0 opt-out).
+    pub noexport: bool,
 }
 
 /// Fully parsed `#[miniextendr]` impl block, ready for code generation.
@@ -1684,9 +1692,13 @@ impl ParsedMethod {
                         })?;
                         method_attrs.r_on_exit = Some(crate::miniextendr_fn::ROnExit { expr, add, after });
                     }
+                } else if meta.path.is_ident("noexport") {
+                    method_attrs.noexport = true;
+                } else if meta.path.is_ident("internal") {
+                    method_attrs.internal = true;
                 } else {
                     return Err(meta.error(
-                        "unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit"
+                        "unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit, noexport, internal"
                     ));
                 }
                 Ok(())
@@ -1715,6 +1727,23 @@ impl ParsedMethod {
             ));
         }
         method_attrs.error_in_r = resolved_error_in_r;
+
+        // Method-level `internal` / `noexport` are currently only honoured by the R6
+        // active-binding doc path (emits `#' @field <name> NULL`, the roxygen2 8.0.0
+        // opt-out). Accepting them silently elsewhere would be a no-op surface: regular
+        // instance methods, static methods, and trait methods don't currently consume
+        // these flags. Reject them at parse time so the failure is loud rather than silent.
+        // Class-level `#[miniextendr(internal)]` / `noexport` continue to work for whole
+        // impl blocks via `parsed_impl.internal` / `parsed_impl.noexport`.
+        if (method_attrs.internal || method_attrs.noexport) && !method_attrs.r6.active {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "method-level `internal` / `noexport` are currently only supported on R6 \
+                 active bindings (use `#[miniextendr(r6(active), noexport)]`). For other \
+                 method positions, set `internal` / `noexport` at the impl-block level \
+                 (`#[miniextendr(s7, internal)] impl Foo { ... }`) instead.",
+            ));
+        }
 
         Ok(method_attrs)
     }

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -416,28 +416,35 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             // Add inline @field documentation for active bindings
             // roxygen2 requires @field tags (not @description) for active bindings
             let method_name = ctx.method.r_method_name();
-            if ctx.method.doc_tags.is_empty() {
+            let method_noexport =
+                ctx.method.method_attrs.noexport || ctx.method.method_attrs.internal;
+            if method_noexport {
+                // roxygen2 8.0.0 opt-out: `@field name NULL` suppresses documentation
+                // for fields and active bindings without excluding the binding itself.
+                lines.push(format!("    #' @field {} NULL", method_name));
+            } else if ctx.method.doc_tags.is_empty() {
                 lines.push(format!("    #' @field {} Active binding.", method_name));
-            }
-            for tag in &ctx.method.doc_tags {
-                for (line_idx, line) in tag.lines().enumerate() {
-                    // Convert @description/@title to @field on first line only
-                    let line = if line_idx == 0 {
-                        if let Some(desc) = line.strip_prefix("@description ") {
-                            format!("@field {} {}", method_name, desc)
-                        } else if let Some(desc) = line.strip_prefix("@title ") {
-                            format!("@field {} {}", method_name, desc)
-                        } else if !line.starts_with('@') {
-                            // Plain doc comment - treat as field description
-                            format!("@field {} {}", method_name, line)
+            } else {
+                for tag in &ctx.method.doc_tags {
+                    for (line_idx, line) in tag.lines().enumerate() {
+                        // Convert @description/@title to @field on first line only
+                        let line = if line_idx == 0 {
+                            if let Some(desc) = line.strip_prefix("@description ") {
+                                format!("@field {} {}", method_name, desc)
+                            } else if let Some(desc) = line.strip_prefix("@title ") {
+                                format!("@field {} {}", method_name, desc)
+                            } else if !line.starts_with('@') {
+                                // Plain doc comment - treat as field description
+                                format!("@field {} {}", method_name, line)
+                            } else {
+                                line.to_string()
+                            }
                         } else {
+                            // Continuation lines stay as-is
                             line.to_string()
-                        }
-                    } else {
-                        // Continuation lines stay as-is
-                        line.to_string()
-                    };
-                    lines.push(format!("    #' {}", line));
+                        };
+                        lines.push(format!("    #' {}", line));
+                    }
                 }
             }
 

--- a/miniextendr-macros/src/miniextendr_impl/tests.rs
+++ b/miniextendr-macros/src/miniextendr_impl/tests.rs
@@ -294,6 +294,74 @@ fn r6_wrapper_defaults_unchanged() {
     assert!(!wrapper.contains("inherit ="));
     assert!(!wrapper.contains("portable = FALSE"));
 }
+
+#[test]
+fn r6_active_binding_noexport_emits_field_null() {
+    // roxygen2 8.0.0: `@field name NULL` suppresses documentation for active bindings
+    // tagged with `#[miniextendr(noexport)]`.
+    let item_impl: syn::ItemImpl = syn::parse_quote! {
+        impl Sensor {
+            pub fn new(v: f64, r: i32) -> Self { unimplemented!() }
+            #[miniextendr(r6(active))]
+            pub fn value(&self) -> f64 { unimplemented!() }
+            #[miniextendr(r6(active), noexport)]
+            pub fn raw_bytes(&self) -> i32 { unimplemented!() }
+        }
+    };
+
+    let parsed = parse_impl(ClassSystem::R6, item_impl);
+    let wrapper = generate_r6_r_wrapper(&parsed);
+
+    // Exported active binding: normal `@field name <description>` form.
+    // (Default text when no doc comment provided is "Active binding.")
+    assert!(
+        wrapper.contains("#' @field value Active binding."),
+        "exported active binding must have '@field value Active binding.'\n{}",
+        wrapper
+    );
+
+    // Noexported active binding: roxygen2 8.0.0 opt-out form.
+    assert!(
+        wrapper.contains("#' @field raw_bytes NULL"),
+        "noexported active binding must emit '@field raw_bytes NULL'\n{}",
+        wrapper
+    );
+
+    // Must NOT emit "Active binding." for the noexported binding.
+    assert!(
+        !wrapper.contains("#' @field raw_bytes Active binding."),
+        "noexported active binding must not have regular description\n{}",
+        wrapper
+    );
+}
+
+#[test]
+fn r6_active_binding_internal_emits_field_null() {
+    // `#[miniextendr(internal)]` on an active binding also emits `@field name NULL`.
+    let item_impl: syn::ItemImpl = syn::parse_quote! {
+        impl Device {
+            pub fn new() -> Self { unimplemented!() }
+            #[miniextendr(r6(active))]
+            pub fn status(&self) -> i32 { unimplemented!() }
+            #[miniextendr(r6(active), internal)]
+            pub fn debug_ptr(&self) -> i32 { unimplemented!() }
+        }
+    };
+
+    let parsed = parse_impl(ClassSystem::R6, item_impl);
+    let wrapper = generate_r6_r_wrapper(&parsed);
+
+    assert!(
+        wrapper.contains("#' @field debug_ptr NULL"),
+        "internal active binding must emit '@field debug_ptr NULL'\n{}",
+        wrapper
+    );
+    assert!(
+        !wrapper.contains("#' @field debug_ptr Active binding."),
+        "internal active binding must not have regular description\n{}",
+        wrapper
+    );
+}
 // endregion
 
 // region: S3 class system tests

--- a/miniextendr-macros/tests/ui/impl_method_unknown_option.stderr
+++ b/miniextendr-macros/tests/ui/impl_method_unknown_option.stderr
@@ -1,4 +1,4 @@
-error: unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit
+error: unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit, noexport, internal
   --> tests/ui/impl_method_unknown_option.rs:13:19
    |
 13 |     #[miniextendr(bogus_option)]

--- a/miniextendr-macros/tests/ui/impl_method_unknown_top_level_attr.stderr
+++ b/miniextendr-macros/tests/ui/impl_method_unknown_top_level_attr.stderr
@@ -1,4 +1,4 @@
-error: unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit
+error: unknown attribute; expected one of: env, r6, s3, s4, s7, vctrs, defaults, unsafe, check_interrupt, coerce, no_coerce, rng, unwrap_in_r, error_in_r, no_error_in_r, as, lifecycle, r_name, r_entry, r_post_checks, r_on_exit, noexport, internal
  --> tests/ui/impl_method_unknown_top_level_attr.rs:7:19
   |
 7 |     #[miniextendr(typo_option)]


### PR DESCRIPTION
Phase 1 of splitting #378.

## Why split

PR #378 simultaneously added (a) parser arms in `miniextendr-macros` and (b) an rpkg fixture using them. CI's `bootstrap.R` runs in the build-staging dir (just `rpkg/`, no workspace), and cargo-revendor fetches `miniextendr-macros` from **upstream main** — which didn't yet have the new arms. Chicken-and-egg: the fixture failed to compile in every CI run, regardless of rebases or sccache state.

This PR lands the macros change in isolation so the rpkg fixture (phase 2) can succeed.

## What's in this PR

- `miniextendr-macros/src/miniextendr_impl.rs`: parse `noexport` / `internal` on per-method `#[miniextendr(...)]`. Restrict to R6 active bindings (`r6(active)`) — other method positions error loudly rather than silently no-op. Class-level `internal` / `noexport` unaffected.
- `miniextendr-macros/src/miniextendr_impl/r6_class.rs`: when an active binding has `noexport` or `internal`, emit `#' @field <name> NULL` (the roxygen2 8.0.0 opt-out) instead of the normal description.
- `miniextendr-macros/src/miniextendr_impl/tests.rs`: self-contained unit test asserting both branches.
- `tests/ui/impl_method_unknown_option.stderr` + `tests/ui/impl_method_unknown_top_level_attr.stderr`: error-message expectations updated to list the new options.

No rpkg/ changes — those land in phase 2.

## Test plan

- [x] `cargo test -p miniextendr-macros` — 308 passed, 66 ignored
- [x] `cargo clippy -p miniextendr-macros --all-targets -- -D warnings` — clean
- [ ] CI

## Follow-up

Phase 2 will refresh #378 to contain only the rpkg-side artefacts (`r6_noexport_field_tests.rs`, R6SensorReading fixture, testthat coverage, Rd, NAMESPACE). It will compile cleanly once this PR is merged because main's macros will know `noexport` / `internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
