### PR TITLE
ci: webR wasm32 cargo-check workflow (#470)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -48,6 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # build.rs:64 unconditionally runs `R RHOME`; $RUNNER_TEMP is always a
+      # real directory so Path::new(&r_home).is_dir() passes. cargo check never
+      # links, so the dummy value is sufficient. Same pattern as rust-lint in ci.yml.
+      - name: Set dummy R_HOME
+        run: echo "R_HOME=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -62,9 +68,8 @@ jobs:
       - name: cargo check (miniextendr-api)
         run: cargo check -p miniextendr-api --target wasm32-unknown-emscripten
 
-      - name: Configure rpkg
-        run: bash ./rpkg/configure
-
-      - name: cargo check (rpkg)
-        working-directory: rpkg/src/rust
-        run: cargo check --target wasm32-unknown-emscripten
+      # rpkg/configure invokes ${R_HOME}/bin/Rscript directly for feature
+      # detection (configure.ac:133, :275, :473). The dummy R_HOME has no
+      # Rscript binary, so configure fails. Deferred to a follow-up that either
+      # adds r-lib/actions/setup-r@v2 or waits for the build.rs wasm32 guard
+      # (see #482). Only miniextendr-api is checked in tier 1.

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -1,0 +1,70 @@
+name: webR / wasm32
+
+on:
+  pull_request:
+    paths:
+      - 'miniextendr-api/**'
+      - 'miniextendr-macros/**'
+      - 'miniextendr-engine/**'
+      - 'miniextendr-lint/**'
+      - 'rpkg/**'
+      - 'tests/cross-package/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile.webr'
+      - '.github/workflows/webr.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'miniextendr-api/**'
+      - 'miniextendr-macros/**'
+      - 'miniextendr-engine/**'
+      - 'miniextendr-lint/**'
+      - 'rpkg/**'
+      - 'tests/cross-package/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile.webr'
+      - '.github/workflows/webr.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  cargo-check:
+    name: wasm32 check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-emscripten
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm32-check
+          cache-on-failure: true
+
+      - name: cargo check (miniextendr-api)
+        run: cargo check -p miniextendr-api --target wasm32-unknown-emscripten
+
+      - name: Configure rpkg
+        run: bash ./rpkg/configure
+
+      - name: cargo check (rpkg)
+        working-directory: rpkg/src/rust
+        run: cargo check --target wasm32-unknown-emscripten


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/webr.yml`: a paths-gated CI job that runs `cargo check --target wasm32-unknown-emscripten` against `miniextendr-api` and `rpkg/src/rust`
- Catches cfg-gating regressions and macro-emission bugs on the wasm32 target without requiring a full webR container or emscripten link step
- Refs #470 (tier 1 of the webR CI follow-ups)

## Tier scope

This PR implements **tier 1 only**: `cargo check` on `wasm32-unknown-emscripten`.

- **Tier 1 (this PR)**: `cargo check` — catch cfg-gate and macro regressions; no linking, no runtime
- **Tier 2 (deferred)**: full wasm32 link via emscripten/webR Docker image; verifies no missing symbols
- **Tier 3 (deferred)**: runtime webR smoke tests

Tiers 2 and 3 are deferred per `plans/webr-ci.md` — they require a webR container, substantially more CI time, and are blocked on resolving the emscripten toolchain integration.

## Paths filter rationale

The workflow triggers on changes to:
- `miniextendr-api/**` — primary wasm32 surface; cfg gates live here
- `miniextendr-macros/**` — emits the cfg-gated code
- `miniextendr-engine/**` — codegen engine; affects what macros emit
- `miniextendr-lint/**` — build-time lint runs as build-dep on wasm32 builds
- `rpkg/**` — rpkg src + `wasm_registry.rs`
- `tests/cross-package/**` — cross-package crates use miniextendr-api
- `Cargo.toml` / `Cargo.lock` — workspace member / dep changes
- `Dockerfile.webr` — webR base digest changes (signals tier 2/3 environment shift)
- `.github/workflows/webr.yml` — re-trigger on workflow edits

Excluded: `miniextendr-bench/**` (native perf only), `miniextendr-cli/**` (tooling, not built into wasm rpkg), docs/site/markdown.

## Open question: preflight status

**Preflight skipped locally — relying on the PR's first CI run as verification.**

The local environment does not have `wasm32-unknown-emscripten` installed, so `cargo check --target wasm32-unknown-emscripten` was not run locally before opening this PR.

Additionally, `bash ./rpkg/configure` calls `R RHOME` early. If the CI runner lacks R, configure may error before writing `.cargo/config.toml`, causing the rpkg cargo check to resolve `miniextendr-api` from git instead of the local workspace siblings.

**Fallback plan if first CI run fails due to missing R:**
1. Add a `r-lib/actions/setup-r@v2` step before "Configure rpkg" (~45 s overhead), **or**
2. Drop the rpkg cargo check from tier 1 and run only `cargo check -p miniextendr-api` until a configure-without-R solution is in place

The reviewer should check the first CI run and advise which fallback to apply.

## Acceptance checklist

- [x] Single new file only (`.github/workflows/webr.yml`)
- [x] Action versions match other workflows (`actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`)
- [x] Env vars match `ci.yml` global env (`CARGO_TERM_COLOR`, `RUST_BACKTRACE`, `CARGO_INCREMENTAL`)
- [x] Concurrency block matches `ci.yml` pattern
- [x] Paths filter has all 10 entries in both `pull_request.paths` and `push.paths`
- [x] `dtolnay/rust-toolchain@stable` has `targets: wasm32-unknown-emscripten`
- [x] "Configure rpkg" step precedes "cargo check (rpkg)"
- [ ] At least one green `wasm32 check / cargo check` status visible (pending first CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)