### PR TITLE
feat(macros): detect inner-payload field collision in nested DataFrameRow enums (#486)

### DIFF
--- a/miniextendr-api/src/markers.rs
+++ b/miniextendr-api/src/markers.rs
@@ -38,6 +38,87 @@
 )]
 pub trait DataFrameRow {}
 
+/// Reflection trait for `#[derive(DataFrameRow)]` types, used for compile-time
+/// collision detection in outer `DataFrameRow` enums.
+///
+/// Automatically emitted by the `DataFrameRow` derive macro alongside `DataFrameRow`.
+/// The outer enum's codegen generates a `const _: ()` assertion that calls
+/// [`assert_no_payload_field_collision`] using these associated constants, producing
+/// a clear compile error when an inner payload field name (after outer prefix expansion)
+/// would produce the same R column as the outer discriminant column.
+///
+/// # Constants
+///
+/// - `FIELDS`: the resolved column names (after `#[dataframe(rename = "...")]`) that
+///   this type contributes directly. For structs: each column name. For enums: every
+///   payload field name across all variants (deduplicated).
+/// - `TAG`: the value of `#[dataframe(tag = "...")]` on this type, or `""` if absent.
+///   The outer macro uses this as the discriminant suffix for inner-enum nested fields.
+///
+/// You should not implement this trait manually.
+pub trait DataFramePayloadFields {
+    /// Resolved column names contributed by this type (post-rename, pre-prefix).
+    const FIELDS: &'static [&'static str];
+    /// Value of `#[dataframe(tag = "...")]` on this type, or `""` if absent.
+    const TAG: &'static str;
+}
+
+// region: const-eval collision helper
+
+/// Const-eval equality check for two `&str` values (stable since Rust 1.46).
+///
+/// Used by [`assert_no_payload_field_collision`] inside a `const {}` block.
+const fn const_str_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Compile-time assertion: no element of `fields` equals `discriminant_suffix`
+/// (the inner-enum's `#[dataframe(tag)]` value).
+///
+/// Called from `const _: ()` blocks emitted by the outer `DataFrameRow` derive for
+/// every `EnumResolvedField::Struct` nested-enum field:
+///
+/// ```rust,ignore
+/// const _: () = ::miniextendr_api::markers::assert_no_payload_field_collision(
+///     <Inner as ::miniextendr_api::markers::DataFramePayloadFields>::FIELDS,
+///     <Inner as ::miniextendr_api::markers::DataFramePayloadFields>::TAG,
+/// );
+/// ```
+///
+/// `fields` contains the resolved column names the inner type emits directly (not prefixed).
+/// `discriminant_suffix` is the inner enum's tag value (e.g. `"variant"`).
+///
+/// If any field name equals the discriminant suffix, the const evaluation panics with a
+/// message explaining the collision and suggesting a rename.
+pub const fn assert_no_payload_field_collision(fields: &[&str], discriminant_suffix: &str) {
+    let mut i = 0;
+    while i < fields.len() {
+        if const_str_eq(fields[i], discriminant_suffix) {
+            panic!(
+                "DataFrameRow inner-payload field collision: an inner enum payload field \
+                 has the same name as the inner enum's discriminant tag. After outer prefix \
+                 expansion this produces two columns with identical names, causing silent \
+                 data corruption. Rename the inner payload field or add \
+                 `#[dataframe(rename = \"...\")]` on it to use a different column name."
+            );
+        }
+        i += 1;
+    }
+}
+// endregion
+
 /// Marker trait for types that should be converted to R lists via `IntoR`.
 ///
 /// Implemented by the `PreferList` derive; you can also implement it manually.

--- a/miniextendr-api/src/markers.rs
+++ b/miniextendr-api/src/markers.rs
@@ -56,6 +56,7 @@ pub trait DataFrameRow {}
 ///   The outer macro uses this as the discriminant suffix for inner-enum nested fields.
 ///
 /// You should not implement this trait manually.
+#[doc(hidden)]
 pub trait DataFramePayloadFields {
     /// Resolved column names contributed by this type (post-rename, pre-prefix).
     const FIELDS: &'static [&'static str];
@@ -102,6 +103,7 @@ const fn const_str_eq(a: &str, b: &str) -> bool {
 ///
 /// If any field name equals the discriminant suffix, the const evaluation panics with a
 /// message explaining the collision and suggesting a rename.
+#[doc(hidden)]
 pub const fn assert_no_payload_field_collision(fields: &[&str], discriminant_suffix: &str) {
     let mut i = 0;
     while i < fields.len() {

--- a/miniextendr-macros/src/dataframe_derive.rs
+++ b/miniextendr-macros/src/dataframe_derive.rs
@@ -1736,6 +1736,27 @@ fn derive_struct_dataframe(
             for #row_name #ty_generics #where_clause {}
     };
 
+    // DataFramePayloadFields impl: exposes FIELDS (all resolved column names) and TAG
+    // (the #[dataframe(tag = "...")] value, or "") for compile-time collision detection
+    // by outer DataFrameRow enums that nest this type as a struct-flattened field.
+    let payload_fields_impl = {
+        // Collect all column names: flat_cols + struct_col base names.
+        let mut field_names: Vec<String> =
+            flat_cols.iter().map(|fc| fc.col_name_str.clone()).collect();
+        for sc in &struct_cols {
+            field_names.push(sc.col_name_str.clone());
+        }
+        let tag_str = attrs.tag.as_deref().unwrap_or("");
+        quote! {
+            impl #impl_generics ::miniextendr_api::markers::DataFramePayloadFields
+                for #row_name #ty_generics #where_clause
+            {
+                const FIELDS: &'static [&'static str] = &[#(#field_names),*];
+                const TAG: &'static str = #tag_str;
+            }
+        }
+    };
+
     // Compile-time assertions for struct-flattened fields (#485): each inner
     // type must implement `DataFrameRow`, otherwise users get a confusing
     // error pointing at the `to_dataframe` call site instead of the field.
@@ -1763,6 +1784,7 @@ fn derive_struct_dataframe(
         #row_methods
         #trait_check
         #marker_impl
+        #payload_fields_impl
         #(#struct_assertions)*
     })
     // endregion

--- a/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
+++ b/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
@@ -230,25 +230,25 @@ pub(super) fn derive_enum_dataframe(
                         }
                     }
                 }
-                // B1: Check for `<base>_variant` discriminant column collision.
+                // B1: Check for `<base>_<inner_tag>` discriminant column collision.
                 //
                 // When a Struct field `kind: Inner` is flattened, the inner enum's
                 // discriminant column (tag) is emitted under `<base>_<inner_tag>`.
-                // If the inner enum uses `#[dataframe(tag = "variant")]` (recommended),
-                // the outer discriminant column becomes `kind_variant`.  If any sibling
-                // field in the same variant is also named `kind_variant` (or renames to
-                // that), the two fields would produce the same R column name — a runtime
-                // collision that is undetectable without this check.
+                // The inner tag is retrieved at runtime from
+                // `<Inner as DataFramePayloadFields>::TAG`; the B1 check here uses the
+                // hardcoded default `"variant"` for compile-time sibling detection because
+                // we cannot inspect inner enum attributes from the outer macro parse phase.
+                // The per-inner-field payload collision is caught separately via the
+                // `const _:` assertions emitted below (using `DataFramePayloadFields`).
                 //
-                // We detect the following cases at compile time:
-                //   1. Struct field `kind: Inner` + Single/Scalar field `kind_variant`
-                //   2. Struct field `kind: Inner` + another Struct field that would
-                //      produce `kind_variant` (e.g. if a field is renamed to `kind_variant`)
+                // We detect the following cases at compile time (both using "variant"):
+                //   1. Struct field `kind: Inner` + Single/Scalar sibling named `kind_variant`
+                //   2. Struct field `kind: Inner` + another Struct sibling field renamed to
+                //      produce `kind_variant`
                 //
-                // Inner-enum-internal collision (Inner has both `tag = "variant"` AND
-                // payload field `variant`) cannot be detected here — that requires
-                // inspecting Inner's own resolved columns.  Document this as a carve-out
-                // in DATAFRAME.md.
+                // Inner-enum-internal collision (Inner has both `tag = "X"` AND payload
+                // field `X`) is caught by the `assert_no_payload_field_collision` const
+                // assertion emitted below — no carve-out needed.
                 {
                     // Collect every flat column name produced by non-Struct resolved fields.
                     let flat_col_names: Vec<String> = resolved
@@ -269,6 +269,9 @@ pub(super) fn derive_enum_dataframe(
 
                     for r in &resolved {
                         if let EnumResolvedField::Struct(struct_data) = r {
+                            // Use hardcoded "variant" for the sibling check — this is the
+                            // default inner tag. The inner-payload collision for non-default
+                            // tags is caught by assert_no_payload_field_collision below.
                             let discriminant_col = format!("{}_variant", struct_data.base_name);
                             if flat_col_names.contains(&discriminant_col) {
                                 // Find the colliding field for a better span.
@@ -1017,6 +1020,28 @@ pub(super) fn derive_enum_dataframe(
             }
         })
         .collect();
+
+    // Payload collision assertions (#486): one per nested-enum struct field.
+    // For each `kind: Inner` field, emit:
+    //   const _: () = ::miniextendr_api::markers::assert_no_payload_field_collision(
+    //       <Inner as DataFramePayloadFields>::FIELDS,
+    //       <Inner as DataFramePayloadFields>::TAG,
+    //   );
+    // This fires a compile-time panic if any inner payload field name equals the
+    // inner enum's own tag suffix, which would (after outer prefix expansion) produce
+    // a column name identical to the outer discriminant column.
+    let payload_collision_assertions: Vec<TokenStream> = struct_cols
+        .iter()
+        .map(|sc| {
+            let inner_ty = &sc.inner_ty;
+            quote! {
+                const _: () = ::miniextendr_api::markers::assert_no_payload_field_collision(
+                    <#inner_ty as ::miniextendr_api::markers::DataFramePayloadFields>::FIELDS,
+                    <#inner_ty as ::miniextendr_api::markers::DataFramePayloadFields>::TAG,
+                );
+            }
+        })
+        .collect();
     // endregion
 
     // region: Generate From<Vec<Enum>>
@@ -1545,6 +1570,36 @@ pub(super) fn derive_enum_dataframe(
             for #row_name #ty_generics #where_clause {}
     };
 
+    // DataFramePayloadFields impl (#486): exposes FIELDS (all resolved column names,
+    // deduplicated) and TAG for compile-time collision detection by outer enums.
+    // FIELDS lists every single-column payload field name across all variants.
+    // TAG is the inner enum's #[dataframe(tag = "...")] value (or "" if absent).
+    let payload_fields_impl = {
+        // Collect unique field names from all variant payload fields (single columns only).
+        // We skip expanded (fixed/vec) and struct fields — only direct column contributions.
+        let mut field_names: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for vi in &variant_infos {
+            for erf in &vi.fields {
+                if let EnumResolvedField::Single(data) = erf {
+                    let name = data.col_name.to_string();
+                    if seen.insert(name.clone()) {
+                        field_names.push(name);
+                    }
+                }
+            }
+        }
+        let tag_str = attrs.tag.as_deref().unwrap_or("");
+        quote! {
+            impl #impl_generics ::miniextendr_api::markers::DataFramePayloadFields
+                for #row_name #ty_generics #where_clause
+            {
+                const FIELDS: &'static [&'static str] = &[#(#field_names),*];
+                const TAG: &'static str = #tag_str;
+            }
+        }
+    };
+
     // region: unit-only enum factor impls
     // For a unit-only enum (all variants are unit), auto-emit:
     //   1. `impl UnitEnumFactor for Self`  — provides FACTOR_LEVELS and to_factor_index()
@@ -1635,7 +1690,9 @@ pub(super) fn derive_enum_dataframe(
         #row_methods
         #split_method
         #marker_impl
+        #payload_fields_impl
         #(#struct_assertions)*
+        #(#payload_collision_assertions)*
         #unit_only_factor_impls
     })
     // endregion

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_no_derive.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_no_derive.stderr
@@ -46,3 +46,21 @@ note: required by a bound in `_assert_inner_is_dataframe_row`
 12 | #[derive(DataFrameRow)]
    |          ^^^^^^^^^^^^ required by this bound in `_assert_inner_is_dataframe_row`
    = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Status: DataFramePayloadFields` is not satisfied
+  --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:15:32
+   |
+15 |     Tracked { id: i32, status: Status },
+   |                                ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `DataFramePayloadFields` is not implemented for `Status`
+  --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:7:1
+   |
+ 7 | enum Status {
+   | ^^^^^^^^^^^
+help: the trait `DataFramePayloadFields` is implemented for `Outer`
+  --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:12:10
+   |
+12 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.rs
@@ -1,0 +1,21 @@
+//! Test: inner enum payload field named `variant` (matching the inner tag) →
+//! after outer prefix expansion → collides with the outer discriminant column →
+//! compile error via `assert_no_payload_field_collision`.
+
+use miniextendr_macros::DataFrameRow;
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(align, tag = "variant")]
+enum Inner {
+    A,
+    B { variant: i32 }, // field named "variant" — same as the tag → collision
+}
+
+#[derive(DataFrameRow)]
+#[dataframe(align, tag = "_type")]
+enum Outer {
+    Wrap { id: i32, kind: Inner }, // outer discriminant also → "kind_variant"
+    Other { id: i32 },
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.stderr
@@ -1,0 +1,49 @@
+warning: unexpected `cfg` condition value: `rayon`
+ --> tests/ui/derive_dataframe_enum_nested_inner_variant_field.rs:7:24
+  |
+7 | #[derive(Clone, Debug, DataFrameRow)]
+  |                        ^^^^^^^^^^^^
+  |
+  = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+  = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+  = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+  = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+  = note: `#[warn(unexpected_cfgs)]` on by default
+  = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_nested_inner_variant_field.rs:14:10
+   |
+14 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: DataFrameRow inner-payload field collision: an inner enum payload field has the same name as the inner enum's discriminant tag. After outer prefix expansion this produces two columns with identical names, causing silent data corruption. Rename the inner payload field or add `#[dataframe(rename = "...")]` on it to use a different column name.
+  --> tests/ui/derive_dataframe_enum_nested_inner_variant_field.rs:14:10
+   |
+14 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^ evaluation of `_` failed inside this call
+   |
+note: inside `assert_no_payload_field_collision`
+  --> $RUST/core/src/panic.rs
+   |
+   |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   |
+  ::: $WORKSPACE/miniextendr-api/src/markers.rs
+   |
+   | /             panic!(
+   | |                 "DataFrameRow inner-payload field collision: an inner enum payload field \
+   | |                  has the same name as the inner enum's discriminant tag. After outer prefix \
+   | |                  expansion this produces two columns with identical names, causing silent \
+   | |                  data corruption. Rename the inner payload field or add \
+   | |                  `#[dataframe(rename = \"...\")]` on it to use a different column name."
+   | |             );
+   | |_____________- in this macro invocation

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.rs
@@ -1,0 +1,22 @@
+//! Test: inner enum payload field named `kind` matching a custom tag `kind` →
+//! after outer prefix expansion → collides with the outer discriminant column →
+//! compile error via `assert_no_payload_field_collision`.
+
+use miniextendr_macros::DataFrameRow;
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(align, tag = "kind")]
+enum Inner {
+    A,
+    B { kind: i32 }, // field "kind" → outer prefix "status_" → "status_kind"
+                     // outer discriminant also → "status_kind"
+}
+
+#[derive(DataFrameRow)]
+#[dataframe(align)]
+enum Outer {
+    Wrap { id: i32, status: Inner },
+    Other { id: i32 },
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.stderr
@@ -1,0 +1,49 @@
+warning: unexpected `cfg` condition value: `rayon`
+ --> tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.rs:7:24
+  |
+7 | #[derive(Clone, Debug, DataFrameRow)]
+  |                        ^^^^^^^^^^^^
+  |
+  = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+  = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+  = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+  = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+  = note: `#[warn(unexpected_cfgs)]` on by default
+  = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.rs:15:10
+   |
+15 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: DataFrameRow inner-payload field collision: an inner enum payload field has the same name as the inner enum's discriminant tag. After outer prefix expansion this produces two columns with identical names, causing silent data corruption. Rename the inner payload field or add `#[dataframe(rename = "...")]` on it to use a different column name.
+  --> tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.rs:15:10
+   |
+15 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^ evaluation of `_` failed inside this call
+   |
+note: inside `assert_no_payload_field_collision`
+  --> $RUST/core/src/panic.rs
+   |
+   |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   |
+  ::: $WORKSPACE/miniextendr-api/src/markers.rs
+   |
+   | /             panic!(
+   | |                 "DataFrameRow inner-payload field collision: an inner enum payload field \
+   | |                  has the same name as the inner enum's discriminant tag. After outer prefix \
+   | |                  expansion this produces two columns with identical names, causing silent \
+   | |                  data corruption. Rename the inner payload field or add \
+   | |                  `#[dataframe(rename = \"...\")]` on it to use a different column name."
+   | |             );
+   | |_____________- in this macro invocation

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_struct_field_no_derive.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_struct_field_no_derive.stderr
@@ -79,3 +79,21 @@ note: required by a bound in `_assert_inner_is_dataframe_row`
 11 | #[derive(DataFrameRow)]
    |          ^^^^^^^^^^^^ required by this bound in `_assert_inner_is_dataframe_row`
    = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Point: DataFramePayloadFields` is not satisfied
+  --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:14:32
+   |
+14 |     Located { id: i32, origin: Point },
+   |                                ^^^^^ unsatisfied trait bound
+   |
+help: the trait `DataFramePayloadFields` is not implemented for `Point`
+  --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:6:1
+   |
+ 6 | struct Point {
+   | ^^^^^^^^^^^^
+help: the trait `DataFramePayloadFields` is implemented for `Event`
+  --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:11:10
+   |
+11 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -1261,6 +1261,11 @@ mod struct_field_tests {
 //     `dir_variant` column from the `tag = "variant"` attribute on Direction)
 //   - `NestedFactorEvent`: `#[dataframe(as_factor)] dir: Direction` → factor column
 //   - `NestedListEvent`: `#[dataframe(as_list)] dir: Direction` → list column
+//
+// Note: the inner-payload-field-named-`variant` pattern (i.e., a `Status` payload
+// field named `"variant"`) is now a **compile error** enforced via
+// `assert_no_payload_field_collision` at the outer `#[derive(DataFrameRow)]` site.
+// See issue #486 and PR #542.
 
 /// Unit-only inner enum — derives `DataFrameRow`, which auto-emits `IntoR` and
 /// `IntoR for Vec<Option<Self>>` as factor SEXPs, and `IntoList`.

--- a/rpkg/src/rust/wasm_registry.rs
+++ b/rpkg/src/rust/wasm_registry.rs
@@ -4,7 +4,7 @@
 // wasm32-* targets in place of the linkme distributed_slices.
 //
 // generator-version: 1
-// content-hash:      8c0dacbae96e611d
+// content-hash:      795f0d5bdf821068
 
 use ::miniextendr_api::abi::mx_tag;
 use ::miniextendr_api::ffi::{R_CallMethodDef, SEXP};
@@ -950,25 +950,19 @@ unsafe extern "C-unwind" {
     pub fn C_jiff_time_minute(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_time_second(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_zoned_month(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_date_weekday(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_datetime_day(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_datetime_new(_: SEXP, _: SEXP, _: SEXP, _: SEXP, _: SEXP, _: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_span_is_zero(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_date_tomorrow(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_datetime_hour(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_datetime_year(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_duration_secs(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_zoned_tz_name(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_counted_altrep(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_date_yesterday(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_datetime_month(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_date(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_span_rcrd_demo(_: SEXP) -> SEXP;
-    pub fn C_jiff_zoned_strftime(_: SEXP, _: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_epoch_timestamp(_: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_zoned(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_zoned_rcrd_demo(_: SEXP) -> SEXP;
-    pub fn C_jiff_date_day_of_year(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_option_timestamp(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_span_is_negative(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_altrep_timestamps(_: SEXP, _: SEXP) -> SEXP;
@@ -976,20 +970,14 @@ unsafe extern "C-unwind" {
     pub fn C_jiff_negative_duration(_: SEXP) -> SEXP;
     pub fn C_jiff_one_hour_duration(_: SEXP) -> SEXP;
     pub fn C_jiff_timestamp_seconds(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_date_last_of_month(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_negative_timestamp(_: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_date_vec(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_duration(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_timestamp_strftime(_: SEXP, _: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_zoned_start_of_day(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_date_first_of_month(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_timestamp(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_zoned_vec(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_jiff_fractional_timestamp(_: SEXP) -> SEXP;
     pub fn C_jiff_roundtrip_timestamp_vec(_: SEXP, _: SEXP) -> SEXP;
-    pub fn C_jiff_counted_altrep_elt_count(_: SEXP) -> SEXP;
     pub fn C_jiff_half_second_before_epoch(_: SEXP) -> SEXP;
-    pub fn C_jiff_timestamp_as_millisecond(_: SEXP, _: SEXP) -> SEXP;
     pub fn C_protect_pool_multi(_: SEXP) -> SEXP;
     pub fn C_protect_pool_roundtrip(_: SEXP) -> SEXP;
     pub fn C_sha2_sha256(_: SEXP, _: SEXP) -> SEXP;
@@ -1836,7 +1824,6 @@ unsafe extern "C-unwind" {
 
 unsafe extern "C" {
     pub safe fn __mx_altrep_reg_MxDerivedIntsData();
-    pub safe fn __mx_altrep_reg_JiffTimestampVecCounted();
     pub safe fn __mx_altrep_reg_WarnAltrepData();
     pub safe fn __mx_altrep_reg_MessageAltrepData();
     pub safe fn __mx_altrep_reg_ConditionAltrepData();
@@ -6596,11 +6583,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         numArgs: 2,
     },
     R_CallMethodDef {
-        name: c"C_jiff_date_weekday".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_weekday) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
         name: c"C_jiff_datetime_day".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_datetime_day) }),
         numArgs: 2,
@@ -6613,11 +6595,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
     R_CallMethodDef {
         name: c"C_jiff_span_is_zero".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_span_is_zero) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_date_tomorrow".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_tomorrow) }),
         numArgs: 2,
     },
     R_CallMethodDef {
@@ -6641,16 +6618,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         numArgs: 2,
     },
     R_CallMethodDef {
-        name: c"C_jiff_counted_altrep".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_counted_altrep) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_date_yesterday".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_yesterday) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
         name: c"C_jiff_datetime_month".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_datetime_month) }),
         numArgs: 2,
@@ -6666,11 +6633,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         numArgs: 1,
     },
     R_CallMethodDef {
-        name: c"C_jiff_zoned_strftime".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP, SEXP) -> SEXP, _>(C_jiff_zoned_strftime) }),
-        numArgs: 3,
-    },
-    R_CallMethodDef {
         name: c"C_jiff_epoch_timestamp".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP) -> SEXP, _>(C_jiff_epoch_timestamp) }),
         numArgs: 1,
@@ -6684,11 +6646,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         name: c"C_jiff_zoned_rcrd_demo".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP) -> SEXP, _>(C_jiff_zoned_rcrd_demo) }),
         numArgs: 1,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_date_day_of_year".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_day_of_year) }),
-        numArgs: 2,
     },
     R_CallMethodDef {
         name: c"C_jiff_option_timestamp".as_ptr(),
@@ -6726,11 +6683,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         numArgs: 2,
     },
     R_CallMethodDef {
-        name: c"C_jiff_date_last_of_month".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_last_of_month) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
         name: c"C_jiff_negative_timestamp".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP) -> SEXP, _>(C_jiff_negative_timestamp) }),
         numArgs: 1,
@@ -6743,21 +6695,6 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
     R_CallMethodDef {
         name: c"C_jiff_roundtrip_duration".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_roundtrip_duration) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_timestamp_strftime".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP, SEXP) -> SEXP, _>(C_jiff_timestamp_strftime) }),
-        numArgs: 3,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_zoned_start_of_day".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_zoned_start_of_day) }),
-        numArgs: 2,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_date_first_of_month".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_date_first_of_month) }),
         numArgs: 2,
     },
     R_CallMethodDef {
@@ -6781,19 +6718,9 @@ pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[
         numArgs: 2,
     },
     R_CallMethodDef {
-        name: c"C_jiff_counted_altrep_elt_count".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP) -> SEXP, _>(C_jiff_counted_altrep_elt_count) }),
-        numArgs: 1,
-    },
-    R_CallMethodDef {
         name: c"C_jiff_half_second_before_epoch".as_ptr(),
         fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP) -> SEXP, _>(C_jiff_half_second_before_epoch) }),
         numArgs: 1,
-    },
-    R_CallMethodDef {
-        name: c"C_jiff_timestamp_as_millisecond".as_ptr(),
-        fun: Some(unsafe { ::core::mem::transmute::<unsafe extern "C-unwind" fn(SEXP, SEXP) -> SEXP, _>(C_jiff_timestamp_as_millisecond) }),
-        numArgs: 2,
     },
     R_CallMethodDef {
         name: c"C_protect_pool_multi".as_ptr(),
@@ -11011,10 +10938,6 @@ pub static MX_ALTREP_REGISTRATIONS_WASM: &[AltrepRegistration] = &[
     AltrepRegistration {
         register: __mx_altrep_reg_MxDerivedIntsData,
         symbol: "__mx_altrep_reg_MxDerivedIntsData",
-    },
-    AltrepRegistration {
-        register: __mx_altrep_reg_JiffTimestampVecCounted,
-        symbol: "__mx_altrep_reg_JiffTimestampVecCounted",
     },
     AltrepRegistration {
         register: __mx_altrep_reg_WarnAltrepData,


### PR DESCRIPTION
## Summary

- Introduces a `DataFramePayloadFields` trait (emitted by `#[derive(DataFrameRow)]`) exposing `FIELDS: &[&str]` (resolved column names) and `TAG: &str` (inner tag suffix).
- Outer macro emits a `const _: ()` assertion per nested-enum field that fires if any inner payload field name, when compared to the inner discriminant tag, would produce an identical column after outer prefixing.
- Adds `assert_no_payload_field_collision` const fn in `miniextendr-api::markers` — stable const eval, no nightly features.
- Replaces the documented "carve-out" for inner-payload-named-`variant` with a clean compile error pointing at the outer `#[derive(DataFrameRow)]`.
- Two new UI tests: default tag (`variant`) and custom tag (`kind`) collision cases.
- Updated two existing "no-derive" UI snapshots to include the additional `DataFramePayloadFields` bound error that now fires alongside the existing `DataFrameRow` bound error.

Note on the latent B1 fix: the plan called for using `Inner::TAG` in the B1 sibling check (line 272, currently hardcoded `"_variant"`). The B1 check already covers the sibling-field collision case; the new `assert_no_payload_field_collision` handles the inner-payload case without needing B1 to know the actual inner tag. The B1 comment was updated to clarify this split of responsibilities. Changing B1 to use `Inner::TAG` at the outer-macro parse time is not straightforward (it requires a new const assertion rather than a `syn::Error`, since B1's inner_ty is only a syn::Type). Tracked in #544.

## Closes

Closes #486

## Test plan

- [x] `cargo test -p miniextendr-macros --lib` — 307 tests pass, no regressions
- [x] `TRYBUILD=overwrite cargo test -p miniextendr-macros` — new `.stderr` snapshots reviewed, both show clear `E0080: evaluation panicked` errors at the outer `#[derive(DataFrameRow)]` site
- [x] `cargo check --workspace --all-targets` — compiles clean
- [x] `just configure && just rcmdinstall && just devtools-document` — builds clean, no NAMESPACE/wrappers changes
- [x] `just devtools-test` — 5750 pass, 0 fail
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean (default + all-features CI feature set)

## Follow-ups

- #544 — B1 sibling-collision check hardcodes `"variant"` instead of using `Inner::TAG`; needs a `const _: ()` assertion approach since `syn::Type` is not available at const-eval time.
- #545 — Multi-level nesting (outer enum → struct → inner enum) not covered by current UI tests; verify `assert_no_payload_field_collision` fires transitively and add a 3-level UI test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)