### PR TITLE
feat(configure): emit [env] in .cargo/config.toml for R-ABI matching

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -83,6 +83,13 @@ $(SHLIB): $(OBJECTS) $(CARGO_AR)
 #
 # OBJECTS are passed to cargo as link-args so the Rust crate can reference
 # symbols from C shim files (bindgen-generated static inline wrappers).
+#
+# Note: configure.ac emits an [env] block in src/rust/.cargo/config.toml with
+# platform-derived MACOSX_DEPLOYMENT_TARGET (macOS), CARGO_TARGET_*_LINKER
+# (Windows rtools), and AR_<target> overrides. Cargo inherits these on every
+# invocation below; they ensure the Rust staticlib's ABI matches R's build.
+# To override, set the variable in your shell — shell env wins over [env].
+# See `bash ./configure` output for the values actually emitted.
 $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	@set -e; \
 	TARGET_OPT=""; \

--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.win
@@ -9,4 +9,9 @@ include Makevars
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
 # Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+#
+# Note: configure.ac sets CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and the
+# aarch64 equivalent) in src/rust/.cargo/config.toml [env] when rtools is
+# detected via `R CMD config CC`. This pins cargo's linker to rtools' gcc
+# rather than whichever gcc happens to be on PATH (MSYS2's separate gcc, etc).
 PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -343,6 +343,139 @@ if test -n "$MONOREPO_ROOT"; then
   fi
 fi
 
+dnl ---- derive Cargo [env] block (R-ABI matching) ----
+dnl Goal: every cargo invocation (local dev, CI, end-user R CMD INSTALL) inherits
+dnl R-compatible toolchain settings so the Rust staticlib's ABI matches R's build.
+dnl
+dnl Shell env wins over `[env]` (no `force = true`) — users can still override
+dnl via `MACOSX_DEPLOYMENT_TARGET=12.0 R CMD INSTALL .` etc.
+dnl
+dnl Per-platform derivations:
+dnl   macOS   : MACOSX_DEPLOYMENT_TARGET (4-step fallback: env → R config → otool → arch default).
+dnl   Windows : CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and aarch64) from rtools gcc when detected.
+dnl   Linux   : conservative — only AR_<target>/RANLIB_<target> overrides if R's are non-default.
+dnl   All     : CARGO_NET_GIT_FETCH_WITH_CLI = "true" (works around in-tree rustls/CA issues).
+dnl
+dnl We pre-compute derivation variables here so AC_CONFIG_COMMANDS just writes
+dnl the lines out. The block is emitted as the FIRST table in each install-mode
+dnl branch of .cargo/config.toml (TOML table-scoping requires it).
+
+dnl Rust target triple for *_<target> environment variables. Prefer the user's
+dnl explicit CARGO_BUILD_TARGET; otherwise ask rustc for its default host.
+CARGO_ENV_RUST_TARGET="$CARGO_BUILD_TARGET"
+if test -z "$CARGO_ENV_RUST_TARGET"; then
+  CARGO_ENV_RUST_TARGET=`"$RUSTC" -vV 2>/dev/null | $SED -n 's/^host: //p'`
+fi
+
+dnl Uppercase + s/-/_/g, e.g. aarch64-apple-darwin -> AARCH64_APPLE_DARWIN.
+CARGO_ENV_RUST_TARGET_UPPER=`echo "$CARGO_ENV_RUST_TARGET" | tr 'a-z-' 'A-Z_'`
+
+dnl --- macOS: derive MACOSX_DEPLOYMENT_TARGET ----
+dnl Derivation order (first match wins, logged via AC_MSG_NOTICE):
+dnl   1. Shell env MACOSX_DEPLOYMENT_TARGET (caller's value)
+dnl   2. -mmac(os|osx)-version-min=X.Y in R CMD config {CC,CXX,FC}
+dnl   3. otool -l "$R_HOME/bin/exec/R" → LC_BUILD_VERSION minos
+dnl   4. Arch default: aarch64 → 14.0, x86_64 → 11.0 (per R-admin §macOS).
+CARGO_ENV_MACOS_DEPLOY_TARGET=""
+CARGO_ENV_MACOS_DEPLOY_SOURCE=""
+case "$host_os" in
+  darwin*)
+    dnl Step 1: shell env wins (cargo [env] no-force semantics mean we could
+    dnl emit it and shell would still win, but skipping emission keeps the
+    dnl config.toml output stable across invocations with different env vars).
+    if test -n "${MACOSX_DEPLOYMENT_TARGET}"; then
+      CARGO_ENV_MACOS_DEPLOY_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="shell env"
+    fi
+
+    dnl Step 2: parse R CMD config CC / CXX / FC. clang spells it
+    dnl `-mmacos-version-min`; legacy gfortran / older clang use `-mmacosx-version-min`.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      for _cfg_key in CC CXX FC; do
+        _flag_val=`"${R_HOME}/bin/R" CMD config "$_cfg_key" 2>/dev/null \
+          | $SED -n 's/.*-mmac[ox]*-version-min=\(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/p' \
+          | head -n1`
+        if test -n "$_flag_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_flag_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="R CMD config $_cfg_key"
+          break
+        fi
+      done
+    fi
+
+    dnl Step 3: otool -l on R binary. LC_BUILD_VERSION's `minos` field is
+    dnl the authoritative target R was linked against.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      if command -v otool >/dev/null 2>&1; then
+        _otool_val=`otool -l "${R_HOME}/bin/exec/R" 2>/dev/null \
+          | awk '/LC_BUILD_VERSION/ {found=1} found && /minos/ {print $2; exit}'`
+        if test -n "$_otool_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_otool_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="otool LC_BUILD_VERSION"
+        fi
+      fi
+    fi
+
+    dnl Step 4: arch default. R-admin (Sec. "macOS") states current CRAN
+    dnl targets are macOS 14.0 (arm64) and 11.0 (Intel).
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      case "$host_cpu" in
+        arm64|aarch64) CARGO_ENV_MACOS_DEPLOY_TARGET="14.0" ;;
+        *)             CARGO_ENV_MACOS_DEPLOY_TARGET="11.0" ;;
+      esac
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="arch default ($host_cpu)"
+    fi
+
+    AC_MSG_NOTICE([MACOSX_DEPLOYMENT_TARGET = $CARGO_ENV_MACOS_DEPLOY_TARGET (source: $CARGO_ENV_MACOS_DEPLOY_SOURCE)])
+    ;;
+esac
+
+dnl --- Windows: derive rtools gcc linker path ----
+dnl Strategy: R CMD config CC's first token is the C compiler path. If its
+dnl sibling `gcc` (or `gcc.exe`) exists, use that as the cargo linker for
+dnl x86_64-pc-windows-gnu / aarch64-pc-windows-gnu. This pins cargo to rtools'
+dnl gcc rather than whichever gcc happens to be on PATH (MSYS2's, etc).
+CARGO_ENV_WIN_LINKER=""
+case "$host_os" in
+  *msys*|*cygwin*|*mingw*)
+    _r_cc=`"${R_HOME}/bin/R" CMD config CC 2>/dev/null | awk '{print $1}'`
+    if test -n "$_r_cc"; then
+      _r_cc_bindir=`dirname "$_r_cc"`
+      for _gcc_cand in "$_r_cc_bindir/gcc.exe" "$_r_cc_bindir/gcc"; do
+        if test -x "$_gcc_cand"; then
+          dnl Cargo's [env] consumes the path raw; TOML needs forward slashes.
+          dnl `cygpath -m` produces a Windows-native path with forward slashes,
+          dnl which is exactly what cargo's TOML parser wants.
+          _gcc_native="$_gcc_cand"
+          if test "x$CYGPATH" != "xno"; then
+            _gcc_native=`"$CYGPATH" -m "$_gcc_cand" 2>/dev/null || echo "$_gcc_cand"`
+          fi
+          CARGO_ENV_WIN_LINKER="$_gcc_native"
+          break
+        fi
+      done
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      AC_MSG_NOTICE([rtools linker        = $CARGO_ENV_WIN_LINKER])
+    else
+      AC_MSG_NOTICE([rtools linker        = (not detected — cargo will use default gcc on PATH)])
+    fi
+    ;;
+esac
+
+dnl --- AR / RANLIB overrides (all platforms, only if non-default) ----
+dnl R may be configured with a non-default AR/RANLIB (e.g. a cross-toolchain
+dnl prefix). Cargo's default is `ar` / `ranlib`, so we only emit overrides
+dnl when R's values differ — otherwise we'd just add noise to the config.
+CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
+CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
+
+dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
+dnl via the trailing variable-pass list, and the [env] block body is composed
+dnl inline inside that shell context. Pre-composing here and passing a single
+dnl newline-separated string trips on AC_CONFIG_COMMANDS' heredoc-style
+dnl variable propagation (embedded `"` breaks the outer assignment quoting).
+
 dnl ---- output files ----
 dnl Create .cargo directory (it's a hidden dir not included in tarball)
 dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
@@ -420,12 +553,46 @@ AC_CONFIG_COMMANDS([cargo-config],
   RPKG_CFG="src/rust/.cargo/config.toml"
   rm -f "$RPKG_CFG"
 
+  dnl `[env]` is emitted as the FIRST table in every branch. TOML table-scoping
+  dnl makes any later `[…]` heading end the previous table — so `[env]` must
+  dnl precede `[source.*]` / `[patch.*]` / `[build]` to stay independent.
+  dnl Cargo applies these to every cargo invocation in this package. Shell env
+  dnl wins (no `force = true`), so users can override case-by-case.
+  dnl
+  dnl Derivation variables are passed individually via the variable-pass list
+  dnl (see second arg) — composing the body here keeps quoting predictable.
+  emit_env_block() {
+    echo "@<:@env@:>@"
+    if test -n "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      echo "MACOSX_DEPLOYMENT_TARGET = \"$CARGO_ENV_MACOS_DEPLOY_TARGET\""
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      case "$CARGO_ENV_RUST_TARGET_UPPER" in
+        *AARCH64*WINDOWS*)
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+        *)
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+      esac
+    fi
+    echo 'CARGO_NET_GIT_FETCH_WITH_CLI = "true"'
+    if test -n "$CARGO_ENV_R_AR" && test "$CARGO_ENV_R_AR" != "ar"; then
+      echo "AR_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_AR\""
+    fi
+    if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
+      echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    echo ""
+  }
+
   if test "$IS_TARBALL_INSTALL" = "true"; then
     {
       echo "# Autogenerated by configure — DO NOT EDIT"
       echo "# Tarball install: redirect crates.io and the miniextendr git source"
       echo "# to the unpacked inst/vendor.tar.xz."
       echo ""
+      emit_env_block
       echo "@<:@source.crates-io@:>@"
       echo 'replace-with = "vendored-sources"'
       echo ""
@@ -452,6 +619,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# Source install (monorepo): patch the miniextendr git source to"
       echo "# resolve against local workspace crates."
       echo ""
+      emit_env_block
       echo '@<:@patch."https://github.com/A2-ai/miniextendr"@:>@'
       echo "miniextendr-api    = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-api\" }"
       echo "miniextendr-lint   = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-lint\" }"
@@ -469,6 +637,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# declared in Cargo.toml. First build downloads, subsequent"
       echo "# builds use cargo's git cache."
       echo ""
+      emit_env_block
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
@@ -480,6 +649,12 @@ AC_CONFIG_COMMANDS([cargo-config],
  MONOREPO_ROOT_CARGO="$MONOREPO_ROOT_CARGO"
  VENDOR_OUT_CARGO="$VENDOR_OUT_CARGO"
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
+ CARGO_ENV_MACOS_DEPLOY_TARGET="$CARGO_ENV_MACOS_DEPLOY_TARGET"
+ CARGO_ENV_WIN_LINKER="$CARGO_ENV_WIN_LINKER"
+ CARGO_ENV_RUST_TARGET="$CARGO_ENV_RUST_TARGET"
+ CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
+ CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
+ CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -83,6 +83,13 @@ $(SHLIB): $(OBJECTS) $(CARGO_AR)
 #
 # OBJECTS are passed to cargo as link-args so the Rust crate can reference
 # symbols from C shim files (bindgen-generated static inline wrappers).
+#
+# Note: configure.ac emits an [env] block in src/rust/.cargo/config.toml with
+# platform-derived MACOSX_DEPLOYMENT_TARGET (macOS), CARGO_TARGET_*_LINKER
+# (Windows rtools), and AR_<target> overrides. Cargo inherits these on every
+# invocation below; they ensure the Rust staticlib's ABI matches R's build.
+# To override, set the variable in your shell — shell env wins over [env].
+# See `bash ./configure` output for the values actually emitted.
 $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	@set -e; \
 	TARGET_OPT=""; \

--- a/minirextendr/inst/templates/rpkg/Makevars.win
+++ b/minirextendr/inst/templates/rpkg/Makevars.win
@@ -9,4 +9,9 @@ include Makevars
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
 # Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+#
+# Note: configure.ac sets CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and the
+# aarch64 equivalent) in src/rust/.cargo/config.toml [env] when rtools is
+# detected via `R CMD config CC`. This pins cargo's linker to rtools' gcc
+# rather than whichever gcc happens to be on PATH (MSYS2's separate gcc, etc).
 PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -395,6 +395,139 @@ if test -n "$MONOREPO_ROOT"; then
   fi
 fi
 
+dnl ---- derive Cargo [env] block (R-ABI matching) ----
+dnl Goal: every cargo invocation (local dev, CI, end-user R CMD INSTALL) inherits
+dnl R-compatible toolchain settings so the Rust staticlib's ABI matches R's build.
+dnl
+dnl Shell env wins over `[env]` (no `force = true`) — users can still override
+dnl via `MACOSX_DEPLOYMENT_TARGET=12.0 R CMD INSTALL .` etc.
+dnl
+dnl Per-platform derivations:
+dnl   macOS   : MACOSX_DEPLOYMENT_TARGET (4-step fallback: env → R config → otool → arch default).
+dnl   Windows : CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and aarch64) from rtools gcc when detected.
+dnl   Linux   : conservative — only AR_<target>/RANLIB_<target> overrides if R's are non-default.
+dnl   All     : CARGO_NET_GIT_FETCH_WITH_CLI = "true" (works around in-tree rustls/CA issues).
+dnl
+dnl We pre-compute derivation variables here so AC_CONFIG_COMMANDS just writes
+dnl the lines out. The block is emitted as the FIRST table in each install-mode
+dnl branch of .cargo/config.toml (TOML table-scoping requires it).
+
+dnl Rust target triple for *_<target> environment variables. Prefer the user's
+dnl explicit CARGO_BUILD_TARGET; otherwise ask rustc for its default host.
+CARGO_ENV_RUST_TARGET="$CARGO_BUILD_TARGET"
+if test -z "$CARGO_ENV_RUST_TARGET"; then
+  CARGO_ENV_RUST_TARGET=`"$RUSTC" -vV 2>/dev/null | $SED -n 's/^host: //p'`
+fi
+
+dnl Uppercase + s/-/_/g, e.g. aarch64-apple-darwin -> AARCH64_APPLE_DARWIN.
+CARGO_ENV_RUST_TARGET_UPPER=`echo "$CARGO_ENV_RUST_TARGET" | tr 'a-z-' 'A-Z_'`
+
+dnl --- macOS: derive MACOSX_DEPLOYMENT_TARGET ----
+dnl Derivation order (first match wins, logged via AC_MSG_NOTICE):
+dnl   1. Shell env MACOSX_DEPLOYMENT_TARGET (caller's value)
+dnl   2. -mmac(os|osx)-version-min=X.Y in R CMD config {CC,CXX,FC}
+dnl   3. otool -l "$R_HOME/bin/exec/R" → LC_BUILD_VERSION minos
+dnl   4. Arch default: aarch64 → 14.0, x86_64 → 11.0 (per R-admin §macOS).
+CARGO_ENV_MACOS_DEPLOY_TARGET=""
+CARGO_ENV_MACOS_DEPLOY_SOURCE=""
+case "$host_os" in
+  darwin*)
+    dnl Step 1: shell env wins (cargo [env] no-force semantics mean we could
+    dnl emit it and shell would still win, but skipping emission keeps the
+    dnl config.toml output stable across invocations with different env vars).
+    if test -n "${MACOSX_DEPLOYMENT_TARGET}"; then
+      CARGO_ENV_MACOS_DEPLOY_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="shell env"
+    fi
+
+    dnl Step 2: parse R CMD config CC / CXX / FC. clang spells it
+    dnl `-mmacos-version-min`; legacy gfortran / older clang use `-mmacosx-version-min`.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      for _cfg_key in CC CXX FC; do
+        _flag_val=`"${R_HOME}/bin/R" CMD config "$_cfg_key" 2>/dev/null \
+          | $SED -n 's/.*-mmac[ox]*-version-min=\(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/p' \
+          | head -n1`
+        if test -n "$_flag_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_flag_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="R CMD config $_cfg_key"
+          break
+        fi
+      done
+    fi
+
+    dnl Step 3: otool -l on R binary. LC_BUILD_VERSION's `minos` field is
+    dnl the authoritative target R was linked against.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      if command -v otool >/dev/null 2>&1; then
+        _otool_val=`otool -l "${R_HOME}/bin/exec/R" 2>/dev/null \
+          | awk '/LC_BUILD_VERSION/ {found=1} found && /minos/ {print $2; exit}'`
+        if test -n "$_otool_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_otool_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="otool LC_BUILD_VERSION"
+        fi
+      fi
+    fi
+
+    dnl Step 4: arch default. R-admin (Sec. "macOS") states current CRAN
+    dnl targets are macOS 14.0 (arm64) and 11.0 (Intel).
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      case "$host_cpu" in
+        arm64|aarch64) CARGO_ENV_MACOS_DEPLOY_TARGET="14.0" ;;
+        *)             CARGO_ENV_MACOS_DEPLOY_TARGET="11.0" ;;
+      esac
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="arch default ($host_cpu)"
+    fi
+
+    AC_MSG_NOTICE([MACOSX_DEPLOYMENT_TARGET = $CARGO_ENV_MACOS_DEPLOY_TARGET (source: $CARGO_ENV_MACOS_DEPLOY_SOURCE)])
+    ;;
+esac
+
+dnl --- Windows: derive rtools gcc linker path ----
+dnl Strategy: R CMD config CC's first token is the C compiler path. If its
+dnl sibling `gcc` (or `gcc.exe`) exists, use that as the cargo linker for
+dnl x86_64-pc-windows-gnu / aarch64-pc-windows-gnu. This pins cargo to rtools'
+dnl gcc rather than whichever gcc happens to be on PATH (MSYS2's, etc).
+CARGO_ENV_WIN_LINKER=""
+case "$host_os" in
+  *msys*|*cygwin*|*mingw*)
+    _r_cc=`"${R_HOME}/bin/R" CMD config CC 2>/dev/null | awk '{print $1}'`
+    if test -n "$_r_cc"; then
+      _r_cc_bindir=`dirname "$_r_cc"`
+      for _gcc_cand in "$_r_cc_bindir/gcc.exe" "$_r_cc_bindir/gcc"; do
+        if test -x "$_gcc_cand"; then
+          dnl Cargo's [env] consumes the path raw; TOML needs forward slashes.
+          dnl `cygpath -m` produces a Windows-native path with forward slashes,
+          dnl which is exactly what cargo's TOML parser wants.
+          _gcc_native="$_gcc_cand"
+          if test "x$CYGPATH" != "xno"; then
+            _gcc_native=`"$CYGPATH" -m "$_gcc_cand" 2>/dev/null || echo "$_gcc_cand"`
+          fi
+          CARGO_ENV_WIN_LINKER="$_gcc_native"
+          break
+        fi
+      done
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      AC_MSG_NOTICE([rtools linker        = $CARGO_ENV_WIN_LINKER])
+    else
+      AC_MSG_NOTICE([rtools linker        = (not detected — cargo will use default gcc on PATH)])
+    fi
+    ;;
+esac
+
+dnl --- AR / RANLIB overrides (all platforms, only if non-default) ----
+dnl R may be configured with a non-default AR/RANLIB (e.g. a cross-toolchain
+dnl prefix). Cargo's default is `ar` / `ranlib`, so we only emit overrides
+dnl when R's values differ — otherwise we'd just add noise to the config.
+CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
+CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
+
+dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
+dnl via the trailing variable-pass list, and the [env] block body is composed
+dnl inline inside that shell context. Pre-composing here and passing a single
+dnl newline-separated string trips on AC_CONFIG_COMMANDS' heredoc-style
+dnl variable propagation (embedded `"` breaks the outer assignment quoting).
+
 dnl ---- output files ----
 dnl Create .cargo directory (it's a hidden dir not included in tarball)
 dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
@@ -472,12 +605,46 @@ AC_CONFIG_COMMANDS([cargo-config],
   RPKG_CFG="src/rust/.cargo/config.toml"
   rm -f "$RPKG_CFG"
 
+  dnl `[env]` is emitted as the FIRST table in every branch. TOML table-scoping
+  dnl makes any later `[…]` heading end the previous table — so `[env]` must
+  dnl precede `[source.*]` / `[patch.*]` / `[build]` to stay independent.
+  dnl Cargo applies these to every cargo invocation in this package. Shell env
+  dnl wins (no `force = true`), so users can override case-by-case.
+  dnl
+  dnl Derivation variables are passed individually via the variable-pass list
+  dnl (see second arg) — composing the body here keeps quoting predictable.
+  emit_env_block() {
+    echo "@<:@env@:>@"
+    if test -n "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      echo "MACOSX_DEPLOYMENT_TARGET = \"$CARGO_ENV_MACOS_DEPLOY_TARGET\""
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      case "$CARGO_ENV_RUST_TARGET_UPPER" in
+        *AARCH64*WINDOWS*)
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+        *)
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+      esac
+    fi
+    echo 'CARGO_NET_GIT_FETCH_WITH_CLI = "true"'
+    if test -n "$CARGO_ENV_R_AR" && test "$CARGO_ENV_R_AR" != "ar"; then
+      echo "AR_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_AR\""
+    fi
+    if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
+      echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    echo ""
+  }
+
   if test "$IS_TARBALL_INSTALL" = "true"; then
     {
       echo "# Autogenerated by configure — DO NOT EDIT"
       echo "# Tarball install: redirect crates.io and the miniextendr git source"
       echo "# to the unpacked inst/vendor.tar.xz."
       echo ""
+      emit_env_block
       echo "@<:@source.crates-io@:>@"
       echo 'replace-with = "vendored-sources"'
       echo ""
@@ -504,6 +671,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# Source install (monorepo): patch the miniextendr git source to"
       echo "# resolve against local workspace crates."
       echo ""
+      emit_env_block
       echo '@<:@patch."https://github.com/A2-ai/miniextendr"@:>@'
       echo "miniextendr-api    = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-api\" }"
       echo "miniextendr-lint   = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-lint\" }"
@@ -521,6 +689,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# declared in Cargo.toml. First build downloads, subsequent"
       echo "# builds use cargo's git cache."
       echo ""
+      emit_env_block
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
@@ -532,6 +701,12 @@ AC_CONFIG_COMMANDS([cargo-config],
  MONOREPO_ROOT_CARGO="$MONOREPO_ROOT_CARGO"
  VENDOR_OUT_CARGO="$VENDOR_OUT_CARGO"
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
+ CARGO_ENV_MACOS_DEPLOY_TARGET="$CARGO_ENV_MACOS_DEPLOY_TARGET"
+ CARGO_ENV_WIN_LINKER="$CARGO_ENV_WIN_LINKER"
+ CARGO_ENV_RUST_TARGET="$CARGO_ENV_RUST_TARGET"
+ CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
+ CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
+ CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-14 10:09:57
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-14 10:09:57
+--- a/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
++++ b/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-14 10:16:51
-+++ b/monorepo/rpkg/configure.ac	2026-05-14 10:16:51
+--- a/monorepo/rpkg/configure.ac	2026-05-17 13:41:31
++++ b/monorepo/rpkg/configure.ac	2026-05-17 13:23:10
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -367,20 +367,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -367,4 +345,5 @@
+@@ -500,4 +478,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -541,5 +520,5 @@
+@@ -716,5 +695,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -557,13 +536,22 @@
+@@ -732,13 +711,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-14 10:16:51
-+++ b/rpkg/configure.ac	2026-05-14 10:16:51
+--- a/rpkg/configure.ac	2026-05-17 13:41:31
++++ b/rpkg/configure.ac	2026-05-17 13:21:51
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -589,20 +589,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -367,4 +397,5 @@
+@@ -500,4 +530,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -541,5 +572,5 @@
+@@ -716,5 +747,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -557,13 +588,22 @@
+@@ -732,13 +763,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2636,6 +2636,91 @@ printf '%s\n' "$as_me: monorepo siblings    = $MONOREPO_ROOT (source-mode patch 
   fi
 fi
 
+
+CARGO_ENV_RUST_TARGET="$CARGO_BUILD_TARGET"
+if test -z "$CARGO_ENV_RUST_TARGET"; then
+  CARGO_ENV_RUST_TARGET=`"$RUSTC" -vV 2>/dev/null | $SED -n 's/^host: //p'`
+fi
+
+CARGO_ENV_RUST_TARGET_UPPER=`echo "$CARGO_ENV_RUST_TARGET" | tr 'a-z-' 'A-Z_'`
+
+CARGO_ENV_MACOS_DEPLOY_TARGET=""
+CARGO_ENV_MACOS_DEPLOY_SOURCE=""
+case "$host_os" in
+  darwin*)
+                if test -n "${MACOSX_DEPLOYMENT_TARGET}"; then
+      CARGO_ENV_MACOS_DEPLOY_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="shell env"
+    fi
+
+            if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      for _cfg_key in CC CXX FC; do
+        _flag_val=`"${R_HOME}/bin/R" CMD config "$_cfg_key" 2>/dev/null \
+          | $SED -n 's/.*-mmacox*-version-min=\([0-9]*\.[0-9]*\).*/\1/p' \
+          | head -n1`
+        if test -n "$_flag_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_flag_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="R CMD config $_cfg_key"
+          break
+        fi
+      done
+    fi
+
+            if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      if command -v otool >/dev/null 2>&1; then
+        _otool_val=`otool -l "${R_HOME}/bin/exec/R" 2>/dev/null \
+          | awk '/LC_BUILD_VERSION/ {found=1} found && /minos/ {print $2; exit}'`
+        if test -n "$_otool_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_otool_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="otool LC_BUILD_VERSION"
+        fi
+      fi
+    fi
+
+            if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      case "$host_cpu" in
+        arm64|aarch64) CARGO_ENV_MACOS_DEPLOY_TARGET="14.0" ;;
+        *)             CARGO_ENV_MACOS_DEPLOY_TARGET="11.0" ;;
+      esac
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="arch default ($host_cpu)"
+    fi
+
+    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: MACOSX_DEPLOYMENT_TARGET = $CARGO_ENV_MACOS_DEPLOY_TARGET (source: $CARGO_ENV_MACOS_DEPLOY_SOURCE)" >&5
+printf '%s\n' "$as_me: MACOSX_DEPLOYMENT_TARGET = $CARGO_ENV_MACOS_DEPLOY_TARGET (source: $CARGO_ENV_MACOS_DEPLOY_SOURCE)" >&6;}
+    ;;
+esac
+
+CARGO_ENV_WIN_LINKER=""
+case "$host_os" in
+  *msys*|*cygwin*|*mingw*)
+    _r_cc=`"${R_HOME}/bin/R" CMD config CC 2>/dev/null | awk '{print $1}'`
+    if test -n "$_r_cc"; then
+      _r_cc_bindir=`dirname "$_r_cc"`
+      for _gcc_cand in "$_r_cc_bindir/gcc.exe" "$_r_cc_bindir/gcc"; do
+        if test -x "$_gcc_cand"; then
+                                        _gcc_native="$_gcc_cand"
+          if test "x$CYGPATH" != "xno"; then
+            _gcc_native=`"$CYGPATH" -m "$_gcc_cand" 2>/dev/null || echo "$_gcc_cand"`
+          fi
+          CARGO_ENV_WIN_LINKER="$_gcc_native"
+          break
+        fi
+      done
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: rtools linker        = $CARGO_ENV_WIN_LINKER" >&5
+printf '%s\n' "$as_me: rtools linker        = $CARGO_ENV_WIN_LINKER" >&6;}
+    else
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: rtools linker        = (not detected — cargo will use default gcc on PATH)" >&5
+printf '%s\n' "$as_me: rtools linker        = (not detected — cargo will use default gcc on PATH)" >&6;}
+    fi
+    ;;
+esac
+
+CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
+CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
+
+
 as_dir=src/rust/.cargo; as_fn_mkdir_p
 
 ac_config_files="$ac_config_files src/Makevars:src/Makevars.in src/$PACKAGE_NAME-win.def:src/win.def.in"
@@ -3319,6 +3404,12 @@ IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  MONOREPO_ROOT_CARGO="$MONOREPO_ROOT_CARGO"
  VENDOR_OUT_CARGO="$VENDOR_OUT_CARGO"
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
+ CARGO_ENV_MACOS_DEPLOY_TARGET="$CARGO_ENV_MACOS_DEPLOY_TARGET"
+ CARGO_ENV_WIN_LINKER="$CARGO_ENV_WIN_LINKER"
+ CARGO_ENV_RUST_TARGET="$CARGO_ENV_RUST_TARGET"
+ CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
+ CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
+ CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
  SED="$SED"
 IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  R_HOME="$R_HOME"
@@ -3776,12 +3867,38 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
   RPKG_CFG="src/rust/.cargo/config.toml"
   rm -f "$RPKG_CFG"
 
+                  emit_env_block() {
+    echo "[env]"
+    if test -n "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      echo "MACOSX_DEPLOYMENT_TARGET = \"$CARGO_ENV_MACOS_DEPLOY_TARGET\""
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      case "$CARGO_ENV_RUST_TARGET_UPPER" in
+        *AARCH64*WINDOWS*)
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+        *)
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+      esac
+    fi
+    echo 'CARGO_NET_GIT_FETCH_WITH_CLI = "true"'
+    if test -n "$CARGO_ENV_R_AR" && test "$CARGO_ENV_R_AR" != "ar"; then
+      echo "AR_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_AR\""
+    fi
+    if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
+      echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    echo ""
+  }
+
   if test "$IS_TARBALL_INSTALL" = "true"; then
     {
       echo "# Autogenerated by configure — DO NOT EDIT"
       echo "# Tarball install: redirect crates.io and the miniextendr git source"
       echo "# to the unpacked inst/vendor.tar.xz."
       echo ""
+      emit_env_block
       echo "[source.crates-io]"
       echo 'replace-with = "vendored-sources"'
       echo ""
@@ -3805,6 +3922,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "# Source install (monorepo): patch the miniextendr git source to"
       echo "# resolve against local workspace crates."
       echo ""
+      emit_env_block
       echo '[patch."https://github.com/A2-ai/miniextendr"]'
       echo "miniextendr-api    = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-api\" }"
       echo "miniextendr-lint   = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-lint\" }"
@@ -3822,6 +3940,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "# declared in Cargo.toml. First build downloads, subsequent"
       echo "# builds use cargo's git cache."
       echo ""
+      emit_env_block
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -365,6 +365,139 @@ if test -n "$MONOREPO_ROOT"; then
   fi
 fi
 
+dnl ---- derive Cargo [env] block (R-ABI matching) ----
+dnl Goal: every cargo invocation (local dev, CI, end-user R CMD INSTALL) inherits
+dnl R-compatible toolchain settings so the Rust staticlib's ABI matches R's build.
+dnl
+dnl Shell env wins over `[env]` (no `force = true`) — users can still override
+dnl via `MACOSX_DEPLOYMENT_TARGET=12.0 R CMD INSTALL .` etc.
+dnl
+dnl Per-platform derivations:
+dnl   macOS   : MACOSX_DEPLOYMENT_TARGET (4-step fallback: env → R config → otool → arch default).
+dnl   Windows : CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and aarch64) from rtools gcc when detected.
+dnl   Linux   : conservative — only AR_<target>/RANLIB_<target> overrides if R's are non-default.
+dnl   All     : CARGO_NET_GIT_FETCH_WITH_CLI = "true" (works around in-tree rustls/CA issues).
+dnl
+dnl We pre-compute derivation variables here so AC_CONFIG_COMMANDS just writes
+dnl the lines out. The block is emitted as the FIRST table in each install-mode
+dnl branch of .cargo/config.toml (TOML table-scoping requires it).
+
+dnl Rust target triple for *_<target> environment variables. Prefer the user's
+dnl explicit CARGO_BUILD_TARGET; otherwise ask rustc for its default host.
+CARGO_ENV_RUST_TARGET="$CARGO_BUILD_TARGET"
+if test -z "$CARGO_ENV_RUST_TARGET"; then
+  CARGO_ENV_RUST_TARGET=`"$RUSTC" -vV 2>/dev/null | $SED -n 's/^host: //p'`
+fi
+
+dnl Uppercase + s/-/_/g, e.g. aarch64-apple-darwin -> AARCH64_APPLE_DARWIN.
+CARGO_ENV_RUST_TARGET_UPPER=`echo "$CARGO_ENV_RUST_TARGET" | tr 'a-z-' 'A-Z_'`
+
+dnl --- macOS: derive MACOSX_DEPLOYMENT_TARGET ----
+dnl Derivation order (first match wins, logged via AC_MSG_NOTICE):
+dnl   1. Shell env MACOSX_DEPLOYMENT_TARGET (caller's value)
+dnl   2. -mmac(os|osx)-version-min=X.Y in R CMD config {CC,CXX,FC}
+dnl   3. otool -l "$R_HOME/bin/exec/R" → LC_BUILD_VERSION minos
+dnl   4. Arch default: aarch64 → 14.0, x86_64 → 11.0 (per R-admin §macOS).
+CARGO_ENV_MACOS_DEPLOY_TARGET=""
+CARGO_ENV_MACOS_DEPLOY_SOURCE=""
+case "$host_os" in
+  darwin*)
+    dnl Step 1: shell env wins (cargo [env] no-force semantics mean we could
+    dnl emit it and shell would still win, but skipping emission keeps the
+    dnl config.toml output stable across invocations with different env vars).
+    if test -n "${MACOSX_DEPLOYMENT_TARGET}"; then
+      CARGO_ENV_MACOS_DEPLOY_TARGET="$MACOSX_DEPLOYMENT_TARGET"
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="shell env"
+    fi
+
+    dnl Step 2: parse R CMD config CC / CXX / FC. clang spells it
+    dnl `-mmacos-version-min`; legacy gfortran / older clang use `-mmacosx-version-min`.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      for _cfg_key in CC CXX FC; do
+        _flag_val=`"${R_HOME}/bin/R" CMD config "$_cfg_key" 2>/dev/null \
+          | $SED -n 's/.*-mmac[ox]*-version-min=\(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/p' \
+          | head -n1`
+        if test -n "$_flag_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_flag_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="R CMD config $_cfg_key"
+          break
+        fi
+      done
+    fi
+
+    dnl Step 3: otool -l on R binary. LC_BUILD_VERSION's `minos` field is
+    dnl the authoritative target R was linked against.
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      if command -v otool >/dev/null 2>&1; then
+        _otool_val=`otool -l "${R_HOME}/bin/exec/R" 2>/dev/null \
+          | awk '/LC_BUILD_VERSION/ {found=1} found && /minos/ {print $2; exit}'`
+        if test -n "$_otool_val"; then
+          CARGO_ENV_MACOS_DEPLOY_TARGET="$_otool_val"
+          CARGO_ENV_MACOS_DEPLOY_SOURCE="otool LC_BUILD_VERSION"
+        fi
+      fi
+    fi
+
+    dnl Step 4: arch default. R-admin (Sec. "macOS") states current CRAN
+    dnl targets are macOS 14.0 (arm64) and 11.0 (Intel).
+    if test -z "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      case "$host_cpu" in
+        arm64|aarch64) CARGO_ENV_MACOS_DEPLOY_TARGET="14.0" ;;
+        *)             CARGO_ENV_MACOS_DEPLOY_TARGET="11.0" ;;
+      esac
+      CARGO_ENV_MACOS_DEPLOY_SOURCE="arch default ($host_cpu)"
+    fi
+
+    AC_MSG_NOTICE([MACOSX_DEPLOYMENT_TARGET = $CARGO_ENV_MACOS_DEPLOY_TARGET (source: $CARGO_ENV_MACOS_DEPLOY_SOURCE)])
+    ;;
+esac
+
+dnl --- Windows: derive rtools gcc linker path ----
+dnl Strategy: R CMD config CC's first token is the C compiler path. If its
+dnl sibling `gcc` (or `gcc.exe`) exists, use that as the cargo linker for
+dnl x86_64-pc-windows-gnu / aarch64-pc-windows-gnu. This pins cargo to rtools'
+dnl gcc rather than whichever gcc happens to be on PATH (MSYS2's, etc).
+CARGO_ENV_WIN_LINKER=""
+case "$host_os" in
+  *msys*|*cygwin*|*mingw*)
+    _r_cc=`"${R_HOME}/bin/R" CMD config CC 2>/dev/null | awk '{print $1}'`
+    if test -n "$_r_cc"; then
+      _r_cc_bindir=`dirname "$_r_cc"`
+      for _gcc_cand in "$_r_cc_bindir/gcc.exe" "$_r_cc_bindir/gcc"; do
+        if test -x "$_gcc_cand"; then
+          dnl Cargo's [env] consumes the path raw; TOML needs forward slashes.
+          dnl `cygpath -m` produces a Windows-native path with forward slashes,
+          dnl which is exactly what cargo's TOML parser wants.
+          _gcc_native="$_gcc_cand"
+          if test "x$CYGPATH" != "xno"; then
+            _gcc_native=`"$CYGPATH" -m "$_gcc_cand" 2>/dev/null || echo "$_gcc_cand"`
+          fi
+          CARGO_ENV_WIN_LINKER="$_gcc_native"
+          break
+        fi
+      done
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      AC_MSG_NOTICE([rtools linker        = $CARGO_ENV_WIN_LINKER])
+    else
+      AC_MSG_NOTICE([rtools linker        = (not detected — cargo will use default gcc on PATH)])
+    fi
+    ;;
+esac
+
+dnl --- AR / RANLIB overrides (all platforms, only if non-default) ----
+dnl R may be configured with a non-default AR/RANLIB (e.g. a cross-toolchain
+dnl prefix). Cargo's default is `ar` / `ranlib`, so we only emit overrides
+dnl when R's values differ — otherwise we'd just add noise to the config.
+CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
+CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
+
+dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
+dnl via the trailing variable-pass list, and the [env] block body is composed
+dnl inline inside that shell context. Pre-composing here and passing a single
+dnl newline-separated string trips on AC_CONFIG_COMMANDS' heredoc-style
+dnl variable propagation (embedded `"` breaks the outer assignment quoting).
+
 dnl ---- output files ----
 dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
 dnl written by AC_CONFIG_COMMANDS below because its contents differ across
@@ -441,12 +574,46 @@ AC_CONFIG_COMMANDS([cargo-config],
   RPKG_CFG="src/rust/.cargo/config.toml"
   rm -f "$RPKG_CFG"
 
+  dnl `[env]` is emitted as the FIRST table in every branch. TOML table-scoping
+  dnl makes any later `[…]` heading end the previous table — so `[env]` must
+  dnl precede `[source.*]` / `[patch.*]` / `[build]` to stay independent.
+  dnl Cargo applies these to every cargo invocation in this package. Shell env
+  dnl wins (no `force = true`), so users can override case-by-case.
+  dnl
+  dnl Derivation variables are passed individually via the variable-pass list
+  dnl (see second arg) — composing the body here keeps quoting predictable.
+  emit_env_block() {
+    echo "@<:@env@:>@"
+    if test -n "$CARGO_ENV_MACOS_DEPLOY_TARGET"; then
+      echo "MACOSX_DEPLOYMENT_TARGET = \"$CARGO_ENV_MACOS_DEPLOY_TARGET\""
+    fi
+    if test -n "$CARGO_ENV_WIN_LINKER"; then
+      case "$CARGO_ENV_RUST_TARGET_UPPER" in
+        *AARCH64*WINDOWS*)
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+        *)
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = \"$CARGO_ENV_WIN_LINKER\""
+          ;;
+      esac
+    fi
+    echo 'CARGO_NET_GIT_FETCH_WITH_CLI = "true"'
+    if test -n "$CARGO_ENV_R_AR" && test "$CARGO_ENV_R_AR" != "ar"; then
+      echo "AR_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_AR\""
+    fi
+    if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
+      echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    echo ""
+  }
+
   if test "$IS_TARBALL_INSTALL" = "true"; then
     {
       echo "# Autogenerated by configure — DO NOT EDIT"
       echo "# Tarball install: redirect crates.io and the miniextendr git source"
       echo "# to the unpacked inst/vendor.tar.xz."
       echo ""
+      emit_env_block
       echo "@<:@source.crates-io@:>@"
       echo 'replace-with = "vendored-sources"'
       echo ""
@@ -473,6 +640,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# Source install (monorepo): patch the miniextendr git source to"
       echo "# resolve against local workspace crates."
       echo ""
+      emit_env_block
       echo '@<:@patch."https://github.com/A2-ai/miniextendr"@:>@'
       echo "miniextendr-api    = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-api\" }"
       echo "miniextendr-lint   = { path = \"$MONOREPO_ROOT_CARGO/miniextendr-lint\" }"
@@ -490,6 +658,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "# declared in Cargo.toml. First build downloads, subsequent"
       echo "# builds use cargo's git cache."
       echo ""
+      emit_env_block
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
@@ -501,6 +670,12 @@ AC_CONFIG_COMMANDS([cargo-config],
  MONOREPO_ROOT_CARGO="$MONOREPO_ROOT_CARGO"
  VENDOR_OUT_CARGO="$VENDOR_OUT_CARGO"
  CARGO_TARGET_DIR_CARGO="$CARGO_TARGET_DIR_CARGO"
+ CARGO_ENV_MACOS_DEPLOY_TARGET="$CARGO_ENV_MACOS_DEPLOY_TARGET"
+ CARGO_ENV_WIN_LINKER="$CARGO_ENV_WIN_LINKER"
+ CARGO_ENV_RUST_TARGET="$CARGO_ENV_RUST_TARGET"
+ CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
+ CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
+ CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -83,6 +83,13 @@ $(SHLIB): $(OBJECTS) $(CARGO_AR)
 #
 # OBJECTS are passed to cargo as link-args so the Rust crate can reference
 # symbols from C shim files (bindgen-generated static inline wrappers).
+#
+# Note: configure.ac emits an [env] block in src/rust/.cargo/config.toml with
+# platform-derived MACOSX_DEPLOYMENT_TARGET (macOS), CARGO_TARGET_*_LINKER
+# (Windows rtools), and AR_<target> overrides. Cargo inherits these on every
+# invocation below; they ensure the Rust staticlib's ABI matches R's build.
+# To override, set the variable in your shell — shell env wins over [env].
+# See `bash ./configure` output for the values actually emitted.
 $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 	@set -e; \
 	TARGET_OPT=""; \

--- a/rpkg/src/Makevars.win
+++ b/rpkg/src/Makevars.win
@@ -9,4 +9,9 @@ include Makevars
 # - advapi32: Security functions
 # - secur32: Security Support Provider Interface (GetUserNameExW for whoami crate)
 # Use full path to staticlib to avoid MinGW linker picking up cdylib's .dll.a import lib
+#
+# Note: configure.ac sets CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER (and the
+# aarch64 equivalent) in src/rust/.cargo/config.toml [env] when rtools is
+# detected via `R CMD config CC`. This pins cargo's linker to rtools' gcc
+# rather than whichever gcc happens to be on PATH (MSYS2's separate gcc, etc).
 PKG_LIBS = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a -lws2_32 -lntdll -luserenv -lbcrypt -ladvapi32 -lsecur32


### PR DESCRIPTION
Configure now derives platform-appropriate Rust toolchain settings from the host's R install and bakes them into `.cargo/config.toml`'s `[env]`, so every `cargo build` — local dev, CI, end-user `R CMD INSTALL` — gets ABI-compatible artefacts without per-workflow boilerplate.

<details>
<summary><em>AI-written details (Claude Opus 4.7)</em></summary>

## What changed

- `rpkg/configure.ac` grew a `[env]`-derivation block between the monorepo-detection notice and the output-files section. The existing `AC_CONFIG_COMMANDS([cargo-config], …)` now emits `[env]` as the first table in each of its three install-mode branches (tarball / source-monorepo / source-only).
- Mirrored to `minirextendr/inst/templates/rpkg/configure.ac` and `minirextendr/inst/templates/monorepo/rpkg/configure.ac`.
- Makevars.in / Makevars.win across rpkg + both templates pick up cross-reference comments near the cargo invocation (rpkg's source) and near `PKG_LIBS` (Windows).
- `patches/templates.patch` regenerated via `just templates-approve`; `just templates-check` passes.
- `rpkg/configure` regenerated via `autoconf`.

## Per-platform behaviour

| Platform | Keys emitted | Notes |
|---|---|---|
| macOS (`darwin*`) | `MACOSX_DEPLOYMENT_TARGET`, `CARGO_NET_GIT_FETCH_WITH_CLI`, conditional `AR_<target>` / `RANLIB_<target>` | Deployment target from 4-step derivation (see below) |
| Windows (`*mingw*`/`*msys*`/`*cygwin*`) | `CARGO_TARGET_{X86_64,AARCH64}_PC_WINDOWS_GNU_LINKER` (when rtools gcc detected), `CARGO_NET_GIT_FETCH_WITH_CLI`, conditional `AR_<target>` / `RANLIB_<target>` | Linker uses `cygpath -m` to produce TOML-friendly forward-slash paths |
| Linux + others | `CARGO_NET_GIT_FETCH_WITH_CLI`, conditional `AR_<target>` / `RANLIB_<target>` | Conservative — rustc picks the right linker on Linux |

`AR_<target>` / `RANLIB_<target>` are emitted only when R's values differ from cargo's defaults (`ar` / `ranlib`) — avoids the no-op `AR_… = "ar"` noise.

## `MACOSX_DEPLOYMENT_TARGET` derivation

First match wins; the chosen source is logged at `bash ./configure` time via `AC_MSG_NOTICE`.

1. **Shell env** `$MACOSX_DEPLOYMENT_TARGET` — caller's value passed through verbatim.
2. **R config parse** — `R CMD config {CC,CXX,FC}` scanned for `-mmacos-version-min=X.Y` / `-mmacosx-version-min=X.Y` (both spellings; clang uses `macos`, legacy gfortran uses `macosx`).
3. **Mach-O introspection** — `otool -l "$R_HOME/bin/exec/R"` → `LC_BUILD_VERSION minos` — the authoritative target R was actually linked against.
4. **Arch default** — `aarch64 → 14.0`, `x86_64 → 11.0`, per R-admin §macOS (current CRAN targets).

On the dev host (macOS 25.5, R 4.5.2 arm64 from CRAN binary), step 3 wins with `11.0` — that R was built against the Big Sur SDK. CI runners with newer R builds should pick up `14.0` from the same step 3, falling through to step 4 only if `otool` is missing.

## Why `[env]` first

TOML tables scope until the next `[…]` heading. `[env]` keys must therefore be emitted **before** `[source.crates-io]` / `[patch."https://…"]` / `[build]` — otherwise cargo would interpret them as `[build]` keys (or whichever table was last opened). The `emit_env_block()` shell function in the AC_CONFIG_COMMANDS block handles this consistently across all three install-mode branches.

## Why shell env still wins

The block emits `[env]` without `force = true`. Cargo's documented default semantics give shell env precedence over `[env]` values — users can override with `MACOSX_DEPLOYMENT_TARGET=12.0 R CMD INSTALL .` etc. `force = true` is the wrong floor-vs-ceiling for ABI flags: we want a sane default, not a lock-out.

## Sources

- R Installation and Administration §macOS (r-svn `doc/manual/R-admin.texi`) — CRAN target values (14.0 arm64, 11.0 Intel).
- r-svn `m4/libtool.m4` — R consumes `${MACOSX_DEPLOYMENT_TARGET-10.0}` with fallback but never sets it, hence the 4-step derivation requirement.
- r-devel/actions/setup-macos-tools — current CI flow uses identical values; this PR pushes them down a layer so install-time and CI-time agree.

## Test plan

- [x] `bash ./configure` from clean state — `[env]` lands as first table; values quoted; derivation source logged
- [x] `just configure` — same outcome; runs autoconf first
- [x] Tarball-mode test: `touch inst/vendor.tar.xz` then `bash ./configure` → `[env]` still first, followed by `[source.*]` / `[build]`
- [x] `R CMD INSTALL` end-to-end — package builds and installs cleanly with the new config.toml
- [x] `just check` (Rust workspace check) — green
- [x] `just templates-check` — patches/templates.patch matches actual templates ↔ rpkg delta
- [ ] CI verification on Linux/Windows/macOS runners (CI matrix)

## Out of scope

Filed as follow-up issues:

- #597 — Mirror R's LTO flag into `RUSTFLAGS` via `[env]`
- #598 — Propagate `CFLAGS_<target>` / `CXXFLAGS_<target>` (needs flag-filtering design)
- #599 — `.github/workflows/ci.yml` alignment: remove redundant `MACOSX_DEPLOYMENT_TARGET` exports now that configure provides them

</details>