### PR TITLE
refactor(api): meta-macro for builtin ALTREP impls + registration (#122, closes #125)

### DIFF
--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -1357,8 +1357,14 @@ macro_rules! impl_altcomplex_from_data {
 // region: Meta-macros for built-in ALTREP family instantiation
 //
 // `impl_builtin_altrep_family!` is a single declarative meta-macro that maps a
-// (type, family, dataptr-mode) triple to the correct per-family `impl_alt*_from_data!`
-// call.  All built-in types use `serialize` because they implement `AltrepSerialize`.
+// (type, family, dataptr-mode, sym) 4-tuple to the correct per-family
+// `impl_alt*_from_data!` call AND emits a linkme `MX_ALTREP_REGISTRATIONS` entry
+// so the class is registered at `R_init_*` time (no hand-enumerated list needed).
+//
+// The `$sym:ident` parameter is a unique snake_case identifier used as the suffix
+// for the `#[no_mangle]` registration fn and the linkme static.  It must be unique
+// across all call sites — naming convention: `<container>_<elem>` (e.g. `Vec_i32`,
+// `Box_bool`, `Cow_str`, `Range_i32`).
 //
 // ## Families
 //
@@ -1390,47 +1396,269 @@ macro_rules! impl_altcomplex_from_data {
 // - `&'static [T]` static slices: unique lifetime + writable-assert pattern; left in
 //   the "Static slice implementations" region below.
 
+/// Generate ALTREP trait impls AND a linkme `MX_ALTREP_REGISTRATIONS` entry for a
+/// builtin type.
+///
+/// ## Arguments
+///
+/// - `$ty:ty` — the builtin container type (e.g. `Vec<i32>`, `Box<[f64]>`)
+/// - `$family:ident` — ALTREP family token: `integer`, `real`, `logical`, `raw`,
+///   `string`, or `complex`
+/// - `$mode:ident` — dataptr mode: `dataptr` or `materializing`
+/// - `$reg_fn:ident` — unique `#[no_mangle]` name for the registration fn
+///   (convention: `__mx_altrep_reg_builtin_<sym>`)
+/// - `$entry_ident:ident` — unique name for the linkme static
+///   (convention: `__MX_ALTREP_REG_ENTRY_builtin_<sym>`)
+///
+/// Both identifier arguments must be globally unique across all call sites.
+/// The registration fn is always emitted; the `#[distributed_slice]` attribute
+/// is guarded by `cfg_attr(not(target_arch = "wasm32"), ...)` so linkme's
+/// compile-error arm is not reached on wasm32 targets.
 #[doc(hidden)]
 macro_rules! impl_builtin_altrep_family {
     // dataptr arm — type has a direct contiguous native pointer
-    ($ty:ty, integer, dataptr) => {
+    ($ty:ty, integer, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altinteger_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, real, dataptr) => {
+    ($ty:ty, real, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altreal_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, logical, dataptr) => {
+    ($ty:ty, logical, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altlogical_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, raw, dataptr) => {
+    ($ty:ty, raw, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altraw_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, string, dataptr) => {
+    ($ty:ty, string, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altstring_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, complex, dataptr) => {
+    ($ty:ty, complex, dataptr, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altcomplex_from_data!($ty, dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
     // materializing arm — no direct native pointer; materializes on DATAPTR access.
     // Used for: bool (bool→i32 via LGLSXP), Range<T> (compute-on-access).
     // Guard remains RUnwind (the default) — the underlying macros do not change it.
-    ($ty:ty, integer, materializing) => {
+    ($ty:ty, integer, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altinteger_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, real, materializing) => {
+    ($ty:ty, real, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altreal_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, logical, materializing) => {
+    ($ty:ty, logical, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altlogical_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, raw, materializing) => {
+    ($ty:ty, raw, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altraw_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, string, materializing) => {
+    ($ty:ty, string, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altstring_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
-    ($ty:ty, complex, materializing) => {
+    ($ty:ty, complex, materializing, $reg_fn:ident, $entry_ident:ident) => {
         $crate::impl_altcomplex_from_data!($ty, materializing_dataptr, serialize);
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $reg_fn() {
+            <$ty as $crate::altrep::RegisterAltrep>::get_or_init_class();
+        }
+        #[cfg_attr(
+                    not(target_arch = "wasm32"),
+                    $crate::linkme::distributed_slice($crate::registry::MX_ALTREP_REGISTRATIONS),
+                    linkme(crate = $crate::linkme)
+                )]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        static $entry_ident: $crate::registry::AltrepRegistration =
+            $crate::registry::AltrepRegistration {
+                register: $reg_fn,
+                symbol: stringify!($reg_fn),
+            };
     };
 }
 
@@ -1443,23 +1671,95 @@ macro_rules! impl_builtin_altrep_family {
 
 // Vec<T> — owned, heap-allocated contiguous storage.
 // bool uses `materializing` because bool is not RNativeType (R stores logicals as i32).
-impl_builtin_altrep_family!(Vec<i32>, integer, dataptr);
-impl_builtin_altrep_family!(Vec<f64>, real, dataptr);
-impl_builtin_altrep_family!(Vec<bool>, logical, materializing);
-impl_builtin_altrep_family!(Vec<u8>, raw, dataptr);
-impl_builtin_altrep_family!(Vec<String>, string, dataptr);
-impl_builtin_altrep_family!(Vec<Option<String>>, string, dataptr);
+impl_builtin_altrep_family!(
+    Vec<i32>,
+    integer,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_i32,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_i32
+);
+impl_builtin_altrep_family!(
+    Vec<f64>,
+    real,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_f64,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_f64
+);
+impl_builtin_altrep_family!(
+    Vec<bool>,
+    logical,
+    materializing,
+    __mx_altrep_reg_builtin_Vec_bool,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_bool
+);
+impl_builtin_altrep_family!(
+    Vec<u8>,
+    raw,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_u8,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_u8
+);
+impl_builtin_altrep_family!(
+    Vec<String>,
+    string,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_String,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_String
+);
+impl_builtin_altrep_family!(
+    Vec<Option<String>>,
+    string,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_Option_String,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_Option_String
+);
 // Cow string vectors — zero-copy from R, ALTREP output without copying back.
 // Serialize: Rf_mkCharLenCE hits R's CHARSXP cache (no string data copy for borrowed).
 // Unserialize: TryFromSexp uses charsxp_to_cow (zero-copy borrow for UTF-8).
-impl_builtin_altrep_family!(Vec<std::borrow::Cow<'static, str>>, string, dataptr);
-impl_builtin_altrep_family!(Vec<Option<std::borrow::Cow<'static, str>>>, string, dataptr);
-impl_builtin_altrep_family!(Vec<crate::ffi::Rcomplex>, complex, dataptr);
+impl_builtin_altrep_family!(
+    Vec<std::borrow::Cow<'static, str>>,
+    string,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_Cow_str,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_Cow_str
+);
+impl_builtin_altrep_family!(
+    Vec<Option<std::borrow::Cow<'static, str>>>,
+    string,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_Option_Cow_str,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_Option_Cow_str
+);
+impl_builtin_altrep_family!(
+    Vec<crate::ffi::Rcomplex>,
+    complex,
+    dataptr,
+    __mx_altrep_reg_builtin_Vec_Rcomplex,
+    __MX_ALTREP_REG_ENTRY_builtin_Vec_Rcomplex
+);
 
 // Range<T> — compute-on-access (no direct pointer); materializes into data2 INTSXP/REALSXP.
-impl_builtin_altrep_family!(std::ops::Range<i32>, integer, materializing);
-impl_builtin_altrep_family!(std::ops::Range<i64>, integer, materializing);
-impl_builtin_altrep_family!(std::ops::Range<f64>, real, materializing);
+impl_builtin_altrep_family!(
+    std::ops::Range<i32>,
+    integer,
+    materializing,
+    __mx_altrep_reg_builtin_Range_i32,
+    __MX_ALTREP_REG_ENTRY_builtin_Range_i32
+);
+impl_builtin_altrep_family!(
+    std::ops::Range<i64>,
+    integer,
+    materializing,
+    __mx_altrep_reg_builtin_Range_i64,
+    __MX_ALTREP_REG_ENTRY_builtin_Range_i64
+);
+impl_builtin_altrep_family!(
+    std::ops::Range<f64>,
+    real,
+    materializing,
+    __mx_altrep_reg_builtin_Range_f64,
+    __MX_ALTREP_REG_ENTRY_builtin_Range_f64
+);
 // endregion
 
 // region: Box<[T]> implementations
@@ -1468,78 +1768,79 @@ impl_builtin_altrep_family!(std::ops::Range<f64>, real, materializing);
 // Useful for fixed-size heap allocations.
 // bool uses `materializing` (same reason as Vec<bool>).
 
-impl_builtin_altrep_family!(Box<[i32]>, integer, dataptr);
-impl_builtin_altrep_family!(Box<[f64]>, real, dataptr);
-impl_builtin_altrep_family!(Box<[bool]>, logical, materializing);
-impl_builtin_altrep_family!(Box<[u8]>, raw, dataptr);
-impl_builtin_altrep_family!(Box<[String]>, string, dataptr);
-impl_builtin_altrep_family!(Box<[crate::ffi::Rcomplex]>, complex, dataptr);
+impl_builtin_altrep_family!(
+    Box<[i32]>,
+    integer,
+    dataptr,
+    __mx_altrep_reg_builtin_Box_i32,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_i32
+);
+impl_builtin_altrep_family!(
+    Box<[f64]>,
+    real,
+    dataptr,
+    __mx_altrep_reg_builtin_Box_f64,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_f64
+);
+impl_builtin_altrep_family!(
+    Box<[bool]>,
+    logical,
+    materializing,
+    __mx_altrep_reg_builtin_Box_bool,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_bool
+);
+impl_builtin_altrep_family!(
+    Box<[u8]>,
+    raw,
+    dataptr,
+    __mx_altrep_reg_builtin_Box_u8,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_u8
+);
+impl_builtin_altrep_family!(
+    Box<[String]>,
+    string,
+    dataptr,
+    __mx_altrep_reg_builtin_Box_String,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_String
+);
+impl_builtin_altrep_family!(
+    Box<[crate::ffi::Rcomplex]>,
+    complex,
+    dataptr,
+    __mx_altrep_reg_builtin_Box_Rcomplex,
+    __MX_ALTREP_REG_ENTRY_builtin_Box_Rcomplex
+);
 
 // Cow<'static, [T]> — zero-copy borrow from R with copy-on-write dataptr.
 // Borrowed variants expose R's data directly; Owned behaves like Vec.
-impl_builtin_altrep_family!(std::borrow::Cow<'static, [i32]>, integer, dataptr);
-impl_builtin_altrep_family!(std::borrow::Cow<'static, [f64]>, real, dataptr);
-impl_builtin_altrep_family!(std::borrow::Cow<'static, [u8]>, raw, dataptr);
+impl_builtin_altrep_family!(
+    std::borrow::Cow<'static, [i32]>,
+    integer,
+    dataptr,
+    __mx_altrep_reg_builtin_Cow_i32,
+    __MX_ALTREP_REG_ENTRY_builtin_Cow_i32
+);
+impl_builtin_altrep_family!(
+    std::borrow::Cow<'static, [f64]>,
+    real,
+    dataptr,
+    __mx_altrep_reg_builtin_Cow_f64,
+    __MX_ALTREP_REG_ENTRY_builtin_Cow_f64
+);
+impl_builtin_altrep_family!(
+    std::borrow::Cow<'static, [u8]>,
+    raw,
+    dataptr,
+    __mx_altrep_reg_builtin_Cow_u8,
+    __MX_ALTREP_REG_ENTRY_builtin_Cow_u8
+);
 impl_builtin_altrep_family!(
     std::borrow::Cow<'static, [crate::ffi::Rcomplex]>,
     complex,
-    dataptr
+    dataptr,
+    __mx_altrep_reg_builtin_Cow_Rcomplex,
+    __MX_ALTREP_REG_ENTRY_builtin_Cow_Rcomplex
 );
-
-/// Eagerly register all built-in ALTREP classes.
-///
-/// Must be called during `R_init` so that R can find these classes when
-/// unserializing (readRDS) in a fresh session. Without this, the lazy
-/// `OnceLock` registration means classes don't exist until first use —
-/// too late for readRDS.
-pub(crate) fn register_builtin_altrep_classes() {
-    use crate::altrep::RegisterAltrep;
-
-    // Vec<T>
-    Vec::<i32>::get_or_init_class();
-    Vec::<f64>::get_or_init_class();
-    Vec::<bool>::get_or_init_class();
-    Vec::<u8>::get_or_init_class();
-    Vec::<String>::get_or_init_class();
-    Vec::<Option<String>>::get_or_init_class();
-    Vec::<crate::ffi::Rcomplex>::get_or_init_class();
-
-    // Cow string vectors
-    Vec::<std::borrow::Cow<'static, str>>::get_or_init_class();
-    Vec::<Option<std::borrow::Cow<'static, str>>>::get_or_init_class();
-
-    // Box<[T]>
-    Box::<[i32]>::get_or_init_class();
-    Box::<[f64]>::get_or_init_class();
-    Box::<[bool]>::get_or_init_class();
-    Box::<[u8]>::get_or_init_class();
-    Box::<[String]>::get_or_init_class();
-    Box::<[crate::ffi::Rcomplex]>::get_or_init_class();
-
-    // Cow<'static, [T]>
-    std::borrow::Cow::<'static, [i32]>::get_or_init_class();
-    std::borrow::Cow::<'static, [f64]>::get_or_init_class();
-    std::borrow::Cow::<'static, [u8]>::get_or_init_class();
-    std::borrow::Cow::<'static, [crate::ffi::Rcomplex]>::get_or_init_class();
-
-    // Range types
-    std::ops::Range::<i32>::get_or_init_class();
-    std::ops::Range::<i64>::get_or_init_class();
-    std::ops::Range::<f64>::get_or_init_class();
-}
-
-/// Register Arrow ALTREP classes (behind feature gate).
-#[cfg(feature = "arrow")]
-pub(crate) fn register_arrow_altrep_classes() {
-    use crate::altrep::RegisterAltrep;
-    use crate::optionals::arrow_impl::*;
-
-    Float64Array::get_or_init_class();
-    Int32Array::get_or_init_class();
-    UInt8Array::get_or_init_class();
-    BooleanArray::get_or_init_class();
-    StringArray::get_or_init_class();
-}
 
 // endregion
 

--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -1354,67 +1354,136 @@ macro_rules! impl_altcomplex_from_data {
 }
 // endregion
 
+// region: Meta-macros for built-in ALTREP family instantiation
+//
+// `impl_builtin_altrep_family!` is a single declarative meta-macro that maps a
+// (type, family, dataptr-mode) triple to the correct per-family `impl_alt*_from_data!`
+// call.  All built-in types use `serialize` because they implement `AltrepSerialize`.
+//
+// ## Families
+//
+// | Token     | Delegates to               |
+// |-----------|----------------------------|
+// | `integer` | `impl_altinteger_from_data!` |
+// | `real`    | `impl_altreal_from_data!`    |
+// | `logical` | `impl_altlogical_from_data!` |
+// | `raw`     | `impl_altraw_from_data!`     |
+// | `string`  | `impl_altstring_from_data!`  |
+// | `complex` | `impl_altcomplex_from_data!` |
+//
+// ## Dataptr modes
+//
+// | Token         | Meaning                                                     |
+// |---------------|-------------------------------------------------------------|
+// | `dataptr`     | Type has a direct contiguous pointer (`RNativeType` backed) |
+// | `materializing` | No direct pointer; materializes into data2 on first access  |
+//
+// The `materializing` arm expands to `materializing_dataptr, serialize` in the
+// underlying macro (bool→i32 conversion, Range compute-on-access, etc.).
+// Both arms preserve `const GUARD = AltrepGuard::RUnwind` — the default from
+// `__impl_altrep_base!` and `__impl_altrep_base_with_serialize!`.
+//
+// ## Corner cases NOT handled by this macro
+//
+// - `[T; N]` const-generic arrays: use const generics (`impl<const N>`); left in the
+//   "Array implementations" region below.
+// - `&'static [T]` static slices: unique lifetime + writable-assert pattern; left in
+//   the "Static slice implementations" region below.
+
+#[doc(hidden)]
+macro_rules! impl_builtin_altrep_family {
+    // dataptr arm — type has a direct contiguous native pointer
+    ($ty:ty, integer, dataptr) => {
+        $crate::impl_altinteger_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, real, dataptr) => {
+        $crate::impl_altreal_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, logical, dataptr) => {
+        $crate::impl_altlogical_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, raw, dataptr) => {
+        $crate::impl_altraw_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, string, dataptr) => {
+        $crate::impl_altstring_from_data!($ty, dataptr, serialize);
+    };
+    ($ty:ty, complex, dataptr) => {
+        $crate::impl_altcomplex_from_data!($ty, dataptr, serialize);
+    };
+    // materializing arm — no direct native pointer; materializes on DATAPTR access.
+    // Used for: bool (bool→i32 via LGLSXP), Range<T> (compute-on-access).
+    // Guard remains RUnwind (the default) — the underlying macros do not change it.
+    ($ty:ty, integer, materializing) => {
+        $crate::impl_altinteger_from_data!($ty, materializing_dataptr, serialize);
+    };
+    ($ty:ty, real, materializing) => {
+        $crate::impl_altreal_from_data!($ty, materializing_dataptr, serialize);
+    };
+    ($ty:ty, logical, materializing) => {
+        $crate::impl_altlogical_from_data!($ty, materializing_dataptr, serialize);
+    };
+    ($ty:ty, raw, materializing) => {
+        $crate::impl_altraw_from_data!($ty, materializing_dataptr, serialize);
+    };
+    ($ty:ty, string, materializing) => {
+        $crate::impl_altstring_from_data!($ty, materializing_dataptr, serialize);
+    };
+    ($ty:ty, complex, materializing) => {
+        $crate::impl_altcomplex_from_data!($ty, materializing_dataptr, serialize);
+    };
+}
+
 // region: Built-in implementations for standard types
 // These implementations are provided here to satisfy the orphan rules.
 // User crates can use these types directly with delegate_data.
 //
-// All types that implement AltrepSerialize get the `serialize` option enabled,
-// which allows proper saveRDS/readRDS round-trips.
+// All types implement AltrepSerialize; serialize is injected by the meta-macro.
+// Guard: RUnwind (default from __impl_altrep_base[_with_serialize]! — not overridden).
 
-// Integer types - Vec<i32> supports direct dataptr, ranges materialize on demand
-impl_altinteger_from_data!(Vec<i32>, dataptr, serialize);
-impl_altinteger_from_data!(std::ops::Range<i32>, materializing_dataptr, serialize);
-impl_altinteger_from_data!(std::ops::Range<i64>, materializing_dataptr, serialize);
-
-// Real types - Vec<f64> supports direct dataptr, ranges materialize on demand
-impl_altreal_from_data!(Vec<f64>, dataptr, serialize);
-impl_altreal_from_data!(std::ops::Range<f64>, materializing_dataptr, serialize);
-
-// Logical types — materializing dataptr converts bool→i32 into cached LGLSXP
-impl_altlogical_from_data!(Vec<bool>, materializing_dataptr, serialize);
-
-// Raw types - u8 == Rbyte, supports direct dataptr
-impl_altraw_from_data!(Vec<u8>, dataptr, serialize);
-
-// String types - Vec<String> supports dataptr via materialization into STRSXP
-impl_altstring_from_data!(Vec<String>, dataptr, serialize);
-// Vec<Option<String>> preserves NA_character_ through serialization roundtrips
-impl_altstring_from_data!(Vec<Option<String>>, dataptr, serialize);
+// Vec<T> — owned, heap-allocated contiguous storage.
+// bool uses `materializing` because bool is not RNativeType (R stores logicals as i32).
+impl_builtin_altrep_family!(Vec<i32>, integer, dataptr);
+impl_builtin_altrep_family!(Vec<f64>, real, dataptr);
+impl_builtin_altrep_family!(Vec<bool>, logical, materializing);
+impl_builtin_altrep_family!(Vec<u8>, raw, dataptr);
+impl_builtin_altrep_family!(Vec<String>, string, dataptr);
+impl_builtin_altrep_family!(Vec<Option<String>>, string, dataptr);
 // Cow string vectors — zero-copy from R, ALTREP output without copying back.
 // Serialize: Rf_mkCharLenCE hits R's CHARSXP cache (no string data copy for borrowed).
 // Unserialize: TryFromSexp uses charsxp_to_cow (zero-copy borrow for UTF-8).
-impl_altstring_from_data!(Vec<std::borrow::Cow<'static, str>>, dataptr, serialize);
-impl_altstring_from_data!(
-    Vec<Option<std::borrow::Cow<'static, str>>>,
-    dataptr,
-    serialize
-);
+impl_builtin_altrep_family!(Vec<std::borrow::Cow<'static, str>>, string, dataptr);
+impl_builtin_altrep_family!(Vec<Option<std::borrow::Cow<'static, str>>>, string, dataptr);
+impl_builtin_altrep_family!(Vec<crate::ffi::Rcomplex>, complex, dataptr);
 
-// Complex types - Vec<Rcomplex> supports dataptr
-impl_altcomplex_from_data!(Vec<crate::ffi::Rcomplex>, dataptr, serialize);
+// Range<T> — compute-on-access (no direct pointer); materializes into data2 INTSXP/REALSXP.
+impl_builtin_altrep_family!(std::ops::Range<i32>, integer, materializing);
+impl_builtin_altrep_family!(std::ops::Range<i64>, integer, materializing);
+impl_builtin_altrep_family!(std::ops::Range<f64>, real, materializing);
 // endregion
 
 // region: Box<[T]> implementations
 // Box<[T]> is a fat pointer (Sized) that wraps a DST slice.
 // Unlike Vec<T>, it has no capacity field - just ptr + len (2 words).
 // Useful for fixed-size heap allocations.
+// bool uses `materializing` (same reason as Vec<bool>).
 
-impl_altinteger_from_data!(Box<[i32]>, dataptr, serialize);
-impl_altreal_from_data!(Box<[f64]>, dataptr, serialize);
-impl_altlogical_from_data!(Box<[bool]>, materializing_dataptr, serialize);
-impl_altraw_from_data!(Box<[u8]>, dataptr, serialize);
-impl_altstring_from_data!(Box<[String]>, dataptr, serialize);
-impl_altcomplex_from_data!(Box<[crate::ffi::Rcomplex]>, dataptr, serialize);
+impl_builtin_altrep_family!(Box<[i32]>, integer, dataptr);
+impl_builtin_altrep_family!(Box<[f64]>, real, dataptr);
+impl_builtin_altrep_family!(Box<[bool]>, logical, materializing);
+impl_builtin_altrep_family!(Box<[u8]>, raw, dataptr);
+impl_builtin_altrep_family!(Box<[String]>, string, dataptr);
+impl_builtin_altrep_family!(Box<[crate::ffi::Rcomplex]>, complex, dataptr);
 
 // Cow<'static, [T]> — zero-copy borrow from R with copy-on-write dataptr.
 // Borrowed variants expose R's data directly; Owned behaves like Vec.
-impl_altinteger_from_data!(std::borrow::Cow<'static, [i32]>, dataptr, serialize);
-impl_altreal_from_data!(std::borrow::Cow<'static, [f64]>, dataptr, serialize);
-impl_altraw_from_data!(std::borrow::Cow<'static, [u8]>, dataptr, serialize);
-impl_altcomplex_from_data!(
+impl_builtin_altrep_family!(std::borrow::Cow<'static, [i32]>, integer, dataptr);
+impl_builtin_altrep_family!(std::borrow::Cow<'static, [f64]>, real, dataptr);
+impl_builtin_altrep_family!(std::borrow::Cow<'static, [u8]>, raw, dataptr);
+impl_builtin_altrep_family!(
     std::borrow::Cow<'static, [crate::ffi::Rcomplex]>,
-    dataptr,
-    serialize
+    complex,
+    dataptr
 );
 
 /// Eagerly register all built-in ALTREP classes.

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -1905,4 +1905,109 @@ impl RegisterAltrep for StringArray {
     }
 }
 
+// region: Linkme registration entries for Arrow ALTREP classes
+//
+// Each entry here mirrors what `__impl_builtin_altrep_registration!` emits for
+// the standard builtins.  Arrow types are in a separate module (optionals/) and
+// behind `#[cfg(feature = "arrow")]`, so they cannot be reached by the macro
+// call sites in `altrep_impl.rs` — the entries are emitted here instead.
+//
+// The `#[cfg_attr(not(wasm32), distributed_slice)]` pattern matches the pattern
+// used by user-defined ALTREP types (see `miniextendr-macros/src/altrep.rs`).
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __mx_altrep_reg_builtin_arrow_Float64Array() {
+    Float64Array::get_or_init_class();
+}
+
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    crate::linkme::distributed_slice(crate::registry::MX_ALTREP_REGISTRATIONS),
+    linkme(crate = crate::linkme)
+)]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+static __MX_ALTREP_REG_ENTRY_builtin_arrow_Float64Array: crate::registry::AltrepRegistration =
+    crate::registry::AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_Float64Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_Float64Array",
+    };
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __mx_altrep_reg_builtin_arrow_Int32Array() {
+    Int32Array::get_or_init_class();
+}
+
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    crate::linkme::distributed_slice(crate::registry::MX_ALTREP_REGISTRATIONS),
+    linkme(crate = crate::linkme)
+)]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+static __MX_ALTREP_REG_ENTRY_builtin_arrow_Int32Array: crate::registry::AltrepRegistration =
+    crate::registry::AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_Int32Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_Int32Array",
+    };
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __mx_altrep_reg_builtin_arrow_UInt8Array() {
+    UInt8Array::get_or_init_class();
+}
+
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    crate::linkme::distributed_slice(crate::registry::MX_ALTREP_REGISTRATIONS),
+    linkme(crate = crate::linkme)
+)]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+static __MX_ALTREP_REG_ENTRY_builtin_arrow_UInt8Array: crate::registry::AltrepRegistration =
+    crate::registry::AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_UInt8Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_UInt8Array",
+    };
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __mx_altrep_reg_builtin_arrow_BooleanArray() {
+    BooleanArray::get_or_init_class();
+}
+
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    crate::linkme::distributed_slice(crate::registry::MX_ALTREP_REGISTRATIONS),
+    linkme(crate = crate::linkme)
+)]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+static __MX_ALTREP_REG_ENTRY_builtin_arrow_BooleanArray: crate::registry::AltrepRegistration =
+    crate::registry::AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_BooleanArray,
+        symbol: "__mx_altrep_reg_builtin_arrow_BooleanArray",
+    };
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __mx_altrep_reg_builtin_arrow_StringArray() {
+    StringArray::get_or_init_class();
+}
+
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    crate::linkme::distributed_slice(crate::registry::MX_ALTREP_REGISTRATIONS),
+    linkme(crate = crate::linkme)
+)]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+static __MX_ALTREP_REG_ENTRY_builtin_arrow_StringArray: crate::registry::AltrepRegistration =
+    crate::registry::AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_StringArray,
+        symbol: "__mx_altrep_reg_builtin_arrow_StringArray",
+    };
+
 // endregion

--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -392,15 +392,14 @@ pub unsafe extern "C" fn miniextendr_register_routines(dll: *mut DllInfo) {
     // linked list corrupted" on Linux).
     let wrapper_gen = std::env::var_os("MINIEXTENDR_CDYLIB_WRAPPERS").is_some();
     if !wrapper_gen {
-        // User-defined ALTREP classes (from #[miniextendr] structs)
+        // All ALTREP classes — both user-defined (#[miniextendr] structs) and
+        // builtins (Vec, Box, Range, Cow, Arrow) — register via linkme
+        // MX_ALTREP_REGISTRATIONS. Each call site emits a
+        // `#[distributed_slice(MX_ALTREP_REGISTRATIONS)]` entry, so a single
+        // iteration here covers everything. No hand-enumerated builtin list needed.
         for reg in altrep_regs().iter() {
             (reg.register)();
         }
-        // Built-in ALTREP classes (Vec, Box, Range, Arrow) — must be
-        // registered eagerly so readRDS can find them in fresh sessions.
-        crate::altrep_impl::register_builtin_altrep_classes();
-        #[cfg(feature = "arrow")]
-        crate::altrep_impl::register_arrow_altrep_classes();
 
         // Verify no two ALTREP types registered the same class name.
         // Duplicates cause silent overwrites in R — the wrong type gets

--- a/miniextendr-macros/tests/ui/derive_dataframe_struct_field_multisegment_no_derive.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_struct_field_multisegment_no_derive.stderr
@@ -1,3 +1,17 @@
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_struct_field_multisegment_no_derive.rs:20:10
+   |
+20 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0599]: no function or associated item named `to_dataframe` found for struct `NotADataFrameRow` in the current scope
   --> tests/ui/derive_dataframe_struct_field_multisegment_no_derive.rs:20:10
    |

--- a/rpkg/R/miniextendr-wrappers.R
+++ b/rpkg/R/miniextendr-wrappers.R
@@ -19639,7 +19639,7 @@ uuid_roundtrip_vec <- function(uuids) {
   .val
 }
 
-# Generated from Rust fn `arith_seq` (lib.rs:429:8)
+# Generated from Rust fn `arith_seq` (lib.rs:432:8)
 #' @title arith seq
 #' @param from (no documentation available)
 #' @param step (no documentation available)
@@ -19660,7 +19660,7 @@ arith_seq <- function(from, step, length_out) {
   .val
 }
 
-# Generated from Rust fn `boxed_raw` (lib.rs:1722:8)
+# Generated from Rust fn `boxed_raw` (lib.rs:1725:8)
 #' @title Create a Box<\[u8\]> ALTREP raw vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -20764,7 +20764,7 @@ vec_ptype2.percent.percent <- function(x, y, ...) {
   .val
 }
 
-# Generated from Rust fn `boxed_ints` (lib.rs:1404:8)
+# Generated from Rust fn `boxed_ints` (lib.rs:1407:8)
 #' @title Create an ALTREP integer vector backed by a boxed slice (`Box<[i32]>`)
 #' @rdname altrep_special
 #' @param n Number of elements (generates 1..=n).
@@ -21448,7 +21448,7 @@ derived_rational_class_info <- function() {
   .val
 }
 
-# Generated from Rust fn `boxed_reals` (lib.rs:1692:8)
+# Generated from Rust fn `boxed_reals` (lib.rs:1695:8)
 #' @title Create a Box<\[f64\]> ALTREP real vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -21465,7 +21465,7 @@ boxed_reals <- function(n) {
   .val
 }
 
-# Generated from Rust fn `lazy_string` (lib.rs:1037:8)
+# Generated from Rust fn `lazy_string` (lib.rs:1040:8)
 #' @title Create a lazy string ALTREP that computes elements on demand
 #' @rdname lazy_string_altrep
 #' @param prefix String prefix for generated elements.
@@ -21485,7 +21485,7 @@ lazy_string <- function(prefix, n) {
   .val
 }
 
-# Generated from Rust fn `leaked_ints` (lib.rs:1467:8)
+# Generated from Rust fn `leaked_ints` (lib.rs:1470:8)
 #' @title Create an ALTREP integer vector from a leaked Box (demonstrates Box::leak for 'static lifetime)
 #' @rdname altrep_special
 #' @param n Number of elements (generates 1..=n).
@@ -21502,7 +21502,7 @@ leaked_ints <- function(n) {
   .val
 }
 
-# Generated from Rust fn `static_ints` (lib.rs:1454:8)
+# Generated from Rust fn `static_ints` (lib.rs:1457:8)
 #' @title Create an ALTREP integer vector backed by a static slice (`&'static [i32]`)
 #' @rdname altrep_special
 #' @return An ALTREP integer vector with values 10, 20, 30, 40, 50.
@@ -21514,7 +21514,7 @@ static_ints <- function() {
   .val
 }
 
-# Generated from Rust fn `unit_circle` (lib.rs:1132:8)
+# Generated from Rust fn `unit_circle` (lib.rs:1135:8)
 #' @title Create a complex ALTREP of n points on the unit circle (e^(i*2*pi*k/n))
 #' @rdname altrep_special
 #' @param n Number of points on the unit circle.
@@ -22004,7 +22004,7 @@ arrayvec_roundtrip_int <- function(v) {
   .val
 }
 
-# Generated from Rust fn `constant_int` (lib.rs:345:8)
+# Generated from Rust fn `constant_int` (lib.rs:347:8)
 #' @title Create a constant-value integer ALTREP vector (10 elements, all 42)
 #' @rdname constant_altrep
 #' @return An ALTREP integer vector.
@@ -22016,7 +22016,7 @@ constant_int <- function() {
   .val
 }
 
-# Generated from Rust fn `lazy_int_seq` (lib.rs:652:8)
+# Generated from Rust fn `lazy_int_seq` (lib.rs:655:8)
 #' @title Create a lazy integer sequence ALTREP (like R's `seq()`)
 #' @description Elements are computed on demand; materialization is deferred until R needs the full data pointer.
 #' @rdname altrep_constructors
@@ -22040,7 +22040,7 @@ lazy_int_seq <- function(from, to, by) {
   .val
 }
 
-# Generated from Rust fn `lazy_squares` (lib.rs:813:8)
+# Generated from Rust fn `lazy_squares` (lib.rs:816:8)
 #' @title Example: Lazy computation - compute on demand
 #' @param n Length of the sequence.
 #' @export
@@ -22988,7 +22988,7 @@ streaming_real_squares <- function(n) {
   .val
 }
 
-# Generated from Rust fn `boxed_complex` (lib.rs:1752:8)
+# Generated from Rust fn `boxed_complex` (lib.rs:1755:8)
 #' @title Create a Box<\[Rcomplex\]> ALTREP complex vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -23005,7 +23005,7 @@ boxed_complex <- function(n) {
   .val
 }
 
-# Generated from Rust fn `boxed_strings` (lib.rs:1737:8)
+# Generated from Rust fn `boxed_strings` (lib.rs:1740:8)
 #' @title Create a Box<\[String\]> ALTREP string vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -23022,7 +23022,7 @@ boxed_strings <- function(n) {
   .val
 }
 
-# Generated from Rust fn `constant_real` (lib.rs:395:8)
+# Generated from Rust fn `constant_real` (lib.rs:398:8)
 #' @title Create a constant-value real ALTREP vector (10 elements, all pi)
 #' @rdname constant_altrep
 #' @return An ALTREP real vector.
@@ -23034,7 +23034,7 @@ constant_real <- function() {
   .val
 }
 
-# Generated from Rust fn `repeating_raw` (lib.rs:1078:8)
+# Generated from Rust fn `repeating_raw` (lib.rs:1081:8)
 #' @title Create a repeating raw byte pattern ALTREP vector
 #' @rdname lazy_string_altrep
 #' @param pattern A raw vector containing the byte pattern to repeat.
@@ -23053,7 +23053,7 @@ repeating_raw <- function(pattern, n) {
   .val
 }
 
-# Generated from Rust fn `bench_vec_copy` (lib.rs:846:8)
+# Generated from Rust fn `bench_vec_copy` (lib.rs:849:8)
 #' @title Create a vector of given size using regular copy (IntoR)
 #' @param n Length of the vector.
 #' @export
@@ -23068,7 +23068,7 @@ bench_vec_copy <- function(n) {
   .val
 }
 
-# Generated from Rust fn `boxed_logicals` (lib.rs:1707:8)
+# Generated from Rust fn `boxed_logicals` (lib.rs:1710:8)
 #' @title Create a Box<\[bool\]> ALTREP logical vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -23085,7 +23085,7 @@ boxed_logicals <- function(n) {
   .val
 }
 
-# Generated from Rust fn `iter_int_range` (lib.rs:1573:8)
+# Generated from Rust fn `iter_int_range` (lib.rs:1576:8)
 #' @title Create an integer ALTREP from a collected range iterator
 #' @rdname altrep_iterators
 #' @param from Start of range (inclusive).
@@ -23105,7 +23105,7 @@ iter_int_range <- function(from, to) {
   .val
 }
 
-# Generated from Rust fn `iter_raw_bytes` (lib.rs:1605:8)
+# Generated from Rust fn `iter_raw_bytes` (lib.rs:1608:8)
 #' @title Create a raw bytes ALTREP via iterator collect (cycling 0..255)
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -23122,7 +23122,7 @@ iter_raw_bytes <- function(n) {
   .val
 }
 
-# Generated from Rust fn `small_vec_copy` (lib.rs:794:8)
+# Generated from Rust fn `small_vec_copy` (lib.rs:797:8)
 #' @title Example: Small data - regular copy is fine
 #' @export
 #' @source Generated by miniextendr from Rust fn `small_vec_copy`
@@ -23132,7 +23132,7 @@ small_vec_copy <- function() {
   .val
 }
 
-# Generated from Rust fn `static_strings` (lib.rs:1511:8)
+# Generated from Rust fn `static_strings` (lib.rs:1514:8)
 #' @title Create an ALTREP string vector backed by a static string slice
 #' @rdname altrep_special
 #' @return An ALTREP string vector with 4 static entries.
@@ -23144,7 +23144,7 @@ static_strings <- function() {
   .val
 }
 
-# Generated from Rust fn `vec_int_altrep` (lib.rs:1652:8)
+# Generated from Rust fn `vec_int_altrep` (lib.rs:1655:8)
 #' @title Create a `Vec<i32>` ALTREP integer vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -23512,7 +23512,7 @@ json_serialize_point <- function(x, y) {
   .val
 }
 
-# Generated from Rust fn `altrep_from_raw` (lib.rs:752:8)
+# Generated from Rust fn `altrep_from_raw` (lib.rs:755:8)
 #' @title Create an ALTREP raw vector from raw bytes
 #' @rdname altrep_constructors
 #' @param x A raw vector.
@@ -23526,7 +23526,7 @@ altrep_from_raw <- function(x) {
   .val
 }
 
-# Generated from Rust fn `sparse_iter_int` (lib.rs:1851:8)
+# Generated from Rust fn `sparse_iter_int` (lib.rs:1854:8)
 #' @title Create a sparse integer iterator ALTREP that skips elements
 #' @description Elements are computed on-demand using Iterator::nth(). Once an element is skipped (a higher index is accessed first), it cannot be retrieved and will return NA.
 #' @rdname sparse_altrep
@@ -23547,7 +23547,7 @@ sparse_iter_int <- function(from, to) {
   .val
 }
 
-# Generated from Rust fn `sparse_iter_raw` (lib.rs:2000:8)
+# Generated from Rust fn `sparse_iter_raw` (lib.rs:2003:8)
 #' @title Create a sparse raw iterator ALTREP (cycling bytes 0..255)
 #' @rdname sparse_altrep
 #' @param n Number of elements.
@@ -23564,7 +23564,7 @@ sparse_iter_raw <- function(n) {
   .val
 }
 
-# Generated from Rust fn `vec_real_altrep` (lib.rs:1663:8)
+# Generated from Rust fn `vec_real_altrep` (lib.rs:1666:8)
 #' @title Create a `Vec<f64>` ALTREP real vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -23697,7 +23697,7 @@ complex_roundtrip_vec <- function(v) {
   .val
 }
 
-# Generated from Rust fn `altrep_from_list` (lib.rs:772:8)
+# Generated from Rust fn `altrep_from_list` (lib.rs:775:8)
 #' @title Create an ALTREP list from an R list, preserving the original SEXP
 #' @rdname altrep_constructors
 #' @param x An R list (VECSXP).
@@ -23710,7 +23710,7 @@ altrep_from_list <- function(x) {
   .val
 }
 
-# Generated from Rust fn `bench_vec_altrep` (lib.rs:858:8)
+# Generated from Rust fn `bench_vec_altrep` (lib.rs:861:8)
 #' @title Create a vector of given size using ALTREP zero-copy
 #' @param n Length of the vector.
 #' @export
@@ -23725,7 +23725,7 @@ bench_vec_altrep <- function(n) {
   .val
 }
 
-# Generated from Rust fn `constant_logical` (lib.rs:902:8)
+# Generated from Rust fn `constant_logical` (lib.rs:905:8)
 #' @title Create a constant-value logical ALTREP vector
 #' @rdname constant_altrep
 #' @param value Integer encoding of the logical value (0 = FALSE, NA_integer_ = NA, other = TRUE).
@@ -23745,7 +23745,7 @@ constant_logical <- function(value, n) {
   .val
 }
 
-# Generated from Rust fn `large_vec_altrep` (lib.rs:802:8)
+# Generated from Rust fn `large_vec_altrep` (lib.rs:805:8)
 #' @title Example: Large data - ALTREP avoids copy
 #' @export
 #' @source Generated by miniextendr from Rust fn `large_vec_altrep`
@@ -23755,7 +23755,7 @@ large_vec_altrep <- function() {
   .val
 }
 
-# Generated from Rust fn `range_i64_altrep` (lib.rs:1782:8)
+# Generated from Rust fn `range_i64_altrep` (lib.rs:1785:8)
 #' @title Create a `Range<i64>` ALTREP real vector (i64 stored as f64 bit patterns)
 #' @rdname altrep_vec
 #' @param from Start of range (inclusive).
@@ -23775,7 +23775,7 @@ range_i64_altrep <- function(from, to) {
   .val
 }
 
-# Generated from Rust fn `range_int_altrep` (lib.rs:1771:8)
+# Generated from Rust fn `range_int_altrep` (lib.rs:1774:8)
 #' @title Create a `Range<i32>` ALTREP integer vector
 #' @rdname altrep_vec
 #' @param from Start of range (inclusive).
@@ -23795,7 +23795,7 @@ range_int_altrep <- function(from, to) {
   .val
 }
 
-# Generated from Rust fn `sparse_iter_real` (lib.rs:1914:8)
+# Generated from Rust fn `sparse_iter_real` (lib.rs:1917:8)
 #' @title Create a sparse real iterator ALTREP with arithmetic progression
 #' @rdname sparse_altrep
 #' @param from Start value.
@@ -24217,7 +24217,7 @@ native_sexp_altrep_new <- function(values) {
   .val
 }
 
-# Generated from Rust fn `boxed_data_altrep` (lib.rs:829:8)
+# Generated from Rust fn `boxed_data_altrep` (lib.rs:832:8)
 #' @title Example: Using into_altrep() to store wrapper
 #' @param n Length of the vector.
 #' @export
@@ -24232,7 +24232,7 @@ boxed_data_altrep <- function(n) {
   .val
 }
 
-# Generated from Rust fn `iter_int_from_u16` (lib.rs:1630:8)
+# Generated from Rust fn `iter_int_from_u16` (lib.rs:1633:8)
 #' @title Create an integer ALTREP from u16-range values coerced to i32 via iterator collect
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -24249,7 +24249,7 @@ iter_int_from_u16 <- function(n) {
   .val
 }
 
-# Generated from Rust fn `iter_real_squares` (lib.rs:1583:8)
+# Generated from Rust fn `iter_real_squares` (lib.rs:1586:8)
 #' @title Create a real ALTREP of squared values (0, 1, 4, 9, ...) via iterator collect
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -24266,7 +24266,7 @@ iter_real_squares <- function(n) {
   .val
 }
 
-# Generated from Rust fn `iter_string_items` (lib.rs:1616:8)
+# Generated from Rust fn `iter_string_items` (lib.rs:1619:8)
 #' @title Create a string ALTREP via iterator collect ("item_0", "item_1", ...)
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -24283,7 +24283,7 @@ iter_string_items <- function(n) {
   .val
 }
 
-# Generated from Rust fn `range_real_altrep` (lib.rs:1793:8)
+# Generated from Rust fn `range_real_altrep` (lib.rs:1796:8)
 #' @title Create a `Range<f64>` ALTREP real vector
 #' @rdname altrep_vec
 #' @param from Start of range (inclusive).
@@ -24418,7 +24418,7 @@ ordered_float_roundtrip_vec <- function(x) {
   .val
 }
 
-# Generated from Rust fn `altrep_compact_int` (lib.rs:703:8)
+# Generated from Rust fn `altrep_compact_int` (lib.rs:706:8)
 #' @title Create a compact integer ALTREP from a lazy arithmetic sequence with printing on materialization
 #' @rdname altrep_constructors
 #' @param n Number of elements.
@@ -24441,7 +24441,7 @@ altrep_compact_int <- function(n, start, step) {
   .val
 }
 
-# Generated from Rust fn `iter_real_from_f32` (lib.rs:1641:8)
+# Generated from Rust fn `iter_real_from_f32` (lib.rs:1644:8)
 #' @title Create a real ALTREP from f32-precision values coerced to f64 via iterator collect
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -24458,7 +24458,7 @@ iter_real_from_f32 <- function(n) {
   .val
 }
 
-# Generated from Rust fn `vec_complex_altrep` (lib.rs:1674:8)
+# Generated from Rust fn `vec_complex_altrep` (lib.rs:1677:8)
 #' @title Create a `Vec<Rcomplex>` ALTREP complex vector
 #' @rdname altrep_vec
 #' @param n Number of elements.
@@ -24524,7 +24524,7 @@ condition_panic_with_int_payload <- function() {
   invisible(.val)
 }
 
-# Generated from Rust fn `altrep_from_doubles` (lib.rs:722:8)
+# Generated from Rust fn `altrep_from_doubles` (lib.rs:725:8)
 #' @title Create an ALTREP real vector from a double vector
 #' @rdname altrep_constructors
 #' @param x A double vector.
@@ -24538,7 +24538,7 @@ altrep_from_doubles <- function(x) {
   .val
 }
 
-# Generated from Rust fn `altrep_from_strings` (lib.rs:732:8)
+# Generated from Rust fn `altrep_from_strings` (lib.rs:735:8)
 #' @title Create an ALTREP string vector from a character vector (NA-preserving)
 #' @rdname altrep_constructors
 #' @param x A character vector (may contain NA values).
@@ -24552,7 +24552,7 @@ altrep_from_strings <- function(x) {
   .val
 }
 
-# Generated from Rust fn `sparse_iter_logical` (lib.rs:1955:8)
+# Generated from Rust fn `sparse_iter_logical` (lib.rs:1958:8)
 #' @title Create a sparse logical iterator ALTREP (alternating TRUE/FALSE)
 #' @rdname sparse_altrep
 #' @param n Number of elements.
@@ -25834,7 +25834,7 @@ gc_stress_struct_flatten_nested <- function() {
   .val
 }
 
-# Generated from Rust fn `altrep_from_integers` (lib.rs:762:8)
+# Generated from Rust fn `altrep_from_integers` (lib.rs:765:8)
 #' @title Create an ALTREP integer vector from an integer vector
 #' @rdname altrep_constructors
 #' @param x An integer vector.
@@ -25848,7 +25848,7 @@ altrep_from_integers <- function(x) {
   .val
 }
 
-# Generated from Rust fn `altrep_from_logicals` (lib.rs:742:8)
+# Generated from Rust fn `altrep_from_logicals` (lib.rs:745:8)
 #' @title Create an ALTREP logical vector from a logical vector (NA-preserving)
 #' @rdname altrep_constructors
 #' @param x A logical vector (may contain NA values).
@@ -25861,7 +25861,7 @@ altrep_from_logicals <- function(x) {
   .val
 }
 
-# Generated from Rust fn `integer_sequence_list` (lib.rs:1178:8)
+# Generated from Rust fn `integer_sequence_list` (lib.rs:1181:8)
 #' @title Create a list ALTREP where each element is an integer sequence
 #' @param n Number of elements in the list.
 #' @return A list where element i contains the vector 1:i.
@@ -25882,7 +25882,7 @@ integer_sequence_list <- function(n) {
   .val
 }
 
-# Generated from Rust fn `rpkg_enabled_features` (lib.rs:2041:8)
+# Generated from Rust fn `rpkg_enabled_features` (lib.rs:2044:8)
 #' @title Returns a vector of enabled feature names for this build
 #' @description This function is useful for R tests to skip tests when features are not enabled.
 #' @name rpkg_enabled_features
@@ -25908,7 +25908,7 @@ standalone_dataframe_roundtrip <- function() {
   .val
 }
 
-# Generated from Rust fn `sparse_iter_int_squares` (lib.rs:1867:8)
+# Generated from Rust fn `sparse_iter_int_squares` (lib.rs:1870:8)
 #' @title Create a sparse integer iterator ALTREP that generates squares (0, 1, 4, 9, ...)
 #' @rdname sparse_altrep
 #' @param n Number of elements.
@@ -25925,7 +25925,7 @@ sparse_iter_int_squares <- function(n) {
   .val
 }
 
-# Generated from Rust fn `iter_logical_alternating` (lib.rs:1594:8)
+# Generated from Rust fn `iter_logical_alternating` (lib.rs:1597:8)
 #' @title Create an alternating TRUE/FALSE logical ALTREP via iterator collect
 #' @rdname altrep_iterators
 #' @param n Number of elements.
@@ -25942,7 +25942,7 @@ iter_logical_alternating <- function(n) {
   .val
 }
 
-# Generated from Rust fn `C_lazy_int_seq_is_materialized` (lib.rs:677:26)
+# Generated from Rust fn `C_lazy_int_seq_is_materialized` (lib.rs:680:26)
 #' @title Check if a lazy integer sequence ALTREP has been materialized
 #' @description Takes raw SEXP (extern "C-unwind") because auto-materialization in `TryFromSexp` for SEXP would trigger materialization before we can inspect it.
 #' @rdname altrep_constructors

--- a/rpkg/src/rust/wasm_registry.rs
+++ b/rpkg/src/rust/wasm_registry.rs
@@ -4,7 +4,7 @@
 // wasm32-* targets in place of the linkme distributed_slices.
 //
 // generator-version: 1
-// content-hash:      5e0ce6bb12695b95
+// content-hash:      f9058bca1c87688f
 
 use ::miniextendr_api::abi::mx_tag;
 use ::miniextendr_api::ffi::{R_CallMethodDef, SEXP};
@@ -1880,6 +1880,33 @@ unsafe extern "C" {
     pub safe fn __mx_altrep_reg_InferredVecRealData();
     pub safe fn __mx_altrep_reg_SparseLogicalIterData();
     pub safe fn __mx_altrep_reg_IntegerSequenceListData();
+    pub safe fn __mx_altrep_reg_builtin_Box_u8();
+    pub safe fn __mx_altrep_reg_builtin_Cow_u8();
+    pub safe fn __mx_altrep_reg_builtin_Vec_u8();
+    pub safe fn __mx_altrep_reg_builtin_Box_f64();
+    pub safe fn __mx_altrep_reg_builtin_Box_i32();
+    pub safe fn __mx_altrep_reg_builtin_Cow_f64();
+    pub safe fn __mx_altrep_reg_builtin_Cow_i32();
+    pub safe fn __mx_altrep_reg_builtin_Vec_f64();
+    pub safe fn __mx_altrep_reg_builtin_Vec_i32();
+    pub safe fn __mx_altrep_reg_builtin_Box_bool();
+    pub safe fn __mx_altrep_reg_builtin_Vec_bool();
+    pub safe fn __mx_altrep_reg_builtin_Range_f64();
+    pub safe fn __mx_altrep_reg_builtin_Range_i32();
+    pub safe fn __mx_altrep_reg_builtin_Range_i64();
+    pub safe fn __mx_altrep_reg_builtin_Box_String();
+    pub safe fn __mx_altrep_reg_builtin_Vec_String();
+    pub safe fn __mx_altrep_reg_builtin_Vec_Cow_str();
+    pub safe fn __mx_altrep_reg_builtin_Box_Rcomplex();
+    pub safe fn __mx_altrep_reg_builtin_Cow_Rcomplex();
+    pub safe fn __mx_altrep_reg_builtin_Vec_Rcomplex();
+    pub safe fn __mx_altrep_reg_builtin_Vec_Option_String();
+    pub safe fn __mx_altrep_reg_builtin_Vec_Option_Cow_str();
+    pub safe fn __mx_altrep_reg_builtin_arrow_Int32Array();
+    pub safe fn __mx_altrep_reg_builtin_arrow_UInt8Array();
+    pub safe fn __mx_altrep_reg_builtin_arrow_StringArray();
+    pub safe fn __mx_altrep_reg_builtin_arrow_BooleanArray();
+    pub safe fn __mx_altrep_reg_builtin_arrow_Float64Array();
     pub safe fn __mx_altrep_reg_JiffTimestampVec();
     pub static __VTABLE_COUNTER_FOR_SIMPLECOUNTER: u8;
     pub static __VTABLE_COUNTER_FOR_PANICKYCOUNTER: u8;
@@ -11213,6 +11240,114 @@ pub static MX_ALTREP_REGISTRATIONS_WASM: &[AltrepRegistration] = &[
     AltrepRegistration {
         register: __mx_altrep_reg_IntegerSequenceListData,
         symbol: "__mx_altrep_reg_IntegerSequenceListData",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_u8,
+        symbol: "__mx_altrep_reg_builtin_Box_u8",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Cow_u8,
+        symbol: "__mx_altrep_reg_builtin_Cow_u8",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_u8,
+        symbol: "__mx_altrep_reg_builtin_Vec_u8",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_f64,
+        symbol: "__mx_altrep_reg_builtin_Box_f64",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_i32,
+        symbol: "__mx_altrep_reg_builtin_Box_i32",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Cow_f64,
+        symbol: "__mx_altrep_reg_builtin_Cow_f64",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Cow_i32,
+        symbol: "__mx_altrep_reg_builtin_Cow_i32",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_f64,
+        symbol: "__mx_altrep_reg_builtin_Vec_f64",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_i32,
+        symbol: "__mx_altrep_reg_builtin_Vec_i32",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_bool,
+        symbol: "__mx_altrep_reg_builtin_Box_bool",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_bool,
+        symbol: "__mx_altrep_reg_builtin_Vec_bool",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Range_f64,
+        symbol: "__mx_altrep_reg_builtin_Range_f64",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Range_i32,
+        symbol: "__mx_altrep_reg_builtin_Range_i32",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Range_i64,
+        symbol: "__mx_altrep_reg_builtin_Range_i64",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_String,
+        symbol: "__mx_altrep_reg_builtin_Box_String",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_String,
+        symbol: "__mx_altrep_reg_builtin_Vec_String",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_Cow_str,
+        symbol: "__mx_altrep_reg_builtin_Vec_Cow_str",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Box_Rcomplex,
+        symbol: "__mx_altrep_reg_builtin_Box_Rcomplex",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Cow_Rcomplex,
+        symbol: "__mx_altrep_reg_builtin_Cow_Rcomplex",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_Rcomplex,
+        symbol: "__mx_altrep_reg_builtin_Vec_Rcomplex",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_Option_String,
+        symbol: "__mx_altrep_reg_builtin_Vec_Option_String",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_Vec_Option_Cow_str,
+        symbol: "__mx_altrep_reg_builtin_Vec_Option_Cow_str",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_Int32Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_Int32Array",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_UInt8Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_UInt8Array",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_StringArray,
+        symbol: "__mx_altrep_reg_builtin_arrow_StringArray",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_BooleanArray,
+        symbol: "__mx_altrep_reg_builtin_arrow_BooleanArray",
+    },
+    AltrepRegistration {
+        register: __mx_altrep_reg_builtin_arrow_Float64Array,
+        symbol: "__mx_altrep_reg_builtin_arrow_Float64Array",
     },
     AltrepRegistration {
         register: __mx_altrep_reg_JiffTimestampVec,


### PR DESCRIPTION
## Summary

Collapses two parallel hand-enumerated lists of the same ~22 ALTREP builtin types in `miniextendr-api/src/altrep_impl.rs`:

1. The `impl_alt*_from_data!` calls → now go through `impl_builtin_altrep_family!(type, family, mode, reg_fn, entry_ident)`.
2. The `register_builtin_altrep_classes()` function → **deleted**. The meta-macro now emits a linkme `MX_ALTREP_REGISTRATIONS` entry per call site, matching how user-defined ALTREP types register via `miniextendr-macros/src/altrep.rs`.

`register_arrow_altrep_classes()` is also deleted. Arrow types live in `optionals/arrow_impl.rs` (feature-gated) and can't be reached by the meta-macro arms — their entries are emitted directly there using the same pattern.

`registry.rs` now iterates `altrep_regs()` exactly once for ALL ALTREP types — builtins, Arrow, user-defined. The `assert_altrep_class_uniqueness()` canary stays as a regression guard. The `wrapper_gen` skip guard at `registry.rs:393` is preserved (no second registration path introduced).

This subsumes the scope previously tracked as #125.

## Test plan
- [x] `just check` / `just clippy` / `just test`
- [x] `just rcmdinstall` + `just devtools-test`
- [ ] CI: full R CMD check + cross-package + minirextendr

## Closes
- #122
- #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)