### PR TITLE
refactor(error-kinds): replace magic kind strings with constants (#361)

### DIFF
--- a/miniextendr-api/src/condition.rs
+++ b/miniextendr-api/src/condition.rs
@@ -339,7 +339,9 @@ impl RCondition {
             .to_string();
 
         let kind_sexp = sexp.vector_elt(1);
-        let kind: &str = kind_sexp.string_elt_str(0).unwrap_or("panic");
+        let kind: &str = kind_sexp
+            .string_elt_str(0)
+            .unwrap_or(crate::error_value::kind::PANIC);
 
         // Class slot is element [2] in the 4-element form (NULL in legacy form)
         let class: Option<String> = if len >= 4 {
@@ -353,19 +355,22 @@ impl RCondition {
             None
         };
 
+        use crate::error_value::kind as kind_const;
         let cond = match kind {
-            "error" | "panic" | "result_err" | "none_err" | "other_rust_error" => {
-                RCondition::Error {
-                    message: msg,
-                    class,
-                }
-            }
-            "warning" => RCondition::Warning {
+            kind_const::ERROR
+            | kind_const::PANIC
+            | kind_const::RESULT_ERR
+            | kind_const::NONE_ERR
+            | kind_const::OTHER_RUST_ERROR => RCondition::Error {
                 message: msg,
                 class,
             },
-            "message" => RCondition::Message { message: msg },
-            "condition" => RCondition::Condition {
+            kind_const::WARNING => RCondition::Warning {
+                message: msg,
+                class,
+            },
+            kind_const::MESSAGE => RCondition::Message { message: msg },
+            kind_const::CONDITION => RCondition::Condition {
                 message: msg,
                 class,
             },

--- a/miniextendr-api/src/error_value.rs
+++ b/miniextendr-api/src/error_value.rs
@@ -11,8 +11,7 @@
 //!
 //! The tagged SEXP is a 4-element named list:
 //! - `error`: error message (character scalar)
-//! - `kind`: condition kind string (`"panic"`, `"result_err"`, `"none_err"`,
-//!   `"conversion"`, `"error"`, `"warning"`, `"message"`, `"condition"`)
+//! - `kind`: condition kind string — one of the constants in [`kind`]
 //! - `class`: optional user-supplied custom class (character scalar or `NULL`)
 //! - `call`: the R call SEXP (or `NULL` if not available)
 //! - class attribute: `"rust_condition_value"`
@@ -22,6 +21,46 @@ use crate::cached_class::{
     condition_names_sexp, rust_condition_attr_symbol, rust_condition_class_sexp,
 };
 use crate::ffi::{self, SEXP, SexpExt};
+
+/// Canonical kind strings for tagged condition values.
+///
+/// These constants are emitted into the `kind` slot of
+/// [`make_rust_condition_value`] and consumed by the R-side
+/// `.miniextendr_raise_condition` switch (see
+/// `registry::write_r_wrappers_to_file`). Reference these constants
+/// from codegen and runtime sites instead of bare string literals so a
+/// typo cannot silently change which switch arm fires.
+///
+/// The constants are kept in lockstep with the generated R helper; if a new
+/// kind is added, both the emission site and the R helper need to learn it.
+pub mod kind {
+    /// Default kind for Rust panics that surface to R via the generic panic
+    /// path (no `RCondition` payload). Layered as `rust_error`.
+    pub const PANIC: &str = "panic";
+    /// `Result<_, E>::Err(...)` formatted via `Debug` (raised when the user
+    /// returns an `Err` from a `#[miniextendr]` fn/method).
+    pub const RESULT_ERR: &str = "result_err";
+    /// `Option<T>::None` reached where a value was required (raised by the
+    /// `NoneOnErr` / required-Option return paths).
+    pub const NONE_ERR: &str = "none_err";
+    /// `TryFromSexp` / coerce / strict-mode conversion failed at argument
+    /// unmarshalling.
+    pub const CONVERSION: &str = "conversion";
+    /// User-raised `error!(...)` condition.
+    pub const ERROR: &str = "error";
+    /// User-raised `warning!(...)` condition.
+    pub const WARNING: &str = "warning";
+    /// User-raised `message!(...)` condition.
+    pub const MESSAGE: &str = "message";
+    /// User-raised `condition!(...)` condition.
+    pub const CONDITION: &str = "condition";
+    /// Fallback kind written by [`super::make_rust_condition_value`] when the
+    /// caller's `kind` argument contained an interior NUL and could not be
+    /// converted to a `CString`. Should not appear in normal flow; the match
+    /// arm in [`crate::condition::RCondition::from_sexp`] handles it
+    /// defensively by degrading to `RCondition::Error`.
+    pub const OTHER_RUST_ERROR: &str = "other_rust_error";
+}
 
 /// Convert a `&str` to a `CString`, falling back to `fallback` on interior NUL bytes.
 ///
@@ -54,8 +93,7 @@ fn to_cstring_lossy(s: &str, fallback: &str) -> std::ffi::CString {
 /// # Arguments
 ///
 /// * `message` - Human-readable condition message
-/// * `kind` - Condition kind: `"panic"`, `"result_err"`, `"none_err"`,
-///   `"conversion"`, `"error"`, `"warning"`, `"message"`, or `"condition"`
+/// * `kind` - Condition kind — one of the constants in [`kind`].
 /// * `class` - Optional user-supplied class name to prepend to the layered vector
 /// * `call` - Optional R call SEXP for error context. When `None`, uses `R_NilValue`.
 pub fn make_rust_condition_value(
@@ -83,7 +121,7 @@ pub fn make_rust_condition_value(
         list.set_vector_elt(0, msg_sexp);
 
         // Element 1: kind string
-        let kind_cstr = to_cstring_lossy(kind, "other_rust_error");
+        let kind_cstr = to_cstring_lossy(kind, kind::OTHER_RUST_ERROR);
         let kind_charsxp = ffi::Rf_mkCharCE(kind_cstr.as_ptr(), ffi::CE_UTF8);
         let kind_sexp = SEXP::scalar_string(kind_charsxp);
         ffi::Rf_protect(kind_sexp);

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -447,18 +447,19 @@ where
         Err(payload) => {
             // region: RCondition recognition — same as error_in_r path
             if let Some(cond) = payload.downcast_ref::<crate::condition::RCondition>() {
+                use crate::error_value::kind;
                 let (kind, msg, class) = match cond {
                     crate::condition::RCondition::Error { message, class } => {
-                        ("error", message.as_str(), class.as_deref())
+                        (kind::ERROR, message.as_str(), class.as_deref())
                     }
                     crate::condition::RCondition::Warning { message, class } => {
-                        ("warning", message.as_str(), class.as_deref())
+                        (kind::WARNING, message.as_str(), class.as_deref())
                     }
                     crate::condition::RCondition::Message { message } => {
-                        ("message", message.as_str(), None)
+                        (kind::MESSAGE, message.as_str(), None)
                     }
                     crate::condition::RCondition::Condition { message, class } => {
-                        ("condition", message.as_str(), class.as_deref())
+                        (kind::CONDITION, message.as_str(), class.as_deref())
                     }
                 };
                 return crate::error_value::make_rust_condition_value(msg, kind, class, None);
@@ -468,7 +469,12 @@ where
             // Generic panic path
             let msg = panic_payload_to_string(payload.as_ref());
             crate::panic_telemetry::fire(&msg, crate::panic_telemetry::PanicSource::UnwindProtect);
-            crate::error_value::make_rust_condition_value(&msg, "panic", None, None)
+            crate::error_value::make_rust_condition_value(
+                &msg,
+                crate::error_value::kind::PANIC,
+                None,
+                None,
+            )
         }
     }
 }
@@ -495,18 +501,19 @@ where
         Err(payload) => {
             // region: RCondition recognition — must come before generic panic path
             if let Some(cond) = payload.downcast_ref::<crate::condition::RCondition>() {
+                use crate::error_value::kind;
                 let (kind, msg, class) = match cond {
                     crate::condition::RCondition::Error { message, class } => {
-                        ("error", message.as_str(), class.as_deref())
+                        (kind::ERROR, message.as_str(), class.as_deref())
                     }
                     crate::condition::RCondition::Warning { message, class } => {
-                        ("warning", message.as_str(), class.as_deref())
+                        (kind::WARNING, message.as_str(), class.as_deref())
                     }
                     crate::condition::RCondition::Message { message } => {
-                        ("message", message.as_str(), None)
+                        (kind::MESSAGE, message.as_str(), None)
                     }
                     crate::condition::RCondition::Condition { message, class } => {
-                        ("condition", message.as_str(), class.as_deref())
+                        (kind::CONDITION, message.as_str(), class.as_deref())
                     }
                 };
                 // No panic telemetry for user-raised conditions — they are intentional.
@@ -517,7 +524,12 @@ where
             // Generic panic path — unchanged
             let msg = panic_payload_to_string(payload.as_ref());
             crate::panic_telemetry::fire(&msg, crate::panic_telemetry::PanicSource::UnwindProtect);
-            crate::error_value::make_rust_condition_value(&msg, "panic", None, call)
+            crate::error_value::make_rust_condition_value(
+                &msg,
+                crate::error_value::kind::PANIC,
+                None,
+                call,
+            )
         }
     }
 }

--- a/miniextendr-macros/src/c_wrapper_builder.rs
+++ b/miniextendr-macros/src/c_wrapper_builder.rs
@@ -397,7 +397,7 @@ impl CWrapperContext {
             let rng_panic_handler = quote! {
                 ::miniextendr_api::error_value::make_rust_condition_value(
                     &::miniextendr_api::unwind_protect::panic_payload_to_string(&*payload),
-                    "panic",
+                    ::miniextendr_api::error_value::kind::PANIC,
                     ::core::option::Option::None,
                     Some(__miniextendr_call),
                 )
@@ -512,7 +512,7 @@ impl CWrapperContext {
             quote! {
                 ::miniextendr_api::error_value::make_rust_condition_value(
                     &::miniextendr_api::unwind_protect::panic_payload_to_string(&*payload),
-                    "panic",
+                    ::miniextendr_api::error_value::kind::PANIC,
                     ::core::option::Option::None,
                     Some(__miniextendr_call),
                 )
@@ -551,7 +551,7 @@ impl CWrapperContext {
                             }
                             Err(__panic_msg) => {
                                 ::miniextendr_api::error_value::make_rust_condition_value(
-                                    &__panic_msg, "panic", ::core::option::Option::None, Some(__miniextendr_call),
+                                    &__panic_msg, ::miniextendr_api::error_value::kind::PANIC, ::core::option::Option::None, Some(__miniextendr_call),
                                 )
                             }
                         }
@@ -648,7 +648,7 @@ impl CWrapperContext {
                         let __result = #call_expr;
                         if __result.is_none() {
                             return ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             );
                         }
                         ::miniextendr_api::ffi::SEXP::nil()
@@ -671,7 +671,7 @@ impl CWrapperContext {
                         match __result {
                             Some(v) => v,
                             None => return ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     }
@@ -707,7 +707,7 @@ impl CWrapperContext {
                         let #result_ident = match __result {
                             Some(v) => v,
                             None => return ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         };
                         #conversion
@@ -729,7 +729,7 @@ impl CWrapperContext {
                         let __result = #call_expr;
                         if let Err(e) = __result {
                             return ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             );
                         }
                         ::miniextendr_api::ffi::SEXP::nil()
@@ -751,7 +751,7 @@ impl CWrapperContext {
                         match __result {
                             Ok(v) => v,
                             Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     }
@@ -774,7 +774,7 @@ impl CWrapperContext {
                         let #result_ident = match __result {
                             Ok(v) => v,
                             Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         };
                         #conversion
@@ -881,7 +881,7 @@ impl CWrapperContext {
                     let convert = quote! {
                         if __miniextendr_result.is_none() {
                             ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             )
                         } else {
                             ::miniextendr_api::ffi::SEXP::nil()
@@ -909,7 +909,7 @@ impl CWrapperContext {
                         match __miniextendr_result {
                             Some(v) => v,
                             None => ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     };
@@ -958,7 +958,7 @@ impl CWrapperContext {
                         match __miniextendr_result {
                             Some(#result_ident) => #unwind_fn(|| #conversion, None),
                             None => ::miniextendr_api::error_value::make_rust_condition_value(
-                                #error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     };
@@ -989,7 +989,7 @@ impl CWrapperContext {
                         match __miniextendr_result {
                             Ok(()) => ::miniextendr_api::ffi::SEXP::nil(),
                             Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     };
@@ -1014,7 +1014,7 @@ impl CWrapperContext {
                         match __miniextendr_result {
                             Ok(v) => v,
                             Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     };
@@ -1046,7 +1046,7 @@ impl CWrapperContext {
                                 None,
                             ),
                             Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                                &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                                &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                             ),
                         }
                     };

--- a/miniextendr-macros/src/method_return_builder.rs
+++ b/miniextendr-macros/src/method_return_builder.rs
@@ -17,10 +17,18 @@ use crate::miniextendr_impl::ParsedMethod;
 ///
 /// Expects `.val` to already be assigned (e.g., `.val <- .Call(...)`). Emits a
 /// single line indented by `indent`: when `.val` is a tagged `rust_condition_value`,
-/// hand off to the shared helper and return from the enclosing function. The
-/// helper's `stop()` longjmps for error/panic kinds; for warning/message/
-/// condition it signals and returns `invisible(NULL)`, which the surrounding
-/// `return(...)` propagates as the wrapper's result.
+/// hand off to the shared helper and return from the enclosing function.
+///
+/// The helper dispatches on `.val$kind` (see
+/// [`miniextendr_api::error_value::kind`] for canonical kind strings):
+///
+/// - `error` / `panic` / `result_err` / `none_err` / `conversion` (and any
+///   unknown kind) — `stop()` longjmps with the appropriate `rust_*` class
+///   layering.
+/// - `warning` — `warning()` signals; the wrapper's surrounding `return(...)`
+///   propagates `invisible(NULL)` as the wrapper's result.
+/// - `message` — `message()` signals; same propagation.
+/// - `condition` — `signalCondition()` signals; same propagation.
 pub fn error_in_r_check_lines(indent: &str) -> Vec<String> {
     vec![format!(
         "{indent}if (inherits(.val, \"rust_condition_value\") && isTRUE(attr(.val, \"__rust_condition__\"))) return(.miniextendr_raise_condition(.val, sys.call()))"

--- a/miniextendr-macros/src/return_type_analysis.rs
+++ b/miniextendr-macros/src/return_type_analysis.rs
@@ -180,7 +180,7 @@ fn analyze_option_type(
                 match #rust_result_ident {
                     Some(()) => ::miniextendr_api::ffi::SEXP::nil(),
                     None => ::miniextendr_api::error_value::make_rust_condition_value(
-                        #option_none_error_msg, "none_err", ::core::option::Option::None, Some(__miniextendr_call),
+                        #option_none_error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                     ),
                 }
             }
@@ -270,7 +270,7 @@ fn analyze_result_type(
                 match #rust_result_ident {
                     Ok(()) => ::miniextendr_api::ffi::SEXP::nil(),
                     Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                        &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                        &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                     ),
                 }
             }
@@ -282,7 +282,7 @@ fn analyze_result_type(
                 match #rust_result_ident {
                     Ok(v) => v,
                     Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                        &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                        &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                     ),
                 }
             }
@@ -293,7 +293,7 @@ fn analyze_result_type(
                 match #rust_result_ident {
                     Ok(v) => ::miniextendr_api::into_r::IntoR::into_sexp(v),
                     Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
-                        &format!("{:?}", e), "result_err", ::core::option::Option::None, Some(__miniextendr_call),
+                        &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                     ),
                 }
             }

--- a/miniextendr-macros/src/rust_conversion_builder.rs
+++ b/miniextendr-macros/src/rust_conversion_builder.rs
@@ -111,7 +111,7 @@ impl RustConversionBuilder {
                     Ok(v) => v,
                     Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                         &format!("{}: {e}", #error_msg),
-                        "conversion",
+                        ::miniextendr_api::error_value::kind::CONVERSION,
                         ::core::option::Option::None,
                         Some(__miniextendr_call),
                     ),
@@ -138,7 +138,7 @@ impl RustConversionBuilder {
                     Ok(v) => v,
                     Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                         &format!("{}: {e}", #error_msg),
-                        "conversion",
+                        ::miniextendr_api::error_value::kind::CONVERSION,
                         ::core::option::Option::None,
                         Some(__miniextendr_call),
                     ),
@@ -256,7 +256,7 @@ impl RustConversionBuilder {
                                     Ok(v) => v,
                                     Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                                         &format!("{}: {e}", #em),
-                                        "conversion",
+                                        ::miniextendr_api::error_value::kind::CONVERSION,
                                         ::core::option::Option::None,
                                         Some(__miniextendr_call),
                                     ),
@@ -477,7 +477,7 @@ impl RustConversionBuilder {
                                         Ok(v) => v,
                                         Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                                             &format!("{}: {e}", #error_msg_convert),
-                                            "conversion",
+                                            ::miniextendr_api::error_value::kind::CONVERSION,
                                             ::core::option::Option::None,
                                             Some(__miniextendr_call),
                                         ),
@@ -486,7 +486,7 @@ impl RustConversionBuilder {
                                         Ok(v) => v,
                                         Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                                             &format!("{}: {e}", #error_msg_coerce),
-                                            "conversion",
+                                            ::miniextendr_api::error_value::kind::CONVERSION,
                                             ::core::option::Option::None,
                                             Some(__miniextendr_call),
                                         ),
@@ -524,7 +524,7 @@ impl RustConversionBuilder {
                                         Ok(v) => v,
                                         Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                                             &format!("{}: {e}", #error_msg_convert),
-                                            "conversion",
+                                            ::miniextendr_api::error_value::kind::CONVERSION,
                                             ::core::option::Option::None,
                                             Some(__miniextendr_call),
                                         ),
@@ -536,7 +536,7 @@ impl RustConversionBuilder {
                                         Ok(v) => v,
                                         Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
                                             &format!("{}: {e}", #error_msg_coerce),
-                                            "conversion",
+                                            ::miniextendr_api::error_value::kind::CONVERSION,
                                             ::core::option::Option::None,
                                             Some(__miniextendr_call),
                                         ),


### PR DESCRIPTION
## Summary

Centralises the eight \`kind\` strings (\`\"panic\"\`, \`\"none_err\"\`, \`\"result_err\"\`, \`\"conversion\"\`, \`\"error\"\`, \`\"warning\"\`, \`\"message\"\`, \`\"condition\"\` + \`\"other_rust_error\"\` defensive fallback) into a new \`error_value::kind\` module. Codegen sites and the runtime both reference the same constants, so a typo at a single site can no longer silently change which R-side switch arm fires.

## Sites

- **Codegen emission** (proc-macro):
  - \`c_wrapper_builder.rs\` — 15 sites (panic ×3, none_err ×6, result_err ×6)
  - \`return_type_analysis.rs\` — 4 sites (none_err ×1, result_err ×3)
  - \`rust_conversion_builder.rs\` — 7 \`conversion\` sites
- **Runtime**:
  - \`unwind_protect.rs\` — RCondition tuple match + generic-panic paths (both \`with_r_unwind_protect_shim\` and \`with_r_unwind_protect_error_in_r\`)
  - \`condition.rs\` — \`from_sexp\` match arms + \`unwrap_or\` fallback
  - \`error_value.rs\` — \`to_cstring_lossy\` fallback now references \`kind::OTHER_RUST_ERROR\`
- **Docs**:
  - \`error_value.rs\` module + function doc now points at the \`kind\` module
  - \`method_return_builder.rs\` doc on \`error_in_r_check_lines\` enumerates all dispatched kinds (previously missed result_err/none_err/conversion — issue's side note)

## Not in scope

The R-side \`.miniextendr_raise_condition\` switch in \`registry::write_r_wrappers_to_file\` still emits literal R strings (\`panic = stop(...)\` etc.) — those are R source, not Rust, and are kept in lockstep with the Rust constants by convention. Threading the constants through the R helper template is a clear follow-up but out of scope here.

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test -p miniextendr-macros --lib\` → 307 passed
- [ ] CI green

Closes #361.