### PR TITLE
fix(macros): B1 collision check honors Inner::TAG (#544)

### DIFF
--- a/miniextendr-api/src/markers.rs
+++ b/miniextendr-api/src/markers.rs
@@ -119,6 +119,79 @@ pub const fn assert_no_payload_field_collision(fields: &[&str], discriminant_suf
         i += 1;
     }
 }
+
+/// Compile-time assertion: no element of `sibling_cols` matches `concat!(base, "_", tag)`.
+///
+/// Called from `const _: ()` blocks emitted by the outer `DataFrameRow` derive for every
+/// nested-enum struct field, complementing the parse-time B1 check in `enum_expansion.rs`
+/// (which is hardcoded to the default tag `"variant"`). This assertion catches the
+/// non-default-tag case at compile time.
+///
+/// `sibling_cols` is a slice of all flat column names produced by non-Struct sibling fields
+/// in the same outer enum. `base` is the outer field name (e.g. `"kind"`). `tag` is the
+/// inner enum's `#[dataframe(tag = "...")]` value, retrieved via
+/// `<Inner as DataFramePayloadFields>::TAG`.
+///
+/// If `tag` is empty (structs emit no discriminant column), returns immediately as a no-op.
+///
+/// # Call site (emitted by proc-macro)
+///
+/// ```rust,ignore
+/// const _: () = ::miniextendr_api::markers::assert_no_sibling_field_collision(
+///     &["id", "other_col", /* … */],
+///     "kind",
+///     <Inner as ::miniextendr_api::markers::DataFramePayloadFields>::TAG,
+/// );
+/// ```
+#[doc(hidden)]
+pub const fn assert_no_sibling_field_collision(sibling_cols: &[&str], base: &str, tag: &str) {
+    // Structs don't emit a discriminant column, so tag == "" → no-op.
+    if tag.is_empty() {
+        return;
+    }
+    let expected_len = base.len() + 1 + tag.len();
+    let base_bytes = base.as_bytes();
+    let tag_bytes = tag.as_bytes();
+    let mut i = 0;
+    while i < sibling_cols.len() {
+        let col = sibling_cols[i].as_bytes();
+        if col.len() == expected_len {
+            // Check base prefix byte-by-byte.
+            let mut j = 0;
+            let mut base_match = true;
+            while j < base_bytes.len() {
+                if col[j] != base_bytes[j] {
+                    base_match = false;
+                    break;
+                }
+                j += 1;
+            }
+            // Check separator '_'.
+            let sep_match = col[base_bytes.len()] == b'_';
+            // Check tag suffix byte-by-byte.
+            let mut k = 0;
+            let mut tag_match = true;
+            let offset = base_bytes.len() + 1;
+            while k < tag_bytes.len() {
+                if col[offset + k] != tag_bytes[k] {
+                    tag_match = false;
+                    break;
+                }
+                k += 1;
+            }
+            if base_match && sep_match && tag_match {
+                panic!(
+                    "DataFrameRow B1 sibling-collision: a sibling field in the outer enum \
+                     produces a column name that collides with the discriminant column emitted \
+                     by a nested inner enum. Rename the sibling field or use \
+                     `#[dataframe(tag = \"...\")]` on the inner enum to choose a different \
+                     discriminant column name."
+                );
+            }
+        }
+        i += 1;
+    }
+}
 // endregion
 
 /// Marker trait for types that should be converted to R lists via `IntoR`.

--- a/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
+++ b/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
@@ -1064,6 +1064,53 @@ pub(super) fn derive_enum_dataframe(
             }
         })
         .collect();
+
+    // Sibling collision assertions (#544): one per nested-enum struct field.
+    //
+    // The B1 parse-time check (earlier in this function) hardcodes `"variant"` as the
+    // inner tag when building the discriminant column name to compare against sibling
+    // Single fields. That check covers the common case with better spans/messages.
+    //
+    // This const assertion covers the non-default-tag case: when `Inner` uses
+    // `#[dataframe(tag = "foo")]`, the discriminant column is `<base>_foo`, not
+    // `<base>_variant`. The const assertion uses `<Inner as DataFramePayloadFields>::TAG`
+    // so it resolves to the actual tag at compile time regardless of the value.
+    //
+    // We collect all Single col names across ALL variants (not just the variant that
+    // introduced the struct field) — a collision in any one variant is a bug.
+    let all_single_col_names: Vec<String> = {
+        let mut seen = std::collections::HashSet::new();
+        let mut names = Vec::new();
+        for vi in &variant_infos {
+            for erf in &vi.fields {
+                if let EnumResolvedField::Single(d) = erf {
+                    let col = d.col_name.to_string();
+                    if seen.insert(col.clone()) {
+                        names.push(col);
+                    }
+                }
+            }
+        }
+        names
+    };
+    let sibling_collision_assertions: Vec<TokenStream> = struct_cols
+        .iter()
+        .map(|sc| {
+            let inner_ty = &sc.inner_ty;
+            let base_str = &sc.base_name;
+            let sibling_lits = all_single_col_names
+                .iter()
+                .map(|s| quote! { #s })
+                .collect::<Vec<_>>();
+            quote! {
+                const _: () = ::miniextendr_api::markers::assert_no_sibling_field_collision(
+                    &[#(#sibling_lits),*],
+                    #base_str,
+                    <#inner_ty as ::miniextendr_api::markers::DataFramePayloadFields>::TAG,
+                );
+            }
+        })
+        .collect();
     // endregion
 
     // region: Generate From<Vec<Enum>>
@@ -1794,6 +1841,7 @@ pub(super) fn derive_enum_dataframe(
         #payload_fields_impl
         #(#struct_assertions)*
         #(#payload_collision_assertions)*
+        #(#sibling_collision_assertions)*
         #unit_only_factor_impls
     })
     // endregion

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs
@@ -1,0 +1,33 @@
+//! Test: nested enum flatten field whose discriminant column (`kind_status`)
+//! collides with a sibling field named `kind_status` when the inner enum uses
+//! a non-default tag `#[dataframe(tag = "status")]`.
+//!
+//! The parse-time B1 check only fires for the default `"variant"` tag.
+//! This case must be caught by the `assert_no_sibling_field_collision` const assertion.
+
+use miniextendr_macros::DataFrameRow;
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(tag = "status")]
+enum Inner {
+    Active,
+    Inactive { code: i32 },
+}
+
+/// Outer enum: `kind: Inner` would produce `kind_status` discriminant column
+/// (because Inner uses `tag = "status"`), but the sibling field `kind_status`
+/// also produces a column with that exact name → B1 collision.
+#[derive(DataFrameRow)]
+#[dataframe(tag = "_type")]
+enum Outer {
+    Wrap {
+        id: i32,
+        kind: Inner,
+        kind_status: String, // collides with `kind`'s discriminant column
+    },
+    Other {
+        id: i32,
+    },
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.stderr
@@ -1,0 +1,49 @@
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs:10:24
+   |
+10 | #[derive(Clone, Debug, DataFrameRow)]
+   |                        ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs:20:10
+   |
+20 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: DataFrameRow B1 sibling-collision: a sibling field in the outer enum produces a column name that collides with the discriminant column emitted by a nested inner enum. Rename the sibling field or use `#[dataframe(tag = "...")]` on the inner enum to choose a different discriminant column name.
+  --> tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs:20:10
+   |
+20 | #[derive(DataFrameRow)]
+   |          ^^^^^^^^^^^^ evaluation of `_` failed inside this call
+   |
+note: inside `miniextendr_api::markers::assert_no_sibling_field_collision`
+  --> $RUST/core/src/panic.rs
+   |
+   |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   |
+  ::: $WORKSPACE/miniextendr-api/src/markers.rs
+   |
+   | /                 panic!(
+   | |                     "DataFrameRow B1 sibling-collision: a sibling field in the outer enum \
+   | |                      produces a column name that collides with the discriminant column emitted \
+   | |                      by a nested inner enum. Rename the sibling field or use \
+   | |                      `#[dataframe(tag = \"...\")]` on the inner enum to choose a different \
+   | |                      discriminant column name."
+   | |                 );
+   | |_________________- in this macro invocation


### PR DESCRIPTION
Closes #544.

When an outer `DataFrameRow` enum has a nested-enum field using a non-default `#[dataframe(tag = "...")]`, a sibling field colliding with `<base>_<custom_tag>` was silently accepted, producing duplicate R column names and silent data corruption at runtime.

<details><summary>🤖 AI-written implementation notes (claude-sonnet-4-6)</summary>

## Changes

- **`miniextendr-api/src/markers.rs`** (after `assert_no_payload_field_collision`): Added `assert_no_sibling_field_collision(sibling_cols: &[&str], base: &str, tag: &str)` — a new `pub const fn` that checks whether any element of `sibling_cols` equals `concat!(base, "_", tag)` via byte-level comparison (no `format!` in const fn). Returns immediately if `tag.is_empty()` (structs emit no discriminant column). Exported `pub` with `#[doc(hidden)]` matching the existing helper.

- **`miniextendr-macros/src/dataframe_derive/enum_expansion.rs`** (~line 1066, after `payload_collision_assertions`): Added `all_single_col_names` collection (deduped across all variants) and a `sibling_collision_assertions: Vec<TokenStream>` loop over `struct_cols`. Each entry emits `const _: () = ::miniextendr_api::markers::assert_no_sibling_field_collision(&[...sibling_lits...], base_str, <Inner as DataFramePayloadFields>::TAG)`. Emitted alongside `#(#payload_collision_assertions)*` in the final `Ok(quote! { ... })` block.

- **`miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.rs`** (new): Compile-fail UI test with `Inner` using `#[dataframe(tag = "status")]` and `Outer` having both `kind: Inner` and a sibling `kind_status: String` — exercises the non-default-tag B1 collision path.

- **`miniextendr-macros/tests/ui/derive_dataframe_enum_nested_enum_b1_custom_tag_sibling.stderr`** (new): Generated snapshot showing `E0080: evaluation panicked` at the `#[derive(DataFrameRow)]` on `Outer`, referencing `assert_no_sibling_field_collision` in `miniextendr-api/src/markers.rs`.

## Approach

The new `assert_no_sibling_field_collision` const fn directly parallels `assert_no_payload_field_collision` from PR #542: both live in `miniextendr-api::markers`, both are `pub const fn` with `#[doc(hidden)]`, and both are called from `const _: ()` blocks emitted by the proc-macro. The const fn uses a three-part byte comparison (base prefix, `_` separator, tag suffix) since `format!` is unavailable in const context.

The parse-time B1 `syn::Error` (hardcoded `"variant"`) coexists with the new const assertion intentionally: the parse-time check fires earlier with a better span/message for the common default-tag case, while the const assertion silently handles the non-default-tag case without needing to inspect inner enum attributes from the outer macro parse phase.

Sibling names are collected across ALL variants (not just the variant that introduced the struct field) — a collision in any single variant is a bug regardless of which variant surfaces it.

## Validation

- cargo test: 308 passed, 66 ignored — no regressions; new UI test snapshot confirmed
- clippy_default: pass (`cargo clippy --workspace --all-targets --locked -- -D warnings`)
- clippy_all: pass (features: `rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,default-strict,default-coerce,default-r6,default-worker,jiff`)
- UI snapshot diff reviewed: new `.stderr` shows `E0080: evaluation panicked` at `#[derive(DataFrameRow)]` on `Outer` with "DataFrameRow B1 sibling-collision" message and `assert_no_sibling_field_collision` call stack
- devtools-test: N/A (devtools not installed in this worktree environment; PR is macro-only with no rpkg changes)
</details>