### PR TITLE
build: Dockerfile.webr for local webR/wasm dev (#470)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# `Dockerfile.webr` doesn't `COPY` source into the image, so the build context
+# is only used by `docker build`'s tar step. Keep that step fast by excluding
+# heavy dirs and generated artefacts.
+
+target/
+**/target/
+rust-target/
+ra-target/
+**/rust-target/
+**/ra-target/
+rpkg/src/rust/target/
+tests/cross-package/*/rust-target/
+
+.claude/
+.webr/
+
+node_modules/
+**/node_modules/
+
+site/public/
+
+rpkg-check-output/
+rpkg/inst/vendor.tar.xz
+**/vendor/
+
+*.log
+*.tmp
+
+.git/

--- a/Dockerfile.webr
+++ b/Dockerfile.webr
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1.7
+#
+# Local dev container for testing miniextendr R packages under webR.
+#
+# Inherits the upstream `ghcr.io/r-wasm/webr` image so we don't re-stage
+# Emscripten, flang, nightly Rust + `wasm32-unknown-emscripten` + `rust-src`,
+# or the host/wasm R trees. We layer just enough on top to run `just`-based
+# workflows and have a comfortable interactive shell.
+#
+# Usage (local dev):
+#   just docker-webr-build         # build the image
+#   just docker-webr-shell         # interactive shell, repo bind-mounted at /work
+#
+# Build args:
+#   WEBR_BASE  — pinned base-image digest (default below). Bump deliberately
+#                via PR; webR's `:main` tag rolls without notice.
+#   JUST_VERSION — `just` release to install. Apt's version is too old.
+
+ARG WEBR_BASE=ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+FROM ${WEBR_BASE}
+
+ARG JUST_VERSION=1.36.0
+
+# OS deps + dev quality-of-life. Single apt block to keep the layer tight.
+# `autoconf` is needed because rpkg/configure is regenerated from configure.ac
+# on fresh checkouts. clang is already on the base; we add `lldb` for native
+# debugging when reproducing CI failures inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        ripgrep \
+        fd-find \
+        lldb \
+    && rm -rf /var/lib/apt/lists/*
+
+# `just`. The apt version on Debian/Ubuntu is too old for our justfiles.
+# Using the prebuilt static-musl tarball so libc bumps in the base don't
+# break it.
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) JUST_TRIPLE=x86_64-unknown-linux-musl ;; \
+         arm64) JUST_TRIPLE=aarch64-unknown-linux-musl ;; \
+         *) echo "unsupported arch: $ARCH"; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_TRIPLE}.tar.gz" \
+       | tar -xz -C /usr/local/bin just
+
+# `cargo-limit` (the `cargo lcheck/lclippy/ltest/lbuild` aliases the project
+# uses for fast iteration). Build-dep-free — single binary install via cargo.
+RUN cargo install cargo-limit --locked --version "0.0.13"
+
+# Sanity checks — fail the build immediately if the inherited toolchain
+# regressed or our layered tools are missing, instead of debugging a weird
+# later failure inside a working container.
+RUN set -eux \
+    && rustup target list --installed | grep -q wasm32-unknown-emscripten \
+    && rustup component list --installed | grep -q rust-src \
+    && cargo --version \
+    && emcc --version >/dev/null \
+    && /opt/R/current/bin/R --version >/dev/null \
+    && Rscript -e 'stopifnot(requireNamespace("rwasm", quietly=TRUE))' \
+    && just --version >/dev/null \
+    && autoconf --version >/dev/null \
+    && command -v cargo-lcheck >/dev/null \
+    && command -v rg >/dev/null \
+    && command -v fdfind >/dev/null \
+    && command -v lldb >/dev/null
+
+# `/work` is a plain mount point; CI / local dev binds the repo there. We do
+# *not* `COPY` source into the image — keeping it source-free makes it a pure
+# environment artefact and lets `docker run -v $PWD:/work` work without a
+# rebuild for every code change.
+WORKDIR /work

--- a/justfile
+++ b/justfile
@@ -1141,3 +1141,42 @@ site-serve:
 # Bump version across all Cargo.toml and DESCRIPTION files.
 bump-version version:
     bash scripts/bump-version.sh {{version}}
+
+# ── Local webR/wasm dev container ────────────────────────────────────────────
+#
+# `Dockerfile.webr` inherits ghcr.io/r-wasm/webr (digest-pinned) and layers
+# `just`, `autoconf`, dev tools. See the Dockerfile header for what's already
+# in the base. Use this when reproducing webR/wasm32 build issues locally.
+
+docker_webr_image := "miniextendr-webr-dev:latest"
+
+# Build the local webR dev image. Re-run when Dockerfile.webr changes.
+docker-webr-build:
+    docker build -f Dockerfile.webr -t {{docker_webr_image}} .
+
+# Drop into an interactive shell in the webR dev container with this repo
+# bind-mounted at /work. From inside, run `just configure / rcmdinstall /
+# devtools-test` etc. as if on Linux. The container is amd64-only (webR
+# upstream); on Apple Silicon Docker emulates via Rosetta — slower but works.
+docker-webr-shell:
+    docker run --rm -it \
+        -v "{{justfile_directory()}}:/work" \
+        -w /work \
+        {{docker_webr_image}} bash
+
+# Non-interactive: run an arbitrary command inside the container with the
+# repo mounted. e.g. `just docker-webr-run "cargo check --target wasm32-unknown-emscripten -p miniextendr-api"`.
+docker-webr-run *cmd:
+    docker run --rm \
+        -v "{{justfile_directory()}}:/work" \
+        -w /work \
+        {{docker_webr_image}} bash -c "{{cmd}}"
+
+# Smoke-test the wasm32 build path inside the container. Checks
+# `miniextendr-api` (no git deps, so works directly). For an rpkg-side
+# wasm32 check, drop into a shell with `just docker-webr-shell` and run
+# `bash ./rpkg/configure && cd rpkg/src/rust && cargo check --target
+# wasm32-unknown-emscripten` — `configure` writes the right `[patch."git+url"]`
+# overrides into `.cargo/config.toml` for the workspace siblings.
+docker-webr-test: docker-webr-build
+    just docker-webr-run "cargo check --target wasm32-unknown-emscripten -p miniextendr-api"


### PR DESCRIPTION
Stacked on #475. Base = `webr-support-step7`. Single squashed commit. 3 files, +140.

Local dev container for testing miniextendr R packages against webR's wasm32 toolchain — what you actually asked for, not a CI workflow.

Refs #470.

## What you get

```bash
just docker-webr-build      # build the image (one-time, ~2 min on warm cache)
just docker-webr-shell      # interactive bash, repo bind-mounted at /work
just docker-webr-run "<cmd>" # non-interactive command runner
just docker-webr-test       # cargo check miniextendr-api on wasm32-unknown-emscripten
```

## Image shape

Inherits `ghcr.io/r-wasm/webr@sha256:0b9e6e41…` (digest-pinned — `:main` rolls without notice). Already provides:

- nightly Rust 1.97 + `wasm32-unknown-emscripten` target + `rust-src` component
- Emscripten 4.0.8
- R 4.5.1 native + R-for-WASM under `/opt/webr/`
- `pak`, `rwasm` R packages
- `clang`, `pkg-config`

Layered (one apt block + cargo install for parsimony):

| Tool | Why |
|---|---|
| `just` 1.36.0 | apt's version is too old for our justfiles. Static-musl tarball install. |
| `autoconf` | `rpkg/configure` is regenerated from `configure.ac`. |
| `cargo-limit` 0.0.13 | `cargo lcheck/lclippy/ltest/lbuild` aliases per CLAUDE.md. |
| `ripgrep`, `fd-find`, `lldb` | Interactive dev quality-of-life. |

Sanity checks fail the build if anything regresses, so you don't end up debugging a weird later failure inside a working container.

## Verified end-to-end

```
$ docker build -f Dockerfile.webr -t miniextendr-webr-dev:latest .
[...] DONE
$ just docker-webr-test
[...]
   Compiling miniextendr-api v0.1.0 (/work/miniextendr-api)
[...]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.28s
```

## Apple Silicon caveat

webR's upstream image is amd64-only. On arm64 Macs Docker Desktop emulates via Rosetta — slower but correct. Tracking webR upstream beats forking for arm64.

## What's *not* in this PR

- No CI workflow. You said "I'm not sure what you want to do in CI" — dropping that ambition. This is local dev only.
- For an rpkg-side wasm32 check inside the container, drop into the shell first and run `bash ./rpkg/configure && cd rpkg/src/rust && cargo check --target wasm32-unknown-emscripten` — `configure` writes the right `[patch."git+url"]` overrides to `.cargo/config.toml`. Threading those through `--config` flags via just→bash→docker→bash→cargo is too many escape layers to bother with.
- No deeper `R CMD INSTALL` / `rwasm::build_pkg` / Node-driven smoke test recipe yet — those are bigger and benefit from a `just configure` setup pass first; happy to add them once we exercise the container in real use.

## Test plan

- [ ] CI green on all native targets after the rest of the stack lands
- [ ] User runs `just docker-webr-build && just docker-webr-shell` and confirms it Just Works on their machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)