### PR TITLE
docs(webr): refresh post-merge — building locally + CC=emcc cooperation + CI (#470)

### DIFF
--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -147,11 +147,12 @@ be exported during the wasm install — `webr-vars.mk` references both.
   by Phase 1's native build and shipped through into Phase 2's source tree.
 - **Worker thread is off.** R-on-WASM is single-threaded; the
   `worker-thread` feature must be disabled. Already feature-gated.
-- **`RUSTFLAGS` for the side-module link** are not yet locked in — there's
-  a `# TODO(#470)` in `rpkg/src/Makevars.in` flagging
-  `-C relocation-model=pic -C link-args=-s SIDE_MODULE=1` as the proposed
-  set. The smoke script is the empirical validator; if the wasm side-module
-  fails to link, that's the next thing to verify against `rwasm`'s flags.
+- **`RUSTFLAGS` for the side-module link** are not yet locked in. The
+  proposed set is `-C relocation-model=pic -C link-args=-s SIDE_MODULE=1`
+  (per `plans/webr-support.md`); `rwasm`'s flags are the canonical
+  reference and the smoke script is the empirical validator. If the wasm
+  side-module fails to link, that's the next thing to verify against
+  `rwasm`. Tracked via #470.
 
 ## CI
 

--- a/site/content/manual/webr.md
+++ b/site/content/manual/webr.md
@@ -1,4 +1,8 @@
-# WebR / WASM support
++++
+title = "WebR / WASM support"
+weight = 50
+description = "Building miniextendr for webR — R compiled to WebAssembly via Emscripten."
++++
 
 Building miniextendr for [webR](https://docs.r-wasm.org/webr/latest/) — R
 compiled to WebAssembly via Emscripten.

--- a/site/content/manual/webr.md
+++ b/site/content/manual/webr.md
@@ -151,11 +151,12 @@ be exported during the wasm install — `webr-vars.mk` references both.
   by Phase 1's native build and shipped through into Phase 2's source tree.
 - **Worker thread is off.** R-on-WASM is single-threaded; the
   `worker-thread` feature must be disabled. Already feature-gated.
-- **`RUSTFLAGS` for the side-module link** are not yet locked in — there's
-  a `# TODO(#470)` in `rpkg/src/Makevars.in` flagging
-  `-C relocation-model=pic -C link-args=-s SIDE_MODULE=1` as the proposed
-  set. The smoke script is the empirical validator; if the wasm side-module
-  fails to link, that's the next thing to verify against `rwasm`'s flags.
+- **`RUSTFLAGS` for the side-module link** are not yet locked in. The
+  proposed set is `-C relocation-model=pic -C link-args=-s SIDE_MODULE=1`
+  (per `plans/webr-support.md`); `rwasm`'s flags are the canonical
+  reference and the smoke script is the empirical validator. If the wasm
+  side-module fails to link, that's the next thing to verify against
+  `rwasm`. Tracked via #470.
 
 ## CI
 


### PR DESCRIPTION
## Summary

Refreshes `docs/WEBR.md` to reflect the merged webR stack (#481 step 8, #480 CI tier 1, #488 local smoke script) and ports doc-worthy content out of the in-flight plans into the long-lived contributor doc. No code changes.

Refs #470.

## What changed

- **Status** flipped from "in progress" to "supported for local dev."
- **New section: Building locally** — `just docker-webr-{build,shell,test,smoke}` with the smoke script's three phases (native install regenerates `wasm_registry.rs` → wasm32 `R CMD INSTALL` with `webr-vars.mk` → webR Node session runs `testthat::test_local()`). Includes the "1–2 hour first cold run on Apple Silicon" note.
- **New section: How `CC=emcc` cooperates with our build** — `IS_WASM_INSTALL` semantics, the configure.ac detection block, the `wasm_registry.rs` / `build.rs` generator-version invariant, the `$(WRAPPERS_R)` rule split.
- **New section: Two R installations inside the container** — table mapping `/opt/R/current/bin/R` (native), `/opt/webr/host/R-4.5.1/bin/R` (webR cross-compile host R), and `/opt/webr/wasm/.../lib/R/library/` (wasm install target).
- **New section: CI** — tier 1 cargo-check workflow, `R_HOME=$RUNNER_TEMP` shim, why the rpkg cargo-check is deferred from tier 1, link to follow-up #482.
- **Updated bullet** about side-module link flags — replaces stale "exact set TBD" with a reference to the plans / `rwasm` as canonical and the smoke script as empirical validator.
- **See also** rewritten — each plan flagged with its merged-PR or open-status.

## Regenerated artifacts

- `site/content/manual/webr.md` — regenerated via `just site-docs`. New file in git: the auto-generated mirror simply hadn't been mirrored yet (CI runs `docs-to-site.sh` itself before each deploy, so the live site has always been correct; only the in-repo mirror was missing).

## Verification

- `just site-docs` ran clean (81 pages generated from `docs/`).
- Pre-commit hook passed.
- Self-review caught a stale `# TODO(#470)` claim against `rpkg/src/Makevars.in` (the comment was removed during step8-fixer's relocation, not preserved). Fixed in second commit.