### PR TITLE
feat(configure): accept CARGO_HOME override (#516)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -23,6 +23,7 @@ single signal:
 | `CARGO_PROFILE` | Build profile: `dev` or `release` | `release` |
 | `CARGO_TARGET_DIR` | Artifact directory (must be outside `src/`) | `${abs_top_srcdir}/rust-target` |
 | `CARGO_BUILD_TARGET` | Rust target triple for cross-compilation | Empty (native); auto-detected from autoconf host |
+| `CARGO_HOME` | Cargo registry/cache directory for offline or restricted environments | Empty (cargo's default, `~/.cargo`) |
 | `RUST_TOOLCHAIN` | Toolchain selector (e.g., `+stable`, `+nightly`) | Empty (system default) |
 | `ENV_RUSTFLAGS` | Rust compiler flags, passed as `RUSTFLAGS` to cargo | Value of `RUSTFLAGS` |
 

--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -7,6 +7,7 @@ CARGO_TARGET_DIR      = @CARGO_TARGET_DIR@
 CARGO_PROFILE         = @CARGO_PROFILE@
 CARGO_STATICLIB_NAME  = @CARGO_STATICLIB_NAME@
 ENV_RUSTFLAGS         = @ENV_RUSTFLAGS@
+CARGO_HOME            = @CARGO_HOME@
 CARGO_BUILD_TARGET    = @CARGO_BUILD_TARGET@
 ABS_RPKG_SRC_CARGO    = @ABS_RPKG_SRC_CARGO@
 CARGO_LIBDIR          = @CARGO_LIBDIR@
@@ -39,6 +40,7 @@ WASM_REGISTRY_RS = $(ABS_RPKG_SRCDIR)/rust/wasm_registry.rs
 # cdylib for R wrapper generation (platform-specific extension)
 CARGO_CDYLIB = $(CARGO_LIBDIR)/$(CDYLIB_PREFIX)$(CARGO_STATICLIB_NAME).$(CDYLIB_EXT)
 ## ----------------------------------------------------------------------
+export CARGO_HOME
 
 # FORCE_CARGO: phony target to ensure Cargo is invoked every time make runs,
 # letting Cargo's own incremental compilation decide what to rebuild.

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -215,6 +215,12 @@ AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
 AC_SUBST([ENV_RUSTFLAGS])
 
+AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \
+  useful in restricted environments where HOME is read-only)])
+: ${CARGO_HOME=""}
+AC_SUBST([CARGO_HOME])
+AS_IF([test -n "$CARGO_HOME"], [AC_MSG_NOTICE([CARGO_HOME           = $CARGO_HOME])])
+
 AC_ARG_VAR([CARGO_BUILD_TARGET], [Cargo build target triple (e.g. aarch64-apple-darwin)])
 if test -z "$CARGO_BUILD_TARGET"; then
   if test -n "$host" && test -n "$build" && test "$host" != "$build"; then

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -7,6 +7,7 @@ CARGO_TARGET_DIR      = @CARGO_TARGET_DIR@
 CARGO_PROFILE         = @CARGO_PROFILE@
 CARGO_STATICLIB_NAME  = @CARGO_STATICLIB_NAME@
 ENV_RUSTFLAGS         = @ENV_RUSTFLAGS@
+CARGO_HOME            = @CARGO_HOME@
 CARGO_BUILD_TARGET    = @CARGO_BUILD_TARGET@
 ABS_RPKG_SRC_CARGO    = @ABS_RPKG_SRC_CARGO@
 CARGO_LIBDIR          = @CARGO_LIBDIR@
@@ -39,6 +40,7 @@ WASM_REGISTRY_RS = $(ABS_RPKG_SRCDIR)/rust/wasm_registry.rs
 # cdylib for R wrapper generation (platform-specific extension)
 CARGO_CDYLIB = $(CARGO_LIBDIR)/$(CDYLIB_PREFIX)$(CARGO_STATICLIB_NAME).$(CDYLIB_EXT)
 ## ----------------------------------------------------------------------
+export CARGO_HOME
 
 # FORCE_CARGO: phony target to ensure Cargo is invoked every time make runs,
 # letting Cargo's own incremental compilation decide what to rebuild.

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -267,6 +267,12 @@ AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
 AC_SUBST([ENV_RUSTFLAGS])
 
+AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \
+  useful in restricted environments where HOME is read-only)])
+: ${CARGO_HOME=""}
+AC_SUBST([CARGO_HOME])
+AS_IF([test -n "$CARGO_HOME"], [AC_MSG_NOTICE([CARGO_HOME           = $CARGO_HOME])])
+
 AC_ARG_VAR([CARGO_BUILD_TARGET], [Cargo build target triple (e.g. aarch64-apple-darwin)])
 if test -z "$CARGO_BUILD_TARGET"; then
   if test -n "$host" && test -n "$build" && test "$host" != "$build"; then

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-14 10:07:47
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-14 10:07:47
+--- a/monorepo/rpkg/bootstrap.R	2026-05-14 10:09:57
++++ b/monorepo/rpkg/bootstrap.R	2026-05-14 10:09:57
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-14 10:07:47
-+++ b/monorepo/rpkg/configure.ac	2026-05-14 10:07:47
+--- a/monorepo/rpkg/configure.ac	2026-05-14 10:16:51
++++ b/monorepo/rpkg/configure.ac	2026-05-14 10:16:51
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -288,7 +288,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-@@ -266,4 +230,8 @@
+@@ -272,4 +236,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -297,7 +297,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -273,21 +241,29 @@
+@@ -279,21 +247,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -337,7 +337,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -306,18 +282,20 @@
+@@ -312,18 +288,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -367,20 +367,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -361,4 +339,5 @@
+@@ -367,4 +345,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -535,5 +514,5 @@
+@@ -541,5 +520,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -551,13 +530,22 @@
+@@ -557,13 +536,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-14 10:07:47
-+++ b/rpkg/configure.ac	2026-05-14 10:07:47
+--- a/rpkg/configure.ac	2026-05-14 10:16:51
++++ b/rpkg/configure.ac	2026-05-14 10:16:51
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -510,7 +510,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-@@ -266,4 +282,8 @@
+@@ -272,4 +288,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -519,7 +519,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -273,21 +293,29 @@
+@@ -279,21 +299,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -559,7 +559,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -306,18 +334,20 @@
+@@ -312,18 +340,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -589,20 +589,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -361,4 +391,5 @@
+@@ -367,4 +397,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -535,5 +566,5 @@
+@@ -541,5 +572,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -551,13 +582,22 @@
+@@ -557,13 +588,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -601,6 +601,7 @@ TAR_FORCE_LOCAL
 CARGO_STATICLIB_NAME
 CARGO_LIBDIR
 CARGO_BUILD_TARGET
+CARGO_HOME
 ENV_RUSTFLAGS
 CARGO_PROFILE
 CARGO_TARGET_DIR_CARGO
@@ -678,6 +679,7 @@ RUST_TOOLCHAIN
 CARGO_TARGET_DIR
 CARGO_PROFILE
 ENV_RUSTFLAGS
+CARGO_HOME
 CARGO_BUILD_TARGET'
 
 
@@ -1308,6 +1310,8 @@ Some influential environment variables:
               Cargo build profile (dev or release)
   ENV_RUSTFLAGS
               Rust compiler flags passed as RUSTFLAGS
+  CARGO_HOME  cargo registry/cache directory (defaults to ~/.cargo; useful in
+              restricted environments where HOME is read-only)
   CARGO_BUILD_TARGET
               Cargo build target triple (e.g. aarch64-apple-darwin)
 
@@ -2492,6 +2496,15 @@ fi
 
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
 
+
+
+: ${CARGO_HOME=""}
+
+if test -n "$CARGO_HOME"
+then :
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: CARGO_HOME           = $CARGO_HOME" >&5
+printf '%s\n' "$as_me: CARGO_HOME           = $CARGO_HOME" >&6;}
+fi
 
 
 if test -z "$CARGO_BUILD_TARGET"; then

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -251,6 +251,12 @@ AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
 AC_SUBST([ENV_RUSTFLAGS])
 
+AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \
+  useful in restricted environments where HOME is read-only)])
+: ${CARGO_HOME=""}
+AC_SUBST([CARGO_HOME])
+AS_IF([test -n "$CARGO_HOME"], [AC_MSG_NOTICE([CARGO_HOME           = $CARGO_HOME])])
+
 AC_ARG_VAR([CARGO_BUILD_TARGET], [Cargo build target triple (e.g. aarch64-apple-darwin)])
 if test -z "$CARGO_BUILD_TARGET"; then
   if test -n "$host" && test -n "$build" && test "$host" != "$build"; then

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -7,6 +7,7 @@ CARGO_TARGET_DIR      = @CARGO_TARGET_DIR@
 CARGO_PROFILE         = @CARGO_PROFILE@
 CARGO_STATICLIB_NAME  = @CARGO_STATICLIB_NAME@
 ENV_RUSTFLAGS         = @ENV_RUSTFLAGS@
+CARGO_HOME            = @CARGO_HOME@
 CARGO_BUILD_TARGET    = @CARGO_BUILD_TARGET@
 ABS_RPKG_SRC_CARGO    = @ABS_RPKG_SRC_CARGO@
 CARGO_LIBDIR          = @CARGO_LIBDIR@
@@ -39,6 +40,7 @@ WASM_REGISTRY_RS = $(ABS_RPKG_SRCDIR)/rust/wasm_registry.rs
 # cdylib for R wrapper generation (platform-specific extension)
 CARGO_CDYLIB = $(CARGO_LIBDIR)/$(CDYLIB_PREFIX)$(CARGO_STATICLIB_NAME).$(CDYLIB_EXT)
 ## ----------------------------------------------------------------------
+export CARGO_HOME
 
 # FORCE_CARGO: phony target to ensure Cargo is invoked every time make runs,
 # letting Cargo's own incremental compilation decide what to rebuild.


### PR DESCRIPTION
## Summary

- Adds `AC_ARG_VAR([CARGO_HOME], [...])` to `rpkg/configure.ac` (and both
  minirextendr templates) so the variable is documented in `./configure --help`,
  cached in `config.status`, and forwarded to cargo invocations.
- Adds `CARGO_HOME = @CARGO_HOME@` + `export CARGO_HOME` to `Makevars.in`
  (and template copies) so the value reaches cargo at build time.
- Documents `CARGO_HOME` in `docs/ENVIRONMENT_VARIABLES.md`.
- Regenerates `rpkg/configure` via `autoconf`.
- Regenerates `patches/templates.patch` via `just templates-approve`.

Default behavior is unchanged: when `CARGO_HOME` is unset, cargo uses `~/.cargo`
as before.

## Test plan

- [ ] `./configure --help | grep CARGO_HOME` shows the description.
- [ ] Unset `CARGO_HOME`: `grep CARGO_HOME rpkg/src/Makevars` → empty value, build unaffected.
- [ ] Set `CARGO_HOME=/tmp/test-cargo-home just rcmdinstall` → cargo populates `/tmp/test-cargo-home/`.
- [ ] `just templates-check` passes.

Closes #516