### PR TITLE
fix(ci): drop plans/ references from pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'site/**'
       - 'docs/**'
-      - 'plans/**'
       - 'scripts/**'
       - '*/src/**'
       - 'rpkg/src/rust/**'
@@ -124,7 +123,7 @@ jobs:
       - name: Generate manual from docs/
         run: bash scripts/docs-to-site.sh
 
-      - name: Generate roadmap data (issues + plans)
+      - name: Generate roadmap data (issues)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -132,7 +131,6 @@ jobs:
           gh issue list --state open --limit 500 \
             --json number,title,labels,url,createdAt,updatedAt,assignees,state \
             > site/data/issues.json
-          bash scripts/plans-to-json.sh > site/data/plans.json
 
       - name: Build Zola site
         run: cd site && zola build


### PR DESCRIPTION
## Summary

#512 retired `plans/` and `scripts/plans-to-json.sh`, but the Pages deploy still invoked the generator — every push to main has been failing with:

\`\`\`
bash: scripts/plans-to-json.sh: No such file or directory
\`\`\`

This drops the `plans-to-json.sh` invocation and the now-dead `plans/**` path filter. Zola sources (`site/content/`, `site/templates/`, `site/config.toml`) have no `plans.json` consumers — only stale strings in `site/public/` build output, which gets overwritten next build.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Pages deploy runs without the file-not-found error