### PR TITLE
ci(pages): mark rpkg rustdoc steps continue-on-error (#79)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,10 +55,17 @@ jobs:
       # ../../vendor/miniextendr-api etc. Populate vendor/ so the
       # patch paths resolve. `just vendor` calls `cargo revendor` directly;
       # does NOT need autoconf or `just configure` (no Rscript, no Makevars).
+      #
+      # The rpkg rustdoc build requires `just vendor` (autoconf + cargo-revendor
+      # + R headers) and adds ~5 min plus failure points. Mark these steps
+      # continue-on-error so the site still deploys when rpkg-specific tooling
+      # regresses; workspace rustdoc + Zola build remain strict (#79).
       - name: Install cargo-revendor
+        continue-on-error: true
         run: cargo install --path cargo-revendor
 
       - name: Restore rpkg vendor directory cache
+        continue-on-error: true
         id: rpkg-vendor-cache
         uses: actions/cache/restore@v5
         with:
@@ -66,14 +73,17 @@ jobs:
           key: ${{ runner.os }}-rpkg-vendor-${{ hashFiles('Cargo.lock', 'rpkg/src/rust/Cargo.lock', 'miniextendr-api/**/*.rs', 'miniextendr-macros/**/*.rs', 'miniextendr-lint/**/*.rs') }}
 
       - name: Install just
+        continue-on-error: true
         if: steps.rpkg-vendor-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@just
 
       - name: Generate rpkg/vendor
+        continue-on-error: true
         if: steps.rpkg-vendor-cache.outputs.cache-hit != 'true'
         run: just vendor
 
       - name: Save rpkg vendor directory cache
+        continue-on-error: true
         if: steps.rpkg-vendor-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
@@ -81,6 +91,7 @@ jobs:
           key: ${{ steps.rpkg-vendor-cache.outputs.cache-primary-key }}
 
       - name: Build rustdoc (rpkg)
+        continue-on-error: true
         env:
           RUSTFLAGS: --cfg=docsrs
           RUSTDOCFLAGS: >-
@@ -97,6 +108,7 @@ jobs:
       # build produced with --enable-index-page. After merging, regenerate
       # crates.js so the workspace index links to rpkg crates too.
       - name: Merge rpkg rustdoc into main docs
+        continue-on-error: true
         run: |
           if [ -d rpkg/src/rust/target/doc ]; then
             # Copy rpkg crate directories but preserve workspace index.html,


### PR DESCRIPTION
## Summary
- Mark the rpkg-specific rustdoc chain in `.github/workflows/pages.yml` as `continue-on-error: true`.
- Workspace rustdoc + Zola build remain strict — only the rpkg-extension steps can soft-fail.

## Why
The rpkg rustdoc build requires `just vendor` (autoconf + cargo-revendor + R headers) and adds ~5 min plus several failure points. A regression in any of those tools currently breaks the entire site deploy. Per #79, the rpkg crate docs are bonus content — the workspace rustdoc at `/rustdoc/` is what users land on.

## Steps marked continue-on-error
- `Install cargo-revendor`
- `Restore rpkg vendor directory cache`
- `Install just`
- `Generate rpkg/vendor`
- `Save rpkg vendor directory cache`
- `Build rustdoc (rpkg)`
- `Merge rpkg rustdoc into main docs`

## NOT changed (must remain strict)
- `Build rustdoc (workspace crates)` — primary deliverable
- Zola build, upload artifact, deploy

## Test plan
- [ ] `yaml.safe_load(...)` parses cleanly
- [ ] Inspect workflow YAML diff: no `continue-on-error` on workspace rustdoc / Zola / deploy steps
- [ ] Next pages workflow run still produces a deployable site

## Follow-up
A separate issue should be opened to surface rpkg-rustdoc soft-failures in the workflow summary via an `::warning::` annotation, so silent regressions stay visible.