### PR TITLE
feat(macros): absorb impl_alt*_from_data! into #[altrep(manual)] derive (#121)

### DIFF
--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -52,6 +52,7 @@ struct AltrepFamilyConfig<'a> {
 /// |-----|------|-------------|
 /// | `len = "field"` | `String` | Name of the struct field that holds the vector length. Auto-detected if a field is named `len` or `length`. |
 /// | `elt = "field"` | `String` | Name of the struct field to return as the element value (produces a constant-value vector). If omitted, the default `elt()` returns `NA` / `NaN` / `0` / `None` depending on the family. |
+/// | `manual` | Flag | Skip automatic `AltrepLen` and `Alt*Data` trait generation. Use when you want to write those trait impls by hand (e.g., for custom `elt` logic, `no_na`, `sum`, etc.). The `impl_alt*_from_data!` registration is still emitted automatically — you do **not** need to call it yourself. Use `no_lowlevel` as an additional escape hatch if you also want to suppress the registration. |
 /// | `no_lowlevel` | Flag | Suppress automatic `impl_alt*_from_data!` macro invocation. Use this when you want to provide your own `Altrep`, `AltVec`, and family-specific trait implementations. |
 /// | `dataptr` | Flag | Enable `Dataptr` method registration, allowing R to get a direct pointer to the underlying data. Mutually exclusive with `subset`. Not supported for List. |
 /// | `serialize` | Flag | Enable `Serialized_state` and `Unserialize` method registration for ALTREP serialization support. |

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -272,7 +272,9 @@ mod zero_copy_tests;
 // The direct registration pattern requires:
 // 1. A data type with #[derive(Altrep)] + #[altrep(class = "...")]
 // 2. High-level data trait impls (AltrepLen, AltIntegerData, etc.)
-// 3. Low-level trait impls generated via impl_alt*_from_data! macro
+//    — or write them by hand and use #[altrep(manual)] to skip auto-generation.
+// 3. The impl_alt*_from_data! registration macro is emitted automatically by the
+//    derive — you do NOT need to call it yourself.
 // No wrapper struct needed — the data type registers directly.
 
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen};
@@ -351,11 +353,12 @@ pub fn constant_int() -> ConstantIntData {
 //
 // The ALTREP API requires:
 // 1. A data type with #[derive(Altrep)] + #[altrep(class = "...")]
-// 2. High-level data trait impls (AltrepLen, Alt*Data)
-// 3. Low-level trait impls generated via impl_alt*_from_data! macro
-//
-// For custom behavior that can't be expressed through the data traits,
-// manually implement the low-level traits on the data type.
+// 2. High-level data trait impls (AltrepLen, Alt*Data) — either auto-generated
+//    by the derive, or hand-written with #[altrep(manual)].
+// 3. The impl_alt*_from_data! registration is emitted automatically by the derive
+//    in both field-based and manual modes. You do NOT need to call it yourself.
+//    Use #[altrep(no_lowlevel)] only if you want to suppress it entirely and
+//    provide the lowest-level Altrep/AltVec impls yourself.
 
 use miniextendr_api::altrep_data::{
     AltListData, AltLogicalData, AltRawData, AltRealData, AltStringData, Logical,


### PR DESCRIPTION
## Summary
The derive already calls `generate_lowlevel` unconditionally regardless of `manual` mode (`altrep_derive.rs:470`) — the codegen was correct. The bug was in documentation:

- The `#[altrep(...)]` attribute table in `altrep_derive.rs` was missing the `manual` row entirely.
- Two comment blocks in `rpkg/src/rust/lib.rs` incorrectly described `impl_alt*_from_data!` registration as something users invoke themselves.

This PR adds the missing `manual` row with an explicit note that the registration is emitted automatically (`no_lowlevel` remains the escape hatch for users who want to suppress it), and updates both stale comment blocks to match reality.

Closes #121.

## Test plan
- [ ] `just check` passes
- [ ] `just clippy` passes
- [ ] `just test` passes
- [ ] `just devtools-test` passes

No new fixture in this PR — the existing rpkg `ConstantIntData` fixture exercises the field-based derive path. A dedicated `#[altrep(manual)]` fixture proving the derive is fully self-sufficient is filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)