### PR TITLE
feat(release-workflow): pin macOS SDK and CRAN libs prefix in scaffolded template

### DIFF
--- a/docs/CRAN_COMPATIBILITY.md
+++ b/docs/CRAN_COMPATIBILITY.md
@@ -211,6 +211,82 @@ See CLAUDE.md "Vendor tarball is a latch" for the full context and the
 - `[ -f inst/vendor.tar.xz ]` is the only source-vs-tarball signal. Don't add
   a second one. Maintenance load lives in the number of switches.
 
+## Toolchain ABI matching
+
+The vendoring story above keeps **Rust dependency sources** in sync between
+maintainer and CRAN's builder. A second, orthogonal problem is keeping the
+**Rust toolchain's compile-time targets** (SDK, deployment floor, system
+library prefix) in sync with the C toolchain CRAN's R was built with. A
+mismatch here produces `.so`s that link locally and segfault under CRAN's R,
+or trip `--as-cran` notes about deployment-target drift.
+
+miniextendr defends against this with three layered checks. The first two are
+load-bearing, the third documents the values.
+
+### Layer 1 — Per-install floor (`./configure` emits `[env]`)
+
+`./configure` derives `MACOSX_DEPLOYMENT_TARGET` (and equivalents) from the
+host R's `R CMD config CC` flags at install time, then writes them into
+`.cargo/config.toml`'s `[env]` table. Every `R CMD INSTALL` of the
+miniextendr-based package — including end-user installs that never see a
+GitHub Actions runner — picks up the same values R is configured against.
+
+This is the load-bearing layer for end users. They don't run the release
+workflow; they `install.packages()` (binary) or `R CMD INSTALL` (source) and
+expect the result to work with the R they have.
+
+### Layer 2 — CI overlay (`r-release.yml` workflow `env:` pins)
+
+The CI workflow that produces release binaries pins the **CRAN-canonical**
+values directly via `MACOSX_DEPLOYMENT_TARGET` in `$GITHUB_ENV` plus
+`xcode-select -s` to select the matching SDK. These override whatever Layer 1
+derived: the release artifact targets CRAN's exact ABI floor, not the
+runner's host R's floor.
+
+GitHub Actions shell `env:` wins over cargo `[env]` by default (cargo's
+`[env]` table is "set if not already set" semantics), so the two layers
+cooperate without conflict: CI uses the pinned values, end-user installs use
+whatever the host R reports.
+
+The same workflow also prefetches CRAN's curated system libraries
+(`r-universe-org/macos-libs`) into `/opt/R/<arch>/lib` and points
+`PKG_CONFIG_PATH` at them, so any Rust `-sys` crate's `pkg-config` lookup
+resolves against the same C libraries CRAN's R was linked with.
+
+See [RELEASE_WORKFLOW.md Gotchas 5 and 6](./RELEASE_WORKFLOW.md#gotcha-5-macos-sdk-and-deployment-target-must-match-cran)
+for the exact YAML snippets and citations.
+
+### Layer 3 — Documented canonical values
+
+The current CRAN-canonical pins are:
+
+| Platform | Arch | Pin | Source |
+|---|---|---|---|
+| macOS | arm64 | `MACOSX_DEPLOYMENT_TARGET=11.0` for the **toolchain**; `14.0` for the **binary** | [R-admin §"Building binary packages"](https://github.com/r-devel/r-svn/blob/master/doc/manual/R-admin.texi#L5854) — `Xcode_26.0` |
+| macOS | x86_64 | `MACOSX_DEPLOYMENT_TARGET=11.0` | R-admin (same) — `Xcode_16.2` |
+| Windows | x86_64 | rtools45 / GCC 14, mingw runtime release `6768` | [`r-windows/rtools-base`](https://github.com/r-windows/rtools-base) |
+| Linux | x86_64 | distro-supplied glibc; no per-platform pin | n/a |
+
+The Windows rtools version is **not currently consumed** by miniextendr's
+template — there's no `build-windows` job in `r-release.yml` yet. The value
+is documented here for completeness, and configure handles the rtools linker
+pin for end-user Windows installs already once the per-install `[env]` floor
+lands. See [issue tracker](https://github.com/A2-ai/miniextendr/issues?q=is%3Aissue+rtools+windows) for the rtools rebase cadence.
+
+### How to update the pins when CRAN moves
+
+CRAN's macOS binary build moves SDKs roughly once per major macOS release.
+When it does, three places must be updated in lockstep:
+
+1. `minirextendr/inst/templates/r-release.yml` — the `xcode-select -s` path
+   and `MACOSX_DEPLOYMENT_TARGET` value in the "Pin macOS SDK and deployment
+   target" step.
+2. `docs/RELEASE_WORKFLOW.md` Gotcha 5 — the version table and prose.
+3. This file — the table in "Layer 3" above.
+
+Cross-reference `r-devel/actions/setup-macos-tools` to confirm the upstream
+values; the `r-devel/actions` repo tracks CRAN's actual build matrix.
+
 ## Symbols cleanup, for grep-bait
 
 Removed entirely from this codebase:

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -2,15 +2,17 @@
 
 Every miniextendr consumer eventually writes an `r-release.yml` GitHub Actions
 workflow that builds and checks their package on multiple platforms. AlmaLinux 8
-containers and macOS arm64 runners surface four reproducible gotchas that
-downstream maintainers hit independently. This document explains each one, gives
-the canonical fix, and explains why miniextendr's own locale check exists — so
-you know not to file a bug upstream.
+containers and macOS runners surface six reproducible gotchas that downstream
+maintainers hit independently. The first four are locale / auth issues uncovered
+in issue #448; the last two align the macOS Rust toolchain ABI with CRAN's
+binary distribution. This document explains each one, gives the canonical fix,
+and explains why miniextendr's own locale check exists — so you know not to file
+a bug upstream.
 
 Use `minirextendr::use_release_workflow()` to scaffold a template that has all
-four fixes already baked in.
+six fixes already baked in.
 
-## The four gotchas
+## The six gotchas
 
 ### Gotcha 1: AlmaLinux 8 minimal defaults to the `C` locale
 
@@ -129,6 +131,121 @@ jobs:
 
 `CARGO_NET_GIT_FETCH_WITH_CLI=true` is safe to set at the workflow level —
 it has no negative effect on AlmaLinux or any other platform.
+
+### Gotcha 5: macOS SDK and deployment target must match CRAN
+
+CRAN's macOS binary R is built against a specific Xcode SDK with a specific
+`MACOSX_DEPLOYMENT_TARGET`. The current binary targets (per `R Installation
+and Administration` §"Building binary packages", r-svn
+[`doc/manual/R-admin.texi:5854-5867`](https://github.com/r-devel/r-svn/blob/master/doc/manual/R-admin.texi#L5854))
+are:
+
+| Arch | macOS target | Deployment floor |
+|---|---|---|
+| arm64 | Sonoma 14 | `MACOSX_DEPLOYMENT_TARGET=14.0` |
+| x86_64 | Big Sur 11 | `MACOSX_DEPLOYMENT_TARGET=11.0` |
+
+If a GitHub Actions runner builds Rust artefacts against a different SDK or
+without a deployment-target pin, two things break under CRAN's R:
+
+- The Rust `cdylib` / `staticlib` emits load commands referencing newer SDK
+  symbols. R's package linker (built against CRAN's SDK) can't resolve them,
+  so `R CMD INSTALL` fails or the resulting `.so` segfaults on load.
+- `dyld` mismatch warnings ("was built for newer macOS version (X) than being
+  linked (Y)") appear in `R CMD check` and trip `--as-cran` notes.
+
+**Fix**: select the matching Xcode and export the deployment target in
+`$GITHUB_ENV` before any Rust toolchain install or cargo build. The pin
+**must run before** `dtolnay/rust-toolchain` and `r-lib/actions/setup-r` so
+both pick up the value. Branch on `uname -m` so the same step works on both
+runners:
+
+```yaml
+- name: Pin macOS SDK and deployment target
+  run: |
+    if [ "$(uname -m)" = "x86_64" ]; then
+      sudo xcode-select -s /Applications/Xcode_16.2.app || true
+      echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
+    else
+      sudo xcode-select -s /Applications/Xcode_26.0.app || true
+      echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+    fi
+    echo "xcode is set: $(xcode-select --print-path)"
+    xcrun --show-sdk-version || true
+```
+
+The values track
+[`r-devel/actions/setup-macos-tools@ec72e88`](https://github.com/r-devel/actions/blob/ec72e88/setup-macos-tools/action.yml#L17-L28).
+The scaffolded template inlines (rather than `uses:`-references) those lines
+so the workflow stays hermetic if the upstream repo is ever archived or
+restructured.
+
+**Why inlined, not `uses:`-referenced?** `r-devel/actions` is a small,
+maintainer-driven repository; a deletion or refactor would silently break
+every downstream workflow that referenced it. Inlining trades a one-line
+`uses:` for ~10 lines of explicit shell that the maintainer can audit and the
+runner can execute without an external repo lookup.
+
+**Per-install floor.** configure also emits these values in
+`.cargo/config.toml` `[env]` so end-user `R CMD INSTALL` (no GitHub Actions
+involvement) gets the same pins derived from the host's R. The workflow pin
+is the CI overlay that locks the values for release builds independent of
+whatever R is installed on the runner. See
+[CRAN_COMPATIBILITY.md](./CRAN_COMPATIBILITY.md#toolchain-abi-matching) for
+the layered defense.
+
+### Gotcha 6: CRAN system libraries on macOS
+
+CRAN's macOS binary R is linked against a curated set of system libraries
+(libcurl, openssl, libtiff, libwebp, …) staged under `/opt/R/<arch>/lib`,
+built and packaged by
+[`r-universe-org/macos-libs`](https://github.com/r-universe-org/macos-libs).
+A Rust crate with a `-sys` C dependency (e.g. `openssl-sys`, `curl-sys`,
+`libtiff-sys`) that uses `pkg-config` to discover its system library will, on
+a stock GitHub Actions macOS runner, resolve against **Homebrew's** version
+rather than CRAN's. The two ABIs are not always compatible — same SONAME,
+different symbol exports — and packages that pass locally segfault under
+CRAN's R.
+
+**Fix**: prefetch the curated tarball into `/opt/`, then point
+`PKG_CONFIG_PATH` at `/opt/R/<arch>/lib/pkgconfig`. Any subsequent
+`cargo build` of a `-sys` crate resolves against the same library set CRAN
+built against:
+
+```yaml
+- name: Download CRAN system libraries
+  run: |
+    sudo mkdir -p /opt
+    sudo chown $USER /opt
+    curl --retry 3 --fail-with-body -sSL \
+      https://github.com/r-universe-org/macos-libs/releases/download/2025-12-13/cranlibs-everything.tar.xz \
+      -o libs.tar.xz
+    sudo tar -xf libs.tar.xz -C / opt
+    rm -f libs.tar.xz
+    echo "PKG_CONFIG_PATH=/opt/R/$(uname -m)/lib/pkgconfig:/opt/R/$(uname -m)/share/pkgconfig" >> $GITHUB_ENV
+```
+
+The tarball URL pins a specific release date so the workflow is reproducible
+across re-runs. Bump the URL when the upstream repo cuts a new release; the
+underlying library versions only change when CRAN itself updates them.
+Inlined from
+[`r-devel/actions/setup-macos-tools@ec72e88`](https://github.com/r-devel/actions/blob/ec72e88/setup-macos-tools/action.yml#L44-L53)
+for the same hermetic reason as Gotcha 5.
+
+**What was skipped from upstream** (and why):
+
+- `brew unlink $(brew list --formula)` — destructive on shared runners and
+  unnecessary once `PKG_CONFIG_PATH` is set (cargo's `pkg-config` lookup
+  prefers the listed paths over the system default).
+- gfortran install — no Fortran-linked Rust deps in miniextendr today.
+  Downstream packages that depend on a Fortran library (e.g. via a `-sys`
+  crate wrapping LAPACK) can add it back.
+- TinyTeX — the default scaffold builds with `--no-manual`, so no PDF
+  toolchain is required.
+- xQuartz — no X11 dependencies in the default scaffold.
+- Adding `/opt/R/<arch>/bin` to `$GITHUB_PATH` — `r-lib/actions/setup-r`
+  installs R independently and puts its `bin/` on PATH; the upstream's path
+  addition is for runs that don't use `setup-r`.
 
 ## Why `package_init` checks for UTF-8
 

--- a/minirextendr/inst/templates/r-release.yml
+++ b/minirextendr/inst/templates/r-release.yml
@@ -1,8 +1,12 @@
-# This template encodes four platform gotchas surfaced by issue #448:
+# This template encodes six platform gotchas:
 #   1. LANG=C.UTF-8 scoped to container jobs (AlmaLinux 8 has no UTF-8 locale by default)
 #   2. NOT set workflow-level (macOS rejects C.UTF-8 — glibc-only locale identifier)
 #   3. AlmaLinux minimal needs `dnf install git gh` + `gh auth setup-git`
 #   4. CARGO_NET_GIT_FETCH_WITH_CLI=true for cargo + private git deps on both platforms
+#   5. macOS SDK + MACOSX_DEPLOYMENT_TARGET pinned to CRAN's binary-distribution targets
+#   6. CRAN system libraries (libcurl, openssl, libtiff, …) prefetched into /opt/R/<arch>
+# Gotchas 1–4 from issue #448; 5–6 align the Rust toolchain's ABI with the C
+# libraries CRAN's macOS R was built against.
 # See docs/RELEASE_WORKFLOW.md for the full rationale.
 #
 # Scaffold this file into your package with:
@@ -73,15 +77,22 @@ jobs:
           R CMD build .
           R CMD check --as-cran --no-manual ./*.tar.gz
 
-  # ── macOS arm64 ───────────────────────────────────────────────────────────
+  # ── macOS (arm64 + Intel) ────────────────────────────────────────────────
   build-macos:
     strategy:
+      fail-fast: false
       matrix:
+        runner: [macos-14, macos-13]
         r-version: ['release', 'oldrel-1']
-    runs-on: macos-14  # arm64 runner
+    runs-on: ${{ matrix.runner }}
 
     # Note: NO LANG/LC_ALL here — macOS runners default to UTF-8 and break
     # if you force C.UTF-8 (glibc-only). See docs/RELEASE_WORKFLOW.md Gotcha 2.
+    #
+    # macos-14 is arm64 (CRAN target: Sonoma / 14.0).
+    # macos-13 is x86_64 (CRAN target: Big Sur / 11.0; last Intel macOS runner).
+    # The SDK / deployment-target pin step below branches on `uname -m`, so it
+    # is safe across both runners.
     steps:
       - uses: actions/checkout@v4
 
@@ -93,6 +104,48 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh auth setup-git
+
+      # Gotcha 5: pin macOS SDK + deployment target to CRAN's binary targets so
+      # Rust artefacts (staticlib / cdylib) link cleanly into R's package build
+      # pipeline. Inlined (not `uses:`-referenced) from
+      # r-devel/actions/setup-macos-tools@ec72e88 (action.yml lines 17-28) to
+      # stay hermetic if that repo is later archived or restructured. Pin values
+      # track CRAN per `R Installation and Administration` §"Building binary
+      # packages" / r-svn doc/manual/R-admin.texi:5854-5867: Sonoma (14.0) for
+      # arm64, Big Sur (11.0) for Intel.
+      # Skipped vs. upstream: brew unlink (destructive), gfortran (no Fortran
+      # deps), TinyTeX (no PDF manuals), xQuartz (no X11), /opt/R/<arch>/bin on
+      # GITHUB_PATH (r-lib/actions/setup-r installs R independently).
+      # See docs/RELEASE_WORKFLOW.md Gotcha 5.
+      - name: Pin macOS SDK and deployment target
+        run: |
+          if [ "$(uname -m)" = "x86_64" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.2.app || true
+            echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
+          else
+            sudo xcode-select -s /Applications/Xcode_26.0.app || true
+            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+          fi
+          echo "xcode is set: $(xcode-select --print-path)"
+          xcrun --show-sdk-version || true
+
+      # Gotcha 6: CRAN's macOS binary R links against /opt/R/<arch>/lib system
+      # libraries (libcurl, openssl, libtiff, …) curated by
+      # r-universe-org/macos-libs. Any Rust crate with a -sys C dep using
+      # pkg-config will resolve against these — the same library set R itself
+      # was built against. Pre-empts the "links fine locally, segfaults under
+      # CRAN's R" trap. Inlined from r-devel/actions/setup-macos-tools@ec72e88
+      # (action.yml lines 44-53). See docs/RELEASE_WORKFLOW.md Gotcha 6.
+      - name: Download CRAN system libraries
+        run: |
+          sudo mkdir -p /opt
+          sudo chown $USER /opt
+          curl --retry 3 --fail-with-body -sSL \
+            https://github.com/r-universe-org/macos-libs/releases/download/2025-12-13/cranlibs-everything.tar.xz \
+            -o libs.tar.xz
+          sudo tar -xf libs.tar.xz -C / opt
+          rm -f libs.tar.xz
+          echo "PKG_CONFIG_PATH=/opt/R/$(uname -m)/lib/pkgconfig:/opt/R/$(uname -m)/share/pkgconfig" >> $GITHUB_ENV
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
The scaffolded `r-release.yml` now pins macOS Xcode + deployment target to CRAN's current binary targets (Sonoma 14.0 on arm64, Big Sur 11.0 on Intel) and pulls in `r-universe-org/macos-libs` so any future `-sys` Rust dep resolves against the same C libraries CRAN's R was built against. `RELEASE_WORKFLOW.md` and `CRAN_COMPATIBILITY.md` document the layered defense and cite both R-admin and `r-devel/actions` as the source-of-truth.

<details>
<summary><sub>AI-written summary, test plan, and follow-up tracking (Claude)</sub></summary>

## What changed

**`minirextendr/inst/templates/r-release.yml`** (1 file, +56/-3):

- Two new steps in `build-macos`, inserted before `r-lib/actions/setup-r`:
  - **Pin macOS SDK and deployment target.** `xcode-select -s` (Xcode 26.0 on arm64, 16.2 on x86_64) and `MACOSX_DEPLOYMENT_TARGET` written into `$GITHUB_ENV`. Branches on `uname -m` so the same step works on both runner archs.
  - **Download CRAN system libraries.** Fetches `r-universe-org/macos-libs` `cranlibs-everything.tar.xz` (date-pinned `2025-12-13`) into `/opt/R/<arch>/lib`, then sets `PKG_CONFIG_PATH`.
- Matrix expanded from single `runs-on: macos-14` to a 2x2 over `runner: [macos-14, macos-13]` x `r-version: ['release', 'oldrel-1']` so the SDK-pin x86_64 branch is actually exercised. Doubles the macOS jobs; release workflow is tag-push-only, so bounded.
- Both steps are inlined (not `uses:`-referenced) from [`r-devel/actions/setup-macos-tools@ec72e88`](https://github.com/r-devel/actions/blob/ec72e88/setup-macos-tools/action.yml) for hermetic-against-upstream-archival reasons. Attribution comments above each step.

**`docs/RELEASE_WORKFLOW.md`** (1 file, +123/-6):

- Gotcha 5 (macOS SDK / deployment target) and Gotcha 6 (CRAN system libraries) added in the same style as 1-4 (symptom / fix snippet / why it matters / citations).
- Both sections cite R-admin (r-svn `doc/manual/R-admin.texi:5854-5867`) and `r-devel/actions@ec72e88` with permalinks.
- Title and intro updated from "four gotchas" to "six gotchas."

**`docs/CRAN_COMPATIBILITY.md`** (1 file, +76):

- New top-level section "Toolchain ABI matching" framing the three-layer defense:
  - Layer 1: `./configure`-emitted `.cargo/config.toml` `[env]` per install.
  - Layer 2: CI workflow `env:` pins (this PR).
  - Layer 3: this doc + RELEASE_WORKFLOW.md citations.
- Includes a pin table and a "How to update the pins when CRAN moves" subsection listing the three sites to keep in sync.

## What was skipped vs. upstream r-devel/actions

(Documented inline in the template's attribution comments and in Gotcha 6 prose):

- `brew unlink $(brew list --formula)` - destructive on shared runners; unnecessary once `PKG_CONFIG_PATH` is set.
- gfortran install - no Fortran-linked Rust deps in miniextendr today.
- TinyTeX install - default scaffold builds with `--no-manual`.
- xQuartz install - no X11 dependencies.
- `/opt/R/<arch>/bin` on `$GITHUB_PATH` - `r-lib/actions/setup-r` puts R's bin on PATH independently.

## Patcher safety

`release_workflow_insert_workdir()` in `minirextendr/R/use-release-workflow.R` greps for two patterns:

- `^        run: bash \./configure\s*$` (configure step)
- `^        run: \|\s*$` *and* next line contains `R CMD build` (build step)

The two new steps use `run: |` but the next lines are `if [ "$(uname -m)" = "x86_64" ]` and `sudo mkdir -p /opt` - neither contains `R CMD build`, so the patcher correctly skips them. Verified by simulating the patcher logic against the new template (4 working-directory lines injected, exactly the 2 configure + 2 build steps across 2 jobs).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` against the new template - parses cleanly.
- [x] `devtools::test(filter = "use-release-workflow |monorepo-gaps")` - 33 PASS, 0 FAIL.
- [x] Full `devtools::test()` - my changes add no new failures (pre-existing 6 failures in `test-scaffold-smoke.R` / `test-templates.R` / `test-use-native.R` reproduce on `origin/main` without my changes).
- [x] `scripts/docs-to-site.sh && zola build` - 95 pages built, 0 orphans, 0 errors.
- [ ] Real CI run on the release workflow - cannot exercise from a PR build (workflow triggers on `push: tags: ["v*"]` and `workflow_dispatch`). Will surface only on the next version tag.

## Out of scope - follow-up issues filed

- #594 - Add a `build-windows` job using rtools45 / `r-windows/rtools-base` mirroring the macOS layer of defense.
- #595 - Bring `.github/workflows/ci.yml`'s `r-check-macos` in line with the same CRAN pins so our own CI tests under the same toolchain ABI we tell downstream maintainers to use.
- #596 - Periodic rebase tracking issue for the two upstream pins (`r-universe-org/macos-libs` tarball date, `r-windows/rtools-base` rtools value).

## Cross-ref

A sibling PR (configure-emitted `[env]` in `.cargo/config.toml`) handles the per-install floor that complements this CI overlay. The docs reference it in prose without linking a specific PR number; the maintainer will weave the cross-ref after both merge.

</details>