### PR TITLE
chore(minirextendr): error on ambiguous find_rpkg_subdir() result

### DIFF
--- a/minirextendr/R/upgrade.R
+++ b/minirextendr/R/upgrade.R
@@ -131,24 +131,33 @@ upgrade_miniextendr_package <- function(path = ".",
 #'
 #' Scans immediate subdirectories of `path` for one that contains a
 #' `configure.ac` with the `CARGO_FEATURES` marker (the canonical signal that
-#' a directory is a miniextendr rpkg). Returns the first match, or `NULL` if
-#' none is found.
+#' a directory is a miniextendr rpkg). Returns the single match, `NULL` if
+#' none is found, or aborts if more than one match is found.
 #'
 #' @param path Path to the monorepo workspace root.
 #' @return Name of the rpkg subdirectory (not a full path), or `NULL`.
 #' @noRd
 find_rpkg_subdir <- function(path) {
   subdirs <- list.dirs(path, full.names = FALSE, recursive = FALSE)
+  matches <- character(0)
   for (d in subdirs) {
     configure_ac <- file.path(path, d, "configure.ac")
     if (file.exists(configure_ac)) {
       content <- readLines(configure_ac, warn = FALSE)
       if (any(grepl("CARGO_FEATURES", content, fixed = TRUE))) {
-        return(d)
+        matches <- c(matches, d)
       }
     }
   }
-  NULL
+  if (length(matches) > 1) {
+    cli::cli_abort(c(
+      "Multiple rpkg subdirectories detected in {.path {path}}:",
+      setNames(matches, rep("*", length(matches))),
+      "i" = "Pass {.code rpkg_subdir = '<name>'} explicitly to disambiguate."
+    ))
+  }
+  if (length(matches) == 0L) return(NULL)
+  matches
 }
 
 #' Check that scaffolding files are clean in git

--- a/minirextendr/tests/testthat/test-monorepo-gaps.R
+++ b/minirextendr/tests/testthat/test-monorepo-gaps.R
@@ -120,6 +120,29 @@ test_that("B2: find_rpkg_subdir() ignores subdirs without CARGO_FEATURES", {
   expect_null(minirextendr:::find_rpkg_subdir(tmp))
 })
 
+test_that("B2: find_rpkg_subdir() aborts with both names when two subdirs match", {
+  tmp <- withr::local_tempdir()
+  for (name in c("rpkg-a", "rpkg-b")) {
+    d <- file.path(tmp, name)
+    dir.create(d)
+    writeLines(c("AC_INIT", 'CARGO_FEATURES=""', "AC_OUTPUT"),
+               file.path(d, "configure.ac"))
+  }
+
+  expect_error(
+    minirextendr:::find_rpkg_subdir(tmp),
+    class = "rlang_error"
+  )
+  expect_error(
+    minirextendr:::find_rpkg_subdir(tmp),
+    regexp = "rpkg-a"
+  )
+  expect_error(
+    minirextendr:::find_rpkg_subdir(tmp),
+    regexp = "rpkg-b"
+  )
+})
+
 test_that("B2: upgrade_miniextendr_package() resolves rpkg subdir in monorepo", {
   tmp <- withr::local_tempdir()
   dirs <- make_minimal_monorepo(tmp)


### PR DESCRIPTION
Closes #525.

## What changed

`find_rpkg_subdir()` previously returned the **first** alphabetical match when multiple immediate subdirs contained a miniextendr `configure.ac`. That silent pick caused confusing behavior when a monorepo had more than one R-package subdir.

**Before:**
```r
# silently returns "rpkg-a" (first alphabetically)
find_rpkg_subdir("/path/to/monorepo-with-rpkg-a-and-rpkg-b")
```

**After:**
```r
# aborts with a clear diagnostic listing both candidates
find_rpkg_subdir("/path/to/monorepo-with-rpkg-a-and-rpkg-b")
#> Error:
#> ! Multiple rpkg subdirectories detected in '/path/to/monorepo':
#> * rpkg-a
#> * rpkg-b
#> ℹ Pass `rpkg_subdir = '<name>'` explicitly to disambiguate.
```

The zero-match (returns `NULL`) and single-match (returns it) branches are unchanged.

## Test

New test in `test-monorepo-gaps.R`: creates a temp dir with two subdirs each containing a `CARGO_FEATURES`-bearing `configure.ac`, then asserts `find_rpkg_subdir()` aborts with `class = "rlang_error"` mentioning both subdir names.

Test run: **FAIL 0 | WARN 0 | SKIP 0 | PASS 27** (all existing tests continue to pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)