### PR TITLE
refactor: rename RErrorAdapter to AsRError (#409)

### DIFF
--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -190,19 +190,19 @@ Functions that explicitly opt out of `error_in_r` via
 `Rf_errorcall` — those modes exist precisely to bypass the condition
 pipeline.
 
-## `RErrorAdapter` — wrapping `std::error::Error`
+## `AsRError` — wrapping `std::error::Error`
 
 For functions that return `Result<T, E>` where `E: std::error::Error`,
-`RErrorAdapter<E>` wraps the error and formats its full cause chain into the
+`AsRError<E>` wraps the error and formats its full cause chain into the
 message:
 
 ```rust
-use miniextendr_api::condition::RErrorAdapter;
+use miniextendr_api::condition::AsRError;
 use miniextendr_api::miniextendr;
 
 #[miniextendr]
-fn parse_number(s: &str) -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
-    s.parse::<i32>().map_err(RErrorAdapter)
+fn parse_number(s: &str) -> Result<i32, AsRError<std::num::ParseIntError>> {
+    s.parse::<i32>().map_err(AsRError)
 }
 ```
 

--- a/miniextendr-api/CLAUDE.md
+++ b/miniextendr-api/CLAUDE.md
@@ -13,7 +13,7 @@ Runtime crate — FFI, ExternalPtr, ALTREP, worker thread, error/condition trans
 - `worker.rs` — worker thread + `Sendable<T>`. Without `worker-thread` feature, `run_on_worker(f) → Ok(f())` inline.
 - `unwind_protect.rs` — `R_UnwindProtect` wrapper; `with_r_unwind_protect_error_in_r` is the user-facing path.
 - `error_value.rs` — tagged-SEXP transport. `make_rust_error_value` (3-elem) + `make_rust_condition_value` (4-elem, custom-class slot). PROTECT discipline matters here (see Gotchas).
-- `condition.rs` — `RCondition` enum + `error!`/`warning!`/`message!`/`condition!` macros + `RErrorAdapter<E: Error>`.
+- `condition.rs` — `RCondition` enum + `error!`/`warning!`/`message!`/`condition!` macros + `AsRError<E: Error>`.
 - `from_r.rs` — `TryFromSexp` + `r_slice` / `r_slice_mut` (handle R's 0x1 empty-vector data pointer).
 - `into_r.rs` — `IntoR` impls; `Box<[T]>` blanket + `bool`/`String` overrides.
 - `coerce.rs` / `as_coerce.rs` / `strict.rs` — conversion paths; strict-mode checked variants.

--- a/miniextendr-api/src/condition.rs
+++ b/miniextendr-api/src/condition.rs
@@ -7,7 +7,7 @@
 //!    `with_r_unwind_protect_error_in_r` before the generic panic→error path,
 //!    then forwarded to R as a structured condition with `rust_*` class layering.
 //!
-//! 2. **[`RErrorAdapter`] struct** — wraps any `E: std::error::Error` and
+//! 2. **[`AsRError`] struct** — wraps any `E: std::error::Error` and
 //!    preserves the full error chain (cause/source) when converting to an R
 //!    error message. Use as the `Err` type in `Result` returns.
 //!
@@ -55,14 +55,14 @@
 //! # [1] "caught!"
 //! ```
 //!
-//! # `RErrorAdapter`
+//! # `AsRError`
 //!
 //! ```ignore
-//! use miniextendr_api::condition::RErrorAdapter;
+//! use miniextendr_api::condition::AsRError;
 //!
 //! #[miniextendr]
-//! fn parse_config(path: &str) -> Result<i32, RErrorAdapter<std::io::Error>> {
-//!     let content = std::fs::read_to_string(path).map_err(RErrorAdapter)?;
+//! fn parse_config(path: &str) -> Result<i32, AsRError<std::io::Error>> {
+//!     let content = std::fs::read_to_string(path).map_err(AsRError)?;
 //!     Ok(content.len() as i32)
 //! }
 //! ```
@@ -413,7 +413,7 @@ pub unsafe fn repanic_if_rust_error(sexp: crate::ffi::SEXP) {
 
 // endregion
 
-// region: RErrorAdapter struct — wraps std::error::Error for Result returns
+// region: AsRError struct — wraps std::error::Error for Result returns
 
 /// Structured error wrapper that preserves the `std::error::Error` cause chain.
 ///
@@ -424,29 +424,29 @@ pub unsafe fn repanic_if_rust_error(sexp: crate::ffi::SEXP) {
 ///   caused by: root cause
 /// ```
 ///
-/// Implements `From<E>` so it works with `?` and `.map_err(RErrorAdapter)`.
+/// Implements `From<E>` so it works with `?` and `.map_err(AsRError)`.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use miniextendr_api::condition::RErrorAdapter;
+/// use miniextendr_api::condition::AsRError;
 /// use std::num::ParseIntError;
 ///
 /// #[miniextendr]
-/// fn parse_number(s: &str) -> Result<i32, RErrorAdapter<ParseIntError>> {
-///     s.parse::<i32>().map_err(RErrorAdapter)
+/// fn parse_number(s: &str) -> Result<i32, AsRError<ParseIntError>> {
+///     s.parse::<i32>().map_err(AsRError)
 /// }
 /// ```
-pub struct RErrorAdapter<E: std::error::Error>(pub E);
+pub struct AsRError<E: std::error::Error>(pub E);
 
-impl<E: std::error::Error> From<E> for RErrorAdapter<E> {
+impl<E: std::error::Error> From<E> for AsRError<E> {
     #[inline]
     fn from(err: E) -> Self {
-        RErrorAdapter(err)
+        AsRError(err)
     }
 }
 
-impl<E: std::error::Error> std::fmt::Display for RErrorAdapter<E> {
+impl<E: std::error::Error> std::fmt::Display for AsRError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Write the top-level message
         write!(f, "{}", self.0)?;
@@ -462,13 +462,13 @@ impl<E: std::error::Error> std::fmt::Display for RErrorAdapter<E> {
     }
 }
 
-impl<E: std::error::Error> std::fmt::Debug for RErrorAdapter<E> {
+impl<E: std::error::Error> std::fmt::Debug for AsRError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RErrorAdapter<{}>({})", std::any::type_name::<E>(), self)
+        write!(f, "AsRError<{}>({})", std::any::type_name::<E>(), self)
     }
 }
 
-impl<E: std::error::Error> RErrorAdapter<E> {
+impl<E: std::error::Error> AsRError<E> {
     /// Get the inner error.
     #[inline]
     pub fn into_inner(self) -> E {

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -531,7 +531,7 @@ pub use as_coerce::{
 };
 
 pub mod condition;
-pub use condition::{RCondition, RErrorAdapter};
+pub use condition::{AsRError, RCondition};
 pub mod convert;
 /// Support for R `...` arguments represented as a validated list.
 pub mod dots;

--- a/rpkg/src/rust/condition_tests.rs
+++ b/rpkg/src/rust/condition_tests.rs
@@ -1,19 +1,19 @@
-//! Test fixtures for RErrorAdapter structured error adapter.
+//! Test fixtures for AsRError structured error adapter.
 
-use miniextendr_api::condition::RErrorAdapter;
+use miniextendr_api::condition::AsRError;
 use miniextendr_api::miniextendr;
 
 // region: Simple errors
 
 /// @export
 #[miniextendr]
-pub fn test_condition_parse_int(s: &str) -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
-    s.parse::<i32>().map_err(RErrorAdapter)
+pub fn test_condition_parse_int(s: &str) -> Result<i32, AsRError<std::num::ParseIntError>> {
+    s.parse::<i32>().map_err(AsRError)
 }
 
 /// @export
 #[miniextendr]
-pub fn test_condition_ok() -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
+pub fn test_condition_ok() -> Result<i32, AsRError<std::num::ParseIntError>> {
     Ok(42)
 }
 
@@ -41,9 +41,9 @@ impl std::error::Error for ConfigError {
 
 /// @export
 #[miniextendr]
-pub fn test_condition_chained(s: &str) -> Result<i32, RErrorAdapter<ConfigError>> {
+pub fn test_condition_chained(s: &str) -> Result<i32, AsRError<ConfigError>> {
     let value = s.parse::<i32>().map_err(|e| {
-        RErrorAdapter(ConfigError {
+        AsRError(ConfigError {
             msg: format!("failed to parse '{s}' as max_threads"),
             source: e,
         })

--- a/rpkg/tests/testthat/test-conditions.R
+++ b/rpkg/tests/testthat/test-conditions.R
@@ -1,23 +1,23 @@
-# Tests for the condition macro system and RErrorAdapter
+# Tests for the condition macro system and AsRError
 
-# region: RErrorAdapter structured error adapter (legacy path)
+# region: AsRError structured error adapter (legacy path)
 
-test_that("RErrorAdapter propagates parse error", {
+test_that("AsRError propagates parse error", {
   expect_error(test_condition_parse_int("not_a_number"), "invalid digit")
 })
 
-test_that("RErrorAdapter passes through on success", {
+test_that("AsRError passes through on success", {
   expect_equal(test_condition_ok(), 42L)
 })
 
-test_that("RErrorAdapter includes cause chain in error message", {
+test_that("AsRError includes cause chain in error message", {
   err <- tryCatch(test_condition_chained("abc"), error = function(e) e)
   expect_true(grepl("config error", err$message))
   expect_true(grepl("caused by", err$message))
   expect_true(grepl("invalid digit", err$message))
 })
 
-test_that("RErrorAdapter chained succeeds on valid input", {
+test_that("AsRError chained succeeds on valid input", {
   expect_equal(test_condition_chained("8"), 8L)
 })
 

--- a/site/content/manual/conditions.md
+++ b/site/content/manual/conditions.md
@@ -194,19 +194,19 @@ Functions that explicitly opt out of `error_in_r` via
 `Rf_errorcall` — those modes exist precisely to bypass the condition
 pipeline.
 
-## `RErrorAdapter` — wrapping `std::error::Error`
+## `AsRError` — wrapping `std::error::Error`
 
 For functions that return `Result<T, E>` where `E: std::error::Error`,
-`RErrorAdapter<E>` wraps the error and formats its full cause chain into the
+`AsRError<E>` wraps the error and formats its full cause chain into the
 message:
 
 ```rust
-use miniextendr_api::condition::RErrorAdapter;
+use miniextendr_api::condition::AsRError;
 use miniextendr_api::miniextendr;
 
 #[miniextendr]
-fn parse_number(s: &str) -> Result<i32, RErrorAdapter<std::num::ParseIntError>> {
-    s.parse::<i32>().map_err(RErrorAdapter)
+fn parse_number(s: &str) -> Result<i32, AsRError<std::num::ParseIntError>> {
+    s.parse::<i32>().map_err(AsRError)
 }
 ```
 


### PR DESCRIPTION
## Summary

Renames the structured error adapter \`RErrorAdapter<E: std::error::Error>\` to \`AsRError<E>\`. Reads more naturally at the use site:

\`\`\`rust
fn parse_number(s: &str) -> Result<i32, AsRError<ParseIntError>> {
    s.parse::<i32>().map_err(AsRError)
}
\`\`\`

\`AsRError\` says \"treat my E as an R-side error\"; the previous name framed it as an internal adapter.

Pre-release; no compat shim.

## Files

- \`miniextendr-api/src/condition.rs\` — struct def + impls + module docs
- \`miniextendr-api/src/lib.rs\` — re-export
- \`miniextendr-api/CLAUDE.md\` — architecture pointer
- \`rpkg/src/rust/condition_tests.rs\` — fixtures
- \`rpkg/tests/testthat/test-conditions.R\` — test names + descriptions
- \`docs/CONDITIONS.md\` + regenerated \`site/content/manual/conditions.md\`

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test -p miniextendr-api --lib\` → 240 passed
- [x] \`just site-docs\` (docs/ → site/content/manual/) clean
- [ ] CI green

Closes #409.