### PR TITLE
fix(api): audit #499 PR B — arrow_impl doc + RecordBatch validation

### DIFF
--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -362,12 +362,15 @@ unsafe fn sexp_to_arrow_buffer<T: RNativeType>(sexp: SEXP) -> Option<arrow_buffe
 ///
 /// # Allocation failure
 ///
-/// `Rf_allocVector` raises an R error (longjmp) on OOM rather than returning
-/// a null pointer. The framework's `R_UnwindProtect` wrapper catches this
-/// longjmp and converts it to a Rust panic, which surfaces to the caller as a
-/// "memory exhausted" R error. The two `.expect()` calls in the body are
-/// therefore unreachable in production — they guard against logic errors
-/// (wrong `len` encoding or unexpected null pointer), not against OOM.
+/// If `Rf_allocVector` cannot satisfy the request, R longjmps from inside
+/// the allocation. `R_UnwindProtect` catches the longjmp, the framework
+/// recognises the R-origin path via `RErrorMarker`, and `R_ContinueUnwind`
+/// re-raises R's original `Error: vector memory exhausted (limit reached?)`
+/// verbatim. The error message is R's, not Rust's — no tagged-SEXP synthesis
+/// happens on this path (cf. `with_r_unwind_protect_error_in_r`). The two
+/// `.expect()` calls in the body are therefore unreachable in production —
+/// they guard against logic errors (wrong `len` encoding or unexpected null
+/// pointer), not against OOM.
 ///
 /// # Example
 ///

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -1035,6 +1035,23 @@ impl TryFromSexp for RecordBatch {
             columns.push(array);
         }
 
+        // Validate that all columns have the same length before calling
+        // RecordBatch::try_new, which would otherwise emit a generic error.
+        if let Some(first) = columns.first() {
+            let nrow = first.len();
+            for (i, col) in columns.iter().enumerate().skip(1) {
+                if col.len() != nrow {
+                    return Err(SexpError::InvalidValue(format!(
+                        "column '{}' has length {} but column '{}' has length {}",
+                        names[i],
+                        col.len(),
+                        names[0],
+                        nrow,
+                    )));
+                }
+            }
+        }
+
         let schema = Arc::new(Schema::new(fields));
         RecordBatch::try_new(schema, columns).map_err(|e| SexpError::InvalidValue(e.to_string()))
     }

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -360,6 +360,15 @@ unsafe fn sexp_to_arrow_buffer<T: RNativeType>(sexp: SEXP) -> Option<arrow_buffe
 ///
 /// Must be called on R's main thread.
 ///
+/// # Allocation failure
+///
+/// `Rf_allocVector` raises an R error (longjmp) on OOM rather than returning
+/// a null pointer. The framework's `R_UnwindProtect` wrapper catches this
+/// longjmp and converts it to a Rust panic, which surfaces to the caller as a
+/// "memory exhausted" R error. The two `.expect()` calls in the body are
+/// therefore unreachable in production — they guard against logic errors
+/// (wrong `len` encoding or unexpected null pointer), not against OOM.
+///
 /// # Example
 ///
 /// ```ignore

--- a/rpkg/tests/testthat/test-arrow.R
+++ b/rpkg/tests/testthat/test-arrow.R
@@ -149,6 +149,18 @@ test_that("RecordBatch handles mixed types", {
   expect_true(is.na(result$chr[2]))
 })
 
+test_that("RecordBatch rejects ragged columns with offending name in error", {
+  # Pass a named list (VECSXP) with columns of unequal lengths.
+  # The pre-validation in TryFromSexp for RecordBatch should catch this and
+  # name the offending column before RecordBatch::try_new sees it.
+  ragged <- list(x = c(1.0, 2.0, 3.0), y = c(10L, 20L))
+  expect_error(
+    arrow_recordbatch_roundtrip(ragged),
+    regexp = "'y'",
+    fixed = FALSE
+  )
+})
+
 # endregion
 
 # region: ArrayRef (dynamic dispatch)


### PR DESCRIPTION
Flight 1 PR B from the #499 audit residuals — two small Arrow-side fixes,
one doc-only and one error-message improvement with a testthat fixture.

<details>
<summary>AI-generated description (Sonnet 4.6)</summary>

## Summary

Addresses items 10 and 11 of the #499 audit (Flight 1 PR B):

- **Item 10** (`84b6fa40`): adds a `# Allocation failure` doc section to
  `alloc_r_backed_buffer` explaining that `Rf_allocVector` longjmps on OOM
  and the framework's `R_UnwindProtect` wrapper converts it to a Rust panic
  surfacing as a "memory exhausted" R error — so the two `.expect()` calls
  in the body are unreachable in production.
- **Item 11** (`a5ded5dd`): adds a column-length pre-validation pass to
  `TryFromSexp for RecordBatch` so the error message names the offending
  column (and the reference column it disagrees with) before reaching
  `RecordBatch::try_new`, which would otherwise emit a generic Arrow error.

## Test plan

- New testthat fixture in `rpkg/tests/testthat/test-arrow.R`:
  `"RecordBatch rejects ragged columns with offending name in error"` —
  passes a named list with column `y` shorter than column `x` to
  `arrow_recordbatch_roundtrip` and asserts the error message contains the
  offending column name `'y'`. The ragged list reaches the new validation
  block (columns build successfully one at a time before the cross-column
  length check), so the test exercises the new code path rather than an
  existing error.
- Local validation:
  - `cargo lcheck -p miniextendr-api --features arrow` passes
  - `cargo clippy --workspace --all-targets --locked -- -D warnings` passes
  - `cargo clippy ... --features <ci.yml clippy_all curated list> -- -D warnings` passes
  - Skipping local `just devtools-test` per coordinator (worktree `rv/`
    has no deps installed); CI will run the full test.

## Scope discipline

- No refactor of `TryFromSexp for RecordBatch` beyond the new pre-validation
  block.
- Item 10 is doc-only; item 11 is ~17 lines of new validation logic.

Refs #499 (items 10, 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>