### PR TITLE
docs(plans): split webR follow-ups into focused plan files (#470)

### DIFF
--- a/plans/webr-ci.md
+++ b/plans/webr-ci.md
@@ -1,0 +1,204 @@
+# WebR CI workflow
+
+Goal: a CI job that exercises the wasm32 build path end-to-end, gated on
+paths so docs-only PRs don't fire it. **Optional.** Steps 2–7 of
+`webr-support.md` are merged; everything compiles for
+`wasm32-unknown-emscripten`. This plan is what closes the loop on
+"reviewer can know wasm32 still works without running it locally."
+
+Status: **not started**. The user explicitly deferred CI ("not sure what
+you want to do in CI") during the implementation sprint. Pick this up
+when the wasm32 path needs ongoing protection.
+
+## What success looks like
+
+A `webr.yml` workflow that runs on PR + push to main when wasm-relevant
+files change, and reports a single `wasm32 check` status. Three
+escalating tiers of work — pick one to start.
+
+## Tier 1 — `cargo check` only (smallest, fastest)
+
+Catches: cfg-gating regressions, macro emission bugs that fail to
+compile on wasm32, anything that breaks the linkme replacement.
+Doesn't catch: link errors, runtime errors.
+
+Cost: ~3 min per PR (cargo check is fast). No emcc / R needed.
+
+```yaml
+# .github/workflows/webr.yml
+name: webR / wasm32
+on:
+  pull_request:
+    paths:
+      - 'miniextendr-api/**'
+      - 'miniextendr-macros/**'
+      - 'rpkg/**'
+      - 'tests/cross-package/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile.webr'
+      - '.github/workflows/webr.yml'
+  push:
+    branches: [main]
+    paths: # …same…
+  workflow_dispatch:
+
+jobs:
+  cargo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-emscripten
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check (miniextendr-api)
+        run: cargo check -p miniextendr-api --target wasm32-unknown-emscripten
+      - name: cargo check (rpkg)
+        run: |
+          bash ./rpkg/configure
+          cd rpkg/src/rust
+          cargo check --target wasm32-unknown-emscripten
+```
+
+`cargo check` for `wasm32-unknown-emscripten` works on **stable** Rust
+without `-Z build-std` because we only need to typecheck — no link.
+Rust ships a precompiled `std` for that target on stable. (Linking
+against webR's pinned Emscripten is what needs nightly + `build-std`,
+and that's tier 2.)
+
+`./rpkg/configure` is needed so `.cargo/config.toml` gets the
+`[patch."git+url"]` overrides that point at workspace siblings. Without
+it, rpkg fetches `miniextendr-api` from `main` (via
+`Cargo.toml`'s `git = "..."` dep) — works on PRs to main, but breaks if
+the PR also touches `miniextendr-api` because the live source isn't
+reflected.
+
+## Tier 2 — Full `R CMD INSTALL` via `Dockerfile.webr`
+
+Catches everything tier 1 catches, plus: link errors, missing
+`wasm_registry.rs`, Makevars issues, the actual rwasm/emcc dance.
+Doesn't catch: runtime behaviour (loading in webR / running R code).
+
+Cost: ~10–15 min per PR (image pull + cdylib build + emcc link +
+R CMD INSTALL into the WASM lib tree).
+
+```yaml
+jobs:
+  rcmd-install:
+    runs-on: ubuntu-latest
+    container: ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+    steps:
+      - uses: actions/checkout@v4
+      # The base image has nightly + `wasm32-unknown-emscripten` + `rust-src`
+      # already. We just need `just` + `autoconf` to drive our recipes.
+      - name: Layer just + autoconf
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends autoconf
+          curl -fsSL "https://github.com/casey/just/releases/download/1.36.0/just-1.36.0-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C /usr/local/bin just
+      - name: Configure rpkg
+        run: |
+          # webR-vars.mk-style overrides: CC=emcc, R_MAKEVARS_USER=webr-vars.mk
+          export R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk
+          bash ./rpkg/configure
+      - name: R CMD INSTALL --no-test-load
+        run: |
+          R_LIBS=/tmp/wasm-lib /opt/R/current/bin/R CMD INSTALL \
+            --no-docs --no-test-load --no-staged-install \
+            --library=/tmp/wasm-lib \
+            rpkg
+```
+
+**Open question:** does the base webR image have a wasm32 R built such
+that `R CMD INSTALL` produces a wasm32 side-module? Verify locally with
+`just docker-webr-shell` before committing the workflow.
+
+**`R_MAKEVARS_USER=webr-vars.mk` is required.** Without it, the install
+uses the host's CC (gcc) and produces a native shared object — not a
+wasm side-module. The webR image ships
+`/opt/webr/packages/webr-vars.mk` with `CC=emcc`, `LDFLAGS=-s
+SIDE_MODULE=1`, etc.
+
+**Ties into step 8.** `rpkg/configure.ac` doesn't yet detect `CC=emcc`
+and adjust cargo / Makevars. Tier 2 needs step 8 landed first;
+otherwise the cargo step still tries to link a native cdylib.
+
+## Tier 3 — Smoke test in webR Node session
+
+Catches everything plus: the package actually loads in webR and a
+`#[miniextendr]` function returns sensible output.
+
+Cost: tier 2 + ~5 min for Node + webR startup + test execution.
+
+```yaml
+- name: Smoke test
+  run: |
+    /opt/webr/host/bin/Rscript -e '
+      .libPaths(c("/tmp/wasm-lib", .libPaths()))
+      library(miniextendr)
+      result <- some_exported_fn(...)
+      stopifnot(...)
+    '
+```
+
+The `webR Node` invocation is what `webr` gem / `r-wasm/webr` runs in
+its own CI. Crib from `.webr/src/tests-webr/` (the local clone of the
+webR repo we vendored as offline reference). The exact incantation has
+to be worked out — webR itself runs tests in a JS host, not via
+`Rscript` directly. Likely looks like:
+
+```bash
+node -e "const { WebR } = require('@r-wasm/webr');
+         const webR = new WebR();
+         await webR.init();
+         await webR.installPackage('/tmp/wasm-lib/miniextendr');
+         const result = await webR.evalR('miniextendr::some_exported_fn()');
+         console.log(await result.toJs());"
+```
+
+Defer until tier 2 is solid.
+
+## What's *not* in scope for this plan
+
+- macOS / Windows wasm32 builds. webR's image is x86_64 Linux only;
+  cross-platform CI is upstream's problem, not ours. amd64 emulation
+  on arm64 macOS via Rosetta works for *local* dev (per `Dockerfile.webr`)
+  but is too slow for CI.
+- Caching the cdylib `target/` dir under `-Z build-std`. tier 2 only —
+  can be added later via `actions/cache@v4` keyed on `Cargo.lock`.
+  Saves 3–5 min per CI run after first warm-up.
+- Mirroring `ghcr.io/r-wasm/webr` to `ghcr.io/a2-ai/...`. Pull-rate-limit
+  hedge. File as follow-up only if rate-limited in practice.
+
+## Recommended starting point
+
+**Tier 1.** Two cargo-check steps + paths filter. ~3 min, catches the
+common regressions, no Docker / emcc / R complications. Tier 2 + 3 land
+once step 8 is in (so `configure.ac` cooperates with `CC=emcc`) and
+once we've manually walked through the workflow inside
+`just docker-webr-shell` to know the exact command shape.
+
+## Implementation steps
+
+1. Open a PR with just the tier-1 workflow file. Verify it reports
+   `wasm32 check / cargo check` as a success status on a no-op PR.
+2. Add `paths:` filter; verify a docs-only PR doesn't fire it.
+3. (Later — after step 8 lands) extend with tier 2: container =
+   pinned webR digest, `R CMD INSTALL --no-test-load`. Verify locally
+   inside `just docker-webr-shell` first.
+4. (Later still) tier 3 smoke test. May want `r-wasm/webr` on npm or
+   the JS shim from `.webr/src/tests-webr/`.
+
+## Risks
+
+- **`Dockerfile.webr` digest divergence.** When webR upstream rolls,
+  we bump the digest in `Dockerfile.webr` deliberately. CI's container
+  digest must match. Either reference the same `WEBR_BASE` arg or
+  hardcode the digest twice and accept the duplication. Lean toward
+  hardcoding twice — `Dockerfile.webr` is local-dev, CI is reviewable
+  in PR; mismatches caught visually.
+- **Tier 2 R CMD INSTALL surface.** The webR upstream install path uses
+  `pak` / `rwasm::build_pkg`, not bare `R CMD INSTALL`. Verify whether
+  the bare invocation works against `webr-vars.mk`. If not, fall back
+  to driving `Rscript -e 'rwasm::build_pkg(...)'` from the workflow.

--- a/plans/webr-configure-and-build-rs.md
+++ b/plans/webr-configure-and-build-rs.md
@@ -1,0 +1,245 @@
+# `rpkg/configure.ac` wasm32 detection + `rpkg/build.rs` snapshot validation
+
+Two coupled rpkg-side compile-time concerns that close out the wasm32
+install path. Both are step 8 of `webr-support.md` (split here for
+clarity).
+
+Status: **not started**. The plumbing for wasm32 cargo check works
+(steps 2–7 merged), but neither piece below is wired up. Without them:
+- `R CMD INSTALL` of rpkg with `CC=emcc` doesn't pass
+  `--target wasm32-unknown-emscripten` to cargo (step 8).
+- A stale or missing `wasm_registry.rs` produces a confusing link error
+  rather than an actionable build-time message (build.rs).
+
+## Part A — `rpkg/configure.ac`: detect `CC=emcc`, set wasm flags
+
+`webr-vars.mk` overrides `CC=emcc` and `LDFLAGS=-s SIDE_MODULE=1` for
+every R package install under WASM (see `.webr/packages/webr-vars.mk`).
+rpkg's `configure.ac` currently doesn't know about that — it writes
+`Makevars` + `.cargo/config.toml` assuming a native build.
+
+### What configure.ac needs to do under `CC=emcc`
+
+1. **Set `CARGO_BUILD_TARGET=wasm32-unknown-emscripten`** so the
+   staticlib step in `Makevars.in` builds for the right target. The
+   variable is already plumbed through `Makevars.in`'s `TARGET_OPT`
+   conditional (`if [ -n "$(CARGO_BUILD_TARGET)" ]`), so this is a
+   single substitution.
+
+2. **Set `IS_WASM_INSTALL=true`** — new substitution. Used to gate the
+   cdylib + wrapper-gen pass off (no host R can `dyn.load` a wasm side
+   module). The `WRAPPERS_R` recipe in `Makevars.in` becomes a no-op
+   on wasm32 — both `R/<pkg>-wrappers.R` and `src/rust/wasm_registry.rs`
+   are expected to be pre-generated on host and shipped into the
+   tarball / bundle.
+
+3. **Pass `RUSTFLAGS`** for emscripten side-module link:
+   `-C relocation-model=pic -C link-args=-s SIDE_MODULE=1` (exact set
+   TBD — verify against rwasm's flags. Plan `webr-support.md` flagged
+   this as needing experimental confirmation.)
+
+4. **Use nightly + `-Z build-std=std,panic_abort`** because rustup's
+   precompiled std for `wasm32-unknown-emscripten` is built against
+   *some* Emscripten that may not match webR's pinned version, and
+   doesn't have `panic = "abort"` baked into std. Set
+   `RUST_TOOLCHAIN=+nightly` and add
+   `-Z build-std=std,panic_abort` to the cargo invocation.
+
+   Plumbing: `RUST_TOOLCHAIN` is already a configure substitution. Add
+   `CARGO_BUILD_STD_FLAG = -Z build-std=std,panic_abort` (empty on
+   native). Thread through the `cargo build` and `cargo rustc` lines
+   in `Makevars.in`.
+
+5. **Refuse to build if `wasm_registry.rs` is absent.** configure
+   fails with a clear message ("Run `R CMD INSTALL` on host first to
+   generate `src/rust/wasm_registry.rs`, then ship the source tree
+   to the wasm builder"). Detection: `[ -f
+   "$srcdir/src/rust/wasm_registry.rs" ]`.
+
+### Detection logic
+
+```m4
+# In configure.ac, near the existing CC detection.
+AC_MSG_CHECKING([whether CC is emscripten (webR/wasm32 install)])
+case "${CC}" in
+  *emcc*|*em++*)
+    is_wasm_install=true
+    CARGO_BUILD_TARGET=wasm32-unknown-emscripten
+    RUST_TOOLCHAIN="+nightly"
+    CARGO_BUILD_STD_FLAG="-Z build-std=std,panic_abort"
+    AC_MSG_RESULT([yes])
+    ;;
+  *)
+    is_wasm_install=false
+    CARGO_BUILD_TARGET=
+    CARGO_BUILD_STD_FLAG=
+    AC_MSG_RESULT([no])
+    ;;
+esac
+
+# Refuse if wasm_registry.rs is missing
+if test "$is_wasm_install" = true; then
+  if test ! -f "$srcdir/src/rust/wasm_registry.rs"; then
+    AC_MSG_ERROR([wasm32 install requires src/rust/wasm_registry.rs.
+Run `R CMD INSTALL` (or `just rcmdinstall`) on the host to regenerate
+it from the cdylib slice contents, then ship the source tree to the
+wasm builder.])
+  fi
+fi
+
+AC_SUBST([IS_WASM_INSTALL], [$is_wasm_install])
+AC_SUBST([CARGO_BUILD_TARGET])
+AC_SUBST([CARGO_BUILD_STD_FLAG])
+```
+
+Don't forget `autoconf` to regenerate `rpkg/configure` and commit both.
+
+### Makevars.in changes
+
+```make
+# New substitution (configure-supplied)
+IS_WASM_INSTALL       = @IS_WASM_INSTALL@
+CARGO_BUILD_STD_FLAG  = @CARGO_BUILD_STD_FLAG@
+
+# In CARGO_AR / CARGO_CDYLIB recipes, add the build-std flag:
+$(CARGO) $(RUST_TOOLCHAIN) build $(CARGO_OFFLINE_FLAG) $(CARGO_FEATURES_FLAG) $(CARGO_BUILD_STD_FLAG) $$TARGET_OPT \
+  …
+
+# Gate the wrapper-gen recipe to native:
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+ifeq ($(IS_WASM_INSTALL),true)
+	@echo "wasm32 install: skipping wrapper-gen (uses pre-generated R/$(pkg)-wrappers.R + src/rust/wasm_registry.rs)"
+	@touch $(WRAPPERS_R)  # force timestamp so make doesn't retry
+else
+	@echo "Generating R wrappers + wasm_registry.rs..."
+	# …existing recipe…
+endif
+```
+
+Ports to `minirextendr/inst/templates/{,monorepo/}rpkg/Makevars.in` per
+the project's templates-derived-from-rpkg convention (CLAUDE.md). Run
+`just templates-approve` to lock the delta in `patches/templates.patch`.
+
+### Non-goals
+
+- Detecting webR via mechanisms other than `CC=emcc`. The `--with-wasm`
+  configure flag mentioned in older planning is dropped — `CC=emcc` is
+  the unambiguous signal that webR's `webr-vars.mk` is in scope.
+- Side-module link flags beyond what's strictly needed. Defer
+  optimisation (`-O3`, LTO) until a working build exists.
+- `tests/cross-package/*` configure changes — those packages don't ship
+  a `webr-vars.mk` install path. See `webr-cross-package-stubs.md`.
+
+## Part B — `rpkg/build.rs`: validate `wasm_registry.rs`
+
+`miniextendr_init!` macro emits `#[cfg(target_arch = "wasm32")]
+#[path = "wasm_registry.rs"] mod __miniextendr_wasm_registry;` and
+references three statics from it. Without `wasm_registry.rs`:
+
+- File missing → `mod` declaration fails to resolve. rustc gives a
+  filesystem path error pointing at the macro expansion. Confusing.
+- File present but **stale** (generated against an older miniextendr-api
+  with a different slice layout) → compiles, links, then crashes
+  at `R_init` with `register: <fnptr>` pointing to whatever bytes
+  happened to be at that address.
+
+Both are catastrophic and avoidable. A tiny `build.rs` in rpkg gets us
+a clear early diagnostic.
+
+### What build.rs should do (wasm32 only)
+
+```rust
+// rpkg/src/rust/build.rs
+fn main() {
+    // Re-run if the snapshot or this build script changes
+    println!("cargo:rerun-if-changed=wasm_registry.rs");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch != "wasm32" {
+        return;
+    }
+
+    let path = std::path::Path::new("wasm_registry.rs");
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => panic!(
+            "wasm32 build requires src/rust/wasm_registry.rs.\n\
+             Run `just rcmdinstall` (or equivalent) on the host to regenerate it."
+        ),
+    };
+
+    // Parse `// generator-version: <N>` from the header
+    let header_version: u32 = content
+        .lines()
+        .find_map(|l| l.strip_prefix("// generator-version: "))
+        .and_then(|v| v.trim().parse().ok())
+        .expect("wasm_registry.rs missing or malformed `generator-version` header");
+
+    // Must match miniextendr-api's GENERATOR_VERSION constant
+    const EXPECTED_VERSION: u32 = 1; // bump in lockstep with
+                                      // miniextendr-api/src/wasm_registry_writer.rs
+    if header_version != EXPECTED_VERSION {
+        panic!(
+            "wasm_registry.rs was generated by an older miniextendr (generator-version {header_version}, \
+             this build expects {EXPECTED_VERSION}). Run `just rcmdinstall` on host to regenerate."
+        );
+    }
+
+    // Optional: validate content-hash matches (defends against
+    // hand-edited or partial snapshots). The header carries the
+    // FNV-1a-64 hash of the body; recompute and compare.
+    // Skip for v1 — the timing window where a stale snapshot is
+    // shipped is tight enough that generator-version catches most cases.
+}
+```
+
+### Coupling to miniextendr-api
+
+`EXPECTED_VERSION` must mirror `miniextendr-api/src/wasm_registry_writer.rs`'s
+`GENERATOR_VERSION` constant. Two ways to keep them in sync:
+
+1. **Hand-mirror with a comment** (current sketch above). Cheap;
+   relies on convention. Bump both together when the format changes.
+2. **Re-export from `miniextendr-api` and read in build.rs**. Means
+   build.rs has `miniextendr-api` as a build-dependency, which is
+   awkward (chicken-and-egg if api itself fails to build).
+
+Lean toward (1). The format changes rarely — every macro/struct
+reshape that affects emission. A lint or test in the api crate that
+greps for `GENERATOR_VERSION` mentions and bumps both together would
+help, but is overengineering until we hit a v2.
+
+### Ports
+
+build.rs is rpkg-specific (it reads rpkg's `wasm_registry.rs`). If
+cross-package crates eventually grow their own snapshots
+(`webr-cross-package-stubs.md`), they each get their own build.rs
+with the same pattern.
+
+## Order of operations
+
+**Land Part A first, then Part B.** Part A makes wasm32 install
+actually pass cargo + linker. Part B is the diagnostic improvement on
+top — useful but not blocking.
+
+Each is a small focused PR. Combined diff is ~150 lines (configure.ac
++ Makevars.in updates + templates port + build.rs + minor CLAUDE.md
+note).
+
+## Verification
+
+For Part A:
+- Inside `just docker-webr-shell`: `bash ./rpkg/configure` writes
+  `Makevars` with `IS_WASM_INSTALL=true` and `CARGO_BUILD_STD_FLAG`
+  populated. `make -C rpkg/src` builds a wasm side-module.
+- On native: `IS_WASM_INSTALL=false`, build is unchanged.
+
+For Part B:
+- Delete `rpkg/src/rust/wasm_registry.rs`, run `cargo check --target
+  wasm32-unknown-emscripten`. Expect: build.rs panic with the
+  "Run `just rcmdinstall`" message.
+- Tamper with the file's `// generator-version: 1` line (set to 2),
+  re-run cargo check. Expect: build.rs panic with version-mismatch
+  message.
+- Native cargo check: build.rs is a no-op (early-returns on non-wasm32).

--- a/plans/webr-cross-package-stubs.md
+++ b/plans/webr-cross-package-stubs.md
@@ -1,0 +1,70 @@
+# Cross-package `wasm_registry.rs` stubs
+
+Status: **not started**. Low priority — `tests/cross-package/{consumer,producer}.pkg`
+are native-only trait-ABI test crates, never deployed to webR.
+
+## What's needed
+
+`miniextendr_init!()` macro now emits a wasm32-cfg-gated
+`#[path = "wasm_registry.rs"] mod __miniextendr_wasm_registry;` (landed
+with #475). Any crate that calls `miniextendr_init!()` therefore needs
+a `wasm_registry.rs` next to its `lib.rs` for the wasm32 build to
+succeed.
+
+The cross-package crates each invoke `miniextendr_init!()`:
+
+```
+$ grep -rn "miniextendr_init" tests/cross-package
+tests/cross-package/consumer.pkg/src/rust/lib.rs:11:miniextendr_api::miniextendr_init!();
+tests/cross-package/producer.pkg/src/rust/lib.rs:15:miniextendr_api::miniextendr_init!();
+```
+
+So:
+- `tests/cross-package/consumer.pkg/src/rust/wasm_registry.rs` — empty stub
+- `tests/cross-package/producer.pkg/src/rust/wasm_registry.rs` — empty stub
+
+Both modeled on `rpkg/src/rust/wasm_registry.rs`'s stub format:
+
+```rust
+// AUTO-GENERATED — DO NOT EDIT.
+// generator-version: 1
+// content-hash:      0000000000000000
+//
+// THIS IS A STUB. Cross-package test crates aren't deployed to webR;
+// the file exists only so `cargo check --target
+// wasm32-unknown-emscripten` resolves the wasm32-gated `mod` decl
+// emitted by `miniextendr_init!()`.
+
+use ::miniextendr_api::ffi::R_CallMethodDef;
+use ::miniextendr_api::registry::{AltrepRegistration, TraitDispatchEntry};
+
+pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[];
+pub static MX_ALTREP_REGISTRATIONS_WASM: &[AltrepRegistration] = &[];
+pub static MX_TRAIT_DISPATCH_WASM: &[TraitDispatchEntry] = &[];
+```
+
+## Why low priority
+
+- The stubs don't get loaded — they exist purely to satisfy the
+  `mod` declaration. If you never `cargo check --target
+  wasm32-unknown-emscripten` on consumer.pkg / producer.pkg, you
+  never need them.
+- Native build (the only one that matters for these crates) is unaffected
+  — the `mod` is `#[cfg(target_arch = "wasm32")]`-gated, so on native
+  the file isn't required.
+
+## When to do this
+
+- If a future PR adds wasm32 to CI and runs cargo check on
+  cross-package (unlikely — they're trait-ABI tests, not deployment
+  targets).
+- If trait dispatch ends up needing a cross-crate `wasm_registry.rs`
+  merge protocol (see `wasm-registry-codegen.md` Risks #5). At that
+  point the cross-package stubs become real test fixtures, not stubs.
+
+Until then: skip.
+
+## Implementation
+
+Trivial: two new files, copy-paste of rpkg's stub. ~50 lines total.
+File as a follow-up issue if needed; otherwise don't bother.

--- a/plans/webr-support.md
+++ b/plans/webr-support.md
@@ -6,23 +6,38 @@ Goal: build miniextendr-api (and the rpkg `miniextendr` R package) for the
 
 ## Companion artefacts
 
-This plan is the index. The detailed work is split across three files:
+This plan is the index. The detailed work is split across these files:
+
+**Landed (steps 1–7 + Dockerfile, in #470's stack):**
 
 - **`plans/wasm-registry-codegen.md`** — the linkme replacement. How we
   snapshot the runtime data (`MX_CALL_DEFS`, `MX_ALTREP_REGISTRATIONS`,
   `MX_TRAIT_DISPATCH`) on host and reconstruct it via a generated
   `wasm_registry.rs` on WASM. Owns the macro-emission changes,
-  symbol-name stabilisation, cdylib JSON writer, and `build.rs` codegen.
-  Steps 3-5 below dispatch there.
-- **`plans/webr-dockerfile.md`** — the build environment.
-  `Dockerfile.webr` (inheriting `ghcr.io/r-wasm/webr` digest-pinned),
-  `just docker-webr-*` recipes, CI sequencing (cargo check → R CMD
-  INSTALL → `rwasm::build_pkg` → webR Node smoke test). Step 6 below
-  dispatches there.
+  symbol-name stabilisation, cdylib writer, and the `mod` include in
+  `miniextendr_init!`. Steps 2–5 + 7 dispatched there.
+- **`plans/webr-dockerfile.md`** — local-dev build environment.
+  `Dockerfile.webr` inheriting `ghcr.io/r-wasm/webr` digest-pinned,
+  `just docker-webr-*` recipes. Landed in #476.
 - **`docs/WEBR.md`** — user-facing summary of the toolchain
   requirements (target triple, why nightly, why
-  `-Z build-std=std,panic_abort`). Anything that belongs in long-lived
-  contributor docs goes there, not here.
+  `-Z build-std=std,panic_abort`). Long-lived contributor docs.
+
+**Open follow-ups (still to do):**
+
+- **`plans/webr-ci.md`** — three escalating tiers of CI (cargo check
+  only / Docker `R CMD INSTALL` / webR Node smoke test). Tier 1 is
+  the recommended starting point — small, fast, catches the common
+  cfg-gating regressions. Step 6 of this doc.
+- **`plans/webr-configure-and-build-rs.md`** — `rpkg/configure.ac`
+  detection of `CC=emcc` (sets `CARGO_BUILD_TARGET=wasm32-unknown-emscripten`,
+  nightly `+`, `-Z build-std=std,panic_abort`, side-module RUSTFLAGS,
+  refuses build if `wasm_registry.rs` missing) + `rpkg/build.rs`
+  validation of the snapshot's generator-version. Step 8 of this doc.
+- **`plans/webr-cross-package-stubs.md`** — empty `wasm_registry.rs`
+  stubs in `tests/cross-package/{consumer,producer}.pkg/src/rust/`.
+  Low priority; only matters if cross-package crates ever land in
+  CI's wasm32 path.
 
 When information here goes stale, prefer to delete it and link out
 rather than duplicate.
@@ -170,41 +185,47 @@ Symbol-name stability, vtable encoding, schema versioning,
 cross-crate trait dispatch, and the alternatives we didn't pick (inventory,
 ctor) — all in `plans/wasm-registry-codegen.md`.
 
-## Next concrete steps
+## Steps
 
-1. **Read `r-wasm/rwasm`** — confirm exact cargo invocation, vendoring
-   handling, and Makevars overrides it expects. Update this plan with
-   findings before writing any code.
-2. **Audit proc-macro emission** — list every `#[distributed_slice(...)]`
-   site in `miniextendr-macros`, confirm each emits a corresponding extern
-   "C" symbol (or uniquely-named pub static) usable by name from
-   `wasm_registry.rs`.
-3. **Replace linkme on WASM** — full design in
-   `plans/wasm-registry-codegen.md`. Three sub-steps: stabilise symbol
-   names (altrep + vtable `#[no_mangle]`), `cfg_attr`-gate every
-   `#[distributed_slice]` attribute the macros emit, extend the cdylib
-   write step to serialise a `wasm_registry.json` snapshot.
-4. **`miniextendr-api` build.rs**: read `wasm_registry.json` under
-   `cfg(target_arch = "wasm32")`, emit `wasm_registry.rs` to `OUT_DIR`,
-   `include!` it from `registry.rs`. (Detail in
-   `plans/wasm-registry-codegen.md`.)
-5. **Verify**: `cargo check --target wasm32-unknown-emscripten -Z
-   build-std=std,panic_abort` on `miniextendr-api` and `rpkg/src/rust`.
-   Linker should resolve all wrapper / altrep / vtable extern names
-   from the user crate's `#[no_mangle]` exports.
-6. **Docker + CI**: implement the build environment per
-   `plans/webr-dockerfile.md` — single-stage `Dockerfile.webr` inheriting
-   `ghcr.io/r-wasm/webr` (digest-pinned), layering `just`, `autoconf`,
-   `clang`/`libclang-dev`, `pkg-config`. Add `just docker-webr-build` /
-   `just docker-webr-shell` recipes. The CI job exercises this image
-   through cargo check → R CMD INSTALL → `rwasm::build_pkg` → webR Node
-   smoke test, gated on a `paths:` filter so docs-only PRs don't fire it.
-7. **rpkg `Makevars.in`**: branch on `CARGO_BUILD_TARGET=wasm32-*` to skip
-   cdylib + Rscript wrapper-gen and pass the right `RUSTFLAGS`.
-8. **`configure.ac`**: detect `CC=emcc` (or an explicit `--with-wasm`
-   override) and set `CARGO_BUILD_TARGET=wasm32-unknown-emscripten` +
-   `IS_WASM_INSTALL=true`. Refuse to build if `wasm_registry.rs` /
-   wrappers are missing (with a pointer to `just wasm-prepare`).
+✅ = landed in #470's stack; ⏳ = open follow-up.
+
+1. ✅ **Stabilise symbol names** — closed by #392, #393, #394 (altrep
+   register fn `#[no_mangle]`, trait vtable `#[no_mangle]`, generic
+   vtable name collision via FNV hash suffix).
+2. ✅ **`cfg_attr`-gate `#[distributed_slice]` emissions** — #471.
+3. ✅ **Symbol fields on entry types** — #472. `AltrepRegistration.symbol`
+   + `TraitDispatchEntry.vtable_symbol`. (`MX_CALL_DEFS` already has
+   `name == symbol`, no enrichment needed.)
+4. ✅ **Host-time `wasm_registry.rs` writer** — #473. Pure formatter +
+   C-callable entry point `miniextendr_write_wasm_registry`.
+5. ✅ **Cfg-branch registry slices** — #474. `OnceLock`-backed runtime
+   table on wasm32 + `install_wasm_runtime_slices(...)` public fn.
+   Departure from earlier plan: snapshot lives in user-crate, not
+   miniextendr-api (see commit message for rationale).
+6. ⏳ **CI workflow** — see `plans/webr-ci.md`. Three escalating tiers;
+   tier 1 (cargo check only) is recommended starting point.
+7. ✅ **`miniextendr_init!` + `Makevars.in` wiring** — #475. Macro
+   emits cfg-gated `mod __miniextendr_wasm_registry;` + install call;
+   Makevars co-generates `R/<pkg>-wrappers.R` + `src/rust/wasm_registry.rs`
+   in the same cdylib pass.
+8. ⏳ **`rpkg/configure.ac` `CC=emcc` detection + `rpkg/build.rs`
+   snapshot validation** — see `plans/webr-configure-and-build-rs.md`.
+
+## Other open follow-ups
+
+- ⏳ **Cross-package wasm32 stubs** — `plans/webr-cross-package-stubs.md`.
+  Low priority; only the rpkg path is exercised in practice.
+
+## Stack-ordering gotcha (from the merge cascade)
+
+Step 7's `Makevars` calls `miniextendr_write_wasm_registry` via
+`getNativeSymbolInfo`. For that symbol to appear in the cdylib's
+dynamic symbol table, the `as *const ()` reference in
+`miniextendr_register_routines` (added in step 5) must be present.
+Step 5 must merge before step 7's CI will pass — the linker won't
+pull a Rust dep-crate `#[no_mangle]` fn into a cdylib unless something
+in the final crate's call graph references it. Recorded for future
+reorderings of this plan's steps.
 
 ## Non-goals for this branch
 


### PR DESCRIPTION
Plans-only PR. No code changes. 4 files, +585/-45.

The webR implementation stack (#471–#476) landed steps 1–5, 7, and `Dockerfile.webr`. This PR captures the **three remaining open items** as focused plan files so future implementation rounds can pick them up after a context reset.

Refs #470.

## What's in this PR

| File | What | Status |
|---|---|---|
| `plans/webr-ci.md` | CI workflow exercising wasm32. Three escalating tiers — cargo check only / Docker R CMD INSTALL / webR Node smoke test. | new |
| `plans/webr-configure-and-build-rs.md` | `rpkg/configure.ac` `CC=emcc` detection + `rpkg/build.rs` snapshot validation. Step 8 of webr-support.md. | new |
| `plans/webr-cross-package-stubs.md` | Empty `wasm_registry.rs` stubs for `tests/cross-package/{consumer,producer}.pkg`. Low priority. | new |
| `plans/webr-support.md` | Index plan rewritten to reflect post-merge state. Each step marked ✅ landed / ⏳ open. Links to new plan files. Records the stack-ordering gotcha caught during the merge cascade. | updated |

## Recommended next implementation round

1. **`webr-configure-and-build-rs.md`** first. Without it, `R CMD INSTALL` of rpkg with `CC=emcc` doesn't actually pass `--target wasm32-unknown-emscripten` to cargo. Step 8 is what unlocks "wasm32 install actually works."
2. **`webr-ci.md` tier 1** second — three lines of CI YAML, catches the common cfg-gating regressions, doesn't need step 8 to land first.
3. `webr-ci.md` tiers 2/3 only after step 8.
4. Cross-package stubs only if/when cross-package wasm32 ends up in CI.

## Stack-ordering note (recorded in plans/webr-support.md)

Step 7's `Makevars` calls `miniextendr_write_wasm_registry` via `getNativeSymbolInfo`. For that symbol to appear in the cdylib's dynamic symbol table, the `as *const ()` reference in `miniextendr_register_routines` (added in step 5) must be present. Step 5 must merge before step 7's CI passes — the linker won't pull a Rust dep-crate `#[no_mangle]` fn into a cdylib unless something in the final crate's call graph references it.

Useful for future PR sequencing or if these steps ever need to be reorganised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
