### PR TITLE
fix(api): audit #499 PR A — core PROTECT/assert fixes

### DIFF
--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -633,7 +633,7 @@ pub trait RConnectionImpl: Sized + 'static {
 #[inline]
 unsafe fn get_state<T: RConnectionImpl>(conn: *mut Rconn) -> &'static mut T {
     let private = unsafe { (*conn).private };
-    debug_assert!(!private.is_null(), "Connection private pointer is null");
+    assert!(!private.is_null(), "Connection private pointer is null");
     unsafe { &mut *private.cast::<T>() }
 }
 

--- a/miniextendr-api/src/optionals/bytes_impl.rs
+++ b/miniextendr-api/src/optionals/bytes_impl.rs
@@ -643,7 +643,7 @@ mod tests {
 
     impl RBufMut for TestBufMut {
         fn remaining_mut(&self) -> i32 {
-            self.data.borrow().remaining_mut() as i32
+            i32::try_from(self.data.borrow().remaining_mut()).unwrap_or(i32::MAX)
         }
 
         fn put_u8(&self, val: i32) {
@@ -867,10 +867,9 @@ mod tests {
     #[test]
     fn test_rbufmut_has_remaining() {
         let buf = TestBufMut::with_capacity(10);
-        // BytesMut is growable, so remaining_mut() returns usize::MAX - len
-        // which when cast to i32 may overflow. But has_remaining_mut() uses > 0.
-        // For our test implementation, remaining_mut as i32 overflows to negative,
-        // so let's just check that we can write to the buffer.
+        // BytesMut is growable: remaining_mut() returns usize::MAX - len, which
+        // saturates to i32::MAX via try_from. has_remaining_mut() returns true.
+        assert!(buf.remaining_mut() > 0);
         buf.put_u8(1);
         assert_eq!(buf.len(), 1);
     }

--- a/miniextendr-api/src/optionals/indexmap_impl.rs
+++ b/miniextendr-api/src/optionals/indexmap_impl.rs
@@ -51,8 +51,9 @@
 
 pub use indexmap::IndexMap;
 
-use crate::ffi::{R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{R_xlen_t, Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
+use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
 
 // region: TryFromSexp for IndexMap<String, T>
@@ -129,30 +130,23 @@ where
     type Error = std::convert::Infallible;
 
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
-        Ok(unsafe {
-            let n = self.len();
-            let list = Rf_allocVector(SEXPTYPE::VECSXP, n as R_xlen_t);
-            Rf_protect(list);
+        let n = self.len();
+        let list = unsafe { OwnedProtect::new(Rf_allocVector(SEXPTYPE::VECSXP, n as R_xlen_t)) };
+        let names = unsafe { OwnedProtect::new(Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t)) };
 
-            // Allocate names vector
-            let names = Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t);
-            Rf_protect(names);
-
-            for (i, (key, value)) in self.into_iter().enumerate() {
-                // Set list element
-                list.set_vector_elt(i as R_xlen_t, value.into_sexp());
-
-                // Set name
+        for (i, (key, value)) in self.into_iter().enumerate() {
+            // `value.into_sexp()` and `checked_mkchar` can trigger GC;
+            // `list` and `names` are protected for the duration by OwnedProtect.
+            unsafe {
+                list.get().set_vector_elt(i as R_xlen_t, value.into_sexp());
                 let charsxp = crate::altrep_impl::checked_mkchar(&key);
-                names.set_string_elt(i as R_xlen_t, charsxp);
+                names.get().set_string_elt(i as R_xlen_t, charsxp);
             }
+        }
 
-            // Attach names attribute
-            list.set_names(names);
-
-            Rf_unprotect(2);
-            list
-        })
+        list.get().set_names(names.get());
+        // Guards drop here; the returned SEXP is rooted by the caller.
+        Ok(list.get())
     }
 }
 // endregion

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -422,9 +422,8 @@ fn array_to_sexp(arr: &[TomlValue]) -> SEXP {
                 });
 
                 if all_fit {
-                    // Protect sexp: the fill loop calls i32::try_from which may
-                    // theoretically allocate on some platforms (and consistency
-                    // with the String/float/boolean branches matters for R-devel GC).
+                    // Protect sexp for consistency with the String/float/boolean
+                    // branches — PROTECT discipline against R-devel's aggressive GC.
                     let sexp = unsafe {
                         OwnedProtect::new(Rf_allocVector(
                             SEXPTYPE::INTSXP,

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -422,64 +422,68 @@ fn array_to_sexp(arr: &[TomlValue]) -> SEXP {
                 });
 
                 if all_fit {
+                    // Protect sexp: the fill loop calls i32::try_from which may
+                    // theoretically allocate on some platforms (and consistency
+                    // with the String/float/boolean branches matters for R-devel GC).
                     let sexp = unsafe {
-                        Rf_allocVector(
+                        OwnedProtect::new(Rf_allocVector(
                             SEXPTYPE::INTSXP,
                             isize::try_from(arr.len()).expect("length exceeds R_xlen_t"),
-                        )
+                        ))
                     };
-                    let dst: &mut [i32] = unsafe { SexpExt::as_mut_slice(&sexp) };
+                    let dst: &mut [i32] = unsafe { SexpExt::as_mut_slice(&sexp.get()) };
                     for (i, v) in arr.iter().enumerate() {
                         if let TomlValue::Integer(n) = v {
                             dst[i] = i32::try_from(*n).expect("validated by i64_fits_r_int");
                         }
                     }
-                    return sexp;
+                    return sexp.get();
                 }
                 // Fall back to REALSXP if any value is out of range
                 let sexp = unsafe {
-                    Rf_allocVector(
+                    OwnedProtect::new(Rf_allocVector(
                         SEXPTYPE::REALSXP,
                         isize::try_from(arr.len()).expect("length exceeds R_xlen_t"),
-                    )
+                    ))
                 };
-                let dst: &mut [f64] = unsafe { SexpExt::as_mut_slice(&sexp) };
+                let dst: &mut [f64] = unsafe { SexpExt::as_mut_slice(&sexp.get()) };
                 for (i, v) in arr.iter().enumerate() {
                     if let TomlValue::Integer(n) = v {
                         dst[i] = i64_precise_as_f64(*n);
                     }
                 }
-                return sexp;
+                return sexp.get();
             }
             TomlValue::Float(_) => {
                 let sexp = unsafe {
-                    Rf_allocVector(
+                    OwnedProtect::new(Rf_allocVector(
                         SEXPTYPE::REALSXP,
                         isize::try_from(arr.len()).expect("length exceeds R_xlen_t"),
-                    )
+                    ))
                 };
-                let dst: &mut [f64] = unsafe { SexpExt::as_mut_slice(&sexp) };
+                let dst: &mut [f64] = unsafe { SexpExt::as_mut_slice(&sexp.get()) };
                 for (i, v) in arr.iter().enumerate() {
                     if let TomlValue::Float(f) = v {
                         dst[i] = *f;
                     }
                 }
-                return sexp;
+                return sexp.get();
             }
             TomlValue::Boolean(_) => {
                 let sexp = unsafe {
-                    Rf_allocVector(
+                    OwnedProtect::new(Rf_allocVector(
                         SEXPTYPE::LGLSXP,
                         isize::try_from(arr.len()).expect("length exceeds R_xlen_t"),
-                    )
+                    ))
                 };
-                let dst: &mut [crate::ffi::RLogical] = unsafe { SexpExt::as_mut_slice(&sexp) };
+                let dst: &mut [crate::ffi::RLogical] =
+                    unsafe { SexpExt::as_mut_slice(&sexp.get()) };
                 for (i, v) in arr.iter().enumerate() {
                     if let TomlValue::Boolean(b) = v {
                         dst[i] = crate::ffi::RLogical::from(*b);
                     }
                 }
-                return sexp;
+                return sexp.get();
             }
             _ => {
                 // Tables, arrays, datetimes - fall through to list

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -307,6 +307,52 @@ pub fn gc_stress_jiff_zoned_vec() {
     }
 }
 
+/// Exercise `array_to_sexp` PROTECT discipline for integer, float, and boolean
+/// TOML arrays under GC pressure.
+///
+/// Constructs `TomlValue::Array` values covering the four homogeneous branches
+/// of `array_to_sexp` and converts each to SEXP via `IntoR`, verifying that
+/// the `OwnedProtect` guards keep each allocation live across the fill loop.
+/// No arguments — suitable for the fast gctorture no-arg fixture sweep.
+#[cfg(feature = "toml")]
+#[miniextendr]
+pub fn gc_stress_toml_array() {
+    use miniextendr_api::into_r::IntoR as _;
+    use miniextendr_api::toml_impl::TomlValue;
+
+    // Integer branch (all fit in i32) → INTSXP
+    let int_arr = TomlValue::Array(vec![
+        TomlValue::Integer(1),
+        TomlValue::Integer(2),
+        TomlValue::Integer(i64::from(i32::MAX)),
+    ]);
+    let _ = int_arr.into_sexp();
+
+    // Integer branch (one value exceeds i32 range) → REALSXP fallback
+    let big_int_arr = TomlValue::Array(vec![
+        TomlValue::Integer(1),
+        TomlValue::Integer(i64::from(i32::MAX) + 1),
+        TomlValue::Integer(3),
+    ]);
+    let _ = big_int_arr.into_sexp();
+
+    // Float branch → REALSXP
+    let float_arr = TomlValue::Array(vec![
+        TomlValue::Float(1.1),
+        TomlValue::Float(2.2),
+        TomlValue::Float(3.3),
+    ]);
+    let _ = float_arr.into_sexp();
+
+    // Boolean branch → LGLSXP
+    let bool_arr = TomlValue::Array(vec![
+        TomlValue::Boolean(true),
+        TomlValue::Boolean(false),
+        TomlValue::Boolean(true),
+    ]);
+    let _ = bool_arr.into_sexp();
+}
+
 /// Convert an R vector to an ALTREP-backed vector by materializing then re-wrapping.
 /// Dispatches on `type_of()`: INTSXP, REALSXP, STRSXP.
 /// @param x An integer, numeric, or character vector to convert.


### PR DESCRIPTION
Flight 1 / PR A from #499. Four small correctness fixes in `miniextendr-api/src/`.

<details>
<summary>AI-written breakdown (Claude Sonnet 4.6, drafted via planner → implementer pipeline)</summary>

## Summary

Per the [Flight 1 plan](https://github.com/A2-ai/miniextendr/blob/main/journal/2026-05-16-flight1-499-plan.md), this PR groups the four `still-applies` audit residuals that all live under `miniextendr-api/src/` and touch FFI PROTECT / assert discipline.

### Commits (in order)

1. **`fix(connection): runtime assert null private pointer`** — `connection.rs:636` `debug_assert!` → `assert!`. The null check is elided in release builds today; promoting to runtime makes the catastrophic-UB site safe in all profiles.
2. **`fix(toml): OwnedProtect integer/float/boolean array branches`** — `toml_impl.rs::array_to_sexp` had its String branch wrapped in `OwnedProtect` but the Integer (×2 — INTSXP path + REALSXP fallback), Float, and Boolean branches returned unprotected SEXPs. Brought all four into line with the String branch's pattern. Also adds a no-arg `gc_stress_toml_array()` fixture in `rpkg/src/rust/gc_stress_fixtures.rs` (gated on `#[cfg(feature = "toml")]`) per the #430 convention — exercises all four homogeneous array branches.
3. **`fix(bytes): replace lossy as-cast in TestBufMut::remaining_mut`** — test impl was doing `self.data.borrow().remaining_mut() as i32` for a growable `BytesMut` whose `remaining_mut()` returns `usize::MAX - len`. Replaced with `i32::try_from(...).unwrap_or(i32::MAX)` (matches the trait-docs pattern at `bytes_impl.rs:248–249`). Replaced the apologetic comment in `test_rbufmut_has_remaining` with an assertion that exercises the now-correct behaviour.
4. **`fix(indexmap): migrate IndexMap IntoR to OwnedProtect`** — replaced the manual `Rf_protect(list); Rf_protect(names); … Rf_unprotect(2)` in `IndexMap<String, T>::try_into_sexp` with `OwnedProtect`. `value.into_sexp()` and `checked_mkchar` both allocate inside the fill loop; RAII guards root both vectors for the duration. Drops the unused `Rf_protect`/`Rf_unprotect` imports.

### Validation

- `just configure` — clean (source mode, monorepo override).
- `cargo lcheck -p miniextendr-api --features 'toml bytes indexmap'` — passes.
- `cargo ltest -p miniextendr-api --features 'toml bytes indexmap'` — 5 doctests pass, 221 ignored, 0 failed.
- `just rcmdinstall` — passes from the worktree.
- `just devtools-test` — 5887 PASS, 29 SKIP, 1 FAIL pre-existing on a different branch (`test-arrow.R:157` ragged-RecordBatch test belongs to audit item #11 / PR B's scope; not in `origin/main`).
- `just clippy` (CI's `clippy_default`) — passes.
- `cargo clippy --workspace --all-targets --locked --features '<CI clippy_all curated list>' -- -D warnings` — passes.

### Things explicitly NOT in this PR

Per the planner's scope notes:
- Audit items 1, 2, 4, 5, 6, 8, 9, 15, 16 — already fixed since the audit was written.
- Audit items 10, 11 — PR B (Arrow doc + RecordBatch column-length pre-validation).
- Audit item 19 — PR C (GC_PROTECT.md ProtectPool section).
- Audit items 7, 12, 14, 20 — `needs-decision`, surfaced to the maintainer separately.

Refs #499 (items 3, 13, 17, 18)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)