### PR TITLE
fix(minirextendr): cran-prep trap-cleans inst/vendor.tar.xz on failure (#454)

### DIFF
--- a/minirextendr/inst/templates/monorepo/justfile
+++ b/minirextendr/inst/templates/monorepo/justfile
@@ -142,8 +142,12 @@ vendor-lib crate dev_path:
 # `just install` / `devtools::install("{{rpkg}}")` silently switch to tarball
 # mode (configure's only signal is `[ -f inst/vendor.tar.xz ]`), which freezes
 # out monorepo workspace-crate edits via `[patch."git+url"]`.
-cran-prep: vendor rbuild rcheck
-    rm -f {{rpkg}}/inst/vendor.tar.xz
+[script("bash")]
+cran-prep: vendor
+    set -euo pipefail
+    trap 'rm -f {{rpkg}}/inst/vendor.tar.xz' EXIT
+    just rbuild
+    just rcheck
 
 # ============================================================================
 # Version management

--- a/minirextendr/inst/templates/rpkg/justfile
+++ b/minirextendr/inst/templates/rpkg/justfile
@@ -143,14 +143,17 @@ vendor:
 
 # Prepare for CRAN submission: vendor deps, build, check
 #
-# Cleanup: rpkg/inst/vendor.tar.xz must be removed after the build/check
+# Cleanup: inst/vendor.tar.xz must be removed after the build/check
 # pipeline. Otherwise the leftover in the source tree makes the next
 # `just install` / `devtools::install(".")` silently switch to tarball mode
 # (configure's only signal is `[ -f inst/vendor.tar.xz ]`), which freezes out
 # any cargo-resolved dependency edits.
-cran-prep: vendor rbuild rcheck
-    # TODO(#454): trap-clean on failure — see issue #454
-    rm -f inst/vendor.tar.xz
+[script("bash")]
+cran-prep: vendor
+    set -euo pipefail
+    trap 'rm -f inst/vendor.tar.xz' EXIT
+    just rbuild
+    just rcheck
 
 # ============================================================================
 # Version management

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-14 09:18:35
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
+--- a/monorepo/rpkg/bootstrap.R	2026-05-14 10:07:47
++++ b/monorepo/rpkg/bootstrap.R	2026-05-14 10:07:47
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
-+++ b/monorepo/rpkg/configure.ac	2026-05-10 17:31:33
+--- a/monorepo/rpkg/configure.ac	2026-05-14 10:07:47
++++ b/monorepo/rpkg/configure.ac	2026-05-14 10:07:47
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-10 17:31:33
-+++ b/rpkg/configure.ac	2026-05-10 17:31:33
+--- a/rpkg/configure.ac	2026-05-14 10:07:47
++++ b/rpkg/configure.ac	2026-05-14 10:07:47
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])


### PR DESCRIPTION
## Summary

- Fixes the latch-leak bug in `cran-prep` in both template justfiles: if
  `rbuild` or `rcheck` fails mid-run, the `rm -f inst/vendor.tar.xz` line
  was never reached, leaving the tarball in the source tree and silently
  switching subsequent `configure` runs into tarball mode.
- Ports the `[script("bash")]` + `trap 'rm -f …' EXIT` pattern already used
  by the root justfile's `r-cmd-build` and `r-cmd-check` recipes.
- Moves `rbuild` and `rcheck` from recipe deps to the body, so the trap
  covers them (deps run before the body; a trap registered in the body cannot
  catch dep failures).
- Regenerates `patches/templates.patch` to keep CI's sync-check passing.

**Files changed:**
- `minirextendr/inst/templates/rpkg/justfile` — standalone template
- `minirextendr/inst/templates/monorepo/justfile` — monorepo template
  (same root cause; included per the "no branch scoping" project rule)
- `patches/templates.patch` — regenerated via `just templates-approve`

## Test plan

- [ ] `just templates-check` exits 0
- [ ] Failure simulation: inject `false` before `just rcheck` → verify
      `inst/vendor.tar.xz` is absent after `cran-prep` fails
- [ ] CI sync-check passes (templates.patch up to date)

Closes #454