### PR TITLE
refactor(panic): panic_payload_to_string returns Cow<'_, str> (#364)

### DIFF
--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -15,6 +15,7 @@
 //! error paths.
 use std::{
     any::Any,
+    borrow::Cow,
     ffi::c_void,
     panic::{AssertUnwindSafe, catch_unwind},
     sync::OnceLock,
@@ -163,17 +164,22 @@ pub(crate) fn get_continuation_token() -> SEXP {
 
 /// Extract a message from a panic payload.
 ///
-/// Handles `&str`, `String`, and `&String` payloads consistently.
-/// Returns a descriptive fallback for unrecognised payload types.
-pub fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
+/// Handles `&str`, `String`, and `&String` payloads consistently. The borrowed
+/// variants are returned as `Cow::Borrowed`, so the common `panic!("literal")`
+/// case avoids the heap allocation that a `String` return would force.
+/// Unrecognised payload types fall back to a `Cow::Borrowed` static string.
+///
+/// Call `.into_owned()` (or `.to_string()`) at sites that need an owned
+/// `String`.
+pub fn panic_payload_to_string(payload: &(dyn Any + Send)) -> Cow<'_, str> {
     if let Some(&s) = payload.downcast_ref::<&str>() {
-        s.to_string()
+        Cow::Borrowed(s)
     } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
+        Cow::Borrowed(s.as_str())
     } else if let Some(s) = payload.downcast_ref::<&String>() {
-        (*s).clone()
+        Cow::Borrowed(s.as_str())
     } else {
-        "unknown panic".to_string()
+        Cow::Borrowed("unknown panic")
     }
 }
 

--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -492,7 +492,9 @@ mod worker_channel {
             // the loop (e.g., after an R longjmp consumed the last WorkRequest).
             let to_send: Result<Box<dyn Any + Send>, String> = match result {
                 Ok(val) => Ok(Box::new(val)),
-                Err(payload) => Err(crate::unwind_protect::panic_payload_to_string(&*payload)),
+                Err(payload) => {
+                    Err(crate::unwind_protect::panic_payload_to_string(&*payload).into_owned())
+                }
             };
             let _ = worker_tx.send(WorkerMessage::Done(to_send));
         });
@@ -598,7 +600,8 @@ mod worker_channel {
                             Ok(_) => {
                                 // Check if trampoline caught a panic
                                 if let Some(payload) = data.panic_payload.take() {
-                                    Err(crate::unwind_protect::panic_payload_to_string(&*payload))
+                                    Err(crate::unwind_protect::panic_payload_to_string(&*payload)
+                                        .into_owned())
                                 } else {
                                     // Normal completion - return the result
                                     Ok(data
@@ -614,7 +617,8 @@ mod worker_channel {
                                     ffi::R_ContinueUnwind(token);
                                 }
                                 // Rust panic - return as error response
-                                Err(crate::unwind_protect::panic_payload_to_string(&*payload))
+                                Err(crate::unwind_protect::panic_payload_to_string(&*payload)
+                                    .into_owned())
                             }
                         }
                     };


### PR DESCRIPTION
## Summary

`panic_payload_to_string` returned `String`, which forced a heap alloc on every panic surfaced to R — even though all three matched payload types (`&str`, `String`, `&String`) let us borrow without allocating.

Switched the return to `Cow<'_, str>`. The `panic!(\"literal\")` hot path (`&'static str` payload) becomes a pure borrow; the \`String\` payload still avoids the clone by borrowing through the panic Box. One of the two redundant per-panic allocations goes away (the second is unavoidable at the \`CString::new\` boundary).

## Callsites

- 13 callers in source (excludes `vendor/` copies, regenerated by CI).
- All but three use the result via \`&msg\` / \`{msg}\` formatting / \`r_stop(&msg)\` / \`make_rust_condition_value(&msg, ...)\` — \`&Cow<str>\` → \`&str\` via \`Deref\` coercion, no change needed.
- Three sites in \`worker.rs\` return \`Err(String)\` (worker channel \`Result<T, String>\` contract) — explicit \`.into_owned()\`.

Pre-release; public-API signature change, no compat shim per project policy.

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo clippy -p miniextendr-api --all-targets\`
- [ ] CI green

Closes #364.