### PR TITLE
docs(api): tighten miniextendr_set_altrep_pkg_name safety contract (#533)

### DIFF
--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -327,6 +327,13 @@ pub static ALTREP_PKG_NAME: AltrepPkgName = AltrepPkgName;
 /// # Safety
 /// The provided pointer must point to a valid null-terminated C string
 /// that lives for the duration of the R session.
+///
+/// The strict requirement is narrower: R copies the bytes via `install()`
+/// inside each `R_make_alt*_class` call that consults this global (see
+/// `RegisterClass` in R's `src/main/altrep.c`), so the pointer only has to
+/// remain valid across those calls. We keep the session-lifetime contract
+/// because we don't track which registrations are still pending; a string
+/// literal passed from C satisfies both.
 #[doc(hidden)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn miniextendr_set_altrep_pkg_name(name: *const std::ffi::c_char) {


### PR DESCRIPTION
Closes #533.

Documents the narrower actual safety requirement on `miniextendr_set_altrep_pkg_name` without weakening the published contract. R copies the bytes via `install()` inside each `R_make_alt*_class` call that consults this global (`RegisterClass` in R's `src/main/altrep.c`), so the pointer only needs to remain valid across those calls — not for the full R session. We keep the conservative session-lifetime requirement because we don't track which registrations are still pending; a string literal passed from C satisfies both contracts.

Pure doc change. No code, no tests, no API churn.

<details><summary>🤖 AI-written (claude-opus-4-7 dispatcher, in-session implementation)</summary>

Direct in-session edit — issue is a 7-line doc comment fix, too small for the agent pipeline. Original audit and the two suggested wordings come from #533's filer; landed the conservative second option (keep contract, add explanatory note) so existing callers' invariants aren't weakened.

</details>
