### PR TITLE
fix(vendor): bootstrap.R lock regeneration + miniextendr_vendor() consistency

### DIFF
--- a/minirextendr/R/vendor.R
+++ b/minirextendr/R/vendor.R
@@ -6,6 +6,13 @@
 # pre-seeding `vendor/miniextendr-{api,macros,lint,engine}` from a github
 # download or a local checkout is gone — Cargo.toml uses git-URL deps for
 # those crates, so they get vendored alongside every other transitive dep.
+#
+# Checksum policy (post PR #408): cargo-revendor computes real SHA-256
+# checksums into .cargo-checksum.json after CRAN-trim, and retains
+# `checksum = "..."` lines in Cargo.lock so cargo can verify vendored
+# crates match the registry entries.  Do NOT overwrite .cargo-checksum.json
+# to {"files":{}} and do NOT strip checksum lines from Cargo.lock — both
+# defeat cargo's verification and diverge from `just vendor` output.
 
 #' Run cargo revendor and CRAN-trim the result
 #'
@@ -133,12 +140,8 @@ strip_vendored_dir <- function(vendor_path) {
         fs::file_delete(f)
       }
     }
-
-    # Clear cargo-checksum.json (content was modified by stripping)
-    checksum_file <- fs::path(crate_dir, ".cargo-checksum.json")
-    if (fs::file_exists(checksum_file)) {
-      writeLines('{"files":{}}', checksum_file)
-    }
+    # .cargo-checksum.json: cargo-revendor already wrote valid SHA-256s
+    # (recomputed post-CRAN-trim in PR #408). Do not overwrite it.
   }
 
   invisible()

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -165,14 +165,11 @@ miniextendr_vendor <- function(path = ".") {
   inst_dir <- usethis::proj_path("inst")
   tarball <- fs::path(inst_dir, "vendor.tar.xz")
 
-  # Step 2: strip checksums from Cargo.lock (vendored crates have empty checksums)
-  if (fs::file_exists(lockfile)) {
-    lock_content <- readLines(lockfile, warn = FALSE)
-    lock_content <- lock_content[!grepl("^checksum = ", lock_content)]
-    writeLines(lock_content, lockfile)
-  }
-
-  # Step 3: compress into inst/vendor.tar.xz
+  # Step 2: compress into inst/vendor.tar.xz
+  # Note: Cargo.lock checksum lines are intentionally retained. cargo-revendor
+  # (post PR #408) writes valid .cargo-checksum.json entries with real SHA-256s,
+  # so stripping `checksum = "..."` from Cargo.lock is no longer needed and
+  # would diverge from the `just vendor` reference output.
   cli::cli_h2("Step 2: compress vendor tarball")
   fs::dir_create(inst_dir)
 

--- a/minirextendr/inst/templates/rpkg/bootstrap.R
+++ b/minirextendr/inst/templates/rpkg/bootstrap.R
@@ -33,6 +33,50 @@ if (!file.exists("inst/vendor.tar.xz")) {
       call. = FALSE
     )
   }
+
+  # Regenerate Cargo.lock in tarball-shape before vendoring.
+  #
+  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+  # paths.  cargo then records `source = "path+file:///..."` entries in
+  # Cargo.lock.  Those path-source entries are invalid at offline install time
+  # (the workspace paths don't exist inside the tarball), so we must regenerate
+  # the lock against the bare git URLs before invoking cargo-revendor.
+  #
+  # Steps mirror `just vendor`:
+  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+  #   2. Delete Cargo.lock so cargo resolves fresh.
+  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+  #      `source = "git+https://...#<commit>"`, which is what cargo's
+  #      source-replacement mechanism needs during offline install.
+  #   4. Restore .cargo/config.toml.
+  rust_dir <- file.path(getwd(), "src", "rust")
+  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+
+  if (file.exists(cargo_cfg)) {
+    file.rename(cargo_cfg, cargo_cfg_backup)
+  }
+  if (file.exists(cargo_lock)) {
+    file.remove(cargo_lock)
+  }
+  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+  lock_status <- system2("cargo", c(
+    "generate-lockfile",
+    "--manifest-path", cargo_manifest
+  ))
+  if (file.exists(cargo_cfg_backup)) {
+    file.rename(cargo_cfg_backup, cargo_cfg)
+  }
+  if (lock_status != 0) {
+    stop(
+      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+      call. = FALSE
+    )
+  }
+
   message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
   dir.create("inst", showWarnings = FALSE)
   status <- system2("cargo", c(

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,7 +1,7 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-10 16:31:19
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-10 16:31:19
-@@ -1,53 +1,11 @@
+--- a/monorepo/rpkg/bootstrap.R	2026-05-11 13:04:44
++++ b/monorepo/rpkg/bootstrap.R	2026-05-11 13:03:35
+@@ -1,97 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 -# the source directory before R CMD build seals the tarball. Two jobs:
@@ -40,6 +40,50 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -      call. = FALSE
 -    )
 -  }
+-
+-  # Regenerate Cargo.lock in tarball-shape before vendoring.
+-  #
+-  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+-  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+-  # paths.  cargo then records `source = "path+file:///..."` entries in
+-  # Cargo.lock.  Those path-source entries are invalid at offline install time
+-  # (the workspace paths don't exist inside the tarball), so we must regenerate
+-  # the lock against the bare git URLs before invoking cargo-revendor.
+-  #
+-  # Steps mirror `just vendor`:
+-  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+-  #   2. Delete Cargo.lock so cargo resolves fresh.
+-  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+-  #      `source = "git+https://...#<commit>"`, which is what cargo's
+-  #      source-replacement mechanism needs during offline install.
+-  #   4. Restore .cargo/config.toml.
+-  rust_dir <- file.path(getwd(), "src", "rust")
+-  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+-  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+-  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+-  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+-
+-  if (file.exists(cargo_cfg)) {
+-    file.rename(cargo_cfg, cargo_cfg_backup)
+-  }
+-  if (file.exists(cargo_lock)) {
+-    file.remove(cargo_lock)
+-  }
+-  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+-  lock_status <- system2("cargo", c(
+-    "generate-lockfile",
+-    "--manifest-path", cargo_manifest
+-  ))
+-  if (file.exists(cargo_cfg_backup)) {
+-    file.rename(cargo_cfg_backup, cargo_cfg)
+-  }
+-  if (lock_status != 0) {
+-    stop(
+-      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+-      call. = FALSE
+-    )
+-  }
+-
 -  message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
 -  dir.create("inst", showWarnings = FALSE)
 -  status <- system2("cargo", c(
@@ -64,8 +108,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-10 16:33:09
-+++ b/monorepo/rpkg/configure.ac	2026-05-10 16:34:53
+--- a/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
++++ b/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -340,8 +384,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-10 16:33:09
-+++ b/rpkg/configure.ac	2026-05-10 16:34:00
+--- a/rpkg/configure.ac	2026-05-11 13:03:35
++++ b/rpkg/configure.ac	2026-05-11 13:03:35
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/bootstrap.R
+++ b/rpkg/bootstrap.R
@@ -33,6 +33,50 @@ if (!file.exists("inst/vendor.tar.xz")) {
       call. = FALSE
     )
   }
+
+  # Regenerate Cargo.lock in tarball-shape before vendoring.
+  #
+  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+  # paths.  cargo then records `source = "path+file:///..."` entries in
+  # Cargo.lock.  Those path-source entries are invalid at offline install time
+  # (the workspace paths don't exist inside the tarball), so we must regenerate
+  # the lock against the bare git URLs before invoking cargo-revendor.
+  #
+  # Steps mirror `just vendor`:
+  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+  #   2. Delete Cargo.lock so cargo resolves fresh.
+  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+  #      `source = "git+https://...#<commit>"`, which is what cargo's
+  #      source-replacement mechanism needs during offline install.
+  #   4. Restore .cargo/config.toml.
+  rust_dir <- file.path(getwd(), "src", "rust")
+  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+
+  if (file.exists(cargo_cfg)) {
+    file.rename(cargo_cfg, cargo_cfg_backup)
+  }
+  if (file.exists(cargo_lock)) {
+    file.remove(cargo_lock)
+  }
+  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+  lock_status <- system2("cargo", c(
+    "generate-lockfile",
+    "--manifest-path", cargo_manifest
+  ))
+  if (file.exists(cargo_cfg_backup)) {
+    file.rename(cargo_cfg_backup, cargo_cfg)
+  }
+  if (lock_status != 0) {
+    stop(
+      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+      call. = FALSE
+    )
+  }
+
   message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
   dir.create("inst", showWarnings = FALSE)
   status <- system2("cargo", c(


### PR DESCRIPTION
## Summary

Two fixes for vendor + lockfile plumbing identified in `analysis/build-system-investigation-2026-05-11.md` §7.5, §7.6:

### C1 — `bootstrap.R` regenerates Cargo.lock before vendoring

`just vendor` does a regenerate-lock dance (move config aside, delete lock, `cargo generate-lockfile`, restore config) before invoking cargo-revendor — so the lock ends up in "tarball-shape" with `git+` sources for miniextendr-{api,lint,macros} instead of dev-mode `path+file:///` sources.

`bootstrap.R` only invoked cargo-revendor against the on-disk lock. If a developer had a source-shape (dirty) lock when running `devtools::build()` / `rcmdcheck()` / `r-lib/actions/check-r-package`, the built tarball shipped a source-shape lock that fails offline install with "requires a lock file" error.

Fix: bootstrap.R now does the same regenerate-lock dance as `just vendor`. Mirrored in `minirextendr/inst/templates/rpkg/bootstrap.R` (standalone template) and the templates patch.

### C2 — `miniextendr_vendor()` stops stripping checksums (post PR #408)

Post-PR #408, `cargo-revendor` writes valid checksums into `.cargo-checksum.json` AND the Cargo.lock retains `checksum = ` lines. The R-side `miniextendr_vendor()` was still:
- Overwriting `.cargo-checksum.json` to `{"files":{}}` (`minirextendr/R/vendor.R:137-142`).
- Stripping `checksum = ` lines from `Cargo.lock` (`minirextendr/R/workflow.R:169-173`).

Two vendor-producing paths (`just vendor` vs `miniextendr_vendor()`) producing different vendor trees is a "works for maintainer, fails for scaffolded user" trap. Both broken behaviors removed.

## Risk

PR-C is the highest-risk of the four `analysis/build-system-fixes/*` PRs — vendor plumbing affects every install path that hits bootstrap.R. Split into two commits (C1 first, C2 second) for bisectability. Both should keep "vendor.tar.xz inside tarball produces working offline install."

## Test plan

- [ ] C1: dirty source-shape lock → `devtools::build()` → tarball contains tarball-shape lock (no `path+` sources for framework crates)
- [ ] C1: that tarball installs offline cleanly
- [ ] C2: `just vendor` and `miniextendr_vendor()` produce byte-identical `vendor/<crate>/{Cargo.toml,.cargo-checksum.json}` trees
- [ ] C2: no `"files":{}` (empty map) anywhere in `vendor/`
- [ ] `just lock-shape-check` passes
- [ ] `just r-cmd-check` passes

Follow-up tracked at #523: investigate whether `miniextendr_vendor()` should be replaced with a thin shell-out to `cargo-revendor` for single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)