### PR TITLE
refactor(minirextendr): explicit auto_detect_subdir parameter in use_release_workflow

### DIFF
--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -234,6 +234,11 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
   stub_src <- template_path("stub.c", subdir = "rpkg")
   fs::file_copy(stub_src, usethis::proj_path(rpkg_name, "src", "stub.c"), overwrite = TRUE)
   bullet_created(file.path(rpkg_name, "src", "stub.c"))
+  # r_shim.h — wraps <Rinternals.h> in a scoped clang pragma; avoids
+  # -Wno-unknown-warning-option in PKG_CFLAGS (R CMD check --as-cran WARNING)
+  shim_src <- template_path("r_shim.h", subdir = "rpkg")
+  fs::file_copy(shim_src, usethis::proj_path(rpkg_name, "src", "r_shim.h"), overwrite = TRUE)
+  bullet_created(file.path(rpkg_name, "src", "r_shim.h"))
   use_template("win.def.in", save_as = file.path(rpkg_name, "src", "win.def.in"), subdir = "rpkg")
   # cdylib-exports.def: Windows DLL symbol export for wrapper generation
   cdylib_src <- template_path("cdylib-exports.def", subdir = "rpkg")

--- a/minirextendr/R/upgrade.R
+++ b/minirextendr/R/upgrade.R
@@ -10,7 +10,18 @@
 #'
 #' User-authored files (lib.rs, Cargo.toml, R/ code) are never touched.
 #'
-#' @param path Path to the R package root, or `"."` to use the current directory.
+#' In a monorepo layout (workspace root containing an rpkg subdirectory),
+#' `upgrade_miniextendr_package()` automatically detects the rpkg subdir and
+#' operates on it rather than the workspace root. The rpkg subdir is the first
+#' immediate child directory that contains a miniextendr `configure.ac`. Pass
+#' `rpkg_subdir` explicitly if auto-detection is ambiguous.
+#'
+#' @param path Path to the R package root (standalone) or the monorepo workspace
+#'   root. Defaults to `"."`. For a monorepo, this is the directory containing
+#'   `Cargo.toml` — the rpkg subdir is resolved automatically.
+#' @param rpkg_subdir For monorepo layouts: name of the R package subdirectory
+#'   (e.g. `"rpkg"`). If `NULL` (default), auto-detected by scanning immediate
+#'   subdirectories for a miniextendr `configure.ac`.
 #' @param version Version of miniextendr crates to vendor (default: `"main"`).
 #' @param local_path Optional path to local miniextendr repository for vendoring.
 #' @param configure_ac Logical. If `TRUE`, overwrites configure.ac with the
@@ -25,12 +36,34 @@
 #' @return Invisibly returns TRUE on success.
 #' @export
 upgrade_miniextendr_package <- function(path = ".",
+                                         rpkg_subdir = NULL,
                                          version = "main",
                                          local_path = NULL,
                                          configure_ac = FALSE,
                                          autoconf = TRUE,
                                          allow_dirty = FALSE) {
-  with_project(path)
+  # Resolve path to an absolute path so we can probe it before setting as project.
+  resolved_path <- normalizePath(path, mustWork = FALSE)
+
+  # Detect monorepo: if path has a Cargo.toml but no configure.ac (or no
+  # DESCRIPTION), it's likely a workspace root rather than an rpkg root.
+  project_type <- detect_project_type(resolved_path)
+  if (identical(project_type, "monorepo") &&
+      !file.exists(file.path(resolved_path, "configure.ac"))) {
+    # Path is the workspace root — need to resolve to the rpkg subdir.
+    subdir <- rpkg_subdir %||% find_rpkg_subdir(resolved_path)
+    if (is.null(subdir)) {
+      cli::cli_abort(c(
+        "Could not find an rpkg subdirectory in {.path {resolved_path}}.",
+        "i" = "Pass {.code rpkg_subdir = '<name>'} explicitly.",
+        "i" = "Expected a subdirectory with a miniextendr {.path configure.ac}."
+      ))
+    }
+    resolved_path <- file.path(resolved_path, subdir)
+    cli::cli_alert_info("Monorepo layout detected — upgrading rpkg subdir {.path {subdir}}")
+  }
+
+  with_project(resolved_path)
 
   if (!is_miniextendr_package()) {
     cli::cli_abort(c(
@@ -92,6 +125,30 @@ upgrade_miniextendr_package <- function(path = ".",
   ))
 
   invisible(TRUE)
+}
+
+#' Find the rpkg subdirectory in a monorepo workspace root
+#'
+#' Scans immediate subdirectories of `path` for one that contains a
+#' `configure.ac` with the `CARGO_FEATURES` marker (the canonical signal that
+#' a directory is a miniextendr rpkg). Returns the first match, or `NULL` if
+#' none is found.
+#'
+#' @param path Path to the monorepo workspace root.
+#' @return Name of the rpkg subdirectory (not a full path), or `NULL`.
+#' @noRd
+find_rpkg_subdir <- function(path) {
+  subdirs <- list.dirs(path, full.names = FALSE, recursive = FALSE)
+  for (d in subdirs) {
+    configure_ac <- file.path(path, d, "configure.ac")
+    if (file.exists(configure_ac)) {
+      content <- readLines(configure_ac, warn = FALSE)
+      if (any(grepl("CARGO_FEATURES", content, fixed = TRUE))) {
+        return(d)
+      }
+    }
+  }
+  NULL
 }
 
 #' Check that scaffolding files are clean in git

--- a/minirextendr/R/use-release-workflow.R
+++ b/minirextendr/R/use-release-workflow.R
@@ -22,20 +22,26 @@
 #' `rpkg/`), the `bash ./configure` and `R CMD build` steps must run from inside
 #' that subdirectory. Pass `rpkg_subdir` to activate this; the generated workflow
 #' will add `working-directory: <rpkg_subdir>` to those steps. When `rpkg_subdir`
-#' is `NULL` (default), auto-detection via [detect_project_type()] is attempted.
-#' For a confirmed standalone package, auto-detection is skipped and the plain
-#' template is written unchanged.
+#' is `NULL` (default) and `auto_detect_subdir` is `TRUE` (default),
+#' auto-detection via [detect_project_type()] is attempted.
+#' For a confirmed standalone package, set `auto_detect_subdir = FALSE` to skip
+#' detection and write the plain template unchanged.
 #'
 #' @param path Path to the package root (standalone) or monorepo workspace root.
 #'   Defaults to `"."`.
 #' @param rpkg_subdir For monorepo layouts: name of the R package subdirectory
-#'   (e.g. `"rpkg"`). If `NULL` (default), auto-detected. Pass `""` or `FALSE`
-#'   to force standalone mode and suppress auto-detection.
+#'   (e.g. `"rpkg"`). If `NULL` (default) and `auto_detect_subdir` is `TRUE`,
+#'   the subdirectory is auto-detected. If a string, it is used directly
+#'   regardless of `auto_detect_subdir`.
+#' @param auto_detect_subdir If `TRUE` (default) and `rpkg_subdir` is `NULL`,
+#'   attempts to auto-detect the monorepo layout via [detect_project_type()].
+#'   Set to `FALSE` to force standalone mode and suppress auto-detection.
 #' @param overwrite If `TRUE`, replace an existing
 #'   `.github/workflows/r-release.yml`. Default `FALSE`.
 #' @return The path to the written file, invisibly.
 #' @export
 use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
+                                  auto_detect_subdir = TRUE,
                                   overwrite = FALSE) {
   dest_dir <- file.path(path, ".github", "workflows")
   dest_file <- file.path(dest_dir, "r-release.yml")
@@ -47,9 +53,14 @@ use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
     ))
   }
 
-  # Resolve rpkg_subdir: explicit "" / FALSE → standalone; NULL → auto-detect.
+  # Resolve rpkg_subdir:
+  #   - explicit string → use it directly.
+  #   - NULL + auto_detect_subdir = TRUE → attempt auto-detection.
+  #   - NULL + auto_detect_subdir = FALSE → standalone (no detection).
   resolved_subdir <- NULL
-  if (is.null(rpkg_subdir)) {
+  if (!is.null(rpkg_subdir)) {
+    resolved_subdir <- as.character(rpkg_subdir)
+  } else if (auto_detect_subdir) {
     resolved_path <- normalizePath(path, mustWork = FALSE)
     project_type <- detect_project_type(resolved_path)
     if (identical(project_type, "monorepo") &&
@@ -62,8 +73,6 @@ use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
         ))
       }
     }
-  } else if (nzchar(rpkg_subdir) && !identical(rpkg_subdir, FALSE)) {
-    resolved_subdir <- as.character(rpkg_subdir)
   }
 
   src <- system.file("templates", "r-release.yml", package = "minirextendr",

--- a/minirextendr/R/use-release-workflow.R
+++ b/minirextendr/R/use-release-workflow.R
@@ -18,12 +18,25 @@
 #' rationale, and \code{\link[miniextendr]{assert_utf8_locale_now}} for why the
 #' UTF-8 check exists.
 #'
-#' @param path Path to the package root. Defaults to `"."`.
+#' For **monorepo layouts** (where the R package lives in a subdirectory such as
+#' `rpkg/`), the `bash ./configure` and `R CMD build` steps must run from inside
+#' that subdirectory. Pass `rpkg_subdir` to activate this; the generated workflow
+#' will add `working-directory: <rpkg_subdir>` to those steps. When `rpkg_subdir`
+#' is `NULL` (default), auto-detection via [detect_project_type()] is attempted.
+#' For a confirmed standalone package, auto-detection is skipped and the plain
+#' template is written unchanged.
+#'
+#' @param path Path to the package root (standalone) or monorepo workspace root.
+#'   Defaults to `"."`.
+#' @param rpkg_subdir For monorepo layouts: name of the R package subdirectory
+#'   (e.g. `"rpkg"`). If `NULL` (default), auto-detected. Pass `""` or `FALSE`
+#'   to force standalone mode and suppress auto-detection.
 #' @param overwrite If `TRUE`, replace an existing
 #'   `.github/workflows/r-release.yml`. Default `FALSE`.
 #' @return The path to the written file, invisibly.
 #' @export
-use_release_workflow <- function(path = ".", overwrite = FALSE) {
+use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
+                                  overwrite = FALSE) {
   dest_dir <- file.path(path, ".github", "workflows")
   dest_file <- file.path(dest_dir, "r-release.yml")
 
@@ -34,11 +47,40 @@ use_release_workflow <- function(path = ".", overwrite = FALSE) {
     ))
   }
 
+  # Resolve rpkg_subdir: explicit "" / FALSE → standalone; NULL → auto-detect.
+  resolved_subdir <- NULL
+  if (is.null(rpkg_subdir)) {
+    resolved_path <- normalizePath(path, mustWork = FALSE)
+    project_type <- detect_project_type(resolved_path)
+    if (identical(project_type, "monorepo") &&
+        !file.exists(file.path(resolved_path, "configure.ac"))) {
+      resolved_subdir <- find_rpkg_subdir(resolved_path)
+      if (is.null(resolved_subdir)) {
+        cli::cli_warn(c(
+          "Monorepo layout detected but could not find an rpkg subdirectory.",
+          "i" = "Pass {.code rpkg_subdir = '<name>'} explicitly for a monorepo-aware workflow."
+        ))
+      }
+    }
+  } else if (nzchar(rpkg_subdir) && !identical(rpkg_subdir, FALSE)) {
+    resolved_subdir <- as.character(rpkg_subdir)
+  }
+
   src <- system.file("templates", "r-release.yml", package = "minirextendr",
                      mustWork = TRUE)
 
   fs::dir_create(dest_dir, recurse = TRUE)
-  fs::file_copy(src, dest_file, overwrite = overwrite)
+
+  if (is.null(resolved_subdir)) {
+    # Standalone: copy template unchanged.
+    fs::file_copy(src, dest_file, overwrite = TRUE)
+  } else {
+    # Monorepo: insert `working-directory: <subdir>` after configure and build steps.
+    cli::cli_alert_info("Adding {.code working-directory: {resolved_subdir}} to configure/build steps")
+    lines <- readLines(src, warn = FALSE)
+    lines <- release_workflow_insert_workdir(lines, resolved_subdir)
+    writeLines(lines, dest_file)
+  }
 
   cli::cli_alert_success("Written {.path {dest_file}}")
   cli::cli_alert_info(c(
@@ -47,4 +89,37 @@ use_release_workflow <- function(path = ".", overwrite = FALSE) {
   ))
 
   invisible(dest_file)
+}
+
+#' Insert working-directory lines into r-release.yml lines
+#'
+#' Post-processes the r-release.yml template lines to add
+#' `working-directory: <subdir>` after each `run: bash ./configure` and
+#' `run: |` line that begins a `R CMD build` block.
+#'
+#' The template has two instances of each step (one per job). Both are patched.
+#'
+#' @param lines Character vector of template lines.
+#' @param subdir Subdirectory name (e.g. `"rpkg"`).
+#' @return Modified character vector.
+#' @noRd
+release_workflow_insert_workdir <- function(lines, subdir) {
+  wd_line <- paste0("        working-directory: ", subdir)
+  result <- character(0)
+  i <- 1L
+  while (i <= length(lines)) {
+    line <- lines[[i]]
+    # Match the two configure/build `run:` patterns used in the template.
+    # Pattern 1: `        run: bash ./configure`  (single-line run)
+    # Pattern 2: `        run: |`                 (multi-line run starting R CMD build)
+    is_configure_step <- grepl("^        run: bash \\./configure\\s*$", line)
+    is_build_step <- grepl("^        run: \\|\\s*$", line) &&
+      i < length(lines) && grepl("R CMD build", lines[[i + 1L]])
+    result <- c(result, line)
+    if (is_configure_step || is_build_step) {
+      result <- c(result, wd_line)
+    }
+    i <- i + 1L
+  }
+  result
 }

--- a/minirextendr/inst/templates/monorepo/rpkg/r_shim.h
+++ b/minirextendr/inst/templates/monorepo/rpkg/r_shim.h
@@ -1,0 +1,29 @@
+/* r_shim.h — local include that locally suppresses clang 21+'s
+ * "-Wunknown-warning-option" warning emitted for upstream R's
+ *   #pragma clang diagnostic ignored "-Wfixed-enum-extension"
+ * in Boolean.h (R 4.5+). The pragma is upstream R, not us.
+ *
+ * Why local push/pop instead of -Wno-unknown-warning-option in PKG_CFLAGS:
+ * R CMD check --as-cran flags any non-portable "warning suppressor" flag
+ * in PKG_CFLAGS, producing a CI-blocking WARNING for downstream packages
+ * that don't pin error-on='"error"'. Scoped pragma keeps the flag out of
+ * PKG_CFLAGS — see issue #443.
+ *
+ * Use this header *instead of* including <Rinternals.h> directly in
+ * package C sources.
+ */
+#ifndef MINIEXTENDR_R_SHIM_H
+#define MINIEXTENDR_R_SHIM_H
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wunknown-warning-option"
+#endif
+
+#include <Rinternals.h>
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#endif
+
+#endif /* MINIEXTENDR_R_SHIM_H */

--- a/minirextendr/tests/testthat/test-monorepo-gaps.R
+++ b/minirextendr/tests/testthat/test-monorepo-gaps.R
@@ -245,7 +245,7 @@ test_that("B3: use_release_workflow() with rpkg_subdir inserts working-directory
 test_that("B3: use_release_workflow() standalone produces no working-directory lines", {
   tmp <- withr::local_tempdir()
 
-  use_release_workflow(path = tmp, rpkg_subdir = "")
+  use_release_workflow(path = tmp, auto_detect_subdir = FALSE)
 
   dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
   expect_true(file.exists(dest))
@@ -259,7 +259,7 @@ test_that("B3: use_release_workflow() standalone produces no working-directory l
 test_that("B3: use_release_workflow() standalone content matches bundled template", {
   tmp <- withr::local_tempdir()
 
-  use_release_workflow(path = tmp, rpkg_subdir = "")
+  use_release_workflow(path = tmp, auto_detect_subdir = FALSE)
 
   written <- readLines(file.path(tmp, ".github", "workflows", "r-release.yml"),
                        warn = FALSE)
@@ -268,6 +268,20 @@ test_that("B3: use_release_workflow() standalone content matches bundled templat
     warn = FALSE
   )
   expect_identical(written, template)
+})
+
+test_that("B3: use_release_workflow() auto_detect_subdir=FALSE on monorepo root produces no working-directory lines", {
+  tmp <- withr::local_tempdir()
+  make_minimal_monorepo(tmp, rpkg_subdir = "rpkg")
+
+  # Even with a detectable monorepo, auto_detect_subdir = FALSE forces standalone.
+  use_release_workflow(path = tmp, auto_detect_subdir = FALSE)
+
+  dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
+  lines <- readLines(dest, warn = FALSE)
+  wd_lines <- grep("working-directory:", lines, value = TRUE)
+  expect_equal(length(wd_lines), 0L,
+               info = "auto_detect_subdir=FALSE should suppress monorepo detection")
 })
 
 test_that("B3: use_release_workflow() auto-detects monorepo and inserts working-directory", {

--- a/minirextendr/tests/testthat/test-monorepo-gaps.R
+++ b/minirextendr/tests/testthat/test-monorepo-gaps.R
@@ -1,0 +1,300 @@
+# Tests for the three monorepo scaffolding gaps (B1, B2, B3)
+# PR: fix(minirextendr): monorepo scaffolding gaps — r_shim.h, upgrade path, release workflow
+
+# region: helpers -------------------------------------------------------
+
+# Build a minimal monorepo directory structure in tmp without running cargo or
+# autoconf. Returns a list(root, rpkg) of absolute paths.
+make_minimal_monorepo <- function(tmp, rpkg_subdir = "rpkg") {
+  root <- tmp
+  rpkg <- file.path(root, rpkg_subdir)
+  src <- file.path(rpkg, "src", "rust")
+  dir.create(src, recursive = TRUE)
+  # Workspace Cargo.toml so detect_project_type() sees a monorepo root
+  writeLines(c(
+    "[workspace]",
+    paste0('members = ["', rpkg_subdir, '/src/rust"]')
+  ), file.path(root, "Cargo.toml"))
+  # Minimal configure.ac with CARGO_FEATURES so is_miniextendr_package() passes
+  writeLines(c(
+    "AC_INIT([mypkg], [0.0.1])",
+    "CARGO_FEATURES=\"\"",
+    "AC_OUTPUT"
+  ), file.path(rpkg, "configure.ac"))
+  # Minimal DESCRIPTION
+  writeLines(c(
+    "Package: mypkg",
+    "Version: 0.0.1"
+  ), file.path(rpkg, "DESCRIPTION"))
+  # Minimal src/Makevars.in (required by is_miniextendr_package)
+  dir.create(file.path(rpkg, "src"), recursive = TRUE, showWarnings = FALSE)
+  writeLines("# stub Makevars.in", file.path(rpkg, "src", "Makevars.in"))
+  # Minimal src/rust/Cargo.toml
+  writeLines(c(
+    "[package]",
+    'name = "mypkg"',
+    'version = "0.0.1"'
+  ), file.path(src, "Cargo.toml"))
+  list(root = root, rpkg = rpkg)
+}
+
+# endregion ---------------------------------------------------------------
+
+# region: B1 — r_shim.h in monorepo template ---------------------------
+
+test_that("B1: monorepo rpkg template directory contains r_shim.h", {
+  shim <- system.file("templates", "monorepo", "rpkg", "r_shim.h",
+                      package = "minirextendr")
+  expect_true(nzchar(shim), info = "r_shim.h missing from monorepo/rpkg/ template")
+  expect_true(file.exists(shim))
+})
+
+test_that("B1: monorepo/rpkg/r_shim.h is byte-identical to rpkg/r_shim.h", {
+  mono_shim <- system.file("templates", "monorepo", "rpkg", "r_shim.h",
+                            package = "minirextendr", mustWork = TRUE)
+  rpkg_shim <- system.file("templates", "rpkg", "r_shim.h",
+                            package = "minirextendr", mustWork = TRUE)
+  expect_identical(readLines(mono_shim, warn = FALSE),
+                   readLines(rpkg_shim, warn = FALSE))
+})
+
+test_that("B1: create_rpkg_subdirectory() copies r_shim.h into rpkg/src/", {
+  skip_if_not(nzchar(Sys.which("cargo")), "Rust toolchain not available")
+
+  tmp <- withr::local_tempdir()
+  usethis::local_project(tmp, force = TRUE, setwd = FALSE)
+  minirextendr:::set_template_type("monorepo")
+  on.exit(minirextendr:::set_template_type("rpkg"), add = TRUE)
+
+  data <- list(
+    package = "mypkg",
+    package_rs = "mypkg",
+    Package = "Mypkg",
+    crate_name = "mypkg-rs",
+    rpkg_name = "rpkg",
+    features_var = "CARGO_FEATURES",
+    year = "2026"
+  )
+
+  suppressMessages(minirextendr:::create_rpkg_subdirectory(data, rpkg_name = "rpkg"))
+
+  shim_dest <- file.path(tmp, "rpkg", "src", "r_shim.h")
+  expect_true(file.exists(shim_dest),
+              info = "r_shim.h should be placed at rpkg/src/r_shim.h")
+
+  # Should be identical to the template
+  shim_tpl <- system.file("templates", "monorepo", "rpkg", "r_shim.h",
+                           package = "minirextendr", mustWork = TRUE)
+  expect_identical(readLines(shim_dest, warn = FALSE),
+                   readLines(shim_tpl, warn = FALSE))
+})
+
+# endregion ---------------------------------------------------------------
+
+# region: B2 — upgrade_miniextendr_package() monorepo awareness ---------
+
+test_that("B2: find_rpkg_subdir() returns the subdir with CARGO_FEATURES configure.ac", {
+  tmp <- withr::local_tempdir()
+  # Write a configure.ac with CARGO_FEATURES in a subdir called "rpkg"
+  rpkg <- file.path(tmp, "rpkg")
+  dir.create(rpkg)
+  writeLines(c("AC_INIT", "CARGO_FEATURES=\"\"", "AC_OUTPUT"),
+             file.path(rpkg, "configure.ac"))
+
+  result <- minirextendr:::find_rpkg_subdir(tmp)
+  expect_equal(result, "rpkg")
+})
+
+test_that("B2: find_rpkg_subdir() returns NULL when no matching subdir exists", {
+  tmp <- withr::local_tempdir()
+  # No subdirs at all
+  expect_null(minirextendr:::find_rpkg_subdir(tmp))
+})
+
+test_that("B2: find_rpkg_subdir() ignores subdirs without CARGO_FEATURES", {
+  tmp <- withr::local_tempdir()
+  other <- file.path(tmp, "other")
+  dir.create(other)
+  writeLines(c("AC_INIT", "AC_OUTPUT"), file.path(other, "configure.ac"))
+
+  expect_null(minirextendr:::find_rpkg_subdir(tmp))
+})
+
+test_that("B2: upgrade_miniextendr_package() resolves rpkg subdir in monorepo", {
+  tmp <- withr::local_tempdir()
+  dirs <- make_minimal_monorepo(tmp)
+
+  # Record where upgrade thinks the project root is
+  upgraded_path <- NULL
+
+  # Mock the heavy upgrade steps — we only want to verify path resolution
+  local_mocked_bindings(
+    is_miniextendr_package = function() TRUE,
+    check_scaffolding_clean = function() invisible(),
+    use_miniextendr_stub = function(path = ".") invisible(),
+    use_miniextendr_makevars = function(path = ".") invisible(),
+    use_miniextendr_mx_abi = function(path = ".") invisible(),
+    use_miniextendr_build_rs = function(path = ".") invisible(),
+    use_miniextendr_bootstrap = function(path = ".") invisible(),
+    use_miniextendr_cleanup = function(path = ".") invisible(),
+    use_miniextendr_configure_win = function(path = ".") invisible(),
+    use_miniextendr_config_scripts = function(path = ".") invisible(),
+    use_miniextendr_description = function(path = ".") invisible(),
+    use_miniextendr_rbuildignore = function(path = ".") invisible(),
+    upgrade_gitignore = function() invisible(),
+    check_configure_ac_drift = function() invisible(),
+    .package = "minirextendr"
+  )
+
+  # Capture proj_get() inside upgrade to verify the resolved path
+  withr::with_envvar(list(), {
+    suppressMessages(
+      upgrade_miniextendr_package(path = dirs$root, allow_dirty = TRUE)
+    )
+    # If resolution worked, usethis::proj_get() will have been set to the rpkg
+    # subdir at some point. We verify by checking no error was thrown and the
+    # function found the rpkg subdir (not errored with "monorepo" detection).
+    expect_true(TRUE)  # reached here without error
+  })
+})
+
+test_that("B2: upgrade_miniextendr_package() errors clearly when rpkg subdir undetectable", {
+  tmp <- withr::local_tempdir()
+  # Write a Cargo.toml so it looks like a monorepo root, but no rpkg subdir
+  writeLines("[workspace]", file.path(tmp, "Cargo.toml"))
+
+  expect_error(
+    suppressMessages(upgrade_miniextendr_package(path = tmp, allow_dirty = TRUE)),
+    "Could not find an rpkg subdirectory"
+  )
+})
+
+test_that("B2: upgrade_miniextendr_package() respects explicit rpkg_subdir=", {
+  tmp <- withr::local_tempdir()
+  # Create monorepo with rpkg under a custom name
+  dirs <- make_minimal_monorepo(tmp, rpkg_subdir = "mypkg-r")
+
+  local_mocked_bindings(
+    is_miniextendr_package = function() TRUE,
+    check_scaffolding_clean = function() invisible(),
+    use_miniextendr_stub = function(path = ".") invisible(),
+    use_miniextendr_makevars = function(path = ".") invisible(),
+    use_miniextendr_mx_abi = function(path = ".") invisible(),
+    use_miniextendr_build_rs = function(path = ".") invisible(),
+    use_miniextendr_bootstrap = function(path = ".") invisible(),
+    use_miniextendr_cleanup = function(path = ".") invisible(),
+    use_miniextendr_configure_win = function(path = ".") invisible(),
+    use_miniextendr_config_scripts = function(path = ".") invisible(),
+    use_miniextendr_description = function(path = ".") invisible(),
+    use_miniextendr_rbuildignore = function(path = ".") invisible(),
+    upgrade_gitignore = function() invisible(),
+    check_configure_ac_drift = function() invisible(),
+    .package = "minirextendr"
+  )
+
+  # Should not error — explicit rpkg_subdir bypasses auto-detect
+  expect_no_error(
+    suppressMessages(
+      upgrade_miniextendr_package(path = dirs$root, rpkg_subdir = "mypkg-r",
+                                  allow_dirty = TRUE)
+    )
+  )
+})
+
+# endregion ---------------------------------------------------------------
+
+# region: B3 — use_release_workflow() monorepo working-directory --------
+
+test_that("B3: release_workflow_insert_workdir() adds working-directory to configure step", {
+  lines <- c(
+    "      - name: Configure package",
+    "        run: bash ./configure",
+    "      - name: Build",
+    "        run: |",
+    "          R CMD build .",
+    "          R CMD check ./*.tar.gz"
+  )
+  result <- minirextendr:::release_workflow_insert_workdir(lines, "rpkg")
+
+  cfg_idx <- which(grepl("run: bash ./configure", result, fixed = TRUE))
+  expect_true(length(cfg_idx) > 0)
+  expect_match(result[[cfg_idx + 1L]], "working-directory: rpkg")
+
+  build_idx <- which(grepl("run: |", result, fixed = TRUE))
+  expect_true(length(build_idx) > 0)
+  expect_match(result[[build_idx + 1L]], "working-directory: rpkg")
+})
+
+test_that("B3: use_release_workflow() with rpkg_subdir inserts working-directory", {
+  tmp <- withr::local_tempdir()
+
+  use_release_workflow(path = tmp, rpkg_subdir = "rpkg")
+
+  dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
+  expect_true(file.exists(dest))
+
+  lines <- readLines(dest, warn = FALSE)
+  # Both configure and build steps should have working-directory: rpkg
+  wd_lines <- grep("working-directory: rpkg", lines, value = TRUE)
+  # There are two jobs in the template (linux + macos), each with configure + build
+  expect_true(length(wd_lines) >= 2,
+              info = paste("Expected at least 2 working-directory lines, got:",
+                           length(wd_lines)))
+})
+
+test_that("B3: use_release_workflow() standalone produces no working-directory lines", {
+  tmp <- withr::local_tempdir()
+
+  use_release_workflow(path = tmp, rpkg_subdir = "")
+
+  dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
+  expect_true(file.exists(dest))
+
+  lines <- readLines(dest, warn = FALSE)
+  wd_lines <- grep("working-directory:", lines, value = TRUE)
+  expect_equal(length(wd_lines), 0L,
+               info = "Standalone workflow should have no working-directory lines")
+})
+
+test_that("B3: use_release_workflow() standalone content matches bundled template", {
+  tmp <- withr::local_tempdir()
+
+  use_release_workflow(path = tmp, rpkg_subdir = "")
+
+  written <- readLines(file.path(tmp, ".github", "workflows", "r-release.yml"),
+                       warn = FALSE)
+  template <- readLines(
+    system.file("templates", "r-release.yml", package = "minirextendr"),
+    warn = FALSE
+  )
+  expect_identical(written, template)
+})
+
+test_that("B3: use_release_workflow() auto-detects monorepo and inserts working-directory", {
+  tmp <- withr::local_tempdir()
+  dirs <- make_minimal_monorepo(tmp, rpkg_subdir = "rpkg")
+
+  # path = monorepo root (has Cargo.toml, no configure.ac at root)
+  use_release_workflow(path = dirs$root)
+
+  dest <- file.path(dirs$root, ".github", "workflows", "r-release.yml")
+  expect_true(file.exists(dest))
+
+  lines <- readLines(dest, warn = FALSE)
+  wd_lines <- grep("working-directory: rpkg", lines, value = TRUE)
+  expect_true(length(wd_lines) >= 2)
+})
+
+test_that("B3: use_release_workflow() standalone auto-detect (no Cargo.toml) is unchanged", {
+  tmp <- withr::local_tempdir()
+  # No Cargo.toml → auto-detect returns NULL / non-monorepo → standalone copy
+
+  use_release_workflow(path = tmp)
+
+  dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
+  lines <- readLines(dest, warn = FALSE)
+  wd_lines <- grep("working-directory:", lines, value = TRUE)
+  expect_equal(length(wd_lines), 0L)
+})
+
+# endregion ---------------------------------------------------------------


### PR DESCRIPTION
Stacks on top of #521 — addresses Opus reviewer note #1.

## Why

PR #521 introduced `use_release_workflow(rpkg_subdir = ...)` with a sentinel-style API:
- `rpkg_subdir = NULL` → auto-detect.
- `rpkg_subdir = "rpkg"` → use it.
- `rpkg_subdir = ""` or `rpkg_subdir = FALSE` → force standalone (suppress auto-detect).

Using `FALSE` (or empty string) as a sentinel for "turn off detection" is unidiomatic in R API design — `NULL` and string are the natural cases; `FALSE` surprises users.

## What

Replace the sentinel with an explicit boolean parameter:

```r
use_release_workflow(path, rpkg_subdir = NULL, auto_detect_subdir = TRUE, overwrite = FALSE)
```

New semantics:

| `rpkg_subdir` | `auto_detect_subdir` | Behavior |
|---|---|---|
| `"name"` | _ignored_ | Use `"name"` |
| `NULL` | `TRUE` (default) | Auto-detect via `detect_project_type()` |
| `NULL` | `FALSE` | Treat as standalone — no detection |

This is an unreleased project, so no backwards-compat shim for the old `FALSE`/`""` form.

## Files

- `minirextendr/R/use-release-workflow.R` — parameter + docs + dispatch logic
- `minirextendr/tests/testthat/test-monorepo-gaps.R` — two tests updated (`rpkg_subdir = ""` → `auto_detect_subdir = FALSE`), one new test for `auto_detect_subdir = FALSE` suppressing detection in a valid monorepo

`upgrade_miniextendr_package()` already used a clean `NULL` → auto-detect pattern (no `FALSE` sentinel), so no change needed there.

## Test plan

- [x] `devtools::test("minirextendr")` → **417 PASS (+1 new)**, 6 pre-existing unrelated failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)