### PR TITLE
docs: document MXL110/111/112 + to_dataframe_split enum split mode

### DIFF
--- a/docs/DATAFRAME.md
+++ b/docs/DATAFRAME.md
@@ -254,6 +254,29 @@ enum Observation {
 }
 ```
 
+### Enum Split Mode (`to_dataframe_split`)
+
+Alongside `to_dataframe` (which produces a single aligned data.frame with `NA`/`NULL` fill for variants that don't carry a field), enums also expose `to_dataframe_split` which partitions the rows by variant. Each partition is a data.frame with **only that variant's own columns** — no `NA`-filled columns from sibling variants.
+
+| Variants × rows in input | Return type |
+|--------------------------|-------------|
+| **Single-variant enum**, any number of rows | bare `data.frame` |
+| **Multi-variant enum**, mixed rows | named `list` of data.frames, one per variant in `snake_case` |
+
+```rust
+let rows = vec![
+    Event::Click      { id: 1, x: 1.5, y: 2.5 },
+    Event::Impression { id: 2, slot: "top_banner".to_string() },
+    Event::Error      { id: 3, code: 404, message: "not found".to_string() },
+];
+Event::to_dataframe_split(rows)
+// In R: list(click = <1-row df with id, x, y>,
+//            impression = <1-row df with id, slot>,
+//            error = <1-row df with id, code, message>)
+```
+
+Variants absent from the input still appear in the result as 0-row data.frames carrying that variant's column shape. Unit variants produce a 0-column data.frame with the correct row count. Tuple variants name positional columns `_0`, `_1`, … . See the cardinality matrix in `rpkg/tests/testthat/test-dataframe-enum-payload-matrix.R` for the full set of guarantees (PR #463).
+
 ### With Serde (when `serde` feature enabled)
 
 ```rust
@@ -289,6 +312,16 @@ impl Measurement {
 
     /// Transpose columns back to rows
     pub fn from_dataframe(df: MeasurementDataFrame) -> Vec<Self>;
+}
+```
+
+For enums, the derive additionally generates:
+
+```rust
+impl Event {
+    /// Partition rows by variant. Returns `data.frame` for single-variant enums,
+    /// or a named `list` of per-variant data.frames otherwise. See "Enum Split Mode".
+    pub fn to_dataframe_split(rows: Vec<Self>) -> miniextendr_api::List;
 }
 ```
 

--- a/docs/MACRO_ERRORS.md
+++ b/docs/MACRO_ERRORS.md
@@ -45,6 +45,9 @@ MINIEXTENDR_LINT=0 cargo check --manifest-path=rpkg/src/rust/Cargo.toml
 | **MXL107** | Missing `#[miniextendr] impl Trait for Type` | Add the attribute to the trait impl |
 | **MXL108** | Missing registration for trait impl | Add `#[miniextendr]` to the trait impl |
 | **MXL109** | `#[cfg]` mismatch between `mod` declarations | Ensure `#[cfg]` attributes are consistent |
+| **MXL110** | Parameter name is an R reserved word | Rename the parameter — generated R wrapper would fail to parse |
+| **MXL111** | `s4_*` method on `#[miniextendr(s4)]` impl | Drop the `s4_` prefix — codegen auto-prepends it (you'd get `s4_s4_*`) |
+| **MXL112** | Explicit lifetime parameter on `#[miniextendr]` fn or impl | Use owned types (`Vec<T>` / `String`) — `&[T]` and `&str` arguments work without explicit lifetime annotations |
 
 ### Warnings (P1: important)
 

--- a/site/content/manual/dataframe.md
+++ b/site/content/manual/dataframe.md
@@ -258,6 +258,29 @@ enum Observation {
 }
 ```
 
+### Enum Split Mode (`to_dataframe_split`)
+
+Alongside `to_dataframe` (which produces a single aligned data.frame with `NA`/`NULL` fill for variants that don't carry a field), enums also expose `to_dataframe_split` which partitions the rows by variant. Each partition is a data.frame with **only that variant's own columns** — no `NA`-filled columns from sibling variants.
+
+| Variants × rows in input | Return type |
+|--------------------------|-------------|
+| **Single-variant enum**, any number of rows | bare `data.frame` |
+| **Multi-variant enum**, mixed rows | named `list` of data.frames, one per variant in `snake_case` |
+
+```rust
+let rows = vec![
+    Event::Click      { id: 1, x: 1.5, y: 2.5 },
+    Event::Impression { id: 2, slot: "top_banner".to_string() },
+    Event::Error      { id: 3, code: 404, message: "not found".to_string() },
+];
+Event::to_dataframe_split(rows)
+// In R: list(click = <1-row df with id, x, y>,
+//            impression = <1-row df with id, slot>,
+//            error = <1-row df with id, code, message>)
+```
+
+Variants absent from the input still appear in the result as 0-row data.frames carrying that variant's column shape. Unit variants produce a 0-column data.frame with the correct row count. Tuple variants name positional columns `_0`, `_1`, … . See the cardinality matrix in `rpkg/tests/testthat/test-dataframe-enum-payload-matrix.R` for the full set of guarantees (PR #463).
+
 ### With Serde (when `serde` feature enabled)
 
 ```rust
@@ -293,6 +316,16 @@ impl Measurement {
 
     /// Transpose columns back to rows
     pub fn from_dataframe(df: MeasurementDataFrame) -> Vec<Self>;
+}
+```
+
+For enums, the derive additionally generates:
+
+```rust
+impl Event {
+    /// Partition rows by variant. Returns `data.frame` for single-variant enums,
+    /// or a named `list` of per-variant data.frames otherwise. See "Enum Split Mode".
+    pub fn to_dataframe_split(rows: Vec<Self>) -> miniextendr_api::List;
 }
 ```
 

--- a/site/content/manual/macro-errors.md
+++ b/site/content/manual/macro-errors.md
@@ -49,6 +49,9 @@ MINIEXTENDR_LINT=0 cargo check --manifest-path=rpkg/src/rust/Cargo.toml
 | **MXL107** | Missing `#[miniextendr] impl Trait for Type` | Add the attribute to the trait impl |
 | **MXL108** | Missing registration for trait impl | Add `#[miniextendr]` to the trait impl |
 | **MXL109** | `#[cfg]` mismatch between `mod` declarations | Ensure `#[cfg]` attributes are consistent |
+| **MXL110** | Parameter name is an R reserved word | Rename the parameter — generated R wrapper would fail to parse |
+| **MXL111** | `s4_*` method on `#[miniextendr(s4)]` impl | Drop the `s4_` prefix — codegen auto-prepends it (you'd get `s4_s4_*`) |
+| **MXL112** | Explicit lifetime parameter on `#[miniextendr]` fn or impl | Use owned types (`Vec<T>` / `String`) — `&[T]` and `&str` arguments work without explicit lifetime annotations |
 
 ### Warnings (P1: important)
 


### PR DESCRIPTION
## Summary

Second docs round catching gaps from earlier merged PRs that PR #467 didn't cover.

### MACRO_ERRORS.md

Three lint codes were never documented:

- **MXL110** — parameter name is an R reserved word (codegen breaks)
- **MXL111** — `s4_*` method on `#[miniextendr(s4)]` impl (codegen auto-prepends `s4_`, you'd get `s4_s4_*`)
- **MXL112** — explicit lifetime parameter on `#[miniextendr]` fn/impl (added by #462)

All added under "Warnings (P0: high impact)" since each breaks codegen.

### DATAFRAME.md

`to_dataframe_split` had no doc despite being the primary user-facing enum API alongside `to_dataframe`. Added an "Enum Split Mode" section covering:
- Single-variant enum returning a bare `data.frame`
- Multi-variant enum returning a named list of per-variant data.frames
- Per-variant column shape, no NA-fill from sibling variants
- Unit-variant 0-column / tuple-variant `_0`/`_1`/… semantics
- Reference to the cardinality matrix tests landed in #463

Also extended "Generated Methods" with the `to_dataframe_split` signature for enums.

`site/content/manual/{dataframe,macro-errors}.md` regenerated by `just site-docs`.

## Test plan

- [x] `just site-docs` clean (80 pages)
- [ ] CI green
- [ ] Manual: spot-check rendered tables on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)