### PR TITLE
docs: add OpenMP runtime-loading guide; refresh manual pages

### DIFF
--- a/docs/LINKING.md
+++ b/docs/LINKING.md
@@ -157,5 +157,6 @@ miniextendr always links dynamically to `libR`:
 
 ## See Also
 
+- [OPENMP.md](OPENMP.md)
 - [R Installation and Administration](https://cran.r-project.org/doc/manuals/r-release/R-admin.html)
 - [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front_002dends-to-R)

--- a/docs/OPENMP.md
+++ b/docs/OPENMP.md
@@ -1,0 +1,257 @@
+# OpenMP Runtime Loading
+
+This document explains why packages that use OpenMP can install or load on
+Linux but fail on macOS, and what to check in a miniextendr-backed R package.
+
+## The Short Version
+
+OpenMP is not only a compile-time feature. Code compiled with OpenMP often
+needs a runtime library such as `libomp`, `libgomp`, or a vendor-specific
+equivalent when the final package shared object is loaded by R.
+
+For R packages, the dependency has to be attached to the final package shared
+object loaded by `dyn.load()`. It is not enough for an intermediate Rust crate,
+C object, or C++ object to have been compiled with an OpenMP flag.
+
+macOS exposes missing runtime linkage more often because Apple `clang` does not
+ship native OpenMP support. OpenMP usually comes from a separate `libomp.dylib`,
+and the dynamic loader has to find a version of that dylib compatible with the
+compiler used to build the package.
+
+## Rust Perspective
+
+Pure Rust code does not use OpenMP. Rust has no `#pragma omp` directive, no
+`-fopenmp` flag, and no implicit dependency on `libomp` or `libgomp`. A
+miniextendr package whose Rust dependencies are all pure Rust will not link
+against an OpenMP runtime and is unaffected by this document.
+
+OpenMP enters a miniextendr package through native code compiled by a Rust
+crate's `build.rs` — typically a `*-sys` crate wrapping a C, C++, or Fortran
+library that itself uses OpenMP. Common arrival paths:
+
+- BLAS/LAPACK backends (`openblas-src` with the `system` feature,
+  `intel-mkl-src`, `accelerate-src` on macOS) brought in by linear-algebra
+  crates such as `ndarray-linalg`, `nalgebra` with a BLAS backend, `faer`, or
+  `polars` with a BLAS feature.
+- C++ ML runtimes wrapped via `-sys` crates (ONNX Runtime, Torch via
+  `tch-rs`, certain `xgboost` / `lightgbm` bindings).
+- Image, audio, and numerical libraries with parallel C/C++ kernels gated
+  behind a Cargo feature flag.
+
+`rayon`, `std::thread`, `tokio`, and `crossbeam` are not OpenMP — they are
+pure-Rust parallelism. A package that uses only Rayon needs no
+`SHLIB_OPENMP_*FLAGS` plumbing in `Makevars`.
+
+### What Cargo Does Not Do
+
+Cargo build scripts that compile C, C++, or Fortran via the `cc` crate run
+with the host compiler's defaults. They do not read R's `SHLIB_OPENMP_CFLAGS`
+/ `SHLIB_OPENMP_CXXFLAGS` / `SHLIB_OPENMP_FFLAGS` macros, and they do not know
+that the final shared object will be loaded by R. The consequences:
+
+1. Native source compiled inside the crate may or may not have been built
+   with an OpenMP flag — that depends on the crate's own `build.rs`,
+   environment variables, and feature flags, not on R.
+2. The Rust `staticlib` artifact handed to `R CMD INSTALL` may carry
+   unresolved OpenMP symbols (`omp_get_thread_num`, `__kmpc_fork_call`,
+   `GOMP_parallel`, …).
+3. R's link line — driven by `rpkg/src/Makevars` / `Makevars.in` — is the
+   only place those symbols can be resolved into the final `pkg.so`. If
+   `PKG_LIBS` does not include `$(SHLIB_OPENMP_CFLAGS)` (or the matching
+   CXX/FFLAGS macro), the link succeeds on Linux because lazy binding masks
+   the missing reference, and fails at `dyn.load()` time on macOS.
+
+### Linking Through R, With `openmp-sys` Doing the Compile Half
+
+The split for miniextendr packages: the OpenMP **compile flag** (the
+`-fopenmp` / `/openmp` passed to `cc::Build` in a Rust crate's
+`build.rs`) comes from
+[`openmp-sys`](https://lib.rs/crates/openmp-sys) (source:
+<https://gitlab.com/kornelski/openmp-rs>); the OpenMP **runtime
+library** (`libomp.dylib`, `libgomp.so`, `vcomp.dll`) is linked into
+the final `pkg.so` by R's `SHLIB_OPENMP_*FLAGS` on the
+`R CMD INSTALL` line. Cargo and R cooperate at different layers — they
+do not race to discover the runtime independently.
+
+What `openmp-sys` does on the Rust side:
+
+- Searches `cc -print-search-dirs`, Homebrew, MacPorts, and MSVC's
+  `vcomp.dll` for an OpenMP install at build time.
+- Exposes `DEP_OPENMP_FLAG` so a downstream crate's `build.rs` can
+  call `cc::Build::new().flag(env!("DEP_OPENMP_FLAG")).compile(...)`
+  and have its C/C++ sources compile with the right OpenMP pragma
+  enabled.
+- Emits `cargo:rustc-link-lib=dylib=gomp` / `omp` so a standalone
+  binary built from those crates would link a runtime.
+
+For a miniextendr package, the third item is what would otherwise
+collide with R. The trick is: that `cargo:rustc-link-lib` directive
+travels into the Rust staticlib's metadata and surfaces on R's link
+line, *and* R independently adds `$(SHLIB_OPENMP_CFLAGS)`. As long as
+both name the same runtime — i.e., the OpenMP `openmp-sys` discovered
+matches the one R was built against — the two link directives collapse
+to a single recorded dependency in `pkg.so` and the package loads
+cleanly.
+
+The practical rules:
+
+1. **Prefer pure-Rust parallelism** when the choice is yours.
+   `rayon`, `std::thread`, `tokio`, `crossbeam` need no `Makevars`
+   plumbing and dodge this entire document.
+2. **When you do need OpenMP-using C/C++ compiled inside a Rust
+   crate**, depend on `openmp-sys`, use its `DEP_OPENMP_FLAG` in
+   `cc::Build`, and on the R side declare the runtime via
+   `PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)` (or `CXXFLAGS` / `FFLAGS`
+   matching the underlying language) in `rpkg/src/Makevars.in`. The
+   rule R-Extensions states for plain C/C++ packages applies unchanged.
+3. **Make sure the two halves agree on which runtime is in use.** On
+   macOS the typical hazard is `openmp-sys` finding Homebrew's
+   `libomp.dylib` while R's `clang` was configured against a different
+   `libomp` (system, Apple-supplied, or a CRAN binary build's vendored
+   one). Set `LIBRARY_PATH` / `CFLAGS` for `openmp-sys` discovery, or
+   point R at the same toolchain via `~/.R/Makevars`, so that one
+   runtime is visible to both.
+4. **Do not hand-roll** `cargo:rustc-link-lib=dylib=omp` (or `gomp`)
+   in a miniextendr-package `build.rs`. `openmp-sys` already does this
+   correctly per platform; replicating it is how runtimes start
+   disagreeing.
+5. **On macOS, verify after install.** Run `otool -L src/pkg.so` and
+   confirm exactly one OpenMP runtime is recorded, with a path the
+   loader can resolve. Two entries (e.g., `@rpath/libomp.dylib` from
+   Cargo and `/usr/local/opt/libomp/lib/libomp.dylib` from R) is the
+   canary for the runtimes having drifted apart.
+6. **If R's `SHLIB_OPENMP_*` macro is empty or wrong**, the user's R
+   install is the problem — fix the R install, or add a
+   `SystemRequirements:` entry pointing at the OpenMP runtime, rather
+   than papering over it from the package's `build.rs`.
+
+## Why It Looks macOS-Specific
+
+The bug is portable; the masking behavior is not.
+
+On Linux with GCC, `-fopenmp` typically selects `libgomp`, and the ELF dynamic
+linker often tolerates unresolved or already-satisfied symbols in ways that make
+a missing package-level OpenMP link flag appear harmless. If another library has
+already loaded the OpenMP runtime into the R process, the package may load by
+accident.
+
+On macOS, package code is loaded as a Mach-O bundle by `dyn.load()`. If the
+bundle references OpenMP symbols but does not record a loadable dependency on
+the right runtime, loading fails immediately. The common symptom is an error
+mentioning `libomp.dylib`, `@rpath/libomp.dylib`, or an unresolved `omp_*` /
+`__kmpc_*` symbol.
+
+Windows can have the same class of problem, but it usually appears as a missing
+DLL or as a toolchain mismatch rather than as a `libomp.dylib` error.
+
+## The Rule for R Package Makevars
+
+If package C or C++ code is compiled with an OpenMP macro, the matching macro
+must also be present in `PKG_LIBS`:
+
+```makefile
+PKG_CFLAGS = $(SHLIB_OPENMP_CFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)
+```
+
+For C++:
+
+```makefile
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS)
+```
+
+For Fortran, R packages are usually linked by the C or C++ compiler, so the
+compile flag and link flag can intentionally differ:
+
+```makefile
+PKG_FFLAGS = $(SHLIB_OPENMP_FFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)
+```
+
+If a package contains only Fortran sources using OpenMP and needs the Fortran
+compiler to link the shared object, use R's `USE_FC_TO_LINK` pattern instead:
+
+```makefile
+USE_FC_TO_LINK =
+PKG_FFLAGS = $(SHLIB_OPENMP_FFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_FFLAGS)
+```
+
+Do not hard-code `-lgomp` or `-lomp` in portable package code. The R macros
+carry the compiler-specific flag, and that flag may also set the runtime search
+path correctly.
+
+## What Changes for miniextendr Packages
+
+miniextendr packages still end as ordinary R package shared objects:
+
+1. Cargo builds Rust code into a static library.
+2. `R CMD INSTALL` links that static library into the package shared object.
+3. R loads that shared object with `dyn.load()`.
+
+That final shared object is where the OpenMP runtime dependency must be visible.
+If a Rust dependency compiles C/C++ code with OpenMP internally, R's
+`SHLIB_OPENMP_*FLAGS` macros are not automatically propagated into Cargo's
+native build scripts. You need to ensure both sides agree:
+
+- the native code was compiled with the intended OpenMP-capable compiler;
+- the final package link line includes the matching OpenMP runtime flag;
+- on macOS, the resulting shared object can find the matching `libomp.dylib` at
+  load time.
+
+## Inspection Commands
+
+After installing or building the package, inspect the compiled shared object.
+Replace `mypkg` with the actual package name.
+
+On macOS:
+
+```bash
+otool -L src/mypkg.so
+```
+
+Look for `libomp.dylib` when the package really uses OpenMP. If the dependency
+is recorded as `@rpath/libomp.dylib`, also check that the package or R process
+has a usable rpath for the installed OpenMP runtime.
+
+On Linux:
+
+```bash
+ldd src/mypkg.so
+```
+
+Look for `libgomp.so`, `libomp.so`, or the runtime used by the selected
+compiler. A package that uses OpenMP but shows no OpenMP runtime dependency is
+usually relying on accidental symbol availability.
+
+On Windows:
+
+```bash
+objdump -p src/mypkg.dll | grep 'DLL Name'
+```
+
+Check for the OpenMP runtime DLL expected by the active Rtools or compiler
+toolchain.
+
+## Practical Guidance
+
+Keep OpenMP use in one compiler family when possible. Mixing Apple `clang`,
+LLVM `clang`, GCC, `gfortran`, and vendor OpenMP runtimes can create packages
+that compile successfully but fail at load time.
+
+On macOS, avoid assuming that OpenMP is available because `clang` exists.
+Apple `clang` needs an external OpenMP setup, and the `libomp.dylib` used at
+runtime should match the compiler support used at compile time.
+
+When a package loads on Linux but not macOS, check the final shared object
+before changing Rust code. The common failure is not miniextendr initialization;
+it is that R cannot load the package bundle because the OpenMP runtime
+dependency is missing, mismatched, or unreachable.
+
+## See Also
+
+- [LINKING.md](LINKING.md)
+- [R_BUILD_SYSTEM.md](R_BUILD_SYSTEM.md)
+- [Writing R Extensions: OpenMP support](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#OpenMP-support)
+- [R Installation and Administration: OpenMP Support](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#OpenMP-Support)

--- a/site/content/manual/columnar-option-none.md
+++ b/site/content/manual/columnar-option-none.md
@@ -1,0 +1,57 @@
++++
+title = "ColumnarDataFrame: all-None Option columns"
+weight = 50
+description = "ColumnarDataFrame::from_rows discovers column types by probing runtime values. When every row has None for an Option<T> field the probe never sees a Some, the column stays ColumnBuffer::Generic, and R received list(NULL, NULL, …) instead of an atomic vector with NA. Tibble and dplyr treat list(NULL, …) as a list-column — it cannot be compared to scalars, does not coerce cleanly, and appears as <list> rather than <lgl>/<int>/<dbl>/<chr> in str()."
++++
+
+## The old failure
+
+`ColumnarDataFrame::from_rows` discovers column types by probing runtime values.
+When every row has `None` for an `Option<T>` field the probe never sees a `Some`,
+the column stays `ColumnBuffer::Generic`, and R received `list(NULL, NULL, …)`
+instead of an atomic vector with `NA`. Tibble and dplyr treat `list(NULL, …)` as
+a list-column — it cannot be compared to scalars, does not coerce cleanly, and
+appears as `<list>` rather than `<lgl>/<int>/<dbl>/<chr>` in `str()`.
+
+## The new behaviour
+
+At assembly time, if a `ColumnBuffer::Generic` column has *every* entry as `None`,
+the column is emitted as an `LGLSXP` of length `nrow` filled with `NA_logical_`
+rather than a `VECSXP` of `NULL` elements. This is the assembly-time downgrade.
+No user hint, schema annotation, or derive macro is involved.
+
+The discriminator is in the buffer: `Vec<Option<SEXP>>` where `push_na` (pad for
+missing rows) stores `None`, and `push_value(&None::<T>)` serializes through
+`RSerializer::serialize_none` → returns `SEXP::nil()` → stores `Some(SEXP::nil())`.
+Both represent "no value" in the generic-list context. The downgrade checks
+`v.iter().all(|e| e.is_none() || e.map_or(false, |s| s.is_nil()))` — all entries are
+either missing or NULL. Only this condition fires the downgrade.
+
+## The R coercion guarantee
+
+R's coercion rules make logical NA invisible downstream:
+
+```r
+c(NA, 1L)      # integer NA + integer → integer vector
+c(NA, "x")     # logical NA + character → character vector
+c(NA, 3.14)    # logical NA + double → double vector
+```
+
+`dplyr::bind_rows()`, `tibble::as_tibble()`, `mutate()`, and `coalesce()` all
+coerce on contact. An all-NA logical column is indistinguishable from an all-NA
+typed column for everything users do downstream.
+
+## When this is not what you want
+
+In the rare case where you need a specific typed NA column (for example, R
+metadata systems that inspect the column type before any values arrive), use
+`with_column` to inject a typed NA vector explicitly after assembly:
+
+```rust
+use miniextendr_api::IntoR;
+
+let na_integer = vec![Option::<i32>::None; nrow].into_sexp(); // INTSXP of NA_integer_
+df.with_column("stored_size", na_integer)
+```
+
+This pattern is already described in the issue body for `stored_size: Option<u64>`.

--- a/site/content/manual/cran-compatibility.md
+++ b/site/content/manual/cran-compatibility.md
@@ -21,20 +21,52 @@ That's the entire decision tree. There is no `NOT_CRAN` env var, no
 `PREPARE_CRAN`, no `FORCE_VENDOR`, no auto-detected "build context"; just the
 file-existence test.
 
+## Self-repair: configure auto-vendors when needed
+
+Before the file-existence test, configure runs an **auto-vendor** block that
+produces `inst/vendor.tar.xz` on the fly when ALL of these hold:
+
+1. `inst/vendor.tar.xz` is absent.
+2. `cargo-revendor` is on PATH.
+3. Source tree has no `.git` ancestor (i.e., we are not in a developer's
+   checkout — we are in a build-staging dir or an install-extraction dir).
+
+This is what makes the scaffolding **self-repairing and self-coherent**:
+
+- **Build phase, pkgbuild path**: `devtools::build()` / `pkgbuild::build()` /
+  `r-lib/actions/check-r-package` honor `Config/build/bootstrap: TRUE` →
+  `bootstrap.R` runs in the staging dir → invokes `./configure` → no `.git`
+  ancestor → auto-vendor fires → `inst/vendor.tar.xz` is sealed into the
+  tarball. No explicit `just vendor` needed.
+- **Install phase, end users**: a tarball that arrives missing
+  `inst/vendor.tar.xz` (e.g. published from a raw `R CMD build` that bypassed
+  `bootstrap.R`) is repaired at install time — configure runs, no `.git`,
+  `cargo-revendor` available → vendor produced → tarball mode → offline build.
+- **Dev iteration**: `bash ./configure` from the source tree finds `.git` in
+  an ancestor → auto-vendor block is **skipped** → fast `just configure`,
+  source-mode dev iteration with monorepo path overrides. Use `just vendor`
+  / `miniextendr_vendor()` explicitly when producing a release artifact.
+- **CRAN's offline farm**: `cargo-revendor` is not installed, so the auto-vendor
+  branch is short-circuited → falls through to source mode → `cargo` tries the
+  network → fails loudly. This is the canary: CRAN bouncing a tarball means the
+  maintainer shipped one without vendor inside.
+
 ## Where each install path lands
 
-| You ran | Mode | Vendor used? |
-|---|---|---|
-| `R CMD INSTALL .` (rpkg source dir) | Source | No |
-| `devtools::install("rpkg")` / `load_all` / `install_local` | Source | No |
-| `remotes::install_github("A2-ai/miniextendr", subdir = "rpkg")` | Source | No |
-| `R CMD build rpkg` then `R CMD INSTALL miniextendr_*.tar.gz` | Tarball | Yes |
-| `R CMD check rpkg` (calls R CMD build internally) | Tarball | Yes |
-| CRAN's autobuilder on a submitted tarball | Tarball | Yes |
+| You ran | Mode | Vendor used? | How vendor was produced |
+|---|---|---|---|
+| `R CMD INSTALL .` (rpkg source dir) | Source | No | n/a (`.git` ancestor → skip) |
+| `devtools::install("rpkg")` / `load_all` / `install_local` | Source | No | n/a (`.git` ancestor → skip) |
+| `remotes::install_github("A2-ai/miniextendr", subdir = "rpkg")` | Source | No | n/a (`.git` ancestor in fetched repo) |
+| `R CMD build rpkg` directly (no bootstrap.R) | Tarball | Yes | configure auto-vendor at install time on user's machine |
+| `devtools::build("rpkg")` / `pkgbuild::build()` | Tarball | Yes | bootstrap.R → configure auto-vendor at build time (staging dir, no `.git`) |
+| `just r-cmd-build` / `just r-cmd-check` | Tarball | Yes | explicit `just vendor` (recipe dependency) before R CMD build |
+| CRAN's autobuilder on a submitted tarball | Tarball | Yes | maintainer's `just vendor` baked it into the tarball |
 
-The second column maps directly to the file-existence test. R CMD build is the
-only operation that produces `inst/vendor.tar.xz` (via `just vendor`); every
-other path leaves the file absent and gets source mode.
+The second column maps directly to the file-existence test. The third column
+shows which trigger produced the vendor — there are three layered triggers
+(`just vendor`, `bootstrap.R`-via-pkgbuild, configure auto-vendor at install),
+all converging on the same single signal.
 
 ## Why
 

--- a/site/content/manual/gctorture-testing.md
+++ b/site/content/manual/gctorture-testing.md
@@ -1,0 +1,142 @@
++++
+title = "GC-torture testing — surfacing latent SEXP-protection bugs"
+weight = 50
+description = "R provides gctorture(TRUE) and gctorture2(step, wait, inhibit_release) to make every allocation trigger a full GC. Any SEXP that's reachable through Rust state but not rooted in R's protect mechanism gets collected on the next allocation, surfacing use-after-free that would otherwise hide for thousands of test runs (or only manifest under stricter allocators like glibc R 4.6 release on CI)."
++++
+
+R provides `gctorture(TRUE)` and `gctorture2(step, wait, inhibit_release)` to make every
+allocation trigger a full GC. Any SEXP that's reachable through Rust state but not rooted
+in R's protect mechanism gets collected on the next allocation, surfacing use-after-free
+that would otherwise hide for thousands of test runs (or only manifest under stricter
+allocators like glibc R 4.6 release on CI).
+
+This page documents the harness pattern that works in this codebase, common pitfalls,
+and a recipe for running it across the full `rpkg/` test suite.
+
+## When to use
+
+- A new `unsafe` block reads or writes an SEXP cached in Rust state.
+- A new entry-point allocates SEXPs that linger in `Vec<SEXP>` / `Box<dyn Any>` / similar
+  containers across `.Call` boundaries, ALTREP callbacks, or background threads.
+- CI fails with `malloc(): unsorted double linked list corrupted`, `*** caught segfault ***`,
+  or `address 0x... 'invalid permissions'`, particularly on Linux R release but not on
+  devel/oldrel — that's the strict-allocator signature for a UAF that other runtimes
+  tolerate.
+- Before merging anything that touches `serde/columnar.rs`, ALTREP code, ExternalPtr
+  storage, or the worker-thread serializer.
+
+## The two pitfalls
+
+### 1. Don't enable gctorture before `library(miniextendr)`
+
+`gctorture(TRUE)` is so aggressive that ordinary package-load paths (`initMethodDispatch`,
+S4 method registration, `loadNamespace` hooks) hit unprotected SEXPs in unrelated CRAN
+packages and crash before your tests start. The crash signature is the giveaway —
+traceback ends in `library` / `loadNamespace` / `runHook(".onLoad", ...)`.
+
+**Always** load the package first, then flip gctorture on:
+
+```r
+library(miniextendr)
+library(testthat)
+gctorture(TRUE)
+# ... call your code ...
+gctorture(FALSE)
+```
+
+### 2. `test_dir` loads more packages
+
+`testthat::test_dir` may attach extra packages (rlang, withr, dplyr, …) the first time
+it runs. Each `.onLoad` hook is a gctorture-amplified hazard you don't want to debug.
+For targeted testing, **call exported functions directly via `get(name)()`** rather than
+going through `test_dir`. Keep `test_dir` for the final whole-suite sweep, after you've
+loaded everything you need.
+
+## Recipe — per-function sweep
+
+```r
+library(miniextendr)
+gctorture(TRUE)
+
+funs <- ls("package:miniextendr", pattern = "^test_columnar_")  # or any prefix
+ok <- 0L
+fail <- character(0)
+for (f in funs) {
+  res <- tryCatch({ get(f)(); "ok" }, error = function(e) conditionMessage(e))
+  if (identical(res, "ok")) ok <- ok + 1L
+  else fail <- c(fail, sprintf("%s: %s", f, res))
+}
+gctorture(FALSE)
+cat(sprintf("%d/%d ok\n", ok, length(funs)))
+if (length(fail)) cat(fail, sep = "\n")
+```
+
+This is the cheapest mode: ~1 minute per simple function under `gctorture(TRUE)`.
+Catches every `Rf_allocVector` → unprotected-SEXP-read sequence inside the call.
+
+Crash interpretation:
+- **`exit=0` with truncated output** — the script SIGSEGV'd silently. The last printed
+  function header is the one that crashed. Re-run that single function in isolation to
+  confirm.
+- **Explicit `*** caught segfault ***` with traceback** — R's signal handler caught it.
+  Read the traceback for the immediate cause; the *root* cause is usually one frame up
+  (the allocation that triggered GC, not the one that segfaulted reading freed memory).
+- **`Rscript` exits with backtrace and address `0x...` low** — wild pointer from a freed
+  SEXP, often from `Rf_eval` or `R_NilValue`-adjacent reads.
+
+## Recipe — full `rpkg/` sweep (slow)
+
+For the full suite, use `gctorture2(step = N)` with `N > 1` to keep the run tractable.
+`step = 100` is ~100× slower than baseline (vs. ~1000× for `gctorture(TRUE)`) and still
+surfaces the vast majority of UAF bugs.
+
+```r
+library(miniextendr)
+library(testthat)
+setTimeLimit(Inf, Inf, transient = FALSE)
+options(timeout = Inf)
+
+gctorture2(step = 100, wait = 0, inhibit_release = FALSE)
+res <- test_dir(
+  "rpkg/tests/testthat",
+  reporter = ProgressReporter,
+  stop_on_failure = FALSE
+)
+gctorture2(step = 0)  # disable
+print(res)
+```
+
+Run it as `Rscript /path/to/script.R 2>&1 > /tmp/gctorture-full.log`, in the background,
+and watch the log. Expect hours, not minutes — the full suite at `step = 100` typically
+takes 30–90 minutes locally and substantially longer in CI.
+
+For a tighter feedback loop while bisecting:
+- `step = 10` covers most bugs in <30s/test.
+- `step = 1` matches `gctorture(TRUE)` and only makes sense for single-function bisects.
+
+## What gctorture cannot find
+
+- **Stack-discipline violations on the protect stack** — `Rf_protect` / `Rf_unprotect`
+  imbalances surface as panics from `R_PPStackTop` overflow, not gctorture firings.
+- **Cross-`.Call` lifetime bugs** that depend on R-side caching (e.g., an ExternalPtr
+  that survives one call only because R's namespace cached the wrapping closure).
+- **Thread-affine bugs** — gctorture is single-threaded and won't reproduce data races
+  across the worker thread.
+- **ALTREP materialization order issues** — gctorture stresses GC, not lazy-eval ordering.
+
+## Project-specific reference
+
+- Root cause example for this technique: PR #424 (issue #307) — `ColumnBuffer::Generic`
+  held raw `Vec<Option<SEXP>>` across allocations. The fix was a `ProtectScope` opened
+  in `from_rows` and threaded through `ColumnFiller`. CI surfaced the bug only on Linux
+  R 4.6 release; gctorture surfaced it deterministically in a 30-second local run.
+- Helpers in `miniextendr-api/src/gc_protect.rs` — `OwnedProtect`, `ProtectScope`,
+  `ProtectIndex`, `ReprotectSlot`, `Root`. See module docs for trade-offs.
+- Pool variant for any-order release: `miniextendr-api/src/protect_pool.rs`
+  (`ProtectPool` — VECSXP-backed, generational keys).
+
+## Adding to CI
+
+A nightly `gctorture-nightly` job invoking the full-suite recipe at `step = 100` would
+catch this class of bug before it reaches a release. **Not yet wired up** — the Linux
+release runner needs ~2× current timeout. Tracked at TODO (file an issue when adding).

--- a/site/content/manual/linking.md
+++ b/site/content/manual/linking.md
@@ -161,5 +161,6 @@ miniextendr always links dynamically to `libR`:
 
 ## See Also
 
+- [OPENMP.md](../openmp/)
 - [R Installation and Administration](https://cran.r-project.org/doc/manuals/r-release/R-admin.html)
 - [Writing R Extensions: Linking](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Linking-GUIs-and-other-front_002dends-to-R)

--- a/site/content/manual/openmp.md
+++ b/site/content/manual/openmp.md
@@ -1,0 +1,261 @@
++++
+title = "OpenMP Runtime Loading"
+weight = 50
+description = "This document explains why packages that use OpenMP can install or load on Linux but fail on macOS, and what to check in a miniextendr-backed R package."
++++
+
+This document explains why packages that use OpenMP can install or load on
+Linux but fail on macOS, and what to check in a miniextendr-backed R package.
+
+## The Short Version
+
+OpenMP is not only a compile-time feature. Code compiled with OpenMP often
+needs a runtime library such as `libomp`, `libgomp`, or a vendor-specific
+equivalent when the final package shared object is loaded by R.
+
+For R packages, the dependency has to be attached to the final package shared
+object loaded by `dyn.load()`. It is not enough for an intermediate Rust crate,
+C object, or C++ object to have been compiled with an OpenMP flag.
+
+macOS exposes missing runtime linkage more often because Apple `clang` does not
+ship native OpenMP support. OpenMP usually comes from a separate `libomp.dylib`,
+and the dynamic loader has to find a version of that dylib compatible with the
+compiler used to build the package.
+
+## Rust Perspective
+
+Pure Rust code does not use OpenMP. Rust has no `#pragma omp` directive, no
+`-fopenmp` flag, and no implicit dependency on `libomp` or `libgomp`. A
+miniextendr package whose Rust dependencies are all pure Rust will not link
+against an OpenMP runtime and is unaffected by this document.
+
+OpenMP enters a miniextendr package through native code compiled by a Rust
+crate's `build.rs` — typically a `*-sys` crate wrapping a C, C++, or Fortran
+library that itself uses OpenMP. Common arrival paths:
+
+- BLAS/LAPACK backends (`openblas-src` with the `system` feature,
+  `intel-mkl-src`, `accelerate-src` on macOS) brought in by linear-algebra
+  crates such as `ndarray-linalg`, `nalgebra` with a BLAS backend, `faer`, or
+  `polars` with a BLAS feature.
+- C++ ML runtimes wrapped via `-sys` crates (ONNX Runtime, Torch via
+  `tch-rs`, certain `xgboost` / `lightgbm` bindings).
+- Image, audio, and numerical libraries with parallel C/C++ kernels gated
+  behind a Cargo feature flag.
+
+`rayon`, `std::thread`, `tokio`, and `crossbeam` are not OpenMP — they are
+pure-Rust parallelism. A package that uses only Rayon needs no
+`SHLIB_OPENMP_*FLAGS` plumbing in `Makevars`.
+
+### What Cargo Does Not Do
+
+Cargo build scripts that compile C, C++, or Fortran via the `cc` crate run
+with the host compiler's defaults. They do not read R's `SHLIB_OPENMP_CFLAGS`
+/ `SHLIB_OPENMP_CXXFLAGS` / `SHLIB_OPENMP_FFLAGS` macros, and they do not know
+that the final shared object will be loaded by R. The consequences:
+
+1. Native source compiled inside the crate may or may not have been built
+   with an OpenMP flag — that depends on the crate's own `build.rs`,
+   environment variables, and feature flags, not on R.
+2. The Rust `staticlib` artifact handed to `R CMD INSTALL` may carry
+   unresolved OpenMP symbols (`omp_get_thread_num`, `__kmpc_fork_call`,
+   `GOMP_parallel`, …).
+3. R's link line — driven by `rpkg/src/Makevars` / `Makevars.in` — is the
+   only place those symbols can be resolved into the final `pkg.so`. If
+   `PKG_LIBS` does not include `$(SHLIB_OPENMP_CFLAGS)` (or the matching
+   CXX/FFLAGS macro), the link succeeds on Linux because lazy binding masks
+   the missing reference, and fails at `dyn.load()` time on macOS.
+
+### Linking Through R, With `openmp-sys` Doing the Compile Half
+
+The split for miniextendr packages: the OpenMP **compile flag** (the
+`-fopenmp` / `/openmp` passed to `cc::Build` in a Rust crate's
+`build.rs`) comes from
+[`openmp-sys`](https://lib.rs/crates/openmp-sys) (source:
+<https://gitlab.com/kornelski/openmp-rs>); the OpenMP **runtime
+library** (`libomp.dylib`, `libgomp.so`, `vcomp.dll`) is linked into
+the final `pkg.so` by R's `SHLIB_OPENMP_*FLAGS` on the
+`R CMD INSTALL` line. Cargo and R cooperate at different layers — they
+do not race to discover the runtime independently.
+
+What `openmp-sys` does on the Rust side:
+
+- Searches `cc -print-search-dirs`, Homebrew, MacPorts, and MSVC's
+  `vcomp.dll` for an OpenMP install at build time.
+- Exposes `DEP_OPENMP_FLAG` so a downstream crate's `build.rs` can
+  call `cc::Build::new().flag(env!("DEP_OPENMP_FLAG")).compile(...)`
+  and have its C/C++ sources compile with the right OpenMP pragma
+  enabled.
+- Emits `cargo:rustc-link-lib=dylib=gomp` / `omp` so a standalone
+  binary built from those crates would link a runtime.
+
+For a miniextendr package, the third item is what would otherwise
+collide with R. The trick is: that `cargo:rustc-link-lib` directive
+travels into the Rust staticlib's metadata and surfaces on R's link
+line, *and* R independently adds `$(SHLIB_OPENMP_CFLAGS)`. As long as
+both name the same runtime — i.e., the OpenMP `openmp-sys` discovered
+matches the one R was built against — the two link directives collapse
+to a single recorded dependency in `pkg.so` and the package loads
+cleanly.
+
+The practical rules:
+
+1. **Prefer pure-Rust parallelism** when the choice is yours.
+   `rayon`, `std::thread`, `tokio`, `crossbeam` need no `Makevars`
+   plumbing and dodge this entire document.
+2. **When you do need OpenMP-using C/C++ compiled inside a Rust
+   crate**, depend on `openmp-sys`, use its `DEP_OPENMP_FLAG` in
+   `cc::Build`, and on the R side declare the runtime via
+   `PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)` (or `CXXFLAGS` / `FFLAGS`
+   matching the underlying language) in `rpkg/src/Makevars.in`. The
+   rule R-Extensions states for plain C/C++ packages applies unchanged.
+3. **Make sure the two halves agree on which runtime is in use.** On
+   macOS the typical hazard is `openmp-sys` finding Homebrew's
+   `libomp.dylib` while R's `clang` was configured against a different
+   `libomp` (system, Apple-supplied, or a CRAN binary build's vendored
+   one). Set `LIBRARY_PATH` / `CFLAGS` for `openmp-sys` discovery, or
+   point R at the same toolchain via `~/.R/Makevars`, so that one
+   runtime is visible to both.
+4. **Do not hand-roll** `cargo:rustc-link-lib=dylib=omp` (or `gomp`)
+   in a miniextendr-package `build.rs`. `openmp-sys` already does this
+   correctly per platform; replicating it is how runtimes start
+   disagreeing.
+5. **On macOS, verify after install.** Run `otool -L src/pkg.so` and
+   confirm exactly one OpenMP runtime is recorded, with a path the
+   loader can resolve. Two entries (e.g., `@rpath/libomp.dylib` from
+   Cargo and `/usr/local/opt/libomp/lib/libomp.dylib` from R) is the
+   canary for the runtimes having drifted apart.
+6. **If R's `SHLIB_OPENMP_*` macro is empty or wrong**, the user's R
+   install is the problem — fix the R install, or add a
+   `SystemRequirements:` entry pointing at the OpenMP runtime, rather
+   than papering over it from the package's `build.rs`.
+
+## Why It Looks macOS-Specific
+
+The bug is portable; the masking behavior is not.
+
+On Linux with GCC, `-fopenmp` typically selects `libgomp`, and the ELF dynamic
+linker often tolerates unresolved or already-satisfied symbols in ways that make
+a missing package-level OpenMP link flag appear harmless. If another library has
+already loaded the OpenMP runtime into the R process, the package may load by
+accident.
+
+On macOS, package code is loaded as a Mach-O bundle by `dyn.load()`. If the
+bundle references OpenMP symbols but does not record a loadable dependency on
+the right runtime, loading fails immediately. The common symptom is an error
+mentioning `libomp.dylib`, `@rpath/libomp.dylib`, or an unresolved `omp_*` /
+`__kmpc_*` symbol.
+
+Windows can have the same class of problem, but it usually appears as a missing
+DLL or as a toolchain mismatch rather than as a `libomp.dylib` error.
+
+## The Rule for R Package Makevars
+
+If package C or C++ code is compiled with an OpenMP macro, the matching macro
+must also be present in `PKG_LIBS`:
+
+```makefile
+PKG_CFLAGS = $(SHLIB_OPENMP_CFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)
+```
+
+For C++:
+
+```makefile
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS)
+```
+
+For Fortran, R packages are usually linked by the C or C++ compiler, so the
+compile flag and link flag can intentionally differ:
+
+```makefile
+PKG_FFLAGS = $(SHLIB_OPENMP_FFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)
+```
+
+If a package contains only Fortran sources using OpenMP and needs the Fortran
+compiler to link the shared object, use R's `USE_FC_TO_LINK` pattern instead:
+
+```makefile
+USE_FC_TO_LINK =
+PKG_FFLAGS = $(SHLIB_OPENMP_FFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_FFLAGS)
+```
+
+Do not hard-code `-lgomp` or `-lomp` in portable package code. The R macros
+carry the compiler-specific flag, and that flag may also set the runtime search
+path correctly.
+
+## What Changes for miniextendr Packages
+
+miniextendr packages still end as ordinary R package shared objects:
+
+1. Cargo builds Rust code into a static library.
+2. `R CMD INSTALL` links that static library into the package shared object.
+3. R loads that shared object with `dyn.load()`.
+
+That final shared object is where the OpenMP runtime dependency must be visible.
+If a Rust dependency compiles C/C++ code with OpenMP internally, R's
+`SHLIB_OPENMP_*FLAGS` macros are not automatically propagated into Cargo's
+native build scripts. You need to ensure both sides agree:
+
+- the native code was compiled with the intended OpenMP-capable compiler;
+- the final package link line includes the matching OpenMP runtime flag;
+- on macOS, the resulting shared object can find the matching `libomp.dylib` at
+  load time.
+
+## Inspection Commands
+
+After installing or building the package, inspect the compiled shared object.
+Replace `mypkg` with the actual package name.
+
+On macOS:
+
+```bash
+otool -L src/mypkg.so
+```
+
+Look for `libomp.dylib` when the package really uses OpenMP. If the dependency
+is recorded as `@rpath/libomp.dylib`, also check that the package or R process
+has a usable rpath for the installed OpenMP runtime.
+
+On Linux:
+
+```bash
+ldd src/mypkg.so
+```
+
+Look for `libgomp.so`, `libomp.so`, or the runtime used by the selected
+compiler. A package that uses OpenMP but shows no OpenMP runtime dependency is
+usually relying on accidental symbol availability.
+
+On Windows:
+
+```bash
+objdump -p src/mypkg.dll | grep 'DLL Name'
+```
+
+Check for the OpenMP runtime DLL expected by the active Rtools or compiler
+toolchain.
+
+## Practical Guidance
+
+Keep OpenMP use in one compiler family when possible. Mixing Apple `clang`,
+LLVM `clang`, GCC, `gfortran`, and vendor OpenMP runtimes can create packages
+that compile successfully but fail at load time.
+
+On macOS, avoid assuming that OpenMP is available because `clang` exists.
+Apple `clang` needs an external OpenMP setup, and the `libomp.dylib` used at
+runtime should match the compiler support used at compile time.
+
+When a package loads on Linux but not macOS, check the final shared object
+before changing Rust code. The common failure is not miniextendr initialization;
+it is that R cannot load the package bundle because the OpenMP runtime
+dependency is missing, mismatched, or unreachable.
+
+## See Also
+
+- [LINKING.md](../linking/)
+- [R_BUILD_SYSTEM.md](../r-build-system/)
+- [Writing R Extensions: OpenMP support](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#OpenMP-support)
+- [R Installation and Administration: OpenMP Support](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#OpenMP-Support)

--- a/site/content/manual/vctrs.md
+++ b/site/content/manual/vctrs.md
@@ -399,37 +399,49 @@ This generates coercion methods for both `double` and `integer`.
 
 ## Impl Block Approach (Rust-Backed Protocol Methods)
 
-For types that need Rust-backed vctrs protocol methods (like a custom `format`), use the impl block approach with `#[miniextendr(vctrs(...))]`:
+For types that need Rust-backed vctrs protocol methods (like a custom `format`), use the impl block approach with `#[miniextendr(vctrs(...))]`.
+
+### Constructors and static methods only (MXL120)
+
+A `#[miniextendr(vctrs(...))]` impl may only contain:
+
+- **A constructor** — `pub fn new(...) -> <vector-payload>` (no receiver). The return type must be
+  the vector payload (`Vec<f64>`, `Vec<i32>`, etc.), **not** `Self` or the named type.
+  `new_vctr()` / `new_rcrd()` / `new_list_of()` wrap this value into the S3 class — they
+  require a plain vector, not an `ExternalPtr`.
+- **Static helper methods** — `pub fn helper(args...) -> ...` (no receiver).
+- **vctrs protocol overrides** — static methods annotated with `#[miniextendr(vctrs(format))]`
+  (or other protocol names). These are emitted as `format.<Class>` S3 methods.
+
+`&self`, `&mut self`, `self`, and `self: ExternalPtr<Self>` receivers are **rejected at
+compile time** (MXL120). A vctrs object is an S3-classed base vector — there is no Rust
+`Self` stored in the SEXP. The C wrapper would call `ErasedExternalPtr::from_sexp` on a
+REALSXP/INTSXP and then panic when the downcast fails. Static methods with explicit
+parameters are the correct pattern.
 
 ```rust
-#[derive(miniextendr_api::ExternalPtr)]
-pub struct DerivedCurrency {
-    symbol: String,
-    amounts: Vec<f64>,
-}
+// Zero-sized marker struct (no fields needed — the data is in the R vector)
+pub struct DerivedCurrency;
 
 #[miniextendr(vctrs(kind = "vctr", base = "double", abbr = "$"))]
 impl DerivedCurrency {
-    pub fn new(symbol: String, amounts: Vec<f64>) -> Self {
-        DerivedCurrency { symbol, amounts }
+    /// Returns the amounts payload; wrapped by the R constructor as a vctrs vector.
+    pub fn new(_symbol: String, amounts: Vec<f64>) -> Vec<f64> {
+        amounts
     }
 
-    pub fn symbol(&self) -> String {
-        self.symbol.clone()
-    }
-
-    /// Rust-backed format method override.
+    /// Rust-backed format method override — maps to format.DerivedCurrency in R.
     #[miniextendr(vctrs(format))]
-    pub fn format_currency(&self) -> Vec<String> {
-        self.amounts
+    pub fn format_currency(symbol: String, amounts: Vec<f64>) -> Vec<String> {
+        amounts
             .iter()
-            .map(|a| format!("{}{:.2}", self.symbol, a))
+            .map(|a| format!("{}{:.2}", symbol, a))
             .collect()
     }
 }
 ```
 
-This gives you the same vctrs class registration but lets you override specific protocol methods with Rust implementations. The `format_currency` method is called as `format.derived_currency()` from R.
+The `format_currency` method above is emitted as `format.DerivedCurrency <- function(symbol, amounts)`.
 
 ### Non-`Self` constructors in vctrs impl blocks
 


### PR DESCRIPTION
## Summary
- New `docs/OPENMP.md` covering both halves of the problem:
  - **R/Makevars side**: why a package can install on Linux but fail to `dyn.load()` on macOS, what `SHLIB_OPENMP_CFLAGS` / `SHLIB_OPENMP_CXXFLAGS` / `SHLIB_OPENMP_FFLAGS` are for, platform-specific inspection commands (`otool -L`, `ldd`, `objdump -p`).
  - **Rust side**: pure Rust does not use OpenMP — it enters via `*-sys` crates wrapping C/C++/Fortran libraries (BLAS backends, ML runtimes, parallel native kernels). Cargo build scripts do not read R's `SHLIB_OPENMP_*` macros, so the staticlib handed to `R CMD INSTALL` can carry unresolved OpenMP symbols that only the package's `Makevars` link line resolves. `rayon` / `std::thread` / `tokio` / `crossbeam` are not OpenMP and need no plumbing.
  - **The split for miniextendr packages**: `openmp-sys` provides `DEP_OPENMP_FLAG` so a Rust crate's `build.rs` (using `cc::Build`) compiles its C/C++ with the right `-fopenmp` / `/openmp`; R's `$(SHLIB_OPENMP_*FLAGS)` on the `R CMD INSTALL` link line owns the runtime. The two cooperate at different layers as long as they agree on which OpenMP runtime is in use — drift between Cargo's discovery and R's configured toolchain is the macOS failure mode (`otool -L` showing two `libomp` entries is the canary).
- Cross-link from `docs/LINKING.md`.
- Regenerate `site/content/manual/` from current `docs/` via `just site-docs` — picks up the new `openmp.md`, `columnar-option-none.md`, `gctorture-testing.md` entries plus drift in `cran-compatibility.md` / `linking.md` / `vctrs.md` that had accumulated since the last regen.
- Refresh `site/data/plans.json` to include recently merged `plans/*.md` entries.

Pure docs/site change, no code touched.

## Test plan
- [ ] `just site-build` produces a clean Zola build (CI deploys on merge to main).
- [ ] `site/content/manual/openmp.md` renders with the auto-derived frontmatter from `docs/OPENMP.md`.
- [ ] `site/content/manual/linking.md` shows the new "See Also → OPENMP.md" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)