### PR TITLE
refactor(altrep): scope AltrepSexpExt to data2-only accessors (#124)

### DIFF
--- a/miniextendr-api/src/altrep_ext.rs
+++ b/miniextendr-api/src/altrep_ext.rs
@@ -4,57 +4,20 @@
 //! `clippy::not_unsafe_ptr_arg_deref` in ALTREP trait implementations,
 //! mirroring the pattern established by [`SexpExt`](crate::ffi::SexpExt).
 
-use crate::externalptr::{ExternalPtr, TypedExternal};
 use crate::ffi::SEXP;
 
 /// ALTREP-specific extension methods for SEXP.
 ///
-/// These methods wrap the free functions in `externalptr::altrep_helpers`
-/// and `ffi::altrep`, converting `func(x)` calls to `x.method()` calls.
-/// This avoids the `clippy::not_unsafe_ptr_arg_deref` lint in ALTREP trait
-/// method implementations that receive SEXP as a parameter.
+/// These methods wrap the free functions in `ffi::altrep`, converting
+/// `func(x)` calls to `x.method()` calls. This avoids the
+/// `clippy::not_unsafe_ptr_arg_deref` lint in ALTREP trait method
+/// implementations that receive SEXP as a parameter.
+///
+/// Only data2 (cache) accessors are exposed here; data1 (storage) is
+/// accessed via the `AltrepExtract` trait or the standalone free functions
+/// `altrep_data1_as` / `altrep_data1_as_unchecked` / `altrep_data1_mut` /
+/// `altrep_data1_mut_unchecked`.
 pub trait AltrepSexpExt {
-    /// Extract the ALTREP data1 slot as a typed `ExternalPtr<T>`.
-    ///
-    /// # Safety
-    ///
-    /// - `self` must be a valid ALTREP SEXP
-    /// - Must be called from the R main thread
-    unsafe fn altrep_data1<T: TypedExternal>(&self) -> Option<ExternalPtr<T>>;
-
-    /// Get a mutable reference to data in the ALTREP data1 slot.
-    ///
-    /// # Safety
-    ///
-    /// - `self` must be a valid ALTREP SEXP
-    /// - Must be called from the R main thread
-    /// - The caller must ensure no other references to the data exist
-    unsafe fn altrep_data1_mut_ref<T: TypedExternal>(&self) -> Option<&'static mut T>;
-
-    /// Get the raw SEXP in the ALTREP data1 slot.
-    ///
-    /// # Safety
-    ///
-    /// - `self` must be a valid ALTREP SEXP
-    /// - Must be called from the R main thread
-    unsafe fn altrep_data1_raw(&self) -> SEXP;
-
-    /// Get the raw SEXP in the ALTREP data1 slot (unchecked — no thread routing).
-    ///
-    /// # Safety
-    ///
-    /// - `self` must be a valid ALTREP SEXP
-    /// - Must be called from the R main thread
-    unsafe fn altrep_data1_raw_unchecked(&self) -> SEXP;
-
-    /// Set the ALTREP data1 slot.
-    ///
-    /// # Safety
-    ///
-    /// - `self` must be a valid ALTREP SEXP
-    /// - Must be called from the R main thread
-    unsafe fn set_altrep_data1(&self, data1: SEXP);
-
     /// Get the raw SEXP in the ALTREP data2 slot.
     ///
     /// # Safety
@@ -89,31 +52,6 @@ pub trait AltrepSexpExt {
 }
 
 impl AltrepSexpExt for SEXP {
-    #[inline]
-    unsafe fn altrep_data1<T: TypedExternal>(&self) -> Option<ExternalPtr<T>> {
-        unsafe { crate::altrep_data1_as::<T>(*self) }
-    }
-
-    #[inline]
-    unsafe fn altrep_data1_mut_ref<T: TypedExternal>(&self) -> Option<&'static mut T> {
-        unsafe { crate::altrep_data1_mut::<T>(*self) }
-    }
-
-    #[inline]
-    unsafe fn altrep_data1_raw(&self) -> SEXP {
-        unsafe { SEXP::altrep_data1_raw(*self) }
-    }
-
-    #[inline]
-    unsafe fn altrep_data1_raw_unchecked(&self) -> SEXP {
-        unsafe { SEXP::altrep_data1_raw_unchecked(*self) }
-    }
-
-    #[inline]
-    unsafe fn set_altrep_data1(&self, data1: SEXP) {
-        unsafe { SEXP::set_altrep_data1(*self, data1) }
-    }
-
     #[inline]
     unsafe fn altrep_data2_raw(&self) -> SEXP {
         unsafe { SEXP::altrep_data2_raw(*self) }

--- a/miniextendr-api/src/externalptr/altrep_helpers.rs
+++ b/miniextendr-api/src/externalptr/altrep_helpers.rs
@@ -32,7 +32,7 @@ use crate::ffi::SEXP;
 /// ```
 #[inline]
 pub unsafe fn altrep_data1_as<T: TypedExternal>(x: SEXP) -> Option<ExternalPtr<T>> {
-    unsafe { ExternalPtr::wrap_sexp(x.altrep_data1_raw()) }
+    unsafe { ExternalPtr::wrap_sexp(SEXP::altrep_data1_raw(x)) }
 }
 
 /// Extract the ALTREP data1 slot (unchecked version).
@@ -45,7 +45,7 @@ pub unsafe fn altrep_data1_as<T: TypedExternal>(x: SEXP) -> Option<ExternalPtr<T
 /// - Must be called from the R main thread (guaranteed in ALTREP callbacks)
 #[inline]
 pub unsafe fn altrep_data1_as_unchecked<T: TypedExternal>(x: SEXP) -> Option<ExternalPtr<T>> {
-    unsafe { ExternalPtr::wrap_sexp_unchecked(x.altrep_data1_raw_unchecked()) }
+    unsafe { ExternalPtr::wrap_sexp_unchecked(SEXP::altrep_data1_raw_unchecked(x)) }
 }
 
 /// Extract the ALTREP data2 slot as a typed `ExternalPtr<T>`.
@@ -97,7 +97,7 @@ pub unsafe fn altrep_data2_as_unchecked<T: TypedExternal>(x: SEXP) -> Option<Ext
 #[inline]
 pub unsafe fn altrep_data1_mut<T: TypedExternal>(x: SEXP) -> Option<&'static mut T> {
     unsafe {
-        let mut erased = ErasedExternalPtr::from_sexp(x.altrep_data1_raw());
+        let mut erased = ErasedExternalPtr::from_sexp(SEXP::altrep_data1_raw(x));
         // Transmute the lifetime to 'static - this is safe because:
         // 1. The ExternalPtr is protected by R's GC as part of the ALTREP object
         // 2. The ALTREP object `x` is kept alive by R during the callback
@@ -117,7 +117,7 @@ pub unsafe fn altrep_data1_mut<T: TypedExternal>(x: SEXP) -> Option<&'static mut
 #[inline]
 pub unsafe fn altrep_data1_mut_unchecked<T: TypedExternal>(x: SEXP) -> Option<&'static mut T> {
     unsafe {
-        let mut erased = ErasedExternalPtr::from_sexp(x.altrep_data1_raw_unchecked());
+        let mut erased = ErasedExternalPtr::from_sexp(SEXP::altrep_data1_raw_unchecked(x));
         erased.downcast_mut::<T>().map(|r| std::mem::transmute(r))
     }
 }

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -2485,7 +2485,7 @@ unsafe extern "C-unwind" {
 
     // endregion
 
-    // region: ALTREP support — encapsulated by AltrepSexpExt trait methods
+    // region: ALTREP support — data2 encapsulated by AltrepSexpExt; data1 via standalone helpers
 
     // Issue #112 cat. 6: pub(crate) — no AltrepSexpExt method yet; available for future callers
     pub(crate) fn ALTREP_CLASS(x: SEXP) -> SEXP;

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -204,7 +204,7 @@ pub(crate) fn generate_direct_altrep_registration(
                     });
                 }
 
-                match unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#ident #ty_generics>(&sexp) } {
+                match unsafe { ::miniextendr_api::altrep_data1_as::<#ident #ty_generics>(sexp) } {
                     Some(ptr) => Ok(#ref_ident(ptr)),
                     None => Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::EXTPTRSXP,
@@ -238,7 +238,7 @@ pub(crate) fn generate_direct_altrep_registration(
                     });
                 }
 
-                match unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#ident #ty_generics>(&sexp) } {
+                match unsafe { ::miniextendr_api::altrep_data1_as::<#ident #ty_generics>(sexp) } {
                     Some(ptr) => Ok(#mut_ident(ptr)),
                     None => Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::EXTPTRSXP,

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -765,7 +765,7 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics #where_clause {}
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltList for #name #ty_generics #where_clause {
                     fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
-                        unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
+                        unsafe { ::miniextendr_api::altrep_data1_as::<#name #ty_generics>(x) }
                             .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
                             .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
                     }
@@ -778,7 +778,7 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics #where_clause {}
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltList for #name #ty_generics #where_clause {
                     fn elt(x: ::miniextendr_api::ffi::SEXP, i: ::miniextendr_api::ffi::R_xlen_t) -> ::miniextendr_api::ffi::SEXP {
-                        unsafe { ::miniextendr_api::altrep_ext::AltrepSexpExt::altrep_data1::<#name #ty_generics>(&x) }
+                        unsafe { ::miniextendr_api::altrep_data1_as::<#name #ty_generics>(x) }
                             .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
                             .unwrap_or(::miniextendr_api::ffi::SEXP::nil())
                     }

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_no_derive.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_no_derive.stderr
@@ -47,18 +47,18 @@ note: required by a bound in `_assert_inner_is_dataframe_row`
    |          ^^^^^^^^^^^^ required by this bound in `_assert_inner_is_dataframe_row`
    = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Status: DataFramePayloadFields` is not satisfied
+error[E0277]: the trait bound `Status: miniextendr_api::markers::DataFramePayloadFields` is not satisfied
   --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:15:32
    |
 15 |     Tracked { id: i32, status: Status },
    |                                ^^^^^^ unsatisfied trait bound
    |
-help: the trait `DataFramePayloadFields` is not implemented for `Status`
+help: the trait `miniextendr_api::markers::DataFramePayloadFields` is not implemented for `Status`
   --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:7:1
    |
  7 | enum Status {
    | ^^^^^^^^^^^
-help: the trait `DataFramePayloadFields` is implemented for `Outer`
+help: the trait `miniextendr_api::markers::DataFramePayloadFields` is implemented for `Outer`
   --> tests/ui/derive_dataframe_enum_nested_enum_no_derive.rs:12:10
    |
 12 | #[derive(DataFrameRow)]

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field.stderr
@@ -31,7 +31,7 @@ error[E0080]: evaluation panicked: DataFrameRow inner-payload field collision: a
 14 | #[derive(DataFrameRow)]
    |          ^^^^^^^^^^^^ evaluation of `_` failed inside this call
    |
-note: inside `assert_no_payload_field_collision`
+note: inside `miniextendr_api::markers::assert_no_payload_field_collision`
   --> $RUST/core/src/panic.rs
    |
    |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_inner_variant_field_custom_tag.stderr
@@ -31,7 +31,7 @@ error[E0080]: evaluation panicked: DataFrameRow inner-payload field collision: a
 15 | #[derive(DataFrameRow)]
    |          ^^^^^^^^^^^^ evaluation of `_` failed inside this call
    |
-note: inside `assert_no_payload_field_collision`
+note: inside `miniextendr_api::markers::assert_no_payload_field_collision`
   --> $RUST/core/src/panic.rs
    |
    |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_struct_field_no_derive.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_struct_field_no_derive.stderr
@@ -80,18 +80,18 @@ note: required by a bound in `_assert_inner_is_dataframe_row`
    |          ^^^^^^^^^^^^ required by this bound in `_assert_inner_is_dataframe_row`
    = note: this error originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Point: DataFramePayloadFields` is not satisfied
+error[E0277]: the trait bound `Point: miniextendr_api::markers::DataFramePayloadFields` is not satisfied
   --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:14:32
    |
 14 |     Located { id: i32, origin: Point },
    |                                ^^^^^ unsatisfied trait bound
    |
-help: the trait `DataFramePayloadFields` is not implemented for `Point`
+help: the trait `miniextendr_api::markers::DataFramePayloadFields` is not implemented for `Point`
   --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:6:1
    |
  6 | struct Point {
    | ^^^^^^^^^^^^
-help: the trait `DataFramePayloadFields` is implemented for `Event`
+help: the trait `miniextendr_api::markers::DataFramePayloadFields` is implemented for `Event`
   --> tests/ui/derive_dataframe_enum_struct_field_no_derive.rs:11:10
    |
 11 | #[derive(DataFrameRow)]


### PR DESCRIPTION
## Summary

Closes #124

`AltrepSexpExt` previously exposed both data1 (storage) and data2 (cache) accessors on `SEXP`. Data1 is fully superseded by `AltrepExtract` and the standalone free functions (`altrep_data1_as` / `altrep_data1_as_unchecked` / `altrep_data1_mut` / `altrep_data1_mut_unchecked`). This PR removes the five redundant data1 trait methods so the trait only covers the data2 cache slot, which is the correct boundary.

**Removed from trait + impl:**
- `altrep_data1` → callers use `altrep_data1_as` (free fn)
- `altrep_data1_mut_ref` → callers use `altrep_data1_mut` (free fn)
- `altrep_data1_raw` / `altrep_data1_raw_unchecked` / `set_altrep_data1` → superseded by lower-level `SEXP::altrep_data1_raw*` in `ffi.rs`

**Callers migrated:**
- `altrep_helpers.rs`: `x.altrep_data1_raw()` → `SEXP::altrep_data1_raw(x)` (lower-level ffi directly)
- `miniextendr-macros/src/altrep.rs` + `altrep_derive.rs`: `AltrepSexpExt::altrep_data1` → `::miniextendr_api::altrep_data1_as` (free fn re-export)

**Also:** refreshes 4 UI test snapshots whose expected compiler output drifted with a newer `rustc` (trait-path display change, pre-existing and unrelated).

## Test plan

- [x] `just check` — passes
- [x] `just clippy` — passes clean
- [x] `just test` — passes (including updated UI snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)