### PR TITLE
ci(macos): re-enable r-check-macos as non-gating on-demand probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 6'
 
 permissions:
   contents: read
@@ -447,117 +450,117 @@ jobs:
   # ===========================================================================
   # R Package: R CMD check on macOS
   # ===========================================================================
-  # DISABLED: macOS CI is currently disabled. Uncomment the block below to
-  # re-enable. Remember to also re-add `r-check-macos` to `ci-success.needs`
-  # and its results array.
-  # r-check-macos:
-  #   name: R CMD check / macOS ${{ matrix.arch }}
-  #   runs-on: ${{ matrix.runner }}
-  #   timeout-minutes: 90
-  #   needs: changes
-  #   if: needs.changes.outputs.r == 'true'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - runner: macos-15
-  #           arch: arm64
-  #         - runner: macos-15-intel
-  #           arch: x86_64
-  #
-  #   env:
-  #     GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-  #     R_KEEP_PKG_SOURCE: yes
-  #     SCCACHE_GHA_ENABLED: "true"
-  #
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #       with:
-  #         lfs: true
-  #
-  #     - name: Install just
-  #       run: |
-  #         brew install just
-  #         echo "$(brew --prefix)/bin" >> $GITHUB_PATH
-  #
-  #     - name: Install autoconf
-  #       run: |
-  #         brew install autoconf
-  #
-  #     - name: Setup R
-  #       uses: r-lib/actions/setup-r@v2
-  #       with:
-  #         r-version: release
-  #         use-public-rspm: true
-  #
-  #     - name: Setup R dependencies
-  #       uses: r-lib/actions/setup-r-dependencies@v2
-  #       with:
-  #         working-directory: rpkg
-  #         extra-packages: any::rcmdcheck
-  #         needs: check
-  #
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #
-  #     - name: Setup sccache
-  #       id: sccache
-  #       uses: mozilla-actions/sccache-action@v0.0.9
-  #       continue-on-error: true
-  #
-  #     - name: Set RUSTC_WRAPPER if sccache available
-  #       if: steps.sccache.outcome == 'success'
-  #       run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-  #
-  #     - name: Cache Cargo
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         workspaces: rpkg/src/rust -> target
-  #         shared-key: r-macos-${{ matrix.arch }}
-  #         cache-on-failure: true
-  #
-  #     - name: Install cargo-revendor
-  #       run: cargo install --path cargo-revendor
-  #
-  #     - name: Configure and vendor
-  #       run: |
-  #         just configure
-  #         just vendor
-  #
-  #     - name: R CMD check
-  #       uses: r-lib/actions/check-r-package@v2
-  #       with:
-  #         working-directory: rpkg
-  #         args: 'c("--no-manual", "--as-cran")'
-  #         error-on: '"error"'
-  #         check-dir: '"check"'
-  #         # No NOT_CRAN — configure.ac detects tarball install from inst/vendor.tar.xz
-  #
-  #     - name: Print failed tests
-  #       if: always()
-  #       run: |
-  #         for f in rpkg/check/*.Rcheck/tests/*.Rout.fail; do
-  #           [ -f "$f" ] && echo "=== $f ===" && tail -n100 "$f"
-  #         done || true
-  #
-  #     - name: Print 00check.log and 00install.out
-  #       if: always()
-  #       run: |
-  #         echo "=== 00install.out ==="
-  #         cat rpkg/check/*.Rcheck/00install.out 2>/dev/null || echo "00install.out not found"
-  #         echo ""
-  #         echo "=== 00check.log ==="
-  #         cat rpkg/check/*.Rcheck/00check.log 2>/dev/null || echo "00check.log not found"
-  #
-  #     - name: Upload check results
-  #       if: failure()
-  #       uses: actions/upload-artifact@v7
-  #       with:
-  #         name: logs-macos-${{ matrix.arch }}
-  #         path: |
-  #           rpkg/check
-  #           rpkg/config.log
-  #         retention-days: 7
+  # On-demand: this job runs only on workflow_dispatch + weekly cron (Sat 06:00 UTC).
+  # Non-gating — intentionally not in ci-success.needs. Tracks #95 (macOS x86_64
+  # SIGABRT regression probe). To force a run: gh workflow run ci.yml --ref main
+  r-check-macos:
+    name: R CMD check / macOS ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 90
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install just
+        run: |
+          brew install just
+          echo "$(brew --prefix)/bin" >> $GITHUB_PATH
+
+      - name: Install autoconf
+        run: |
+          brew install autoconf
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: rpkg
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        id: sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Set RUSTC_WRAPPER if sccache available
+        if: steps.sccache.outcome == 'success'
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rpkg/src/rust -> target
+          shared-key: r-macos-${{ matrix.arch }}
+          cache-on-failure: true
+
+      - name: Install cargo-revendor
+        run: cargo install --path cargo-revendor
+
+      - name: Configure and vendor
+        run: |
+          just configure
+          just vendor
+
+      - name: R CMD check
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          working-directory: rpkg
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"error"'
+          check-dir: '"check"'
+          # No NOT_CRAN — configure.ac detects tarball install from inst/vendor.tar.xz
+
+      - name: Print failed tests
+        if: always()
+        run: |
+          for f in rpkg/check/*.Rcheck/tests/*.Rout.fail; do
+            [ -f "$f" ] && echo "=== $f ===" && tail -n100 "$f"
+          done || true
+
+      - name: Print 00check.log and 00install.out
+        if: always()
+        run: |
+          echo "=== 00install.out ==="
+          cat rpkg/check/*.Rcheck/00install.out 2>/dev/null || echo "00install.out not found"
+          echo ""
+          echo "=== 00check.log ==="
+          cat rpkg/check/*.Rcheck/00check.log 2>/dev/null || echo "00check.log not found"
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-macos-${{ matrix.arch }}
+          path: |
+            rpkg/check
+            rpkg/config.log
+          retention-days: 7
 
   # ===========================================================================
   # R Package: R CMD check on Windows
@@ -1132,7 +1135,7 @@ jobs:
       - rust-lint
       - changes
       - r-check-linux
-      # - r-check-macos   # DISABLED — re-enable when macOS job is uncommented above
+      # - r-check-macos   # non-gating: runs only on workflow_dispatch + weekly cron, see #95
       # - r-check-windows # DISABLED — re-enable when Windows job is uncommented above
       - r-tests
       - cross-package-tests
@@ -1152,7 +1155,7 @@ jobs:
             "${{ needs.rust-lint.result }}"
             "${{ needs.changes.result }}"
             "${{ needs.r-check-linux.result }}"
-            # "${{ needs.r-check-macos.result }}"   # DISABLED
+            # "${{ needs.r-check-macos.result }}"   # non-gating, see #95
             # "${{ needs.r-check-windows.result }}" # DISABLED
             "${{ needs.r-tests.result }}"
             "${{ needs.cross-package-tests.result }}"


### PR DESCRIPTION
Refs #95.

## What this does

Re-enables the `r-check-macos` CI job that was commented out entirely in PR #283 (cost reasons), restoring macOS CI signal after the ALTREP subsystem redesign in PR #119 eliminated the original crash code path.

<details>
<summary>AI-written summary</summary>

### Changes

- Adds `workflow_dispatch:` and `schedule: - cron: '0 6 * * 6'` to the top-level `on:` triggers (Saturday 06:00 UTC weekly probe).
- Uncomments the full `r-check-macos` job block, keeping **both** matrix entries: `macos-15` (arm64) and `macos-15-intel` (x86_64). Both archs are intentional — x86_64 is where #95 originally SIGABRTed, arm64 gives baseline coverage at no extra logical cost.
- Adds `if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'` to the job, so it never fires on `pull_request` or `push` events. PR builds remain unaffected.
- Does **not** add `r-check-macos` to `ci-success.needs` — the job is fully non-gating. A failure there cannot block a PR merge.
- Updates comments in `ci-success.needs` / results array to reflect the new state (`# non-gating: runs only on workflow_dispatch + weekly cron, see #95`).

### Post-merge action item

After merge to `main`, trigger the workflow once manually to get a first signal:

```bash
gh workflow run ci.yml --ref main
```

- If both matrix legs go green → close #95.
- If x86_64 still SIGABRTs → update #95 with fresh repro info and investigate.

The job being non-gating means CI green on PRs is unaffected either way.

</details>