### PR TITLE
feat(api,macros): symbol names on ALTREP + trait dispatch entries (step 3, #470)

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -26,18 +26,19 @@ pub static MX_CALL_DEFS: [R_CallMethodDef];
 #[distributed_slice]
 pub static MX_R_WRAPPERS: [RWrapperEntry];
 
-/// ALTREP class registration functions, called once at package init.
+/// ALTREP class registration entries, called once at package init.
 ///
-/// Each ALTREP struct or trait impl emits an entry.
-///
-/// The element type is `extern "C" fn()` so that each registration function
-/// can be declared `pub extern "C"` with `#[unsafe(no_mangle)]`, making it
-/// externally addressable from a separate compilation unit (e.g. a WASM
-/// codegen path). The functions are not `unsafe` — R-thread invariants are a
+/// Each ALTREP struct or trait impl emits an entry pairing the registration
+/// function pointer with its `#[no_mangle]` symbol name. The fn is declared
+/// `pub extern "C"` with `#[unsafe(no_mangle)]`, making it externally
+/// addressable from a separate compilation unit (e.g. the WASM snapshot
+/// codegen path). The fn pointer is not `unsafe` — R-thread invariants are a
 /// module-level contract, not encoded in the type (same convention as the
-/// `extern "C-unwind" fn` entries in `MX_CALL_DEFS`).
+/// `extern "C-unwind" fn` entries in `MX_CALL_DEFS`). The `symbol` string is
+/// consumed by the host-time WASM snapshot writer to emit
+/// `extern "C" { fn <symbol>(); }` declarations in `wasm_registry.rs`.
 #[distributed_slice]
-pub static MX_ALTREP_REGISTRATIONS: [extern "C" fn()];
+pub static MX_ALTREP_REGISTRATIONS: [AltrepRegistration];
 
 /// Trait dispatch entries for [`universal_query`].
 ///
@@ -197,12 +198,34 @@ pub struct TraitDispatchEntry {
     pub trait_tag: mx_tag,
     /// Pointer to the trait's vtable (cast from `&'static SomeVTable`).
     pub vtable: *const c_void,
+    /// Symbol name of the `#[no_mangle]` vtable static
+    /// (e.g. `"__VTABLE_COUNTER_FOR_MYTYPE"`). Consumed by the host-time WASM
+    /// snapshot writer to emit `extern "C" { static <symbol>: u8; }`
+    /// declarations in `wasm_registry.rs`.
+    pub vtable_symbol: &'static str,
 }
 
 // SAFETY: vtable points to a static vtable valid for program lifetime.
 // Tags are Copy values. All fields are safe to read from any thread.
 unsafe impl Sync for TraitDispatchEntry {}
 unsafe impl Send for TraitDispatchEntry {}
+
+/// ALTREP class registration entry: fn pointer + `#[no_mangle]` symbol name.
+///
+/// See [`MX_ALTREP_REGISTRATIONS`] for context.
+#[repr(C)]
+pub struct AltrepRegistration {
+    /// Registration function called once at `R_init_*`.
+    pub register: extern "C" fn(),
+    /// Symbol name of `register` (e.g. `"__mx_altrep_reg_MyType"`). Consumed by
+    /// the host-time WASM snapshot writer to emit `extern "C" { fn <symbol>(); }`
+    /// declarations in `wasm_registry.rs`.
+    pub symbol: &'static str,
+}
+
+// SAFETY: register is a static fn pointer; symbol is a `'static` string.
+unsafe impl Sync for AltrepRegistration {}
+unsafe impl Send for AltrepRegistration {}
 // endregion
 
 // region: Universal Query
@@ -254,8 +277,8 @@ pub unsafe extern "C" fn miniextendr_register_routines(dll: *mut DllInfo) {
     let wrapper_gen = std::env::var_os("MINIEXTENDR_CDYLIB_WRAPPERS").is_some();
     if !wrapper_gen {
         // User-defined ALTREP classes (from #[miniextendr] structs)
-        for reg_fn in MX_ALTREP_REGISTRATIONS.iter() {
-            reg_fn();
+        for reg in MX_ALTREP_REGISTRATIONS.iter() {
+            (reg.register)();
         }
         // Built-in ALTREP classes (Vec, Box, Range, Arrow) — must be
         // registered eagerly so readRDS can find them in fresh sessions.

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -60,23 +60,35 @@ pub(crate) fn generate_direct_altrep_registration(
         ident
     );
 
-    // For non-generic types, emit a distributed_slice ALTREP registration entry.
+    // For non-generic types, emit a registration fn + a distributed_slice
+    // entry pairing the fn pointer with its `#[no_mangle]` symbol name.
     //
     // The function is `pub extern "C"` with `#[unsafe(no_mangle)]` so that a separate
-    // compilation unit (e.g. a WASM codegen path) can reference it by name via an
-    // `extern { fn __mx_altrep_reg_<Ident>(); }` declaration.
+    // compilation unit (the WASM snapshot codegen path) can reference it by name via
+    // an `extern { fn __mx_altrep_reg_<Ident>(); }` declaration. The entry static
+    // carries the symbol string for the host-time snapshot writer (so it doesn't have
+    // to recover the name from a fn pointer).
     //
     // The ident is used verbatim (no `.to_lowercase()`) to avoid case-collision footguns:
     // `MyType` vs `MYType` would both produce the same symbol name if lowercased.
     let altrep_reg_entry = if generics.params.is_empty() {
         let reg_fn_name = quote::format_ident!("__mx_altrep_reg_{}", ident);
+        let entry_ident = quote::format_ident!("__MX_ALTREP_REG_ENTRY_{}", ident);
         quote::quote! {
-            #[cfg_attr(not(target_arch = "wasm32"), ::miniextendr_api::linkme::distributed_slice(::miniextendr_api::registry::MX_ALTREP_REGISTRATIONS), linkme(crate = ::miniextendr_api::linkme))]
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub extern "C" fn #reg_fn_name() {
                 <#ident as ::miniextendr_api::altrep_registration::RegisterAltrep>::get_or_init_class();
             }
+
+            #[cfg_attr(not(target_arch = "wasm32"), ::miniextendr_api::linkme::distributed_slice(::miniextendr_api::registry::MX_ALTREP_REGISTRATIONS), linkme(crate = ::miniextendr_api::linkme))]
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            static #entry_ident: ::miniextendr_api::registry::AltrepRegistration =
+                ::miniextendr_api::registry::AltrepRegistration {
+                    register: #reg_fn_name,
+                    symbol: stringify!(#reg_fn_name),
+                };
         }
     } else {
         quote::quote! {}

--- a/miniextendr-macros/src/miniextendr_impl_trait.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait.rs
@@ -875,6 +875,7 @@ pub fn expand_tpie(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 vtable: unsafe {
                     ::std::ptr::from_ref(&#vtable_static_name).cast::<::std::os::raw::c_void>()
                 },
+                vtable_symbol: stringify!(#vtable_static_name),
             };
     };
 

--- a/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
@@ -341,6 +341,7 @@ pub(super) fn generate_vtable_static(
                     // SAFETY: vtable is a static reference valid for program lifetime
                     ::std::ptr::from_ref(&#vtable_static_name).cast::<::std::os::raw::c_void>()
                 },
+                vtable_symbol: stringify!(#vtable_static_name),
             };
     }
 }


### PR DESCRIPTION
Stacked on #471. Base = `webr-support`. Single squashed commit.

Step 3 of [`plans/webr-support.md`](https://github.com/A2-ai/miniextendr/blob/webr-support/plans/webr-support.md): enrich the two runtime-critical entry types whose elements don't already carry their `#[no_mangle]` symbol name, so the host-time WASM snapshot writer (step 4) can emit `extern "C" { fn|static <symbol>; }` declarations without having to recover names from raw fn / vtable pointers.

Refs #470.

## Why only two slices

`MX_CALL_DEFS.name` already equals the C-wrapper symbol — the macro threads the same C ident through both `R_CallMethodDef.name` and the `#[no_mangle]` fn declaration ([c_wrapper_builder.rs:1162-1208](https://github.com/A2-ai/miniextendr/blob/webr-support/miniextendr-macros/src/c_wrapper_builder.rs#L1162-L1208)). The cdylib snapshot writer can read the field directly via `CStr::from_ptr(...).to_str()`. No enrichment needed.

That leaves `MX_ALTREP_REGISTRATIONS` (element was a bare `extern "C" fn()`) and `MX_TRAIT_DISPATCH` (`TraitDispatchEntry` had no symbol field).

## Changes

- **`miniextendr-api/src/registry.rs`**:
  - New `AltrepRegistration { register: extern "C" fn(), symbol: &'static str }`. `MX_ALTREP_REGISTRATIONS` element type changes from `extern "C" fn()` to `AltrepRegistration`. `miniextendr_register_routines` consumer updated to call `(reg.register)()`.
  - `TraitDispatchEntry` gains `vtable_symbol: &'static str`.
- **`miniextendr-macros`**:
  - `altrep.rs`: split into `pub extern "C" fn __mx_altrep_reg_<Ident>()` (still `#[no_mangle]`) + a separate `static __MX_ALTREP_REG_ENTRY_<Ident>: AltrepRegistration { register, symbol: stringify!(register) }`. The entry static is what's `cfg_attr`-gated by linkme.
  - `miniextendr_impl_trait.rs` + `miniextendr_impl_trait/vtable.rs`: add `vtable_symbol: stringify!(#vtable_static_name)` to the `TraitDispatchEntry` literal.

## Why bundle the symbol into the entry instead of a parallel slice

The original sketch in [`plans/wasm-registry-codegen.md`](https://github.com/A2-ai/miniextendr/blob/webr-support/plans/wasm-registry-codegen.md) proposed `MX_*_SYMBOLS: [&'static str]` indexed in lockstep with the runtime slices. linkme doesn't guarantee positional alignment between two distributed slices — within a crate the linker is free to reorder section contents, and across crates the order is at link-time discretion. The bundled form sidesteps the issue entirely: the symbol travels with its entry, no joining required at write time. Slightly bigger entry struct (8–16 bytes per entry); negligible at miniextendr-scale.

## What this PR does *not* do

- Doesn't add the `wasm_registry.rs` snapshot writer — that's step 4.
- Doesn't gate the `[distributed_slice]` *declarations* in `registry.rs` — that's step 5.
- Doesn't make `cargo check --target wasm32-unknown-emscripten` succeed.

## Verification

- `cargo check -p miniextendr-macros -p miniextendr-api` — clean
- `cargo check` on rpkg with patched paths (touches all 18 macro emission sites in expansion) — clean
- `cargo test -p miniextendr-macros --lib` — 307 pass
- `cargo test -p miniextendr-api --lib` — 230 pass
- `cargo clippy -p miniextendr-macros -p miniextendr-api --tests -- -D warnings` — clean

## Test plan

- [ ] CI green on all native targets after #471 lands
- [ ] No runtime behaviour change: `miniextendr_register_routines` still iterates and calls the same fns; `universal_query` still scans `MX_TRAIT_DISPATCH` and matches the same `(concrete_tag, trait_tag)` pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)