### PR TITLE
fix(vendor): miniextendr_vendor() regenerates Cargo.lock before vendoring (#523 partial)

### DIFF
--- a/minirextendr/R/utils.R
+++ b/minirextendr/R/utils.R
@@ -625,3 +625,28 @@ is_miniextendr_package <- function() {
 bullet_created <- function(path, verb = "Created") {
   cli::cli_alert_success("{verb} {.path {path}}")
 }
+
+#' Rename a file, hard-failing on any error
+#'
+#' `file.rename()` returns `FALSE` on failure without throwing — this wrapper
+#' converts any failure into a hard error so callers never silently swallow a
+#' rename that did not happen (important on Windows where renames are
+#' non-atomic and can fail when the target is locked).
+#'
+#' NOTE: `bootstrap.R` carries an identical inline copy of this helper because
+#' it is a standalone script (not a package), not a package function. See #523.
+#'
+#' @param from Source path.
+#' @param to Destination path.
+#' @param context Human-readable context string included in the error message.
+#' @return Invisibly.
+#' @noRd
+safe_rename <- function(from, to, context) {
+  if (!isTRUE(file.rename(from, to))) {
+    cli::cli_abort(c(
+      "Failed to rename {.path {from}} -> {.path {to}}",
+      "x" = context
+    ))
+  }
+  invisible()
+}

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -169,7 +169,7 @@ miniextendr_vendor <- function(path = ".") {
 
   rust_dir      <- usethis::proj_path("src", "rust")
   cargo_cfg     <- fs::path(rust_dir, ".cargo", "config.toml")
-  cargo_cfg_bak <- paste0(cargo_cfg, ".tmp_vendor")
+  cargo_cfg_bak <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
   cargo_lock    <- fs::path(rust_dir, "Cargo.lock")
   cargo_toml    <- fs::path(rust_dir, "Cargo.toml")
 

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -156,8 +156,67 @@ miniextendr_vendor <- function(path = ".") {
   with_project(path)
   cli::cli_h1("miniextendr vendor workflow")
 
-  # Step 1: cargo revendor + CRAN-trim (delegates to vendor_crates_io)
-  cli::cli_h2("Step 1: vendor all dependencies")
+  # Step 1: regenerate Cargo.lock in tarball-shape.
+  #
+  # In a monorepo dev checkout .cargo/config.toml carries [patch."git+url"]
+  # overrides that redirect miniextendr-{api,lint,macros} to local paths.
+  # cargo records those as `source = "path+file:///..."` in Cargo.lock, which
+  # are invalid at offline install time (the paths don't exist inside the
+  # tarball). Regenerate the lock against the bare git URLs before vendoring.
+  #
+  # Mirrors the same dance in `just vendor` and `bootstrap.R` (PR #526).
+  cli::cli_h2("Step 1: regenerate Cargo.lock in tarball-shape")
+
+  rust_dir      <- usethis::proj_path("src", "rust")
+  cargo_cfg     <- fs::path(rust_dir, ".cargo", "config.toml")
+  cargo_cfg_bak <- paste0(cargo_cfg, ".tmp_vendor")
+  cargo_lock    <- fs::path(rust_dir, "Cargo.lock")
+  cargo_toml    <- fs::path(rust_dir, "Cargo.toml")
+
+  if (!fs::file_exists(cargo_toml)) {
+    cli::cli_abort(c(
+      "{.path src/rust/Cargo.toml} not found",
+      "i" = "Run {.code miniextendr_configure()} first"
+    ))
+  }
+
+  if (fs::file_exists(cargo_cfg)) {
+    safe_rename(
+      cargo_cfg, cargo_cfg_bak,
+      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
+    )
+  }
+  if (fs::file_exists(cargo_lock)) {
+    fs::file_delete(cargo_lock)
+  }
+
+  cli::cli_alert("Regenerating {.path src/rust/Cargo.lock} without monorepo overrides...")
+  lock_status <- system2("cargo", c(
+    "generate-lockfile",
+    "--manifest-path", cargo_toml
+  ))
+
+  # Restore config regardless of lock_status — restore first, then error.
+  if (fs::file_exists(cargo_cfg_bak)) {
+    safe_rename(
+      cargo_cfg_bak, cargo_cfg,
+      paste0(
+        "cannot restore .cargo/config.toml from backup; ",
+        "manual fix required: rename ", cargo_cfg_bak, " -> ", cargo_cfg
+      )
+    )
+  }
+
+  if (lock_status != 0) {
+    cli::cli_abort(c(
+      "{.code cargo generate-lockfile} failed (exit {lock_status})",
+      "i" = "Check the output above for details"
+    ))
+  }
+  cli::cli_alert_success("Cargo.lock regenerated in tarball-shape")
+
+  # Step 2: cargo revendor + CRAN-trim (delegates to vendor_crates_io)
+  cli::cli_h2("Step 2: vendor all dependencies")
   vendor_crates_io()
 
   vendor_dir <- usethis::proj_path("vendor")
@@ -165,12 +224,12 @@ miniextendr_vendor <- function(path = ".") {
   inst_dir <- usethis::proj_path("inst")
   tarball <- fs::path(inst_dir, "vendor.tar.xz")
 
-  # Step 2: compress into inst/vendor.tar.xz
+  # Step 3: compress into inst/vendor.tar.xz
   # Note: Cargo.lock checksum lines are intentionally retained. cargo-revendor
   # (post PR #408) writes valid .cargo-checksum.json entries with real SHA-256s,
   # so stripping `checksum = "..."` from Cargo.lock is no longer needed and
   # would diverge from the `just vendor` reference output.
-  cli::cli_h2("Step 2: compress vendor tarball")
+  cli::cli_h2("Step 3: compress vendor tarball")
   fs::dir_create(inst_dir)
 
   # Create staging directory for clean compression

--- a/minirextendr/tests/testthat/test-regressions.R
+++ b/minirextendr/tests/testthat/test-regressions.R
@@ -281,23 +281,11 @@ test_that("miniextendr_doctor is exported", {
 
 # =============================================================================
 # #523: miniextendr_vendor() must regenerate Cargo.lock before vendoring
+# (Structural test dropped: deparse(body) tests are brittle per project memory
+# rule — implementation theater, not a real fix. Behavioural coverage provided
+# by CI's functional smoke test via `just minirextendr-test`. A mock-based
+# replacement was not added because `mockery` is not in DESCRIPTION Suggests.)
 # =============================================================================
-
-test_that("miniextendr_vendor body includes lock-regen before vendor_crates_io", {
-  # Regression: miniextendr_vendor() was missing the cargo generate-lockfile
-  # dance that just vendor and bootstrap.R both perform. Without it, a monorepo
-  # dev checkout could produce a tarball with path+file:// Cargo.lock entries
-  # that break offline CRAN install. See #523.
-  body_src <- deparse(body(miniextendr_vendor))
-  gen_lock_line  <- grep("generate-lockfile", body_src)
-  vendor_call_line <- grep("vendor_crates_io", body_src)
-  expect_gt(length(gen_lock_line), 0,
-    label = "generate-lockfile must appear in miniextendr_vendor body")
-  expect_gt(length(vendor_call_line), 0,
-    label = "vendor_crates_io must appear in miniextendr_vendor body")
-  expect_lt(gen_lock_line[1], vendor_call_line[1],
-    label = "generate-lockfile must come before vendor_crates_io")
-})
 
 test_that("ensure_dir is defined only once", {
   # Scan all R files for ensure_dir definitions

--- a/minirextendr/tests/testthat/test-regressions.R
+++ b/minirextendr/tests/testthat/test-regressions.R
@@ -279,6 +279,26 @@ test_that("miniextendr_doctor is exported", {
 # P3: ensure_dir is not duplicated
 # =============================================================================
 
+# =============================================================================
+# #523: miniextendr_vendor() must regenerate Cargo.lock before vendoring
+# =============================================================================
+
+test_that("miniextendr_vendor body includes lock-regen before vendor_crates_io", {
+  # Regression: miniextendr_vendor() was missing the cargo generate-lockfile
+  # dance that just vendor and bootstrap.R both perform. Without it, a monorepo
+  # dev checkout could produce a tarball with path+file:// Cargo.lock entries
+  # that break offline CRAN install. See #523.
+  body_src <- deparse(body(miniextendr_vendor))
+  gen_lock_line  <- grep("generate-lockfile", body_src)
+  vendor_call_line <- grep("vendor_crates_io", body_src)
+  expect_gt(length(gen_lock_line), 0,
+    label = "generate-lockfile must appear in miniextendr_vendor body")
+  expect_gt(length(vendor_call_line), 0,
+    label = "vendor_crates_io must appear in miniextendr_vendor body")
+  expect_lt(gen_lock_line[1], vendor_call_line[1],
+    label = "generate-lockfile must come before vendor_crates_io")
+})
+
 test_that("ensure_dir is defined only once", {
   # Scan all R files for ensure_dir definitions
   r_dir <- system.file("R", package = "minirextendr")


### PR DESCRIPTION
## Summary

- `miniextendr_vendor()` was missing the lock-regeneration dance that
  `just vendor` and `bootstrap.R` both perform before invoking `cargo revendor`.
- A developer calling it from a monorepo checkout could silently produce a
  tarball whose `Cargo.lock` contains `source = "path+file:///..."` entries for
  `miniextendr-{api,macros,lint,engine}`, causing offline CRAN install to fail.
- Ports the `safe_rename()` + `cargo generate-lockfile` block from `bootstrap.R`
  (added in PR #526) into `miniextendr_vendor()`.
- Factors `safe_rename()` into a shared `utils.R` internal helper with a comment
  pointing to the inline bootstrap.R copy.

Addresses #523. The full shell-out refactor (`miniextendr_vendor()` → thin wrapper
around `cargo-revendor`, < 60 lines) remains as the main scope of #523.

## Test plan
- [ ] `miniextendr_vendor("../rpkg")` from monorepo: verify zero `path+file://` in
  `Cargo.lock` after run
- [ ] `just minirextendr-test` passes
- [ ] `just templates-check` clean
- [ ] `unlink("rpkg/inst/vendor.tar.xz")` after test to avoid latch leak