### PR TITLE
fix(rpkg,minirextendr): hard-fail on file.rename failure in bootstrap.R lock-regen

### DIFF
--- a/minirextendr/R/vendor.R
+++ b/minirextendr/R/vendor.R
@@ -6,6 +6,13 @@
 # pre-seeding `vendor/miniextendr-{api,macros,lint,engine}` from a github
 # download or a local checkout is gone — Cargo.toml uses git-URL deps for
 # those crates, so they get vendored alongside every other transitive dep.
+#
+# Checksum policy (post PR #408): cargo-revendor computes real SHA-256
+# checksums into .cargo-checksum.json after CRAN-trim, and retains
+# `checksum = "..."` lines in Cargo.lock so cargo can verify vendored
+# crates match the registry entries.  Do NOT overwrite .cargo-checksum.json
+# to {"files":{}} and do NOT strip checksum lines from Cargo.lock — both
+# defeat cargo's verification and diverge from `just vendor` output.
 
 #' Run cargo revendor and CRAN-trim the result
 #'
@@ -133,12 +140,8 @@ strip_vendored_dir <- function(vendor_path) {
         fs::file_delete(f)
       }
     }
-
-    # Clear cargo-checksum.json (content was modified by stripping)
-    checksum_file <- fs::path(crate_dir, ".cargo-checksum.json")
-    if (fs::file_exists(checksum_file)) {
-      writeLines('{"files":{}}', checksum_file)
-    }
+    # .cargo-checksum.json: cargo-revendor already wrote valid SHA-256s
+    # (recomputed post-CRAN-trim in PR #408). Do not overwrite it.
   }
 
   invisible()

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -165,14 +165,11 @@ miniextendr_vendor <- function(path = ".") {
   inst_dir <- usethis::proj_path("inst")
   tarball <- fs::path(inst_dir, "vendor.tar.xz")
 
-  # Step 2: strip checksums from Cargo.lock (vendored crates have empty checksums)
-  if (fs::file_exists(lockfile)) {
-    lock_content <- readLines(lockfile, warn = FALSE)
-    lock_content <- lock_content[!grepl("^checksum = ", lock_content)]
-    writeLines(lock_content, lockfile)
-  }
-
-  # Step 3: compress into inst/vendor.tar.xz
+  # Step 2: compress into inst/vendor.tar.xz
+  # Note: Cargo.lock checksum lines are intentionally retained. cargo-revendor
+  # (post PR #408) writes valid .cargo-checksum.json entries with real SHA-256s,
+  # so stripping `checksum = "..."` from Cargo.lock is no longer needed and
+  # would diverge from the `just vendor` reference output.
   cli::cli_h2("Step 2: compress vendor tarball")
   fs::dir_create(inst_dir)
 

--- a/minirextendr/inst/templates/rpkg/bootstrap.R
+++ b/minirextendr/inst/templates/rpkg/bootstrap.R
@@ -33,6 +33,50 @@ if (!file.exists("inst/vendor.tar.xz")) {
       call. = FALSE
     )
   }
+
+  # Regenerate Cargo.lock in tarball-shape before vendoring.
+  #
+  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+  # paths.  cargo then records `source = "path+file:///..."` entries in
+  # Cargo.lock.  Those path-source entries are invalid at offline install time
+  # (the workspace paths don't exist inside the tarball), so we must regenerate
+  # the lock against the bare git URLs before invoking cargo-revendor.
+  #
+  # Steps mirror `just vendor`:
+  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+  #   2. Delete Cargo.lock so cargo resolves fresh.
+  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+  #      `source = "git+https://...#<commit>"`, which is what cargo's
+  #      source-replacement mechanism needs during offline install.
+  #   4. Restore .cargo/config.toml.
+  rust_dir <- file.path(getwd(), "src", "rust")
+  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+
+  if (file.exists(cargo_cfg)) {
+    file.rename(cargo_cfg, cargo_cfg_backup)
+  }
+  if (file.exists(cargo_lock)) {
+    file.remove(cargo_lock)
+  }
+  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+  lock_status <- system2("cargo", c(
+    "generate-lockfile",
+    "--manifest-path", cargo_manifest
+  ))
+  if (file.exists(cargo_cfg_backup)) {
+    file.rename(cargo_cfg_backup, cargo_cfg)
+  }
+  if (lock_status != 0) {
+    stop(
+      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+      call. = FALSE
+    )
+  }
+
   message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
   dir.create("inst", showWarnings = FALSE)
   status <- system2("cargo", c(

--- a/minirextendr/inst/templates/rpkg/bootstrap.R
+++ b/minirextendr/inst/templates/rpkg/bootstrap.R
@@ -56,8 +56,24 @@ if (!file.exists("inst/vendor.tar.xz")) {
   cargo_lock <- file.path(rust_dir, "Cargo.lock")
   cargo_manifest <- file.path(rust_dir, "Cargo.toml")
 
+  # file.rename() returns FALSE on failure without throwing — wrap it so any
+  # rename failure is a hard error rather than a silent no-op.
+  safe_rename <- function(from, to, context) {
+    if (!isTRUE(file.rename(from, to))) {
+      stop(
+        "bootstrap.R: failed to rename ", from, " -> ", to,
+        " (", context, ")",
+        call. = FALSE
+      )
+    }
+    invisible()
+  }
+
   if (file.exists(cargo_cfg)) {
-    file.rename(cargo_cfg, cargo_cfg_backup)
+    safe_rename(
+      cargo_cfg, cargo_cfg_backup,
+      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
+    )
   }
   if (file.exists(cargo_lock)) {
     file.remove(cargo_lock)
@@ -68,7 +84,13 @@ if (!file.exists("inst/vendor.tar.xz")) {
     "--manifest-path", cargo_manifest
   ))
   if (file.exists(cargo_cfg_backup)) {
-    file.rename(cargo_cfg_backup, cargo_cfg)
+    safe_rename(
+      cargo_cfg_backup, cargo_cfg,
+      paste0(
+        "cannot restore .cargo/config.toml from backup; ",
+        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
+      )
+    )
   }
   if (lock_status != 0) {
     stop(

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,7 +1,7 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-09 16:53:58
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
-@@ -1,53 +1,11 @@
+--- a/monorepo/rpkg/bootstrap.R	2026-05-11 13:04:44
++++ b/monorepo/rpkg/bootstrap.R	2026-05-11 13:03:35
+@@ -1,97 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 -# the source directory before R CMD build seals the tarball. Two jobs:
@@ -40,6 +40,50 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -      call. = FALSE
 -    )
 -  }
+-
+-  # Regenerate Cargo.lock in tarball-shape before vendoring.
+-  #
+-  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+-  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+-  # paths.  cargo then records `source = "path+file:///..."` entries in
+-  # Cargo.lock.  Those path-source entries are invalid at offline install time
+-  # (the workspace paths don't exist inside the tarball), so we must regenerate
+-  # the lock against the bare git URLs before invoking cargo-revendor.
+-  #
+-  # Steps mirror `just vendor`:
+-  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+-  #   2. Delete Cargo.lock so cargo resolves fresh.
+-  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+-  #      `source = "git+https://...#<commit>"`, which is what cargo's
+-  #      source-replacement mechanism needs during offline install.
+-  #   4. Restore .cargo/config.toml.
+-  rust_dir <- file.path(getwd(), "src", "rust")
+-  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+-  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+-  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+-  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+-
+-  if (file.exists(cargo_cfg)) {
+-    file.rename(cargo_cfg, cargo_cfg_backup)
+-  }
+-  if (file.exists(cargo_lock)) {
+-    file.remove(cargo_lock)
+-  }
+-  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+-  lock_status <- system2("cargo", c(
+-    "generate-lockfile",
+-    "--manifest-path", cargo_manifest
+-  ))
+-  if (file.exists(cargo_cfg_backup)) {
+-    file.rename(cargo_cfg_backup, cargo_cfg)
+-  }
+-  if (lock_status != 0) {
+-    stop(
+-      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+-      call. = FALSE
+-    )
+-  }
+-
 -  message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
 -  dir.create("inst", showWarnings = FALSE)
 -  status <- system2("cargo", c(
@@ -64,8 +108,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
-+++ b/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
+--- a/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
++++ b/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -340,8 +384,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-10 17:31:33
-+++ b/rpkg/configure.ac	2026-05-10 17:31:33
+--- a/rpkg/configure.ac	2026-05-11 13:03:35
++++ b/rpkg/configure.ac	2026-05-11 13:03:35
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-11 21:08:00
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-11 21:07:18
+--- a/monorepo/rpkg/bootstrap.R	2026-05-14 09:18:35
++++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-11 21:07:18
-+++ b/monorepo/rpkg/configure.ac	2026-05-11 21:07:18
+--- a/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
++++ b/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-11 21:07:18
-+++ b/rpkg/configure.ac	2026-05-11 21:07:18
+--- a/rpkg/configure.ac	2026-05-10 17:31:33
++++ b/rpkg/configure.ac	2026-05-10 17:31:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,7 +1,7 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-11 13:04:44
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-11 13:03:35
-@@ -1,97 +1,11 @@
+--- a/monorepo/rpkg/bootstrap.R	2026-05-11 21:08:00
++++ b/monorepo/rpkg/bootstrap.R	2026-05-11 21:07:18
+@@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 -# the source directory before R CMD build seals the tarball. Two jobs:
@@ -63,8 +63,24 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -  cargo_lock <- file.path(rust_dir, "Cargo.lock")
 -  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
 -
+-  # file.rename() returns FALSE on failure without throwing — wrap it so any
+-  # rename failure is a hard error rather than a silent no-op.
+-  safe_rename <- function(from, to, context) {
+-    if (!isTRUE(file.rename(from, to))) {
+-      stop(
+-        "bootstrap.R: failed to rename ", from, " -> ", to,
+-        " (", context, ")",
+-        call. = FALSE
+-      )
+-    }
+-    invisible()
+-  }
+-
 -  if (file.exists(cargo_cfg)) {
--    file.rename(cargo_cfg, cargo_cfg_backup)
+-    safe_rename(
+-      cargo_cfg, cargo_cfg_backup,
+-      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
+-    )
 -  }
 -  if (file.exists(cargo_lock)) {
 -    file.remove(cargo_lock)
@@ -75,7 +91,13 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -    "--manifest-path", cargo_manifest
 -  ))
 -  if (file.exists(cargo_cfg_backup)) {
--    file.rename(cargo_cfg_backup, cargo_cfg)
+-    safe_rename(
+-      cargo_cfg_backup, cargo_cfg,
+-      paste0(
+-        "cannot restore .cargo/config.toml from backup; ",
+-        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
+-      )
+-    )
 -  }
 -  if (lock_status != 0) {
 -    stop(
@@ -108,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
-+++ b/monorepo/rpkg/configure.ac	2026-05-11 13:03:35
+--- a/monorepo/rpkg/configure.ac	2026-05-11 21:07:18
++++ b/monorepo/rpkg/configure.ac	2026-05-11 21:07:18
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -384,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-11 13:03:35
-+++ b/rpkg/configure.ac	2026-05-11 13:03:35
+--- a/rpkg/configure.ac	2026-05-11 21:07:18
++++ b/rpkg/configure.ac	2026-05-11 21:07:18
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/bootstrap.R
+++ b/rpkg/bootstrap.R
@@ -33,6 +33,50 @@ if (!file.exists("inst/vendor.tar.xz")) {
       call. = FALSE
     )
   }
+
+  # Regenerate Cargo.lock in tarball-shape before vendoring.
+  #
+  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
+  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
+  # paths.  cargo then records `source = "path+file:///..."` entries in
+  # Cargo.lock.  Those path-source entries are invalid at offline install time
+  # (the workspace paths don't exist inside the tarball), so we must regenerate
+  # the lock against the bare git URLs before invoking cargo-revendor.
+  #
+  # Steps mirror `just vendor`:
+  #   1. Move .cargo/config.toml aside (suppress [patch] override).
+  #   2. Delete Cargo.lock so cargo resolves fresh.
+  #   3. `cargo generate-lockfile` — miniextendr-* entries get
+  #      `source = "git+https://...#<commit>"`, which is what cargo's
+  #      source-replacement mechanism needs during offline install.
+  #   4. Restore .cargo/config.toml.
+  rust_dir <- file.path(getwd(), "src", "rust")
+  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
+  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
+  cargo_lock <- file.path(rust_dir, "Cargo.lock")
+  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
+
+  if (file.exists(cargo_cfg)) {
+    file.rename(cargo_cfg, cargo_cfg_backup)
+  }
+  if (file.exists(cargo_lock)) {
+    file.remove(cargo_lock)
+  }
+  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
+  lock_status <- system2("cargo", c(
+    "generate-lockfile",
+    "--manifest-path", cargo_manifest
+  ))
+  if (file.exists(cargo_cfg_backup)) {
+    file.rename(cargo_cfg_backup, cargo_cfg)
+  }
+  if (lock_status != 0) {
+    stop(
+      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
+      call. = FALSE
+    )
+  }
+
   message("bootstrap.R: generating inst/vendor.tar.xz via cargo-revendor")
   dir.create("inst", showWarnings = FALSE)
   status <- system2("cargo", c(

--- a/rpkg/bootstrap.R
+++ b/rpkg/bootstrap.R
@@ -56,8 +56,24 @@ if (!file.exists("inst/vendor.tar.xz")) {
   cargo_lock <- file.path(rust_dir, "Cargo.lock")
   cargo_manifest <- file.path(rust_dir, "Cargo.toml")
 
+  # file.rename() returns FALSE on failure without throwing — wrap it so any
+  # rename failure is a hard error rather than a silent no-op.
+  safe_rename <- function(from, to, context) {
+    if (!isTRUE(file.rename(from, to))) {
+      stop(
+        "bootstrap.R: failed to rename ", from, " -> ", to,
+        " (", context, ")",
+        call. = FALSE
+      )
+    }
+    invisible()
+  }
+
   if (file.exists(cargo_cfg)) {
-    file.rename(cargo_cfg, cargo_cfg_backup)
+    safe_rename(
+      cargo_cfg, cargo_cfg_backup,
+      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
+    )
   }
   if (file.exists(cargo_lock)) {
     file.remove(cargo_lock)
@@ -68,7 +84,13 @@ if (!file.exists("inst/vendor.tar.xz")) {
     "--manifest-path", cargo_manifest
   ))
   if (file.exists(cargo_cfg_backup)) {
-    file.rename(cargo_cfg_backup, cargo_cfg)
+    safe_rename(
+      cargo_cfg_backup, cargo_cfg,
+      paste0(
+        "cannot restore .cargo/config.toml from backup; ",
+        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
+      )
+    )
   }
   if (lock_status != 0) {
     stop(


### PR DESCRIPTION
Stacks on top of #520 — addresses Opus reviewer note #1.

## Why

`bootstrap.R` moves `.cargo/config.toml` aside before `cargo generate-lockfile` (to suppress the `[patch]` override), then renames it back. Both used bare `file.rename(from, to)`, whose return value (`TRUE`/`FALSE`) was not checked. On Windows, `file.rename` is non-atomic and can fail silently. A silent failure means:

- **Move-aside fails** → `cargo generate-lockfile` runs with `[patch]` still active → source-shape `Cargo.lock` baked into the tarball → offline install of that tarball fails. (This is exactly the bug PR #520 was preventing in the first place.)
- **Restore fails** → `.cargo/config.toml` is left as `.cargo/config.toml.tmp_bootstrap_vendor` on disk; next dev iteration silently runs without monorepo `[patch]` overrides.

## What

`safe_rename()` helper that:

1. No-ops if the source file is absent.
2. Calls `file.rename()` and checks `isTRUE(result)`.
3. `stop()` with a clear message on failure.

For the restore path, the error message includes the exact `.tmp_bootstrap_vendor` path so the user can recover with a manual `mv`.

## Files

- `rpkg/bootstrap.R` (exemplar)
- `minirextendr/inst/templates/rpkg/bootstrap.R` (standalone-template mirror)
- `patches/templates.patch` (regenerated by `just templates-approve`)

The lean monorepo bootstrap template doesn't have this code, so it's untouched.

## Test plan

- [x] `just templates-check` passes
- [x] No regression in existing tests
- [ ] CI green (will populate on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)