### PR TITLE
test(dataframe): add 3-level nesting UI test for payload collision (#545)

### DIFF
--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs
@@ -1,0 +1,37 @@
+//! Test: 3-level nesting where the innermost struct has a payload field whose name
+//! collides with its own `#[dataframe(tag)]` discriminant column.
+//!
+//! Structure:
+//!   Inner (struct, tag = "variant") { variant: String }  ← collision
+//!   Middle (enum) { A { inner: Inner } }
+//!   Outer (enum) { X { middle: Middle } }
+//!
+//! Expected: compile error at `#[derive(DataFrameRow)]` on `Middle`, because
+//! `Middle::derive` emits `assert_no_payload_field_collision(<Inner as
+//! DataFramePayloadFields>::FIELDS, <Inner as DataFramePayloadFields>::TAG)` —
+//! and Inner::FIELDS contains "variant" which equals Inner::TAG = "variant".
+
+use miniextendr_macros::DataFrameRow;
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(tag = "variant")]
+enum Inner {
+    A,
+    B { variant: i32 }, // "variant" == Inner's tag → collision
+}
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(align)]
+enum Middle {
+    A { inner: Inner },
+    Other,
+}
+
+#[derive(Clone, Debug, DataFrameRow)]
+#[dataframe(align)]
+enum Outer {
+    X { middle: Middle },
+    Other,
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.stderr
@@ -1,0 +1,62 @@
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs:16:24
+   |
+16 | #[derive(Clone, Debug, DataFrameRow)]
+   |                        ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs:23:24
+   |
+23 | #[derive(Clone, Debug, DataFrameRow)]
+   |                        ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unexpected `cfg` condition value: `rayon`
+  --> tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs:30:24
+   |
+30 | #[derive(Clone, Debug, DataFrameRow)]
+   |                        ^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: `default-coerce`, `default-r6`, `default-s7`, `default-strict`, `default-worker`, `doc-lint`, and `vctrs`
+   = note: using a cfg inside a derive macro will use the cfgs from the destination crate and not the ones from the defining crate
+   = help: try referring to `DataFrameRow` crate for guidance on how handle this unexpected cfg
+   = help: the derive macro `DataFrameRow` may come from an old version of the `miniextendr_macros` crate, try updating your dependency with `cargo update -p miniextendr_macros`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
+   = note: this warning originates in the derive macro `DataFrameRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: DataFrameRow inner-payload field collision: an inner enum payload field has the same name as the inner enum's discriminant tag. After outer prefix expansion this produces two columns with identical names, causing silent data corruption. Rename the inner payload field or add `#[dataframe(rename = "...")]` on it to use a different column name.
+  --> tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs:23:24
+   |
+23 | #[derive(Clone, Debug, DataFrameRow)]
+   |                        ^^^^^^^^^^^^ evaluation of `_` failed inside this call
+   |
+note: inside `miniextendr_api::markers::assert_no_payload_field_collision`
+  --> $RUST/core/src/panic.rs
+   |
+   |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   |
+  ::: $WORKSPACE/miniextendr-api/src/markers.rs
+   |
+   | /             panic!(
+   | |                 "DataFrameRow inner-payload field collision: an inner enum payload field \
+   | |                  has the same name as the inner enum's discriminant tag. After outer prefix \
+   | |                  expansion this produces two columns with identical names, causing silent \
+   | |                  data corruption. Rename the inner payload field or add \
+   | |                  `#[dataframe(rename = \"...\")]` on it to use a different column name."
+   | |             );
+   | |_____________- in this macro invocation


### PR DESCRIPTION
This PR adds the missing 3-level nesting UI test requested in #545, confirming that the `assert_no_payload_field_collision` check from PR #542 does fire correctly in a 3-level `DataFrameRow` derive chain.

<details><summary>🤖 AI-written (claude-sonnet-4-6 implementer)</summary>

## What was verified

Issue #545 asked whether the collision check from PR #542 propagates transitively through a 3-level nesting:

```rust
#[derive(DataFrameRow)]
#[dataframe(tag = "variant")]
enum Inner {
    A,
    B { variant: i32 }, // collision: field name == tag
}

#[derive(DataFrameRow)]
enum Middle {
    A { inner: Inner },
}

#[derive(DataFrameRow)]
enum Outer {
    X { middle: Middle },
}
```

**Verdict: the check naturally fires — no macro changes needed.**

## How it works

Each `DataFrameRow` derive at its own site emits `const _: ()` assertions for all nested-enum fields it directly references. Specifically:

- `Middle::derive` emits `assert_no_payload_field_collision(<Inner as DataFramePayloadFields>::FIELDS, <Inner as DataFramePayloadFields>::TAG)` — this fires because `Inner::FIELDS = ["variant"]` and `Inner::TAG = "variant"` match.
- `Outer::derive` emits the same check for `Middle`, but `Middle::FIELDS` only contains single-column leaf fields (not transitively nested names), so it wouldn't catch the `Inner` collision on its own.

The check fires at the `#[derive(DataFrameRow)]` site on `Middle` (line 23 in the fixture), not at `Outer`. This is correct and expected: `Middle` must independently derive `DataFrameRow` for the outer nesting to typecheck at all, so its derive site is always present in the same compilation unit and the assertion is always reachable.

## Files changed

- `miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.rs` — new trybuild fixture (3-level chain, collision in `Inner`)
- `miniextendr-macros/tests/ui/derive_dataframe_enum_three_level_nesting_payload_collision.stderr` — snapshot showing `E0080: evaluation panicked` at `Middle::derive` with the payload-collision message

## Validation

- `TRYBUILD=overwrite cargo test -p miniextendr-macros` — 308 passed, 66 ignored; snapshot captured and accepted
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — no issues
- `cargo clippy --workspace --all-targets --locked --features rayon,rand,...,jiff -- -D warnings` (full CI feature list) — no issues

## Limitation note

`Outer::derive` alone does NOT catch the `Inner` collision — only `Middle::derive` does. A hypothetical scenario where `Middle` is not independently derived (impossible in practice since the codegen requires it) would be a false negative. This limitation is inherent to the per-derive-site assertion pattern and does not affect real user code. No GitHub issue filed as no actionable gap exists.

Closes #545.
</details>