### PR TITLE
chore(minirextendr): fix R CMD check non-ASCII + codoc WARNINGs (#507)

### DIFF
--- a/minirextendr/R/doctor.R
+++ b/minirextendr/R/doctor.R
@@ -19,7 +19,7 @@ miniextendr_doctor <- function(path = ".") {
 
   results <- list(pass = character(), warn = character(), fail = character())
 
-  # ── Toolchain checks ──
+  # -- Toolchain checks --
   cli::cli_h2("Toolchain")
 
   # Rust
@@ -67,7 +67,7 @@ miniextendr_doctor <- function(path = ".") {
     results$fail <- c(results$fail, "R development headers missing")
   }
 
-  # ── Cargo.toml check ──
+  # -- Cargo.toml check --
   cli::cli_h2("Cargo.toml")
   cargo_toml_path <- tryCatch(usethis::proj_path("src", "rust", "Cargo.toml"), error = function(e) NULL)
   if (is.null(cargo_toml_path) || !file.exists(cargo_toml_path)) {
@@ -84,12 +84,12 @@ miniextendr_doctor <- function(path = ".") {
     }
   }
 
-  # ── Stale vendor tarball check ──
+  # -- Stale vendor tarball check --
   # inst/vendor.tar.xz is gitignored and only belongs in the source tree
   # transiently (during `just r-cmd-build` / `just r-cmd-check`). If it is
   # left behind after an interrupted build, configure switches to tarball mode
   # and the post-build cleanup in Makevars.in deletes src/rust/.cargo/ from the
-  # source tree — silently breaking the monorepo [patch] override on the next
+  # source tree -- silently breaking the monorepo [patch] override on the next
   # `just rcmdinstall`.
   cli::cli_h2("Install-mode signal")
 
@@ -137,7 +137,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     results$pass <- c(results$pass, "cargo config.toml present")
   }
 
-  # ── Generated file freshness ──
+  # -- Generated file freshness --
   cli::cli_h2("Generated files")
 
   template_pairs <- list(
@@ -168,7 +168,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     }
   }
 
-  # ── NAMESPACE check ──
+  # -- NAMESPACE check --
   cli::cli_h2("NAMESPACE")
 
   namespace_path <- tryCatch(usethis::proj_path("NAMESPACE"), error = function(e) NULL)
@@ -183,7 +183,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     }
   }
 
-  # ── Vendor tarball leak ──
+  # -- Vendor tarball leak --
   cli::cli_h2("Vendor tarball")
 
   tarball_path <- tryCatch(usethis::proj_path("inst", "vendor.tar.xz"), error = function(e) NULL)
@@ -195,7 +195,7 @@ tarball-mode cleanup in Makevars. Fix: \\
         "tarball mode and hides workspace edits."
       ),
       "i" = "Run {.code miniextendr_clean_vendor_leak()} (or {.code just clean-vendor-leak} in the monorepo) to remove it.",
-      "i" = "If you are mid CRAN-prep and have not run {.code R CMD build} yet, this is intentional — ignore."
+      "i" = "If you are mid CRAN-prep and have not run {.code R CMD build} yet, this is intentional -- ignore."
     ))
     results$warn <- c(results$warn, "inst/vendor.tar.xz present (may flip tarball mode)")
   } else {
@@ -203,7 +203,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     results$pass <- c(results$pass, "No vendor tarball leak")
   }
 
-  # ── Cargo.lock shape ──
+  # -- Cargo.lock shape --
   cli::cli_h2("Cargo.lock shape")
 
   lock_path <- tryCatch(usethis::proj_path("src", "rust", "Cargo.lock"), error = function(e) NULL)
@@ -226,7 +226,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     }
   }
 
-  # ── Git Hooks ──
+  # -- Git Hooks --
   cli::cli_h2("Git Hooks")
 
   hook_status <- has_miniextendr_git_hooks(usethis::proj_get())
@@ -240,7 +240,7 @@ tarball-mode cleanup in Makevars. Fix: \\
     results$warn <- c(results$warn, "git hooks missing")
   }
 
-  # ── Summary ──
+  # -- Summary --
   cli::cli_h2("Summary")
   cli::cli_alert_success("{length(results$pass)} passed")
   if (length(results$warn) > 0) {

--- a/minirextendr/R/repair-lock.R
+++ b/minirextendr/R/repair-lock.R
@@ -17,7 +17,7 @@
 #' 3. Strips any remaining `checksum = "..."` lines.
 #' 4. Restores `.cargo/config.toml` on exit (success or error).
 #'
-#' This is the lightweight alternative to [miniextendr_vendor()] — use it
+#' This is the lightweight alternative to [miniextendr_vendor()] -- use it
 #' during dev iteration when you only need a clean lock, not a fresh
 #' `inst/vendor.tar.xz`. Use [miniextendr_vendor()] only before
 #' `R CMD build` for CRAN submission.

--- a/minirextendr/R/upgrade.R
+++ b/minirextendr/R/upgrade.R
@@ -18,7 +18,7 @@
 #'
 #' @param path Path to the R package root (standalone) or the monorepo workspace
 #'   root. Defaults to `"."`. For a monorepo, this is the directory containing
-#'   `Cargo.toml` — the rpkg subdir is resolved automatically.
+#'   `Cargo.toml` -- the rpkg subdir is resolved automatically.
 #' @param rpkg_subdir For monorepo layouts: name of the R package subdirectory
 #'   (e.g. `"rpkg"`). If `NULL` (default), auto-detected by scanning immediate
 #'   subdirectories for a miniextendr `configure.ac`.
@@ -50,7 +50,7 @@ upgrade_miniextendr_package <- function(path = ".",
   project_type <- detect_project_type(resolved_path)
   if (identical(project_type, "monorepo") &&
       !file.exists(file.path(resolved_path, "configure.ac"))) {
-    # Path is the workspace root — need to resolve to the rpkg subdir.
+    # Path is the workspace root -- need to resolve to the rpkg subdir.
     subdir <- rpkg_subdir %||% find_rpkg_subdir(resolved_path)
     if (is.null(subdir)) {
       cli::cli_abort(c(
@@ -60,7 +60,7 @@ upgrade_miniextendr_package <- function(path = ".",
       ))
     }
     resolved_path <- file.path(resolved_path, subdir)
-    cli::cli_alert_info("Monorepo layout detected — upgrading rpkg subdir {.path {subdir}}")
+    cli::cli_alert_info("Monorepo layout detected -- upgrading rpkg subdir {.path {subdir}}")
   }
 
   with_project(resolved_path)

--- a/minirextendr/R/use-release-workflow.R
+++ b/minirextendr/R/use-release-workflow.R
@@ -23,7 +23,7 @@
 #' that subdirectory. Pass `rpkg_subdir` to activate this; the generated workflow
 #' will add `working-directory: <rpkg_subdir>` to those steps. When `rpkg_subdir`
 #' is `NULL` (default) and `auto_detect_subdir` is `TRUE` (default),
-#' auto-detection via [detect_project_type()] is attempted.
+#' auto-detection via `detect_project_type()` is attempted.
 #' For a confirmed standalone package, set `auto_detect_subdir = FALSE` to skip
 #' detection and write the plain template unchanged.
 #'
@@ -34,7 +34,7 @@
 #'   the subdirectory is auto-detected. If a string, it is used directly
 #'   regardless of `auto_detect_subdir`.
 #' @param auto_detect_subdir If `TRUE` (default) and `rpkg_subdir` is `NULL`,
-#'   attempts to auto-detect the monorepo layout via [detect_project_type()].
+#'   attempts to auto-detect the monorepo layout via `detect_project_type()`.
 #'   Set to `FALSE` to force standalone mode and suppress auto-detection.
 #' @param overwrite If `TRUE`, replace an existing
 #'   `.github/workflows/r-release.yml`. Default `FALSE`.

--- a/minirextendr/R/use-release-workflow.R
+++ b/minirextendr/R/use-release-workflow.R
@@ -7,9 +7,9 @@
 #' gotchas surfaced when running release workflows against AlmaLinux 8
 #' container builds and macOS arm64 runners (issue #448):
 #'
-#' 1. `LANG=C.UTF-8` scoped to container jobs — AlmaLinux 8 minimal defaults
+#' 1. `LANG=C.UTF-8` scoped to container jobs -- AlmaLinux 8 minimal defaults
 #'    to the `C` locale, which fails miniextendr's UTF-8 assertion.
-#' 2. Not set workflow-wide — macOS rejects `C.UTF-8` (glibc-only identifier).
+#' 2. Not set workflow-wide -- macOS rejects `C.UTF-8` (glibc-only identifier).
 #' 3. `dnf install git gh` + `gh auth setup-git` for AlmaLinux 8 minimal.
 #' 4. `CARGO_NET_GIT_FETCH_WITH_CLI=true` workflow-wide so cargo uses the
 #'    system git binary and can authenticate private git dependencies.
@@ -54,9 +54,9 @@ use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
   }
 
   # Resolve rpkg_subdir:
-  #   - explicit string → use it directly.
-  #   - NULL + auto_detect_subdir = TRUE → attempt auto-detection.
-  #   - NULL + auto_detect_subdir = FALSE → standalone (no detection).
+  #   - explicit string -> use it directly.
+  #   - NULL + auto_detect_subdir = TRUE -> attempt auto-detection.
+  #   - NULL + auto_detect_subdir = FALSE -> standalone (no detection).
   resolved_subdir <- NULL
   if (!is.null(rpkg_subdir)) {
     resolved_subdir <- as.character(rpkg_subdir)

--- a/minirextendr/man/miniextendr_clean_vendor_leak.Rd
+++ b/minirextendr/man/miniextendr_clean_vendor_leak.Rd
@@ -17,13 +17,14 @@ was already absent.
 \description{
 \code{inst/vendor.tar.xz} is the single signal that flips \code{./configure} into
 offline tarball mode. Once that file exists, every subsequent
-\code{R CMD INSTALL}, \code{devtools::install()}, or \code{devtools::document()} call
+\verb{R CMD INSTALL}, \code{devtools::install()}, or \code{devtools::document()} call
 builds against the vendored snapshot rather than pulling live workspace
 or network sources.
-
+}
+\details{
 This is intentional during CRAN submission prep (run
-\code{\link[=miniextendr_vendor]{miniextendr_vendor()}} first, then \code{R CMD build}). It becomes a trap
-when a prior \code{R CMD build} or check run leaves the file behind in your
+\code{\link[=miniextendr_vendor]{miniextendr_vendor()}} first, then \verb{R CMD build}). It becomes a trap
+when a prior \verb{R CMD build} or check run leaves the file behind in your
 source tree.
 
 Call this function after any unexpected tarball-mode install to restore

--- a/minirextendr/man/miniextendr_repair_lock.Rd
+++ b/minirextendr/man/miniextendr_repair_lock.Rd
@@ -20,17 +20,18 @@ was already in tarball-shape (no action taken).
 \description{
 The committed \code{src/rust/Cargo.lock} must be in \strong{tarball-shape} (no
 \code{checksum = "..."} lines, no \code{path+...} source entries for the
-\code{miniextendr-{api,lint,macros}} framework crates). Day-to-day
-\code{devtools::install()}, \code{cargo build}, or \code{devtools::document()} silently
+\verb{miniextendr-\{api,lint,macros\}} framework crates). Day-to-day
+\code{devtools::install()}, \verb{cargo build}, or \code{devtools::document()} silently
 rewrites the lock in source-shape: checksums come back for crates.io deps
-and framework crates switch to \code{path+file:///...} entries.
-
+and framework crates switch to \verb{path+file:///...} entries.
+}
+\details{
 \code{miniextendr_repair_lock()} is a sub-second lock-only repair:
 \enumerate{
-\item Moves \code{.cargo/config.toml} aside temporarily so \code{cargo update} runs
-without the \code{[patch."git+url"]} override that would re-introduce
-\code{path+} entries.
-\item Runs \code{cargo update} to resolve the lockfile against the bare git URLs.
+\item Moves \code{.cargo/config.toml} aside temporarily so \verb{cargo update} runs
+without the \verb{[patch."git+url"]} override that would re-introduce
+\verb{path+} entries.
+\item Runs \verb{cargo update} to resolve the lockfile against the bare git URLs.
 \item Strips any remaining \code{checksum = "..."} lines.
 \item Restores \code{.cargo/config.toml} on exit (success or error).
 }
@@ -38,7 +39,7 @@ without the \code{[patch."git+url"]} override that would re-introduce
 This is the lightweight alternative to \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} — use it
 during dev iteration when you only need a clean lock, not a fresh
 \code{inst/vendor.tar.xz}. Use \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} only before
-\code{R CMD build} for CRAN submission.
+\verb{R CMD build} for CRAN submission.
 
 For the full invariants and reasoning, see the
 \href{https://a2-ai.github.io/miniextendr/manual/cargo-lock-shape/}{Cargo.lock shape}

--- a/minirextendr/man/miniextendr_repair_lock.Rd
+++ b/minirextendr/man/miniextendr_repair_lock.Rd
@@ -36,7 +36,7 @@ without the \verb{[patch."git+url"]} override that would re-introduce
 \item Restores \code{.cargo/config.toml} on exit (success or error).
 }
 
-This is the lightweight alternative to \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} — use it
+This is the lightweight alternative to \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} -- use it
 during dev iteration when you only need a clean lock, not a fresh
 \code{inst/vendor.tar.xz}. Use \code{\link[=miniextendr_vendor]{miniextendr_vendor()}} only before
 \verb{R CMD build} for CRAN submission.

--- a/minirextendr/man/upgrade_miniextendr_package.Rd
+++ b/minirextendr/man/upgrade_miniextendr_package.Rd
@@ -6,6 +6,7 @@
 \usage{
 upgrade_miniextendr_package(
   path = ".",
+  rpkg_subdir = NULL,
   version = "main",
   local_path = NULL,
   configure_ac = FALSE,
@@ -14,7 +15,13 @@ upgrade_miniextendr_package(
 )
 }
 \arguments{
-\item{path}{Path to the R package root, or \code{"."} to use the current directory.}
+\item{path}{Path to the R package root (standalone) or the monorepo workspace
+root. Defaults to \code{"."}. For a monorepo, this is the directory containing
+\code{Cargo.toml} -- the rpkg subdir is resolved automatically.}
+
+\item{rpkg_subdir}{For monorepo layouts: name of the R package subdirectory
+(e.g. \code{"rpkg"}). If \code{NULL} (default), auto-detected by scanning immediate
+subdirectories for a miniextendr \code{configure.ac}.}
 
 \item{version}{Version of miniextendr crates to vendor (default: \code{"main"}).}
 
@@ -44,4 +51,10 @@ generated C files.
 }
 \details{
 User-authored files (lib.rs, Cargo.toml, R/ code) are never touched.
+
+In a monorepo layout (workspace root containing an rpkg subdirectory),
+\code{upgrade_miniextendr_package()} automatically detects the rpkg subdir and
+operates on it rather than the workspace root. The rpkg subdir is the first
+immediate child directory that contains a miniextendr \code{configure.ac}. Pass
+\code{rpkg_subdir} explicitly if auto-detection is ambiguous.
 }

--- a/minirextendr/man/use_miniextendr_git_hooks.Rd
+++ b/minirextendr/man/use_miniextendr_git_hooks.Rd
@@ -31,7 +31,9 @@ package in a healthy state:
 \itemize{
 \item \strong{pre-commit}: Checks \verb{cargo fmt}, blocks on stale \code{configure} script
 or stale NAMESPACE (when \verb{*-wrappers.R} changed without \code{devtools::document()}),
-notes when \code{inst/vendor.tar.xz} may need updating
+blocks on source-shape \code{src/rust/Cargo.lock} (recommends
+\code{\link[=miniextendr_repair_lock]{miniextendr_repair_lock()}}), notes when \code{inst/vendor.tar.xz} may need
+updating
 \item \strong{post-merge}: Reminds you to reconfigure after pulling changes to
 build files (configure.ac, Makevars.in, Cargo.toml, Rust sources)
 }

--- a/minirextendr/man/use_release_workflow.Rd
+++ b/minirextendr/man/use_release_workflow.Rd
@@ -38,9 +38,9 @@ container builds and macOS arm64 runners (issue #448):
 }
 \details{
 \enumerate{
-\item \code{LANG=C.UTF-8} scoped to container jobs — AlmaLinux 8 minimal defaults
+\item \code{LANG=C.UTF-8} scoped to container jobs -- AlmaLinux 8 minimal defaults
 to the \code{C} locale, which fails miniextendr's UTF-8 assertion.
-\item Not set workflow-wide — macOS rejects \code{C.UTF-8} (glibc-only identifier).
+\item Not set workflow-wide -- macOS rejects \code{C.UTF-8} (glibc-only identifier).
 \item \verb{dnf install git gh} + \verb{gh auth setup-git} for AlmaLinux 8 minimal.
 \item \code{CARGO_NET_GIT_FETCH_WITH_CLI=true} workflow-wide so cargo uses the
 system git binary and can authenticate private git dependencies.

--- a/minirextendr/man/use_release_workflow.Rd
+++ b/minirextendr/man/use_release_workflow.Rd
@@ -4,10 +4,25 @@
 \alias{use_release_workflow}
 \title{Add an r-release.yml workflow with miniextendr platform fixes}
 \usage{
-use_release_workflow(path = ".", overwrite = FALSE)
+use_release_workflow(
+  path = ".",
+  rpkg_subdir = NULL,
+  auto_detect_subdir = TRUE,
+  overwrite = FALSE
+)
 }
 \arguments{
-\item{path}{Path to the package root. Defaults to \code{"."}.}
+\item{path}{Path to the package root (standalone) or monorepo workspace root.
+Defaults to \code{"."}.}
+
+\item{rpkg_subdir}{For monorepo layouts: name of the R package subdirectory
+(e.g. \code{"rpkg"}). If \code{NULL} (default) and \code{auto_detect_subdir} is \code{TRUE},
+the subdirectory is auto-detected. If a string, it is used directly
+regardless of \code{auto_detect_subdir}.}
+
+\item{auto_detect_subdir}{If \code{TRUE} (default) and \code{rpkg_subdir} is \code{NULL},
+attempts to auto-detect the monorepo layout via \code{detect_project_type()}.
+Set to \code{FALSE} to force standalone mode and suppress auto-detection.}
 
 \item{overwrite}{If \code{TRUE}, replace an existing
 \code{.github/workflows/r-release.yml}. Default \code{FALSE}.}
@@ -23,9 +38,9 @@ container builds and macOS arm64 runners (issue #448):
 }
 \details{
 \enumerate{
-\item \code{LANG=C.UTF-8} scoped to container jobs --- AlmaLinux 8 minimal defaults
+\item \code{LANG=C.UTF-8} scoped to container jobs — AlmaLinux 8 minimal defaults
 to the \code{C} locale, which fails miniextendr's UTF-8 assertion.
-\item Not set workflow-wide --- macOS rejects \code{C.UTF-8} (glibc-only identifier).
+\item Not set workflow-wide — macOS rejects \code{C.UTF-8} (glibc-only identifier).
 \item \verb{dnf install git gh} + \verb{gh auth setup-git} for AlmaLinux 8 minimal.
 \item \code{CARGO_NET_GIT_FETCH_WITH_CLI=true} workflow-wide so cargo uses the
 system git binary and can authenticate private git dependencies.
@@ -34,4 +49,13 @@ system git binary and can authenticate private git dependencies.
 See \code{docs/RELEASE_WORKFLOW.md} in the miniextendr repository for the full
 rationale, and \code{\link[miniextendr]{assert_utf8_locale_now}} for why the
 UTF-8 check exists.
+
+For \strong{monorepo layouts} (where the R package lives in a subdirectory such as
+\verb{rpkg/}), the \verb{bash ./configure} and \verb{R CMD build} steps must run from inside
+that subdirectory. Pass \code{rpkg_subdir} to activate this; the generated workflow
+will add \verb{working-directory: <rpkg_subdir>} to those steps. When \code{rpkg_subdir}
+is \code{NULL} (default) and \code{auto_detect_subdir} is \code{TRUE} (default),
+auto-detection via \code{detect_project_type()} is attempted.
+For a confirmed standalone package, set \code{auto_detect_subdir = FALSE} to skip
+detection and write the plain template unchanged.
 }


### PR DESCRIPTION
Closes #507

## Changes

- **`minirextendr/R/doctor.R`**: replaced 11 non-ASCII characters (em-dashes `—` -> ` -- `, box-drawing `──` -> `--`) in section-header comments and one user-facing string
- **`minirextendr/R/upgrade.R`**: replaced 3 em-dashes in comments and a `cli::cli_alert_info()` call
- **`minirextendr/R/use-release-workflow.R`**: fixed broken `[detect_project_type()]` roxygen link (internal function, not exported) -> backtick code style in two places; additionally stripped em-dashes (lines 10, 12) and right-arrows (lines 57-59) that were missed in the original commit
- **`minirextendr/R/repair-lock.R`**: stripped em-dash from roxygen description (propagated to `miniextendr_repair_lock.Rd`)
- **`minirextendr/man/*.Rd`**: regenerated via `devtools::document()` -- `upgrade_miniextendr_package.Rd` now documents `rpkg_subdir`, `use_release_workflow.Rd` and `miniextendr_repair_lock.Rd` now clean of non-ASCII

## Before / After (`just minirextendr-check`)

**Before** (`Status: 1 ERROR, 2 WARNINGs, 1 NOTE`):
```
* checking code files for non-ASCII characters ... WARNING
  Found the following files with non-ASCII characters:
    R/doctor.R
    R/upgrade.R

* checking for code/documentation mismatches ... WARNING
  Codoc mismatches from Rd file 'upgrade_miniextendr_package.Rd': ...
  Codoc mismatches from Rd file 'use_release_workflow.Rd': ...
```

**After** (`Status: 1 ERROR, 1 NOTE`):
```
* checking code files for non-ASCII characters ... OK
* checking for code/documentation mismatches ... OK
* checking R code for possible problems ... OK
```

The remaining 1 ERROR (6 pre-existing test failures in `test-use-native.R`, `test-scaffold-smoke.R`, and `test-templates.R`) and the CLAUDE.md NOTE are pre-existing and unrelated to this PR.

## Deferred

- **#567**: 6 pre-existing test ERRORs in `just minirextendr-check` (`./configure` failures in scaffold/templates tests; `check_native_package` failures in `test-use-native.R`). Not introduced by this PR; same baseline on `origin/main`. Filed per project rule.

## Validation

`just minirextendr-test`: `[ FAIL 6 | WARN 10 | SKIP 4 | PASS 416 ]` (same as baseline on `main`)
`just minirextendr-check`: non-ASCII WARNING gone, codoc WARNING gone
`tools::showNonASCIIfile()` on all affected `.R` and `.Rd` files: empty output

🤖 Generated with [Claude Code](https://claude.com/claude-code)