### PR TITLE
ci(bootstrap): install rv to silence .Rprofile activate.R warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1091,6 +1091,14 @@ jobs:
       - name: Install pkgbuild
         run: Rscript -e 'install.packages("pkgbuild", repos = "https://cloud.r-project.org")'
 
+      - name: Install rv (for .Rprofile activate.R)
+        run: |
+          RV_VERSION=$(curl -sSL https://api.github.com/repos/A2-ai/rv/releases/latest | sed -n 's/.*"tag_name": "\(v[^"]*\)".*/\1/p')
+          curl -sSL "https://github.com/A2-ai/rv/releases/download/${RV_VERSION}/rv-${RV_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/rv.tar.gz
+          tar -xzf /tmp/rv.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/rv-${RV_VERSION}-x86_64-unknown-linux-gnu/rv /usr/local/bin/rv
+          rv --version
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1095,8 +1095,9 @@ jobs:
         run: |
           RV_VERSION=$(curl -sSL https://api.github.com/repos/A2-ai/rv/releases/latest | sed -n 's/.*"tag_name": "\(v[^"]*\)".*/\1/p')
           curl -sSL "https://github.com/A2-ai/rv/releases/download/${RV_VERSION}/rv-${RV_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/rv.tar.gz
+          # Tarball ships a flat `rv` binary at the top level — no subdir.
           tar -xzf /tmp/rv.tar.gz -C /tmp
-          sudo install -m 0755 /tmp/rv-${RV_VERSION}-x86_64-unknown-linux-gnu/rv /usr/local/bin/rv
+          sudo install -m 0755 /tmp/rv /usr/local/bin/rv
           rv --version
 
       - name: Install Rust toolchain


### PR DESCRIPTION
## Summary
- `.Rprofile` sources `rv/scripts/activate.R` which warns "rv is not installed! Install rv, then restart your R session" whenever R starts in this repo without `rv` on PATH.
- The Bootstrap Vendor Test runs `Rscript` inside the repo, so the warning fires on every run.
- Adds a step to fetch the latest `rv` release tarball and install it to `/usr/local/bin/rv` before the test executes.

Linux-only (the job is `ubuntu-latest`).

## Test plan
- [ ] Bootstrap Vendor Test log no longer shows the `rv is not installed!` warning.
- [ ] Job still runs to the same point (the underlying #551 regression is unaffected — this is a noise reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)