### PR TITLE
feat(lint): MXL120 mirror — reject Self-returning vctrs constructors (#415)

### DIFF
--- a/miniextendr-lint/CLAUDE.md
+++ b/miniextendr-lint/CLAUDE.md
@@ -18,6 +18,7 @@ Build-time static analysis. Runs from a downstream crate's `build.rs` (via the `
 - **MXL110** — parameter name is an R reserved word.
 - **MXL111** — `s4_*` method on `#[miniextendr(s4)]` impl (codegen auto-prefixes — yields `s4_s4_*`).
 - **MXL112** — explicit lifetime param on `#[miniextendr]` fn/impl.
+- **MXL120** — vctrs constructor returns `Self`/named type, or impl has an instance-method receiver (`&self`, `self: &ExternalPtr<Self>`, etc.). Mirrors the proc-macro hard error in `miniextendr-macros`.
 - **MXL203** — redundant `internal` + `noexport`.
 - **MXL300** — direct `Rf_error`/`Rf_errorcall` → replace with `panic!()` (framework converts to R error via tagged-SEXP transport).
 - **MXL301** — `_unchecked` FFI outside known-safe contexts (ALTREP callbacks, `with_r_unwind_protect`, `with_r_thread`).

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -15,6 +15,74 @@ use crate::helpers::{
     is_altrep_struct, parse_miniextendr_impl_attrs,
 };
 
+// region: Impl method entry
+
+/// Receiver kind for an impl method, mirroring `ReceiverKind` in `miniextendr-macros`.
+///
+/// Mirror: `miniextendr-macros/src/miniextendr_impl.rs` — `ReceiverKind`.
+/// Keep both in sync: if the macro relaxes one receiver kind, update this enum too.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MethodReceiverKind {
+    /// No self — static / associated function.
+    None,
+    /// `&self`
+    Ref,
+    /// `&mut self`
+    RefMut,
+    /// `self` (consuming)
+    Value,
+    /// `self: &ExternalPtr<Self>`
+    ExternalPtrRef,
+    /// `self: &mut ExternalPtr<Self>`
+    ExternalPtrRefMut,
+    /// `self: ExternalPtr<Self>`
+    ExternalPtrValue,
+}
+
+impl MethodReceiverKind {
+    /// Returns true if this is an instance receiver (any form of `self`).
+    pub fn is_instance(self) -> bool {
+        matches!(
+            self,
+            Self::Ref
+                | Self::RefMut
+                | Self::Value
+                | Self::ExternalPtrRef
+                | Self::ExternalPtrRefMut
+                | Self::ExternalPtrValue
+        )
+    }
+
+    /// Human-readable spelling used in diagnostic messages.
+    pub fn spelling(self) -> &'static str {
+        match self {
+            Self::None => "(none)",
+            Self::Ref => "&self",
+            Self::RefMut => "&mut self",
+            Self::Value => "self",
+            Self::ExternalPtrRef => "self: &ExternalPtr<Self>",
+            Self::ExternalPtrRefMut => "self: &mut ExternalPtr<Self>",
+            Self::ExternalPtrValue => "self: ExternalPtr<Self>",
+        }
+    }
+}
+
+/// Per-method data collected during the crate-index pass for impl-method lint rules.
+#[derive(Clone, Debug)]
+pub struct ImplMethodEntry {
+    pub method_name: String,
+    pub line: usize,
+    pub class_system: String,
+    /// Stringified return type tokens (empty string = `()` / no explicit return).
+    pub return_type_str: String,
+    /// Receiver kind detected from the method signature.
+    pub receiver_kind: MethodReceiverKind,
+    /// True when the method carries `#[miniextendr(constructor)]`.
+    pub has_constructor_attr: bool,
+}
+
+// endregion
+
 // region: Lint item types
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -114,8 +182,8 @@ pub struct FileData {
     pub export_control: HashMap<String, (bool, bool, usize)>,
 
     // Impl method details for per-method lint rules
-    /// Methods per inherent impl type: type_name → Vec<(method_name, line, class_system)>.
-    pub impl_methods: HashMap<String, Vec<(String, usize, String)>>,
+    /// Methods per inherent impl type: type_name → Vec<ImplMethodEntry>.
+    pub impl_methods: HashMap<String, Vec<ImplMethodEntry>>,
 
     // Doc-comment roxygen tags per function/impl name
     /// Known roxygen tags: "@noRd", "@export", "@keywords internal"
@@ -538,18 +606,26 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                                     line,
                                 ));
 
-                                // Collect method names for per-method rules (e.g. MXL111)
+                                // Collect method names for per-method rules (e.g. MXL111, MXL120)
                                 let methods =
                                     data.impl_methods.entry(type_name.clone()).or_default();
                                 for impl_item in &item_impl.items {
                                     if let syn::ImplItem::Fn(method) = impl_item {
                                         let method_name = method.sig.ident.to_string();
                                         let method_line = method.sig.ident.span().start().line;
-                                        methods.push((
+                                        let return_type_str =
+                                            extract_return_type_str(&method.sig.output);
+                                        let receiver_kind = detect_receiver_kind(&method.sig);
+                                        let has_constructor_attr =
+                                            has_constructor_attr(&method.attrs);
+                                        methods.push(ImplMethodEntry {
                                             method_name,
-                                            method_line,
-                                            class_system.clone(),
-                                        ));
+                                            line: method_line,
+                                            class_system: class_system.clone(),
+                                            return_type_str,
+                                            receiver_kind,
+                                            has_constructor_attr,
+                                        });
                                     }
                                 }
 
@@ -672,6 +748,116 @@ fn scan_ffi_unchecked_calls(lines: &[&str], data: &mut FileData) {
         }
     }
 }
+
+// region: Impl method helpers (MXL120 and future per-method rules)
+
+/// Stringify a `syn::ReturnType` to a compact token string.
+///
+/// Returns an empty string for `-> ()` / no explicit return (both mean unit).
+fn extract_return_type_str(output: &syn::ReturnType) -> String {
+    use quote::ToTokens;
+    match output {
+        syn::ReturnType::Default => String::new(),
+        syn::ReturnType::Type(_, ty) => ty.to_token_stream().to_string(),
+    }
+}
+
+/// Detect the receiver kind from a method signature.
+///
+/// Mirror: `miniextendr-macros/src/miniextendr_impl.rs` — `detect_receiver_kind`.
+/// Keep both in sync: if the macro adds a new receiver variant, update this function too.
+fn detect_receiver_kind(sig: &syn::Signature) -> MethodReceiverKind {
+    let first = match sig.inputs.first() {
+        Some(arg) => arg,
+        None => return MethodReceiverKind::None,
+    };
+    match first {
+        syn::FnArg::Receiver(recv) => {
+            if recv.mutability.is_some() {
+                MethodReceiverKind::RefMut
+            } else if recv.reference.is_some() {
+                MethodReceiverKind::Ref
+            } else {
+                MethodReceiverKind::Value
+            }
+        }
+        syn::FnArg::Typed(pat_type) => {
+            // Typed `self:` form — check if it matches `ExternalPtr<Self>` variants.
+            let is_self_param = matches!(&*pat_type.pat, syn::Pat::Ident(pi) if pi.ident == "self");
+            if !is_self_param {
+                return MethodReceiverKind::None;
+            }
+            // Inspect the type: `&ExternalPtr<Self>`, `&mut ExternalPtr<Self>`, `ExternalPtr<Self>`
+            match &*pat_type.ty {
+                syn::Type::Reference(r) => {
+                    if is_external_ptr_self_ty(r.elem.as_ref()) {
+                        if r.mutability.is_some() {
+                            MethodReceiverKind::ExternalPtrRefMut
+                        } else {
+                            MethodReceiverKind::ExternalPtrRef
+                        }
+                    } else if r.mutability.is_some() {
+                        MethodReceiverKind::RefMut
+                    } else {
+                        MethodReceiverKind::Ref
+                    }
+                }
+                ty if is_external_ptr_self_ty(ty) => MethodReceiverKind::ExternalPtrValue,
+                _ => MethodReceiverKind::None,
+            }
+        }
+    }
+}
+
+/// Returns true if `ty` is `ExternalPtr<Self>` (last path segment = `ExternalPtr`,
+/// single type argument = `Self`).
+fn is_external_ptr_self_ty(ty: &syn::Type) -> bool {
+    let syn::Type::Path(p) = ty else {
+        return false;
+    };
+    let Some(last) = p.path.segments.last() else {
+        return false;
+    };
+    if last.ident != "ExternalPtr" {
+        return false;
+    }
+    let syn::PathArguments::AngleBracketed(ref args) = last.arguments else {
+        return false;
+    };
+    matches!(
+        args.args.first(),
+        Some(syn::GenericArgument::Type(syn::Type::Path(tp)))
+            if tp.path.is_ident("Self")
+    )
+}
+
+/// Returns true when the attribute list contains `#[miniextendr(constructor)]` or
+/// `#[miniextendr(r6(constructor))]` / `#[miniextendr(s3(constructor))]` etc.
+fn has_constructor_attr(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if attr
+            .path()
+            .segments
+            .last()
+            .is_none_or(|seg| seg.ident != "miniextendr")
+        {
+            continue;
+        }
+        if let syn::Meta::List(meta_list) = &attr.meta {
+            let tokens = meta_list.tokens.to_string();
+            // Accept both `constructor` at top level and inside `r6(...)`, `s3(...)`, etc.
+            if tokens
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .any(|t| t == "constructor")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// endregion
 
 /// Scan raw source text for direct Rf_error/Rf_errorcall calls.
 fn scan_rf_error_calls(lines: &[&str], data: &mut FileData) {

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -41,12 +41,17 @@ pub enum MethodReceiverKind {
 
 impl MethodReceiverKind {
     /// Returns true if this is an instance receiver (any form of `self`).
+    ///
+    /// Mirrors `ReceiverKind::is_instance` in `miniextendr-macros/src/miniextendr_impl.rs`.
+    /// `Value` (consuming `self`) is **excluded** — the macro treats consuming-`self` methods
+    /// separately: they are either constructors (`returns Self` or `#[miniextendr(constructor)]`)
+    /// or finalizers, not ordinary instance calls.  Including `Value` here would produce a
+    /// false-positive for a vctrs method with `#[miniextendr(constructor)]` that consumes `self`.
     pub fn is_instance(self) -> bool {
         matches!(
             self,
             Self::Ref
                 | Self::RefMut
-                | Self::Value
                 | Self::ExternalPtrRef
                 | Self::ExternalPtrRefMut
                 | Self::ExternalPtrValue
@@ -773,38 +778,45 @@ fn detect_receiver_kind(sig: &syn::Signature) -> MethodReceiverKind {
     };
     match first {
         syn::FnArg::Receiver(recv) => {
-            if recv.mutability.is_some() {
-                MethodReceiverKind::RefMut
-            } else if recv.reference.is_some() {
-                MethodReceiverKind::Ref
+            // syn 2.x parses *all* `self` receiver forms as `FnArg::Receiver`, including
+            // the typed forms `self: &ExternalPtr<Self>`, `self: &mut ExternalPtr<Self>`,
+            // and `self: ExternalPtr<Self>`.  When a colon token is present the receiver
+            // has an explicit type in `recv.ty`; otherwise `recv.reference` / `recv.mutability`
+            // describe the shorthand `(&)(&mut) self`.
+            if recv.colon_token.is_some() {
+                // Typed form: `self: <ty>`.  Classify by inspecting `recv.ty`.
+                match recv.ty.as_ref() {
+                    syn::Type::Reference(r) => {
+                        if is_external_ptr_self_ty(r.elem.as_ref()) {
+                            if r.mutability.is_some() {
+                                MethodReceiverKind::ExternalPtrRefMut
+                            } else {
+                                MethodReceiverKind::ExternalPtrRef
+                            }
+                        } else if r.mutability.is_some() {
+                            MethodReceiverKind::RefMut
+                        } else {
+                            MethodReceiverKind::Ref
+                        }
+                    }
+                    ty if is_external_ptr_self_ty(ty) => MethodReceiverKind::ExternalPtrValue,
+                    _ => MethodReceiverKind::None,
+                }
             } else {
-                MethodReceiverKind::Value
+                // Shorthand form: `self`, `&self`, `&mut self`.
+                if recv.mutability.is_some() {
+                    MethodReceiverKind::RefMut
+                } else if recv.reference.is_some() {
+                    MethodReceiverKind::Ref
+                } else {
+                    MethodReceiverKind::Value
+                }
             }
         }
-        syn::FnArg::Typed(pat_type) => {
-            // Typed `self:` form — check if it matches `ExternalPtr<Self>` variants.
-            let is_self_param = matches!(&*pat_type.pat, syn::Pat::Ident(pi) if pi.ident == "self");
-            if !is_self_param {
-                return MethodReceiverKind::None;
-            }
-            // Inspect the type: `&ExternalPtr<Self>`, `&mut ExternalPtr<Self>`, `ExternalPtr<Self>`
-            match &*pat_type.ty {
-                syn::Type::Reference(r) => {
-                    if is_external_ptr_self_ty(r.elem.as_ref()) {
-                        if r.mutability.is_some() {
-                            MethodReceiverKind::ExternalPtrRefMut
-                        } else {
-                            MethodReceiverKind::ExternalPtrRef
-                        }
-                    } else if r.mutability.is_some() {
-                        MethodReceiverKind::RefMut
-                    } else {
-                        MethodReceiverKind::Ref
-                    }
-                }
-                ty if is_external_ptr_self_ty(ty) => MethodReceiverKind::ExternalPtrValue,
-                _ => MethodReceiverKind::None,
-            }
+        syn::FnArg::Typed(_) => {
+            // In syn 2.x, typed `self:` forms are represented as `FnArg::Receiver`, so
+            // this arm is only reached for genuinely non-`self` parameters.
+            MethodReceiverKind::None
         }
     }
 }

--- a/miniextendr-lint/src/helpers.rs
+++ b/miniextendr-lint/src/helpers.rs
@@ -136,7 +136,10 @@ pub fn parse_miniextendr_impl_attrs(attrs: &[Attribute]) -> MiniextendrImplAttrs
                 continue;
             }
 
-            for part in tokens.split(',') {
+            // Parse the flat top-level comma-separated list, skipping nested parens.
+            // This handles `vctrs(kind = "vctr", base = "double", ...)` as a single
+            // top-level item without being tripped up by the inner commas.
+            for part in split_top_level_commas(tokens) {
                 let part = part.trim();
                 if part.is_empty() {
                     continue;
@@ -154,15 +157,63 @@ pub fn parse_miniextendr_impl_attrs(attrs: &[Attribute]) -> MiniextendrImplAttrs
                     result.noexport = true;
                 } else if part == "strict" {
                     result.strict = true;
-                } else if !part.contains('=') {
-                    // Class system identifier (env, r6, s3, s4, s7)
-                    result.class_system = Some(part.to_string());
+                } else if !part.contains('=') || part.contains('(') {
+                    // Class system identifier: env, r6, s3, s4, s7, vctrs.
+                    // `vctrs` may appear as `vctrs(kind = "vctr", ...)` — keep
+                    // only the leading identifier before any `(`.
+                    let base = part
+                        .find(|c: char| !c.is_alphanumeric() && c != '_')
+                        .map(|i| &part[..i])
+                        .unwrap_or(part);
+                    if !base.is_empty() {
+                        result.class_system = Some(base.to_string());
+                    }
                 }
             }
         }
     }
 
     result
+}
+
+/// Split a token string on top-level commas (ignoring commas inside `(...)` groups).
+fn split_top_level_commas(s: &str) -> impl Iterator<Item = &str> {
+    SplitTopLevelCommas { remaining: s }
+}
+
+struct SplitTopLevelCommas<'a> {
+    remaining: &'a str,
+}
+
+impl<'a> Iterator for SplitTopLevelCommas<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        if self.remaining.is_empty() {
+            return None;
+        }
+        let mut depth: usize = 0;
+        let mut in_str = false;
+        let bytes = self.remaining.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'"' if !in_str => in_str = true,
+                b'"' if in_str => in_str = false,
+                b'(' | b'[' | b'{' if !in_str => depth += 1,
+                b')' | b']' | b'}' if !in_str && depth > 0 => depth -= 1,
+                b',' if !in_str && depth == 0 => {
+                    let item = &self.remaining[..i];
+                    self.remaining = &self.remaining[i + 1..];
+                    return Some(item);
+                }
+                _ => {}
+            }
+        }
+        // Last item (no trailing comma)
+        let item = self.remaining;
+        self.remaining = "";
+        Some(item)
+    }
 }
 
 /// Extract `#[path = "..."]` attribute value from a module declaration.

--- a/miniextendr-lint/src/lint_code.rs
+++ b/miniextendr-lint/src/lint_code.rs
@@ -27,6 +27,11 @@ pub enum LintCode {
     MXL111,
     /// Explicit lifetime parameter on `#[miniextendr]` fn or impl — use owned types instead.
     MXL112,
+    /// vctrs constructor returns `Self` / named type, or impl has an instance-method receiver.
+    ///
+    /// Mirror: `miniextendr-macros/src/miniextendr_impl.rs` (proc-macro hard error).
+    /// Both checks must fire on the same source; keep them in sync.
+    MXL120,
     // endregion
 
     // region: P1: Important
@@ -59,6 +64,10 @@ impl LintCode {
 
             // Codegen-breaking: reserved words produce syntactically invalid R wrappers.
             Self::MXL110 => Severity::Error,
+
+            // Runtime-breaking: vctrs constructors returning Self produce EXTPTRSXP
+            // which vctrs::new_vctr() rejects; instance-method receivers panic at runtime.
+            Self::MXL120 => Severity::Error,
 
             // Everything else is a warning.
             Self::MXL106

--- a/miniextendr-lint/src/rules.rs
+++ b/miniextendr-lint/src/rules.rs
@@ -12,6 +12,7 @@ pub mod lifetime_param;
 pub mod r_reserved_params;
 pub mod rf_error;
 pub mod s4_method_prefix;
+pub mod vctrs_self_ctor;
 
 use crate::crate_index::CrateIndex;
 use crate::diagnostic::Diagnostic;
@@ -43,6 +44,9 @@ pub fn run_all_rules(index: &CrateIndex) -> Vec<Diagnostic> {
 
     // Per-file: explicit lifetime param on #[miniextendr] fn/impl (MXL112)
     lifetime_param::check(index, &mut diagnostics);
+
+    // Per-file: vctrs ctor returns Self / instance receiver on vctrs impl (MXL120)
+    vctrs_self_ctor::check(index, &mut diagnostics);
 
     // Sort by path and line for deterministic output
     diagnostics.sort_by(|a, b| {

--- a/miniextendr-lint/src/rules/s4_method_prefix.rs
+++ b/miniextendr-lint/src/rules/s4_method_prefix.rs
@@ -12,25 +12,26 @@ use crate::lint_code::LintCode;
 pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
     for (path, data) in &index.file_data {
         for (impl_type, methods) in &data.impl_methods {
-            for (method_name, line, class_system) in methods {
-                if class_system != "s4" {
+            for entry in methods {
+                if entry.class_system != "s4" {
                     continue;
                 }
                 // Constructors (`new`) are not auto-prefixed — they become the
                 // class constructor function, named after the type, not `s4_new`.
-                if method_name == "new" {
+                if entry.method_name == "new" {
                     continue;
                 }
-                if let Some(rest) = method_name.strip_prefix("s4_") {
+                if let Some(rest) = entry.method_name.strip_prefix("s4_") {
                     diagnostics.push(
                         Diagnostic::new(
                             LintCode::MXL111,
                             path,
-                            *line,
+                            entry.line,
                             format!(
-                                "method `{impl_type}::{method_name}` will produce R generic \
-                                 `s4_{method_name}` (s4 codegen auto-prepends `s4_`); \
+                                "method `{impl_type}::{}` will produce R generic \
+                                 `s4_{}` (s4 codegen auto-prepends `s4_`); \
                                  rename to `{rest}` to avoid the double prefix",
+                                entry.method_name, entry.method_name,
                             ),
                         )
                         .with_help(

--- a/miniextendr-lint/src/rules/vctrs_self_ctor.rs
+++ b/miniextendr-lint/src/rules/vctrs_self_ctor.rs
@@ -1,0 +1,177 @@
+//! MXL120: vctrs constructor returns `Self` / named type, or impl has an instance-method receiver.
+//!
+//! A `#[miniextendr(vctrs(...))]` impl has two hard invariants:
+//!
+//! 1. **Constructor return type** — the constructor (`fn new` or a method tagged
+//!    `#[miniextendr(constructor)]`) must NOT return `Self`, `&Self`, `&mut Self`,
+//!    `Box<Self>`, the named impl type, `Result<Self, _>`, or `Result<NamedType, _>`.
+//!    The generated R wrapper passes the return value to `vctrs::new_vctr()` /
+//!    `new_rcrd()` / `new_list_of()`, which require a plain vector payload, not an
+//!    `ExternalPtr` (`EXTPTRSXP`).
+//!
+//! 2. **Instance receivers** — no method may carry any form of `self` receiver
+//!    (`&self`, `&mut self`, `self`, `self: &ExternalPtr<Self>`, etc.).
+//!    A vctrs object is an S3-classed base vector; there is no Rust `Self` stored
+//!    inside the SEXP.  The C wrapper cannot reconstruct `Self` from a base vector,
+//!    so calling an instance method would panic at runtime.
+//!
+//! ## Mirror
+//!
+//! The same checks fire as proc-macro hard errors in
+//! `miniextendr-macros/src/miniextendr_impl.rs` (search `MXL120`).
+//! This lint is defence-in-depth: it catches the mistake during the
+//! build-time static-analysis pass (when the macro isn't being expanded,
+//! e.g. lint-only IDE runs, third-party tooling).
+//! Keep both implementations in sync: if the macro relaxes either check,
+//! update this rule too.
+
+use crate::crate_index::{CrateIndex, MethodReceiverKind};
+use crate::diagnostic::Diagnostic;
+use crate::lint_code::LintCode;
+
+pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
+    for (path, data) in &index.file_data {
+        for (impl_type, methods) in &data.impl_methods {
+            for entry in methods {
+                if entry.class_system != "vctrs" {
+                    continue;
+                }
+
+                // Check 1: constructor return type.
+                //
+                // A method is a vctrs constructor when it either:
+                //   (a) is named `new` with no instance receiver, OR
+                //   (b) carries `#[miniextendr(constructor)]`.
+                //
+                // Note: a method with an instance receiver named `new` is already
+                // caught by Check 2 below, so we restrict the `new`-heuristic to
+                // static methods only (receiver == None), matching the macro's
+                // `method.env != ReceiverKind::Ref && method.env != ReceiverKind::RefMut`
+                // guard in `miniextendr_impl.rs:2209-2212`.
+                let is_ctor = (entry.method_name == "new"
+                    && entry.receiver_kind == MethodReceiverKind::None)
+                    || entry.has_constructor_attr;
+
+                if is_ctor && return_type_is_self_or_named(&entry.return_type_str, impl_type) {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            LintCode::MXL120,
+                            path,
+                            entry.line,
+                            format!(
+                                "[MXL120] vctrs constructor `{}` must not return `Self` or `{}`.\n\
+                                 \n\
+                                 The generated R wrapper passes the constructor result to \
+                                 `vctrs::new_vctr()` (or `new_rcrd`/`new_list_of`), which requires a \
+                                 plain vector payload — not an ExternalPtr (`EXTPTRSXP`).\n\
+                                 \n\
+                                 Fix: return the vector payload directly instead of `Self`.\n\
+                                 For example, return `Vec<f64>` (for vctr), a \
+                                 `std::collections::HashMap` / named-list struct (for rcrd), or a \
+                                 `Vec<Vec<T>>` (for list_of).",
+                                entry.method_name, impl_type,
+                            ),
+                        )
+                        .with_help(
+                            "vctrs objects are S3-classed base vectors — there is no ExternalPtr \
+                             to return; return the plain vector payload instead",
+                        ),
+                    );
+                }
+
+                // Check 2: instance receivers are not supported on vctrs impls.
+                if entry.receiver_kind.is_instance() {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            LintCode::MXL120,
+                            path,
+                            entry.line,
+                            format!(
+                                "[MXL120] vctrs impl method `{}` uses a `{}` receiver, which is \
+                                 not supported on `#[miniextendr(vctrs(...))]` impls.\n\
+                                 \n\
+                                 A vctrs object is an S3-classed base vector (REALSXP, INTSXP, \
+                                 etc.). There is no Rust `Self` stored inside the R SEXP — the \
+                                 vector payload IS the R object. The C wrapper cannot reconstruct \
+                                 `Self` from a base vector, so calling an instance method would \
+                                 panic at runtime.\n\
+                                 \n\
+                                 Fix: convert this method to a static method whose parameters \
+                                 receive the vector data directly.",
+                                entry.method_name,
+                                entry.receiver_kind.spelling(),
+                            ),
+                        )
+                        .with_help(
+                            "convert instance methods to static methods; pass the vector data \
+                             (e.g. `Vec<f64>`) as an explicit parameter instead of `self`",
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}
+
+// region: Return-type predicate
+//
+// Mirror of `vctrs_ctor_returns_self_or_type` + `ty_is_self_or_named` in
+// `miniextendr-macros/src/miniextendr_impl.rs`.
+// Intentionally duplicated (not shared) — the lint crate must remain independent
+// of the macros crate at the type level.  When the macro changes the predicate,
+// update both.
+
+/// Returns true if `return_type_str` represents `Self`, `&Self`, `&mut Self`,
+/// `Box<Self>`, the named type, `Result<Self, _>`, or `Result<NamedType, _>`.
+///
+/// `return_type_str` is the stringified token form produced by
+/// `quote::ToTokens::to_token_stream()` on a `syn::ReturnType::Type`.
+/// An empty string means the return type is `()` (no explicit return) and
+/// always returns `false`.
+fn return_type_is_self_or_named(return_type_str: &str, type_name: &str) -> bool {
+    if return_type_str.is_empty() {
+        return false;
+    }
+    // Re-parse the stored token string.  If parsing fails (shouldn't happen for
+    // well-formed Rust), conservatively return false so we don't emit spurious errors.
+    let Ok(ty) = syn::parse_str::<syn::Type>(return_type_str) else {
+        return false;
+    };
+    ty_is_self_or_named(&ty, type_name)
+}
+
+/// Recursively checks whether `ty` is `Self`, `&Self`, `&mut Self`, `Box<Self>`,
+/// the named type, or `Result<(Self | NamedType), _>`.
+fn ty_is_self_or_named(ty: &syn::Type, type_name: &str) -> bool {
+    match ty {
+        syn::Type::Path(p) => {
+            let Some(last) = p.path.segments.last() else {
+                return false;
+            };
+            // Plain `Self` or `TypeName`
+            if last.ident == "Self" || last.ident == type_name {
+                return true;
+            }
+            // `Result<Self, _>` or `Result<TypeName, _>`
+            if last.ident == "Result"
+                && let syn::PathArguments::AngleBracketed(ref args) = last.arguments
+                && let Some(syn::GenericArgument::Type(first_ty)) = args.args.first()
+            {
+                return ty_is_self_or_named(first_ty, type_name);
+            }
+            // `Box<Self>` or `Box<TypeName>`
+            if last.ident == "Box"
+                && let syn::PathArguments::AngleBracketed(ref args) = last.arguments
+                && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+            {
+                return ty_is_self_or_named(inner, type_name);
+            }
+            false
+        }
+        // `&Self` or `&mut Self`
+        syn::Type::Reference(r) => ty_is_self_or_named(r.elem.as_ref(), type_name),
+        _ => false,
+    }
+}
+
+// endregion

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -711,4 +711,159 @@ fn mxl120_no_fire_for_r6_ctor_returns_self() {
     );
 }
 
+#[test]
+fn mxl120_vctrs_ctor_returns_box_self() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Box<Self> { Box::new(MyVec { values }) }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs ctor returning Box<Self>, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_ctor_returns_named_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Named-type return (`fn new() -> MyVec`) exercises the `last.ident == type_name` branch.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> MyVec { MyVec { values } }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs ctor returning named type MyVec, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_instance_method_externalptr_value_receiver() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // `self: ExternalPtr<Self>` (by-value) — distinct from `self: &ExternalPtr<Self>` (ref).
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            pub fn consume(self: ExternalPtr<Self>) -> f64 { 0.0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 for vctrs method with ExternalPtr<Self> by-value receiver, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_constructor_tag_on_non_new() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // `#[miniextendr(constructor)]` on a non-`new` method returning Self — exercises
+    // the `has_constructor_attr` path at `vctrs_self_ctor.rs`.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            #[miniextendr(constructor)]
+            pub fn from_raw(values: Vec<f64>) -> Self { MyVec { values } }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 for vctrs #[miniextendr(constructor)] method returning Self, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_no_false_positive_for_consuming_self_on_vctrs() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Consuming `self` (Value) is NOT an instance receiver per the macro's `is_instance()`.
+    // With `#[miniextendr(constructor)]` and a non-Self return, the macro allows it.
+    // MXL120 Check 2 must NOT fire here — this verifies `is_instance()` parity with
+    // `ReceiverKind::is_instance` in `miniextendr-macros` (which excludes `Value`).
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            #[miniextendr(constructor)]
+            pub fn convert(self) -> Vec<f64> { vec![] }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    // Check 2 (instance receiver) must NOT fire.  Check 1 (ctor return type) also must
+    // not fire because `Vec<f64>` is not Self/named-type.
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL120"),
+        "MXL120 must not fire on consuming `self` with constructor attr + Vec<f64> return, got: {:?}",
+        report.diagnostics
+    );
+}
+
 // endregion

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -531,3 +531,184 @@ fn mxl110_r_reserved_word_as_method_param() {
         report.diagnostics
     );
 }
+
+// region: MXL120 — vctrs Self-returning constructor / instance receiver
+
+#[test]
+fn mxl120_vctrs_ctor_returns_self() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Self { MyVec { values } }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs ctor returning Self, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_ctor_returns_result_self() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Result<Self, String> {
+                Ok(MyVec { values })
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs ctor returning Result<Self, _>, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_instance_method_ref_self() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            pub fn value(&self) -> f64 { 0.0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs instance method &self, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_vctrs_instance_method_external_ptr() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            pub fn value(self: &ExternalPtr<Self>) -> f64 { 0.0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL120"),
+        "expected MXL120 error for vctrs instance method with ExternalPtr<Self> receiver, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_no_fire_for_valid_vctrs_impl() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // All-static methods, constructor returns Vec<f64> — clean.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(vctrs(vctr))]
+        impl MyVec {
+            pub fn new(values: Vec<f64>) -> Vec<f64> { values }
+            pub fn scale(amounts: Vec<f64>, factor: f64) -> Vec<f64> {
+                amounts.into_iter().map(|v| v * factor).collect()
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL120"),
+        "MXL120 must not fire on valid vctrs impl, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl120_no_fire_for_r6_ctor_returns_self() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Non-vctrs class system: MXL120 must NOT fire even if constructor returns Self.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr(r6)]
+        impl MyR6 {
+            pub fn new() -> Self { MyR6 {} }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL120"),
+        "MXL120 must not fire on non-vctrs impl (r6), got: {:?}",
+        report.diagnostics
+    );
+}
+
+// endregion

--- a/rpkg/src/rust/columnar_option_none_tests.rs
+++ b/rpkg/src/rust/columnar_option_none_tests.rs
@@ -132,9 +132,18 @@ pub fn test_columnar_opt_u64_all_none_single() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_all_none_multi() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: None },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: None },
+        WithOptU64 {
+            name: "a".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -213,9 +222,18 @@ pub fn test_columnar_opt_bytes_all_none() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: Some(42) },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: Some(99) },
+        WithOptU64 {
+            name: "a".into(),
+            stored: Some(42),
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: Some(99),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -226,7 +244,10 @@ pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptString { id: 1, label: Some("hello".into()) },
+        WithOptString {
+            id: 1,
+            label: Some("hello".into()),
+        },
         WithOptString { id: 2, label: None },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -242,8 +263,14 @@ pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptBytes { id: 1, data: Some(vec![1u8, 2, 3]) },
-        WithOptBytes { id: 2, data: Some(vec![4u8, 5]) },
+        WithOptBytes {
+            id: 1,
+            data: Some(vec![1u8, 2, 3]),
+        },
+        WithOptBytes {
+            id: 2,
+            data: Some(vec![4u8, 5]),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -259,8 +286,14 @@ pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_and_opt_none() -> ColumnarDataFrame {
     let rows = vec![
-        WithBytesAndOpt { raw: vec![1u8, 2], stored: None },
-        WithBytesAndOpt { raw: vec![3u8], stored: None },
+        WithBytesAndOpt {
+            raw: vec![1u8, 2],
+            stored: None,
+        },
+        WithBytesAndOpt {
+            raw: vec![3u8],
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -278,11 +311,17 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
     let rows = vec![
         WithFlattenedOptField {
             id: 1,
-            inner: InnerWithOpt { size: None, name: "a".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "a".into(),
+            },
         },
         WithFlattenedOptField {
             id: 2,
-            inner: InnerWithOpt { size: None, name: "b".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "b".into(),
+            },
         },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -297,10 +336,7 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
 /// @export
 #[miniextendr]
 pub fn test_columnar_enum_all_none() -> ColumnarDataFrame {
-    let rows = vec![
-        EventWithOptX::A { x: None },
-        EventWithOptX::A { x: None },
-    ];
+    let rows = vec![EventWithOptX::A { x: None }, EventWithOptX::A { x: None }];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
 
@@ -352,7 +388,10 @@ pub fn test_columnar_schema_upgrade_scalar() -> ColumnarDataFrame {
 pub fn test_columnar_schema_upgrade_nested() -> ColumnarDataFrame {
     let rows = vec![
         WithOptPoint { id: 1, point: None },
-        WithOptPoint { id: 2, point: Some(InnerStruct { x: 1.0, y: 2.0 }) },
+        WithOptPoint {
+            id: 2,
+            point: Some(InnerStruct { x: 1.0, y: 2.0 }),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -400,7 +439,10 @@ pub fn test_columnar_schema_upgrade_multi_none_first() -> ColumnarDataFrame {
 pub fn test_columnar_compound_different_shapes() -> ColumnarDataFrame {
     let rows = vec![
         EventDifferentNested::A { value: 1.0 },
-        EventDifferentNested::B { value: 2.0, extra: 3.0 },
+        EventDifferentNested::B {
+            value: 2.0,
+            extra: 3.0,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -235,10 +235,7 @@ pub struct WithSlicePinned<'a> {
 // This enum uses only owned types to verify the enum expand path compiles.
 #[derive(Clone, Debug, DataFrameRow)]
 pub enum WithLifetimeEnumOwned {
-    Row {
-        label: String,
-        value: f64,
-    },
+    Row { label: String, value: f64 },
 }
 
 // Test enum with skip

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -28,13 +28,8 @@ use miniextendr_api::{DataFrameRow, IntoList, List, miniextendr};
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum VecOpaqueEvent {
-    Items {
-        label: String,
-        items: Vec<i32>,
-    },
-    NoItems {
-        label: String,
-    },
+    Items { label: String, items: Vec<i32> },
+    NoItems { label: String },
 }
 
 fn vec_opaque_payload(label: &str, items: Vec<i32>) -> VecOpaqueEvent {
@@ -93,13 +88,8 @@ pub fn vec_opaque_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum HashSetEvent {
-    Tagged {
-        id: i32,
-        tags: HashSet<String>,
-    },
-    Untagged {
-        id: i32,
-    },
+    Tagged { id: i32, tags: HashSet<String> },
+    Untagged { id: i32 },
 }
 
 fn hashset_payload(id: i32, tags: &[&str]) -> HashSetEvent {
@@ -158,13 +148,8 @@ pub fn hashset_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum BTreeSetEvent {
-    Cats {
-        label: String,
-        cats: BTreeSet<i32>,
-    },
-    NoCats {
-        label: String,
-    },
+    Cats { label: String, cats: BTreeSet<i32> },
+    NoCats { label: String },
 }
 
 fn btreeset_payload(label: &str, cats: &[i32]) -> BTreeSetEvent {
@@ -514,16 +499,25 @@ pub enum BorrowedStrEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_str_split_1v1r() -> List {
-    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named { id: 1, name: "alice" }];
+    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named {
+        id: 1,
+        name: "alice",
+    }];
     BorrowedStrEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_str_split_1vnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Named { id: 2, name: "bob" },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
 }
@@ -531,7 +525,10 @@ pub fn borrowed_str_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_str_split_nv1r() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -540,9 +537,15 @@ pub fn borrowed_str_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'static>> {
     ToDataFrame(BorrowedStrEvent::to_dataframe(vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ]))
 }
@@ -550,9 +553,15 @@ pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'stati
 #[miniextendr]
 pub fn borrowed_str_split_nvnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -571,17 +580,28 @@ pub enum BorrowedSliceEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_slice_split_1v1r() -> List {
-    let data: Vec<BorrowedSliceEvent<'static>> =
-        vec![BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] }];
+    let data: Vec<BorrowedSliceEvent<'static>> = vec![BorrowedSliceEvent::Buffer {
+        label: "a".into(),
+        data: &[1.0, 2.0, 3.0],
+    }];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_slice_split_1vnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
-        BorrowedSliceEvent::Buffer { label: "b".into(), data: &[4.0] },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "b".into(),
+            data: &[4.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[],
+        },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
@@ -589,7 +609,10 @@ pub fn borrowed_slice_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_slice_split_nv1r() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -598,9 +621,15 @@ pub fn borrowed_slice_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'static>> {
     ToDataFrame(BorrowedSliceEvent::to_dataframe(vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ]))
 }
@@ -608,9 +637,15 @@ pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'s
 #[miniextendr]
 pub fn borrowed_slice_split_nvnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -1025,7 +1060,10 @@ mod tests {
             df.tally_keys[0].as_deref(),
             Some(vec!["a".to_string(), "z".to_string()].as_slice())
         );
-        assert_eq!(df.tally_values[0].as_deref(), Some(vec![1i32, 3i32].as_slice()));
+        assert_eq!(
+            df.tally_values[0].as_deref(),
+            Some(vec![1i32, 3i32].as_slice())
+        );
     }
 
     #[test]
@@ -1099,9 +1137,18 @@ pub fn struct_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_1vnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1109,7 +1156,10 @@ pub fn struct_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nv1r() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1118,8 +1168,14 @@ pub fn struct_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nvnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ])
@@ -1129,8 +1185,14 @@ pub fn struct_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_align_nvnr() -> ToDataFrame<StructFlattenEventDataFrame> {
     ToDataFrame(StructFlattenEvent::to_dataframe(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ]))
@@ -1153,9 +1215,18 @@ pub fn struct_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_1vnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1163,7 +1234,10 @@ pub fn struct_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_list_split_nv1r() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
     ])
 }
@@ -1172,8 +1246,14 @@ pub fn struct_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_nvnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ])
@@ -1183,8 +1263,14 @@ pub fn struct_list_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_list_align_nvnr() -> ToDataFrame<StructListEventDataFrame> {
     ToDataFrame(StructListEvent::to_dataframe(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ]))
@@ -1201,7 +1287,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_flatten_align_located_rows_have_values() {
         let df = StructFlattenEvent::to_dataframe(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructFlattenEvent::Other { id: 2 },
         ]);
         // origin is present at row 0 (Located), absent at row 1 (Other)
@@ -1221,8 +1310,14 @@ mod struct_field_tests {
     #[ignore = "requires R runtime (calls into_data_frame)"]
     fn test_struct_flatten_split_located_has_correct_count() {
         let split = StructFlattenEvent::to_dataframe_split(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-            StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
+            StructFlattenEvent::Located {
+                id: 2,
+                origin: Point { x: 3.0, y: 4.0 },
+            },
             StructFlattenEvent::Other { id: 3 },
         ]);
         // split returns a list of per-variant data frames
@@ -1233,7 +1328,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_list_align_origin_is_some() {
         let df = StructListEvent::to_dataframe(vec![
-            StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructListEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructListEvent::Other { id: 2 },
         ]);
         // origin is the list-column holding Option<Point>
@@ -1344,9 +1442,18 @@ pub fn nested_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_1vnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ])
 }
 
@@ -1354,7 +1461,10 @@ pub fn nested_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nv1r() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1363,8 +1473,14 @@ pub fn nested_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nvnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ])
@@ -1374,7 +1490,10 @@ pub fn nested_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
     ]))
 }
 
@@ -1382,9 +1501,18 @@ pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ]))
 }
 
@@ -1392,7 +1520,10 @@ pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ]))
 }
@@ -1401,8 +1532,14 @@ pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nvnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ]))
@@ -1425,9 +1562,18 @@ pub fn nested_factor_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_1vnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1435,7 +1581,10 @@ pub fn nested_factor_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nv1r() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ])
 }
@@ -1444,8 +1593,14 @@ pub fn nested_factor_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nvnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ])
@@ -1454,19 +1609,30 @@ pub fn nested_factor_split_nvnr() -> List {
 /// 1v1r align (as_factor): single Move row.
 #[miniextendr]
 pub fn nested_factor_align_1v1r() -> ToDataFrame<NestedFactorEventDataFrame> {
-    ToDataFrame(NestedFactorEvent::to_dataframe(vec![NestedFactorEvent::Move {
-        id: 1,
-        dir: Direction::North,
-    }]))
+    ToDataFrame(NestedFactorEvent::to_dataframe(vec![
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+    ]))
 }
 
 /// 1vNr align (as_factor): multiple Move rows.
 #[miniextendr]
 pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1474,7 +1640,10 @@ pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ]))
 }
@@ -1483,8 +1652,14 @@ pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nvnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ]))
@@ -1507,9 +1682,18 @@ pub fn nested_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_1vnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1517,7 +1701,10 @@ pub fn nested_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_list_split_nv1r() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ])
 }
@@ -1526,8 +1713,14 @@ pub fn nested_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_nvnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ])
@@ -1546,9 +1739,18 @@ pub fn nested_list_align_1v1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1556,7 +1758,10 @@ pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ]))
 }
@@ -1565,8 +1770,14 @@ pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nvnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ]))
@@ -1594,9 +1805,15 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_companion_struct_shape() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
-            NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+            NestedFlattenEvent::Tracked {
+                id: 3,
+                status: Status::Err { code: 404 },
+            },
         ]);
         assert_eq!(df.id[0], Some(1i32));
         assert_eq!(df.id[1], Some(2i32));
@@ -1616,11 +1833,8 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_status_payload_columns() {
         // Verify inner Status companion struct has the expected column layout.
-        let inner_df = Status::to_dataframe(vec![
-            Status::Ok,
-            Status::Err { code: 404 },
-            Status::Ok,
-        ]);
+        let inner_df =
+            Status::to_dataframe(vec![Status::Ok, Status::Err { code: 404 }, Status::Ok]);
         // `code` column: None for Ok rows, Some(i32) for Err rows.
         assert!(inner_df.code[0].is_none()); // Ok has no code
         assert_eq!(inner_df.code[1], Some(404i32));
@@ -1630,7 +1844,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_factor_align_col_types() {
         let df = NestedFactorEvent::to_dataframe(vec![
-            NestedFactorEvent::Move { id: 1, dir: Direction::North },
+            NestedFactorEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedFactorEvent::Stop { id: 2 },
         ]);
         // The companion struct has id: Vec<Option<i32>> and dir: Vec<Option<Direction>>
@@ -1653,7 +1870,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_list_align_col_types() {
         let df = NestedListEvent::to_dataframe(vec![
-            NestedListEvent::Move { id: 1, dir: Direction::North },
+            NestedListEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedListEvent::Stop { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));
@@ -1664,7 +1884,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_align_col_types() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));

--- a/rpkg/src/rust/dataframe_struct_flatten_test.rs
+++ b/rpkg/src/rust/dataframe_struct_flatten_test.rs
@@ -214,9 +214,18 @@ pub fn flat_basic_1row() -> ToDataFrame<FlatLocatedDataFrame> {
 #[miniextendr]
 pub fn flat_basic_nrow() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocated::to_dataframe(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -246,11 +255,17 @@ pub fn flat_mixed_inner_types() -> ToDataFrame<FlatTaggedDataFrame> {
     ToDataFrame(FlatTagged::to_dataframe(vec![
         FlatTagged {
             id: 1,
-            owner: FlatPerson { name: "Ada".to_string(), age: 30 },
+            owner: FlatPerson {
+                name: "Ada".to_string(),
+                age: 30,
+            },
         },
         FlatTagged {
             id: 2,
-            owner: FlatPerson { name: "Linus".to_string(), age: 50 },
+            owner: FlatPerson {
+                name: "Linus".to_string(),
+                age: 50,
+            },
         },
     ]))
 }
@@ -266,16 +281,28 @@ pub fn flat_renamed_inner() -> ToDataFrame<FlatRenamedDataFrame> {
 #[miniextendr]
 pub fn flat_skip_inner() -> ToDataFrame<FlatSkipDataFrame> {
     ToDataFrame(FlatSkip::to_dataframe(vec![
-        FlatSkip { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatSkip { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatSkip {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatSkip {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
 #[miniextendr]
 pub fn flat_as_list_inner() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsList::to_dataframe(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -406,7 +433,10 @@ const _: () = {
     fn _shape_mixed_inner_types() {
         let _ = FlatTaggedDataFrame {
             id: vec![1],
-            owner: vec![FlatPerson { name: "x".to_string(), age: 1 }],
+            owner: vec![FlatPerson {
+                name: "x".to_string(),
+                age: 1,
+            }],
         };
     }
 
@@ -454,9 +484,7 @@ const _: () = {
     // `Vec<List>` column provides the row-count). This verifies that `par_len_field`
     // codegen correctly omits `_len` for this shape and the struct compiles.
     fn _shape_only_as_list() {
-        let _ = FlatOnlyAsListDataFrame {
-            data: vec![],
-        };
+        let _ = FlatOnlyAsListDataFrame { data: vec![] };
     }
 };
 
@@ -470,9 +498,18 @@ const _: () = {
 #[miniextendr]
 pub fn flat_basic_par() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocatedDataFrame::from_rows_par(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -501,8 +538,14 @@ pub fn flat_two_struct_fields_par() -> ToDataFrame<FlatSegmentDataFrame> {
 #[miniextendr]
 pub fn flat_as_list_par() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsListDataFrame::from_rows_par(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -514,11 +557,17 @@ pub fn flat_nested_par() -> ToDataFrame<FlatNestedDataFrame> {
     ToDataFrame(FlatNestedDataFrame::from_rows_par(vec![
         FlatNested {
             id: 1,
-            inner: FlatInner { a: 10.0, sub: FlatSubInner { depth: 100.0 } },
+            inner: FlatInner {
+                a: 10.0,
+                sub: FlatSubInner { depth: 100.0 },
+            },
         },
         FlatNested {
             id: 2,
-            inner: FlatInner { a: 20.0, sub: FlatSubInner { depth: 200.0 } },
+            inner: FlatInner {
+                a: 20.0,
+                sub: FlatSubInner { depth: 200.0 },
+            },
         },
     ]))
 }
@@ -539,7 +588,10 @@ mod par_tests {
             (0..100)
                 .map(|i| FlatLocated {
                     id: i,
-                    origin: FlatPoint { x: i as f64, y: (i as f64) * 2.0 },
+                    origin: FlatPoint {
+                        x: i as f64,
+                        y: (i as f64) * 2.0,
+                    },
                 })
                 .collect()
         };

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -175,9 +175,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // Flatten path: struct-typed field expands to prefixed columns.
     let flatten_rows = vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 4 },
     ];
     let _ = StructFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -185,9 +191,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // as_list path: struct-typed field kept as opaque list-column.
     let list_rows = vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
         StructListEvent::Other { id: 4 },
     ];
     let _ = StructListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -207,9 +219,15 @@ pub fn gc_stress_dataframe_nested_enum() {
     // Flatten path: nested payload-bearing DataFrameRow enum expands to prefixed columns.
     // Uses Status (Ok / Err { code }) so status_variant + status_code columns are exercised.
     let flatten_rows = vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 4 },
     ];
     let _ = NestedFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -217,9 +235,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_factor path: unit-only enum field stored as factor column.
     let factor_rows = vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
         NestedFactorEvent::Stop { id: 2 },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 4 },
     ];
     let _ = NestedFactorEvent::to_dataframe(factor_rows.clone()).into_sexp();
@@ -227,9 +251,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_list path: enum field kept as opaque list-column.
     let list_rows = vec![
-        NestedListEvent::Move { id: 1, dir: Direction::South },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::South,
+        },
         NestedListEvent::Stop { id: 2 },
-        NestedListEvent::Move { id: 3, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 4 },
     ];
     let _ = NestedListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -256,7 +286,10 @@ pub fn gc_stress_native_sexp_altrep() {
     let sexp = native_sexp_altrep_new(values);
 
     // Verify that it is indeed ALTREP.
-    assert!(sexp.is_altrep(), "native_sexp_altrep_new should return an ALTREP SEXP");
+    assert!(
+        sexp.is_altrep(),
+        "native_sexp_altrep_new should return an ALTREP SEXP"
+    );
 
     // Force element access (exercises the Elt path) via the SexpExt trait.
     let n = sexp.len();

--- a/rpkg/src/rust/jiff_adapter_tests.rs
+++ b/rpkg/src/rust/jiff_adapter_tests.rs
@@ -250,8 +250,7 @@ pub fn jiff_zoned_vec_new(zdts: Vec<String>) -> SEXP {
                 .unwrap_or_else(|e| panic!("invalid zoned datetime at index {i} ({s:?}): {e}"))
         })
         .collect();
-    let vec = JiffZonedVec::new(parsed)
-        .unwrap_or_else(|e| panic!("{e}"));
+    let vec = JiffZonedVec::new(parsed).unwrap_or_else(|e| panic!("{e}"));
     vec.into_posixct_sexp()
 }
 
@@ -527,7 +526,9 @@ pub fn jiff_timestamp_as_millisecond(ts: Timestamp) -> f64 {
 static ELT_COUNTER: OnceLock<Arc<AtomicUsize>> = OnceLock::new();
 
 fn elt_counter() -> Arc<AtomicUsize> {
-    ELT_COUNTER.get_or_init(|| Arc::new(AtomicUsize::new(0))).clone()
+    ELT_COUNTER
+        .get_or_init(|| Arc::new(AtomicUsize::new(0)))
+        .clone()
 }
 
 #[derive(miniextendr_api::AltrepReal)]

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -164,7 +164,6 @@ mod decimal_adapter_tests;
 mod default_tests;
 mod display_fromstr_tests;
 mod doc_attr_tests;
-mod multi_para_doc_demo;
 mod dots_tests;
 #[cfg(feature = "either")]
 mod either_adapter_tests;
@@ -205,9 +204,10 @@ mod match_arg_impl_tests;
 mod match_arg_tests;
 mod misc_tests;
 mod missing_tests;
-mod native_sexp_altrep_fixture;
+mod multi_para_doc_demo;
 #[cfg(feature = "nalgebra")]
 mod nalgebra_adapter_tests;
+mod native_sexp_altrep_fixture;
 #[cfg(feature = "ndarray")]
 mod ndarray_tests;
 #[cfg(feature = "num-complex")]


### PR DESCRIPTION
Closes #415.
Also closes (together with #414): #248.

## Summary
- Adds `MXL120` to `miniextendr-lint` as a build-time static-analysis mirror of the proc-macro hard error already in `miniextendr-macros/src/miniextendr_impl.rs`. The lint fires during lint-only IDE/tooling runs before macro expansion.
- Two checks: (1) vctrs constructor must not return `Self`/named-type/`Result<Self,_>`/`Box<Self>`; (2) no instance receiver (`&self`, `self: &ExternalPtr<Self>`, etc.) on any method in a `#[miniextendr(vctrs(...))]` impl.
- Fixes `parse_miniextendr_impl_attrs` helper to use paren-balanced comma splitting, so `vctrs(kind = "vctr", base = "double", ...)` attrs are parsed correctly (the naive `split(',')` broke on inner commas inside the vctrs sub-expression).

## Changed files
- `miniextendr-lint/src/lint_code.rs` — add `MXL120` variant, `Severity::Error`
- `miniextendr-lint/src/crate_index.rs` — add `MethodReceiverKind` enum + `ImplMethodEntry` struct; extend `impl_methods` map to carry return-type string, receiver kind, and constructor-attr flag
- `miniextendr-lint/src/helpers.rs` — fix `parse_miniextendr_impl_attrs` comma splitting; add `split_top_level_commas` helper
- `miniextendr-lint/src/rules/vctrs_self_ctor.rs` — new rule file (two checks + duplicated `ty_is_self_or_named` predicate mirroring the macro)
- `miniextendr-lint/src/rules.rs` — register `vctrs_self_ctor`
- `miniextendr-lint/src/rules/s4_method_prefix.rs` — update to use new `ImplMethodEntry` struct fields
- `miniextendr-lint/tests/tests.rs` — 6 new MXL120 test cases (4 negative, 2 positive controls)
- `miniextendr-lint/CLAUDE.md` — add MXL120 to rule registry
- `rpkg/src/rust/*.rs` — pre-existing formatting drift fixed by `just fmt`

## Test plan
- [x] `cargo test -p miniextendr-lint` — 25 tests pass (4 new MXL120 negative cases + 2 positive controls)
- [x] `just check` — green across all workspace manifests
- [x] `just clippy` — clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (CI clippy_default) — clean
- [x] `cargo clippy --workspace --all-targets --locked --features rayon,... -- -D warnings` (CI clippy_all) — clean
- [x] `just fmt` — clean
- [x] `just lint` — `miniextendr-lint: no issues found`

## Follow-ups
- #608: migrate `is_altrep_struct` in `helpers.rs:300` to use the new `split_top_level_commas` helper (same naive `split(',')` bug class fixed in this PR for `parse_miniextendr_impl_attrs`; out of scope here since current ALTREP mode attrs don't take nested parens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)