### PR TITLE
feat(templates): add drift detection for shared justfile recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Check templates sync
         run: just templates-check
 
+      - name: Check template justfile recipe sync
+        run: just templates-recipes-check
+
       - name: Check lint parser sync
         run: just lint-sync-check
 

--- a/justfile
+++ b/justfile
@@ -950,6 +950,11 @@ templates-check-ci:
       exit 1
     fi
 
+# Check that shared recipe bodies in the two template justfiles stay in sync.
+# Recipes that are identical modulo {{rpkg}}/ path prefix are listed in the script.
+templates-recipes-check:
+    bash scripts/templates-recipes-check.sh
+
 # ==============================================================================
 # Vendor sync check (ensure vendored crates match workspace)
 # ==============================================================================

--- a/minirextendr/inst/templates/monorepo/justfile
+++ b/minirextendr/inst/templates/monorepo/justfile
@@ -78,6 +78,7 @@ rtest FILTER="": configure
     fi
 
 # Generate R documentation with devtools/roxygen2
+# Shared with rpkg/justfile — see scripts/templates-recipes-check.sh
 rdoc: configure
     Rscript -e 'devtools::document("{{rpkg}}")'
 
@@ -94,10 +95,12 @@ rbuild *args: configure
     cd {{rpkg}} && R CMD build {{args}} .
 
 # Run R CMD check
+# Shared with rpkg/justfile — see scripts/templates-recipes-check.sh
 rcheck: configure
     Rscript -e "rcmdcheck::rcmdcheck('{{rpkg}}', args = c('--as-cran', '--no-manual'), error_on = 'warning')"
 
 # Run devtools::check
+# Shared with rpkg/justfile — see scripts/templates-recipes-check.sh
 devtools-check: configure
     Rscript -e 'devtools::check("{{rpkg}}", error_on = "error")'
 
@@ -142,6 +145,8 @@ vendor-lib crate dev_path:
 # `just install` / `devtools::install("{{rpkg}}")` silently switch to tarball
 # mode (configure's only signal is `[ -f inst/vendor.tar.xz ]`), which freezes
 # out monorepo workspace-crate edits via `[patch."git+url"]`.
+#
+# Shared with rpkg/justfile — see scripts/templates-recipes-check.sh
 [script("bash")]
 cran-prep: vendor
     set -euo pipefail

--- a/minirextendr/inst/templates/rpkg/justfile
+++ b/minirextendr/inst/templates/rpkg/justfile
@@ -94,6 +94,7 @@ rtest FILTER="": _assert-no-vendor-leak configure
     fi
 
 # Generate R documentation with devtools/roxygen2
+# Shared with monorepo/justfile — see scripts/templates-recipes-check.sh
 rdoc: configure
     Rscript -e 'devtools::document(".")'
 
@@ -110,10 +111,12 @@ rbuild *args: configure
     R CMD build {{args}} .
 
 # Run R CMD check
+# Shared with monorepo/justfile — see scripts/templates-recipes-check.sh
 rcheck: configure
     Rscript -e "rcmdcheck::rcmdcheck('.', args = c('--as-cran', '--no-manual'), error_on = 'warning')"
 
 # Run devtools::check
+# Shared with monorepo/justfile — see scripts/templates-recipes-check.sh
 devtools-check: configure
     Rscript -e 'devtools::check(".", error_on = "error")'
 
@@ -148,6 +151,8 @@ vendor:
 # `just install` / `devtools::install(".")` silently switch to tarball mode
 # (configure's only signal is `[ -f inst/vendor.tar.xz ]`), which freezes out
 # any cargo-resolved dependency edits.
+#
+# Shared with monorepo/justfile — see scripts/templates-recipes-check.sh
 [script("bash")]
 cran-prep: vendor
     set -euo pipefail

--- a/scripts/templates-recipes-check.sh
+++ b/scripts/templates-recipes-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verify that shared recipe bodies in the two template justfiles stay aligned.
+#
+# Context: minirextendr/inst/templates/ has two template flavours:
+#   rpkg/justfile     - standalone R package
+#   monorepo/justfile - Rust workspace with an embedded R package
+#
+# Several recipes are intentionally identical modulo a {{rpkg}}/ path prefix
+# that the monorepo template prepends (because the R package lives in a
+# subdirectory). This script checks that those recipes have not drifted.
+#
+# Normalisation applied to the monorepo body before diffing:
+#   - Strip leading "{{rpkg}}/" from path arguments
+#   - Replace standalone "{{rpkg}}" (without trailing slash) with "."
+#
+# If a new shared recipe is added to both templates, append its name to
+# SHARED_RECIPES below.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RPKG_JF="$REPO_ROOT/minirextendr/inst/templates/rpkg/justfile"
+MONO_JF="$REPO_ROOT/minirextendr/inst/templates/monorepo/justfile"
+
+# Recipes that must be structurally identical (modulo {{rpkg}}/ prefix).
+# Recipes with intentional differences (e.g. vendor, rbuild, rtest, load,
+# devtools-install) are deliberately excluded.
+SHARED_RECIPES=(
+    cran-prep
+    rcheck
+    rdoc
+    devtools-check
+)
+
+# extract_recipe <file> <name>
+# Prints the recipe header + all indented/continuation lines until the next
+# top-level definition.  Comment lines (# ...) at column 0 are excluded:
+# they vary intentionally between templates (signpost comments, doc strings
+# of sibling recipes) and must not influence the comparison.
+# Works with both BSD awk (macOS) and GNU awk.
+extract_recipe() {
+    local file="$1" name="$2"
+    awk -v recipe="$name" '
+        # Stash just attribute annotations ([script(...)], [private], etc.)
+        /^[[:space:]]*\[/ { attr = $0; next }
+        # Skip top-level comment lines (not inside a recipe)
+        /^#/ { if (!in_recipe) { attr = ""; next } }
+        $0 ~ ("^" recipe "([[:space:]\\*:]|$)") {
+            if (attr != "") { print attr; attr = "" }
+            in_recipe = 1
+            print
+            next
+        }
+        # Clear stashed attribute on any non-attribute, non-matching top-level line
+        /^[a-zA-Z]/ { attr = "" }
+        in_recipe {
+            # Stop at the next top-level definition (letter or [ at col 0)
+            if (/^[a-zA-Z\[]/ ) { in_recipe = 0; exit }
+            # Skip comment lines inside the recipe body too (signpost comments
+            # differ between templates by design)
+            if (/^#/) { next }
+            print
+        }
+    ' "$file" | sed -e 's/[[:space:]]*$//'
+}
+
+# normalise_mono <body>
+# Strip "{{rpkg}}/" prefix from paths; replace bare "{{rpkg}}" with ".".
+normalise_mono() {
+    sed \
+        -e 's|{{rpkg}}/||g' \
+        -e 's|{{rpkg}}|.|g'
+}
+
+fail=0
+
+for recipe in "${SHARED_RECIPES[@]}"; do
+    rpkg_body="$(extract_recipe "$RPKG_JF" "$recipe")"
+    mono_body="$(extract_recipe "$MONO_JF" "$recipe" | normalise_mono)"
+
+    if [ -z "$rpkg_body" ]; then
+        printf 'ERROR: recipe "%s" not found in %s\n' "$recipe" "$RPKG_JF" >&2
+        fail=1
+        continue
+    fi
+    if [ -z "$mono_body" ]; then
+        printf 'ERROR: recipe "%s" not found in %s\n' "$recipe" "$MONO_JF" >&2
+        fail=1
+        continue
+    fi
+
+    diff_out="$(diff <(printf '%s\n' "$rpkg_body") <(printf '%s\n' "$mono_body") || true)"
+    if [ -n "$diff_out" ]; then
+        printf 'DRIFT in recipe "%s":\n' "$recipe" >&2
+        printf '%s\n' "$diff_out" >&2
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    printf '\nShared recipe drift detected. Edit both template justfiles to keep them in sync.\n' >&2
+    printf 'See scripts/templates-recipes-check.sh for the canonical list.\n' >&2
+    exit 1
+fi
+
+printf 'OK: all shared template justfile recipes are in sync.\n'


### PR DESCRIPTION
Adds CI guard for #538 so shared justfile recipes stay in sync.

<details><summary>🤖 AI-written (claude-sonnet-4-6 implementer)</summary>

## What this does

The two template justfiles (`minirextendr/inst/templates/rpkg/justfile` and `minirextendr/inst/templates/monorepo/justfile`) share several recipes that must stay structurally aligned — they differ only in that the monorepo template prepends a `{{rpkg}}/` path prefix (because the R package lives in a subdirectory of the workspace).

Previously there was no automated check for drift between these shared recipes.

## Implementation (Option 2 from the issue)

- **`scripts/templates-recipes-check.sh`**: extracts and diffs four shared recipe bodies (`cran-prep`, `rcheck`, `rdoc`, `devtools-check`), normalising the monorepo bodies by stripping the `{{rpkg}}/` prefix before comparing. Comment lines are excluded from comparison (signpost comments intentionally differ). Works on both BSD awk (macOS) and GNU awk.
- **`justfile`**: new `templates-recipes-check` recipe that invokes the script.
- **`.github/workflows/ci.yml`**: new step `Check template justfile recipe sync` added to the existing `sync-checks` job, alongside `Check templates sync` and `Check vendor sync`.
- **Both template justfiles**: signpost comments added above each shared recipe (`# Shared with <sibling>/justfile — see scripts/templates-recipes-check.sh`) so reviewers editing these files know to check both.

Recipes intentionally excluded from the check (they have structural differences beyond path prefix): `vendor`, `rbuild`, `rtest`, `load`, `devtools-install`, `version-*`.

## Verification

`just templates-recipes-check` passes on current main (no drift today — both files were landed in sync by PR #536).

Closes #538

</details>