### PR TITLE
build(rpkg,minirextendr): skip wrapper-gen cdylib for tarball install

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -108,14 +108,43 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# The rule is split on IS_WASM_INSTALL so the cdylib prerequisite is
-# conditional: on wasm32 the cdylib is a .wasm SIDE_MODULE that host R
-# cannot dyn.load, so the wasm path has no prereq and expects pre-generated
-# files (written during the host devtools::document() pass).
+# Three-way split on build mode:
+#   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
+#             expects pre-generated files from the host devtools::document() pass.
+#   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
+#             the cdylib regeneration would be a no-op (write-if-changed), so
+#             skip the 10-30 s cdylib build entirely. Existence guard catches
+#             a tarball that was manually stripped of its wrappers file.
+#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 ifeq ($(IS_WASM_INSTALL),true)
 $(WRAPPERS_R):
 	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
 	@touch $(WRAPPERS_R)
+else ifeq ($(IS_TARBALL_INSTALL),true)
+ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
+$(WRAPPERS_R):
+	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
+	@if [ ! -f '$(WRAPPERS_R)' ]; then \
+	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	  exit 1; \
+	fi
+	@touch $(WRAPPERS_R)
+else
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
+	@_cdylib='$(CARGO_CDYLIB)'; \
+	_wrappers='$(WRAPPERS_R)'; \
+	_wasm_registry='$(WASM_REGISTRY_RS)'; \
+	if command -v cygpath >/dev/null 2>&1; then \
+	  _cdylib=$$(cygpath -m "$$_cdylib"); \
+	  _wrappers=$$(cygpath -m "$$_wrappers"); \
+	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	fi; \
+	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
+	@echo "Removing cdylib to prevent linker collision with staticlib..."
+	@rm -f '$(CARGO_CDYLIB)'
+endif
 else
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@echo "Generating R wrappers + wasm_registry.rs..."

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -108,14 +108,43 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# The rule is split on IS_WASM_INSTALL so the cdylib prerequisite is
-# conditional: on wasm32 the cdylib is a .wasm SIDE_MODULE that host R
-# cannot dyn.load, so the wasm path has no prereq and expects pre-generated
-# files (written during the host devtools::document() pass).
+# Three-way split on build mode:
+#   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
+#             expects pre-generated files from the host devtools::document() pass.
+#   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
+#             the cdylib regeneration would be a no-op (write-if-changed), so
+#             skip the 10-30 s cdylib build entirely. Existence guard catches
+#             a tarball that was manually stripped of its wrappers file.
+#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 ifeq ($(IS_WASM_INSTALL),true)
 $(WRAPPERS_R):
 	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
 	@touch $(WRAPPERS_R)
+else ifeq ($(IS_TARBALL_INSTALL),true)
+ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
+$(WRAPPERS_R):
+	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
+	@if [ ! -f '$(WRAPPERS_R)' ]; then \
+	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	  exit 1; \
+	fi
+	@touch $(WRAPPERS_R)
+else
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
+	@_cdylib='$(CARGO_CDYLIB)'; \
+	_wrappers='$(WRAPPERS_R)'; \
+	_wasm_registry='$(WASM_REGISTRY_RS)'; \
+	if command -v cygpath >/dev/null 2>&1; then \
+	  _cdylib=$$(cygpath -m "$$_cdylib"); \
+	  _wrappers=$$(cygpath -m "$$_wrappers"); \
+	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	fi; \
+	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
+	@echo "Removing cdylib to prevent linker collision with staticlib..."
+	@rm -f '$(CARGO_CDYLIB)'
+endif
 else
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@echo "Generating R wrappers + wasm_registry.rs..."

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-10 16:31:19
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-10 16:31:19
+--- a/monorepo/rpkg/bootstrap.R	2026-05-09 16:53:58
++++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
 @@ -1,53 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -64,8 +64,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-10 16:33:09
-+++ b/monorepo/rpkg/configure.ac	2026-05-10 16:34:53
+--- a/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
++++ b/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -340,8 +340,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-10 16:33:09
-+++ b/rpkg/configure.ac	2026-05-10 16:34:00
+--- a/rpkg/configure.ac	2026-05-10 17:31:33
++++ b/rpkg/configure.ac	2026-05-10 17:31:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -108,14 +108,43 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# The rule is split on IS_WASM_INSTALL so the cdylib prerequisite is
-# conditional: on wasm32 the cdylib is a .wasm SIDE_MODULE that host R
-# cannot dyn.load, so the wasm path has no prereq and expects pre-generated
-# files (written during the host devtools::document() pass).
+# Three-way split on build mode:
+#   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
+#             expects pre-generated files from the host devtools::document() pass.
+#   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
+#             the cdylib regeneration would be a no-op (write-if-changed), so
+#             skip the 10-30 s cdylib build entirely. Existence guard catches
+#             a tarball that was manually stripped of its wrappers file.
+#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 ifeq ($(IS_WASM_INSTALL),true)
 $(WRAPPERS_R):
 	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
 	@touch $(WRAPPERS_R)
+else ifeq ($(IS_TARBALL_INSTALL),true)
+ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
+$(WRAPPERS_R):
+	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
+	@if [ ! -f '$(WRAPPERS_R)' ]; then \
+	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	  exit 1; \
+	fi
+	@touch $(WRAPPERS_R)
+else
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
+	@_cdylib='$(CARGO_CDYLIB)'; \
+	_wrappers='$(WRAPPERS_R)'; \
+	_wasm_registry='$(WASM_REGISTRY_RS)'; \
+	if command -v cygpath >/dev/null 2>&1; then \
+	  _cdylib=$$(cygpath -m "$$_cdylib"); \
+	  _wrappers=$$(cygpath -m "$$_wrappers"); \
+	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	fi; \
+	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
+	@echo "Removing cdylib to prevent linker collision with staticlib..."
+	@rm -f '$(CARGO_CDYLIB)'
+endif
 else
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@echo "Generating R wrappers + wasm_registry.rs..."


### PR DESCRIPTION
## Summary

When `IS_TARBALL_INSTALL=true`, `R/<pkg>-wrappers.R` is already committed and ships inside the built tarball. The wrapper-gen pass currently rebuilds the same file — but the write itself is already a no-op (write-if-changed in `miniextendr-api/src/registry.rs:918-921`), so the only thing it accomplishes is wasting 10–30 s on the cdylib link + R startup + `dyn.load` round-trip.

This PR adds a three-way split in the Makevars wrapper rule:

| Mode | Behavior |
|---|---|
| `IS_WASM_INSTALL=true` | unchanged — cdylib is a side-module; expects pre-generated files |
| `IS_TARBALL_INSTALL=true` | **NEW** — `touch` wrappers.R only, after asserting it exists |
| dev | unchanged |

### Safety argument

1. The pre-commit hook (`.githooks/pre-commit`) keeps `R/<pkg>-wrappers.R` in sync with the Rust crate.
2. `R CMD build` seals both into the tarball atomically.
3. Therefore the wrappers in the tarball always match the bundled Rust by construction — the cdylib regeneration would produce byte-identical bytes (and the write is already a no-op).

### Existence guard

If a tarball is missing pre-generated `R/<pkg>-wrappers.R`, the new branch fails loudly with `ERROR: tarball is missing pre-generated ...` instead of silently shipping a broken install.

### Escape hatch

`MINIEXTENDR_FORCE_WRAPPER_GEN=1 R CMD INSTALL <tarball>` falls through to the dev recipe even in tarball mode. Useful when debugging wrapper drift.

### Sync

All three `Makevars.in` files (the master in `rpkg/src/` and both `inst/templates/{rpkg,monorepo/rpkg}/`) edited together and verified byte-identical post-edit. `patches/templates.patch` refreshed via `just templates-approve`.

## Investigation ref

§6.4 in `analysis/build-system-investigation-2026-05-11.md`.

## Test plan

- [x] All three `Makevars.in` byte-identical post-edit (`diff` returns empty)
- [ ] Build tarball → install → log shows "tarball install: using pre-shipped" and NO cdylib build line
- [ ] Strip wrappers.R from tarball → install fails with clear error
- [ ] Dev-mode install unchanged (cdylib build still happens)
- [ ] `MINIEXTENDR_FORCE_WRAPPER_GEN=1` in tarball mode triggers regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)