### PR TITLE
feat(macros): reject Option<Map>/smart-pointer wrappers in DataFrameRow (#484)

### DIFF
--- a/docs/DATAFRAME.md
+++ b/docs/DATAFRAME.md
@@ -246,7 +246,7 @@ struct Row {
 }
 ```
 
-**Type aliases** are not automatically unwrapped — `type Counts = HashMap<String, i32>; field: Counts` has `Counts` as the last segment, so map expansion is not triggered. Use the concrete type directly (`field: HashMap<String, i32>`), or annotate with `#[dataframe(as_list)]`.
+**Type aliases** are not automatically unwrapped — `type Counts = HashMap<String, i32>; field: Counts` has `Counts` as the last segment, so map expansion is not triggered. Use the concrete type directly (`field: HashMap<String, i32>`), or annotate with `#[dataframe(as_list)]`. See [#604](https://github.com/A2-ai/miniextendr/issues/604) for tracking.
 
 Note: multi-segment paths whose last segment does NOT implement `DataFrameRow` (e.g. `std::ffi::CString`) produce a clear compile-time error from the `_assert_inner_is_dataframe_row` assertion — this is intentional. Use `#[dataframe(as_list)]` on the field or an import alias to a newtype wrapper if a non-DataFrameRow stdlib type needs to be stored.
 

--- a/docs/DATAFRAME.md
+++ b/docs/DATAFRAME.md
@@ -227,11 +227,26 @@ Absent-variant rows produce `NULL` in both columns (not NA). An empty map produc
 
 **`as_list` opt-out**: annotate the field with `#[dataframe(as_list)]` to keep it as a single opaque named-list column (the pre-expansion behavior). Only use this when the named-list per-row shape is needed directly in R.
 
-**Detection caveats**: `classify_field_type` detects `HashMap` / `BTreeMap` by matching the last path segment (`HashMap` or `BTreeMap`) and requiring exactly two generic type arguments. It also detects struct-typed fields by matching bare path types (single- or multi-segment, e.g. `Point` or `crate::geom::Point`) whose last segment has no generic arguments. Two shapes are not detected and fall through to `Scalar` (opaque list-column); both are tracked under [#484](https://github.com/A2-ai/miniextendr/issues/484):
+**Detection caveats**: `classify_field_type` detects `HashMap` / `BTreeMap` by matching the last path segment (`HashMap` or `BTreeMap`) and requiring exactly two generic type arguments. It also detects struct-typed fields by matching bare path types (single- or multi-segment, e.g. `Point` or `crate::geom::Point`) whose last segment has no generic arguments.
 
-- **Type aliases**: `type Counts = HashMap<String, i32>; field: Counts` — the last segment is `Counts`, not `HashMap`, so map expansion is not triggered. Use the concrete type directly, or annotate with `#[dataframe(as_list)]` and handle the named-list in R.
-- **`Option<HashMap<K,V>>`**: the outer segment is `Option` with one type argument, so the two-argument `HashMap`/`BTreeMap` guard is never reached. Unwrap the `Option` before storing (e.g., store `HashMap<K,V>` and push an empty map for the `None` case), or annotate with `#[dataframe(as_list)]`.
-- **`Option<UserStruct>`** where `UserStruct: DataFrameRow` — silently degrades to Scalar instead of recursively flattening. Tracked under [#484](https://github.com/A2-ai/miniextendr/issues/484).
+**Rejected wrapper types** — the following shapes produce a compile error (since #484) because they cannot be automatically expanded and would otherwise silently produce a confusing opaque list-column:
+
+- `Option<T>` — including `Option<HashMap<K,V>>`, `Option<UserStruct>`, etc.
+- `Cow<T>`, `Rc<T>`, `Arc<T>`, `RefCell<T>`, `Cell<T>`, `Mutex<T>`, `RwLock<T>`
+
+For all of these, use `#[dataframe(as_list)]` to opt into an explicit opaque list-column, or unwrap to the inner type (e.g. store `HashMap<K,V>` directly and use an empty map for the absent case):
+
+```rust
+#[derive(Clone, DataFrameRow)]
+struct Row {
+    id: i32,
+    // `counts: Option<HashMap<String, i32>>` → compile error without `as_list`.
+    #[dataframe(as_list)]
+    counts: Option<HashMap<String, i32>>,
+}
+```
+
+**Type aliases** are not automatically unwrapped — `type Counts = HashMap<String, i32>; field: Counts` has `Counts` as the last segment, so map expansion is not triggered. Use the concrete type directly (`field: HashMap<String, i32>`), or annotate with `#[dataframe(as_list)]`.
 
 Note: multi-segment paths whose last segment does NOT implement `DataFrameRow` (e.g. `std::ffi::CString`) produce a clear compile-time error from the `_assert_inner_is_dataframe_row` assertion — this is intentional. Use `#[dataframe(as_list)]` on the field or an import alias to a newtype wrapper if a non-DataFrameRow stdlib type needs to be stored.
 

--- a/miniextendr-macros/src/dataframe_derive.rs
+++ b/miniextendr-macros/src/dataframe_derive.rs
@@ -325,30 +325,7 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> syn::Result<FieldTypeKind<'
     if let syn::Type::Path(type_path) = ty
         && let Some(seg) = type_path.path.segments.last()
         && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
-        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
     {
-        // Check for Vec<T>
-        if seg.ident == "Vec" {
-            return Ok(FieldTypeKind::VariableVec(inner));
-        }
-
-        // Check for Box<[T]>
-        if seg.ident == "Box"
-            && let syn::Type::Slice(slice) = inner
-        {
-            return Ok(FieldTypeKind::BoxedSlice(&slice.elem));
-        }
-
-        // Check for HashMap<K, V> and BTreeMap<K, V>
-        if (seg.ident == "HashMap" || seg.ident == "BTreeMap")
-            && let Some(syn::GenericArgument::Type(val_ty)) = args.args.iter().nth(1)
-        {
-            return Ok(FieldTypeKind::Map {
-                key_ty: inner,
-                val_ty,
-            });
-        }
-
         // Reject wrapper types that would silently fall through to Scalar /
         // Struct and produce a confusing opaque list-column or a downstream
         // DataFrameRow assertion error.  These are the common smart-pointer
@@ -359,6 +336,12 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> syn::Result<FieldTypeKind<'
         // checking (which is unavailable in proc macros). The user must either
         // unwrap to the inner type, or annotate with `#[dataframe(as_list)]`
         // to opt into an explicit opaque list-column.
+        //
+        // IMPORTANT: The rejection fires on *path identity alone*, before we
+        // inspect generic args.  `Cow<'a, T>` has a lifetime as its first
+        // generic argument, not a type; inspecting `args.args.first()` as a
+        // `GenericArgument::Type` would silently skip `Cow`.  Checking ident
+        // before args makes the rejection robust to any generic shape.
         const REJECTED_WRAPPERS: &[&str] = &[
             "Option", "Cow", "Rc", "Arc", "RefCell", "Cell", "Mutex", "RwLock",
         ];
@@ -373,6 +356,42 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> syn::Result<FieldTypeKind<'
                      a sentinel / empty collection for the absent case)."
                 ),
             ));
+        }
+
+        // For the collection types below we need the first *type* argument.
+        // Skip any leading lifetime or const arguments (e.g. `Cow<'a, B>`
+        // has a lifetime first, but `Cow` is already rejected above so we
+        // only reach here for other angle-bracketed types).
+        let first_type_arg = args.args.iter().find_map(|arg| {
+            if let syn::GenericArgument::Type(t) = arg {
+                Some(t)
+            } else {
+                None
+            }
+        });
+
+        if let Some(inner) = first_type_arg {
+            // Check for Vec<T>
+            if seg.ident == "Vec" {
+                return Ok(FieldTypeKind::VariableVec(inner));
+            }
+
+            // Check for Box<[T]>
+            if seg.ident == "Box"
+                && let syn::Type::Slice(slice) = inner
+            {
+                return Ok(FieldTypeKind::BoxedSlice(&slice.elem));
+            }
+
+            // Check for HashMap<K, V> and BTreeMap<K, V>
+            if (seg.ident == "HashMap" || seg.ident == "BTreeMap")
+                && let Some(syn::GenericArgument::Type(val_ty)) = args.args.iter().nth(1)
+            {
+                return Ok(FieldTypeKind::Map {
+                    key_ty: inner,
+                    val_ty,
+                });
+            }
         }
     }
 

--- a/miniextendr-macros/src/dataframe_derive.rs
+++ b/miniextendr-macros/src/dataframe_derive.rs
@@ -287,7 +287,12 @@ pub(super) enum FieldTypeKind<'a> {
 /// - Any non-scalar bare path type (single- or multi-segment, e.g. `Point` or
 ///   `crate::geom::Point`) -> `Struct`
 /// - Everything else (known scalars, generic types with args, `::abs::Paths`) -> `Scalar`
-pub(super) fn classify_field_type(ty: &syn::Type) -> FieldTypeKind<'_> {
+///
+/// Returns `Err` for shapes the macro cannot classify and that would silently
+/// become opaque list-columns: `Option<T>`, `Cow<T>`, `Rc<T>`, `Arc<T>`,
+/// `RefCell<T>`, `Cell<T>`, `Mutex<T>`, `RwLock<T>`.  Use
+/// `#[dataframe(as_list)]` to opt into list-column treatment explicitly.
+pub(super) fn classify_field_type(ty: &syn::Type) -> syn::Result<FieldTypeKind<'_>> {
     // Check for [T; N]
     if let syn::Type::Array(arr) = ty
         && let syn::Expr::Lit(syn::ExprLit {
@@ -296,14 +301,14 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> FieldTypeKind<'_> {
         }) = &arr.len
         && let Ok(n) = lit_int.base10_parse::<usize>()
     {
-        return FieldTypeKind::FixedArray(&arr.elem, n);
+        return Ok(FieldTypeKind::FixedArray(&arr.elem, n));
     }
 
     // Check for &[T] and &[T; N]
     if let syn::Type::Reference(ref_ty) = ty {
         // &[T] → BorrowedSlice
         if let syn::Type::Slice(slice) = &*ref_ty.elem {
-            return FieldTypeKind::BorrowedSlice(&slice.elem);
+            return Ok(FieldTypeKind::BorrowedSlice(&slice.elem));
         }
         // &[T; N] → FixedArray (same as owned)
         if let syn::Type::Array(arr) = &*ref_ty.elem
@@ -313,7 +318,7 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> FieldTypeKind<'_> {
             }) = &arr.len
             && let Ok(n) = lit_int.base10_parse::<usize>()
         {
-            return FieldTypeKind::FixedArray(&arr.elem, n);
+            return Ok(FieldTypeKind::FixedArray(&arr.elem, n));
         }
     }
 
@@ -324,24 +329,50 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> FieldTypeKind<'_> {
     {
         // Check for Vec<T>
         if seg.ident == "Vec" {
-            return FieldTypeKind::VariableVec(inner);
+            return Ok(FieldTypeKind::VariableVec(inner));
         }
 
         // Check for Box<[T]>
         if seg.ident == "Box"
             && let syn::Type::Slice(slice) = inner
         {
-            return FieldTypeKind::BoxedSlice(&slice.elem);
+            return Ok(FieldTypeKind::BoxedSlice(&slice.elem));
         }
 
         // Check for HashMap<K, V> and BTreeMap<K, V>
         if (seg.ident == "HashMap" || seg.ident == "BTreeMap")
             && let Some(syn::GenericArgument::Type(val_ty)) = args.args.iter().nth(1)
         {
-            return FieldTypeKind::Map {
+            return Ok(FieldTypeKind::Map {
                 key_ty: inner,
                 val_ty,
-            };
+            });
+        }
+
+        // Reject wrapper types that would silently fall through to Scalar /
+        // Struct and produce a confusing opaque list-column or a downstream
+        // DataFrameRow assertion error.  These are the common smart-pointer
+        // and interior-mutability types that wrap a meaningful inner type but
+        // that DataFrameRow does not know how to expand.
+        //
+        // The macro has no way to resolve through the wrapper without type-
+        // checking (which is unavailable in proc macros). The user must either
+        // unwrap to the inner type, or annotate with `#[dataframe(as_list)]`
+        // to opt into an explicit opaque list-column.
+        const REJECTED_WRAPPERS: &[&str] = &[
+            "Option", "Cow", "Rc", "Arc", "RefCell", "Cell", "Mutex", "RwLock",
+        ];
+        let name = seg.ident.to_string();
+        if REJECTED_WRAPPERS.contains(&name.as_str()) {
+            return Err(syn::Error::new_spanned(
+                ty,
+                format!(
+                    "DataFrameRow does not support `{name}<…>` directly as a field type. \
+                     Use `#[dataframe(as_list)]` to opt into an explicit opaque list-column, \
+                     or unwrap to the inner type (e.g. store the inner value directly, using \
+                     a sentinel / empty collection for the absent case)."
+                ),
+            ));
         }
     }
 
@@ -380,13 +411,13 @@ pub(super) fn classify_field_type(ty: &syn::Type) -> FieldTypeKind<'_> {
                     "isize", "u8", "u16", "u32", "u64", "u128", "usize", "String",
                 ];
                 if !KNOWN_SCALARS.contains(&name.as_str()) {
-                    return FieldTypeKind::Struct { inner_ty: ty };
+                    return Ok(FieldTypeKind::Struct { inner_ty: ty });
                 }
             }
         }
     }
 
-    FieldTypeKind::Scalar
+    Ok(FieldTypeKind::Scalar)
 }
 // endregion
 
@@ -541,6 +572,8 @@ fn resolve_struct_field(
     };
 
     let ty = &field.ty;
+    // Propagate classification errors (e.g. Option<T>, Arc<T>) when as_list is
+    // not set.  The as_list branch below uses `.ok()` to suppress errors.
     let kind = classify_field_type(ty);
 
     // as_list suppresses expansion. For struct-typed fields (#485 opt-out), the
@@ -549,8 +582,11 @@ fn resolve_struct_field(
     // behavior is preserved: companion stores `Vec<#ty>` and the field type is
     // serialized natively (this requires `Vec<#ty>: IntoR`).
     if field_attrs.as_list {
-        let (final_ty, needs_into_list) = match classify_field_type(ty) {
-            FieldTypeKind::Struct { .. } => {
+        // Use `.ok()` here: `as_list` is an explicit opt-in, so wrapper types
+        // like `Option<T>` / `Arc<T>` are allowed — they become opaque list-
+        // columns. Any classification error is suppressed and treated as non-Struct.
+        let (final_ty, needs_into_list) = match classify_field_type(ty).ok() {
+            Some(FieldTypeKind::Struct { .. }) => {
                 (syn::parse_quote!(::miniextendr_api::list::List), true)
             }
             _ => (ty.clone(), false),
@@ -565,7 +601,7 @@ fn resolve_struct_field(
         }))));
     }
 
-    match kind {
+    match kind? {
         FieldTypeKind::FixedArray(elem_ty, len) => Ok(Some(ResolvedField::ExpandedFixed(
             Box::new(ExpandedFixedData {
                 rust_name,

--- a/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
+++ b/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
@@ -85,8 +85,14 @@ pub(super) fn derive_enum_dataframe(
                         // companion struct (so no R API is called during row accumulation) and
                         // flag `needs_into_list = true` to trigger per-element conversion in the
                         // dynamic `into_data_frame` path.
-                        let needs_into_list =
-                            matches!(classify_field_type(&f.ty), FieldTypeKind::Struct { .. });
+                        //
+                        // Use `.as_ref().ok()` to suppress classification errors: `as_list` is
+                        // an explicit opt-in, so wrapper types (Option<T>, Arc<T>, …) are
+                        // allowed — they become opaque list-columns.
+                        let needs_into_list = matches!(
+                            classify_field_type(&f.ty).as_ref().ok(),
+                            Some(FieldTypeKind::Struct { .. })
+                        );
                         resolved.push(EnumResolvedField::Single(Box::new(EnumSingleFieldData {
                             col_name: format_ident!("{}", col_name_str),
                             binding: binding.clone(),
@@ -99,7 +105,7 @@ pub(super) fn derive_enum_dataframe(
                         // `as_factor` is only valid on bare-ident enum types (Struct kind).
                         // The inner enum must be unit-only and derive DataFrameRow, which
                         // auto-emits UnitEnumFactor so FactorOptionVec<T> implements IntoR.
-                        match classify_field_type(&f.ty) {
+                        match classify_field_type(&f.ty)? {
                             FieldTypeKind::Struct { .. } => {
                                 resolved.push(EnumResolvedField::Single(Box::new(
                                     EnumSingleFieldData {
@@ -122,7 +128,7 @@ pub(super) fn derive_enum_dataframe(
                             }
                         }
                     } else {
-                        match classify_field_type(&f.ty) {
+                        match classify_field_type(&f.ty)? {
                             FieldTypeKind::FixedArray(elem_ty, len) => {
                                 resolved.push(EnumResolvedField::ExpandedFixed(Box::new(
                                     EnumExpandedFixedData {
@@ -325,8 +331,13 @@ pub(super) fn derive_enum_dataframe(
 
                     // Tuple enum fields: same expansion logic
                     if fa.as_list {
-                        let needs_into_list =
-                            matches!(classify_field_type(&f.ty), FieldTypeKind::Struct { .. });
+                        // Use `.as_ref().ok()` to suppress classification errors: `as_list` is
+                        // an explicit opt-in, so wrapper types (Option<T>, Arc<T>, …) are
+                        // allowed — they become opaque list-columns.
+                        let needs_into_list = matches!(
+                            classify_field_type(&f.ty).as_ref().ok(),
+                            Some(FieldTypeKind::Struct { .. })
+                        );
                         resolved.push(EnumResolvedField::Single(Box::new(EnumSingleFieldData {
                             col_name: format_ident!("{}", col_name_str),
                             binding,
@@ -336,7 +347,7 @@ pub(super) fn derive_enum_dataframe(
                             is_factor: false,
                         })));
                     } else if fa.as_factor {
-                        match classify_field_type(&f.ty) {
+                        match classify_field_type(&f.ty)? {
                             FieldTypeKind::Struct { .. } => {
                                 resolved.push(EnumResolvedField::Single(Box::new(
                                     EnumSingleFieldData {
@@ -359,7 +370,7 @@ pub(super) fn derive_enum_dataframe(
                             }
                         }
                     } else {
-                        match classify_field_type(&f.ty) {
+                        match classify_field_type(&f.ty)? {
                             FieldTypeKind::FixedArray(elem_ty, len) => {
                                 resolved.push(EnumResolvedField::ExpandedFixed(Box::new(
                                     EnumExpandedFixedData {

--- a/miniextendr-macros/tests/ui/derive_dataframe_arc_field.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_arc_field.rs
@@ -1,0 +1,12 @@
+//! Test: Arc<Inner> field without as_list is rejected.
+
+use miniextendr_macros::DataFrameRow;
+use std::sync::Arc;
+
+#[derive(DataFrameRow)]
+struct WithArc {
+    id: i32,
+    payload: Arc<String>,
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_arc_field.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_arc_field.stderr
@@ -1,0 +1,5 @@
+error: DataFrameRow does not support `Arc<…>` directly as a field type. Use `#[dataframe(as_list)]` to opt into an explicit opaque list-column, or unwrap to the inner type (e.g. store the inner value directly, using a sentinel / empty collection for the absent case).
+ --> tests/ui/derive_dataframe_arc_field.rs:9:14
+  |
+9 |     payload: Arc<String>,
+  |              ^^^^^^^^^^^

--- a/miniextendr-macros/tests/ui/derive_dataframe_cow_field.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_cow_field.rs
@@ -1,0 +1,16 @@
+//! Test: Cow<'a, str> field without as_list is rejected.
+//!
+//! Cow's first generic argument is a lifetime, not a type.  The rejection
+//! must fire on path identity alone — not by inspecting the first generic arg
+//! — to catch this shape.
+
+use miniextendr_macros::DataFrameRow;
+use std::borrow::Cow;
+
+#[derive(DataFrameRow)]
+struct WithCow<'a> {
+    id: i32,
+    label: Cow<'a, str>,
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_cow_field.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_cow_field.stderr
@@ -1,0 +1,5 @@
+error: DataFrameRow does not support `Cow<…>` directly as a field type. Use `#[dataframe(as_list)]` to opt into an explicit opaque list-column, or unwrap to the inner type (e.g. store the inner value directly, using a sentinel / empty collection for the absent case).
+  --> tests/ui/derive_dataframe_cow_field.rs:13:12
+   |
+13 |     label: Cow<'a, str>,
+   |            ^^^^^^^^^^^^

--- a/miniextendr-macros/tests/ui/derive_dataframe_option_field.rs
+++ b/miniextendr-macros/tests/ui/derive_dataframe_option_field.rs
@@ -1,0 +1,12 @@
+//! Test: Option<HashMap<String, i32>> field without as_list is rejected.
+
+use miniextendr_macros::DataFrameRow;
+use std::collections::HashMap;
+
+#[derive(DataFrameRow)]
+struct Tallies {
+    id: i32,
+    counts: Option<HashMap<String, i32>>,
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_dataframe_option_field.stderr
+++ b/miniextendr-macros/tests/ui/derive_dataframe_option_field.stderr
@@ -1,0 +1,5 @@
+error: DataFrameRow does not support `Option<…>` directly as a field type. Use `#[dataframe(as_list)]` to opt into an explicit opaque list-column, or unwrap to the inner type (e.g. store the inner value directly, using a sentinel / empty collection for the absent case).
+ --> tests/ui/derive_dataframe_option_field.rs:9:13
+  |
+9 |     counts: Option<HashMap<String, i32>>,
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -3133,7 +3133,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3142,7 +3142,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3488,9 +3488,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3649,9 +3649,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/rpkg/src/rust/columnar_option_none_tests.rs
+++ b/rpkg/src/rust/columnar_option_none_tests.rs
@@ -132,9 +132,18 @@ pub fn test_columnar_opt_u64_all_none_single() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_all_none_multi() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: None },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: None },
+        WithOptU64 {
+            name: "a".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -213,9 +222,18 @@ pub fn test_columnar_opt_bytes_all_none() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: Some(42) },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: Some(99) },
+        WithOptU64 {
+            name: "a".into(),
+            stored: Some(42),
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: Some(99),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -226,7 +244,10 @@ pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptString { id: 1, label: Some("hello".into()) },
+        WithOptString {
+            id: 1,
+            label: Some("hello".into()),
+        },
         WithOptString { id: 2, label: None },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -242,8 +263,14 @@ pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptBytes { id: 1, data: Some(vec![1u8, 2, 3]) },
-        WithOptBytes { id: 2, data: Some(vec![4u8, 5]) },
+        WithOptBytes {
+            id: 1,
+            data: Some(vec![1u8, 2, 3]),
+        },
+        WithOptBytes {
+            id: 2,
+            data: Some(vec![4u8, 5]),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -259,8 +286,14 @@ pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_and_opt_none() -> ColumnarDataFrame {
     let rows = vec![
-        WithBytesAndOpt { raw: vec![1u8, 2], stored: None },
-        WithBytesAndOpt { raw: vec![3u8], stored: None },
+        WithBytesAndOpt {
+            raw: vec![1u8, 2],
+            stored: None,
+        },
+        WithBytesAndOpt {
+            raw: vec![3u8],
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -278,11 +311,17 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
     let rows = vec![
         WithFlattenedOptField {
             id: 1,
-            inner: InnerWithOpt { size: None, name: "a".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "a".into(),
+            },
         },
         WithFlattenedOptField {
             id: 2,
-            inner: InnerWithOpt { size: None, name: "b".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "b".into(),
+            },
         },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -297,10 +336,7 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
 /// @export
 #[miniextendr]
 pub fn test_columnar_enum_all_none() -> ColumnarDataFrame {
-    let rows = vec![
-        EventWithOptX::A { x: None },
-        EventWithOptX::A { x: None },
-    ];
+    let rows = vec![EventWithOptX::A { x: None }, EventWithOptX::A { x: None }];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
 
@@ -352,7 +388,10 @@ pub fn test_columnar_schema_upgrade_scalar() -> ColumnarDataFrame {
 pub fn test_columnar_schema_upgrade_nested() -> ColumnarDataFrame {
     let rows = vec![
         WithOptPoint { id: 1, point: None },
-        WithOptPoint { id: 2, point: Some(InnerStruct { x: 1.0, y: 2.0 }) },
+        WithOptPoint {
+            id: 2,
+            point: Some(InnerStruct { x: 1.0, y: 2.0 }),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -400,7 +439,10 @@ pub fn test_columnar_schema_upgrade_multi_none_first() -> ColumnarDataFrame {
 pub fn test_columnar_compound_different_shapes() -> ColumnarDataFrame {
     let rows = vec![
         EventDifferentNested::A { value: 1.0 },
-        EventDifferentNested::B { value: 2.0, extra: 3.0 },
+        EventDifferentNested::B {
+            value: 2.0,
+            extra: 3.0,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use miniextendr_api::{DataFrameRow, IntoList};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 // Test with Vec fields (no expansion — stays opaque)
 #[derive(Clone, Debug, IntoList, DataFrameRow)]
@@ -235,10 +235,7 @@ pub struct WithSlicePinned<'a> {
 // This enum uses only owned types to verify the enum expand path compiles.
 #[derive(Clone, Debug, DataFrameRow)]
 pub enum WithLifetimeEnumOwned {
-    Row {
-        label: String,
-        value: f64,
-    },
+    Row { label: String, value: f64 },
 }
 
 // Test enum with skip
@@ -271,6 +268,30 @@ pub struct ParallelExpanded {
 pub enum ParallelExpandedEvent {
     Measurement { sensor: String, readings: [f64; 2] },
     Status { sensor: String, code: i32 },
+}
+
+// Test: `Option<HashMap<K, V>>` with `#[dataframe(as_list)]` — escape hatch for #484.
+// The field becomes an opaque list-column (`Vec<Option<HashMap<String, i32>>>` in the
+// companion struct).  Without `as_list` the macro now emits a compile error.
+#[derive(Clone, Debug, DataFrameRow)]
+pub struct WithOptMapAsList {
+    pub id: i32,
+    #[dataframe(as_list)]
+    pub counts: Option<HashMap<String, i32>>,
+}
+
+impl IntoList for WithOptMapAsList {
+    fn into_list(self) -> miniextendr_api::List {
+        use miniextendr_api::{IntoR, ffi::SEXP};
+        let counts_sexp = match self.counts {
+            Some(m) => m.into_list().into_sexp(),
+            None => SEXP::nil(),
+        };
+        miniextendr_api::List::from_raw_pairs(vec![
+            ("id", self.id.into_sexp()),
+            ("counts", counts_sexp),
+        ])
+    }
 }
 
 #[cfg(test)]
@@ -947,5 +968,33 @@ mod tests {
         assert_eq!(df.value.len(), 2);
         assert_eq!(df.value[0], Some(1.0));
         assert_eq!(df.value[1], Some(2.0));
+    }
+
+    #[test]
+    fn test_option_hashmap_as_list() {
+        // Verify that `Option<HashMap<K, V>>` with `#[dataframe(as_list)]` compiles
+        // and produces a single opaque list-column (#484 positive case).  Without the
+        // annotation the macro now emits a compile error, so this test exists to confirm
+        // the escape hatch works end-to-end.
+        let rows = vec![
+            WithOptMapAsList {
+                id: 1,
+                counts: None,
+            },
+            WithOptMapAsList {
+                id: 2,
+                counts: Some({
+                    let mut m = HashMap::new();
+                    m.insert("a".to_string(), 10);
+                    m
+                }),
+            },
+        ];
+        let df = WithOptMapAsList::to_dataframe(rows);
+        // Two rows → two entries in each companion column.
+        assert_eq!(df.id.len(), 2);
+        assert_eq!(df.id[0], 1);
+        assert_eq!(df.id[1], 2);
+        assert_eq!(df.counts.len(), 2);
     }
 }

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -28,13 +28,8 @@ use miniextendr_api::{DataFrameRow, IntoList, List, miniextendr};
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum VecOpaqueEvent {
-    Items {
-        label: String,
-        items: Vec<i32>,
-    },
-    NoItems {
-        label: String,
-    },
+    Items { label: String, items: Vec<i32> },
+    NoItems { label: String },
 }
 
 fn vec_opaque_payload(label: &str, items: Vec<i32>) -> VecOpaqueEvent {
@@ -93,13 +88,8 @@ pub fn vec_opaque_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum HashSetEvent {
-    Tagged {
-        id: i32,
-        tags: HashSet<String>,
-    },
-    Untagged {
-        id: i32,
-    },
+    Tagged { id: i32, tags: HashSet<String> },
+    Untagged { id: i32 },
 }
 
 fn hashset_payload(id: i32, tags: &[&str]) -> HashSetEvent {
@@ -158,13 +148,8 @@ pub fn hashset_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum BTreeSetEvent {
-    Cats {
-        label: String,
-        cats: BTreeSet<i32>,
-    },
-    NoCats {
-        label: String,
-    },
+    Cats { label: String, cats: BTreeSet<i32> },
+    NoCats { label: String },
 }
 
 fn btreeset_payload(label: &str, cats: &[i32]) -> BTreeSetEvent {
@@ -514,16 +499,25 @@ pub enum BorrowedStrEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_str_split_1v1r() -> List {
-    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named { id: 1, name: "alice" }];
+    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named {
+        id: 1,
+        name: "alice",
+    }];
     BorrowedStrEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_str_split_1vnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Named { id: 2, name: "bob" },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
 }
@@ -531,7 +525,10 @@ pub fn borrowed_str_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_str_split_nv1r() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -540,9 +537,15 @@ pub fn borrowed_str_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'static>> {
     ToDataFrame(BorrowedStrEvent::to_dataframe(vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ]))
 }
@@ -550,9 +553,15 @@ pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'stati
 #[miniextendr]
 pub fn borrowed_str_split_nvnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -571,17 +580,28 @@ pub enum BorrowedSliceEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_slice_split_1v1r() -> List {
-    let data: Vec<BorrowedSliceEvent<'static>> =
-        vec![BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] }];
+    let data: Vec<BorrowedSliceEvent<'static>> = vec![BorrowedSliceEvent::Buffer {
+        label: "a".into(),
+        data: &[1.0, 2.0, 3.0],
+    }];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_slice_split_1vnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
-        BorrowedSliceEvent::Buffer { label: "b".into(), data: &[4.0] },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "b".into(),
+            data: &[4.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[],
+        },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
@@ -589,7 +609,10 @@ pub fn borrowed_slice_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_slice_split_nv1r() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -598,9 +621,15 @@ pub fn borrowed_slice_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'static>> {
     ToDataFrame(BorrowedSliceEvent::to_dataframe(vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ]))
 }
@@ -608,9 +637,15 @@ pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'s
 #[miniextendr]
 pub fn borrowed_slice_split_nvnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -1025,7 +1060,10 @@ mod tests {
             df.tally_keys[0].as_deref(),
             Some(vec!["a".to_string(), "z".to_string()].as_slice())
         );
-        assert_eq!(df.tally_values[0].as_deref(), Some(vec![1i32, 3i32].as_slice()));
+        assert_eq!(
+            df.tally_values[0].as_deref(),
+            Some(vec![1i32, 3i32].as_slice())
+        );
     }
 
     #[test]
@@ -1099,9 +1137,18 @@ pub fn struct_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_1vnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1109,7 +1156,10 @@ pub fn struct_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nv1r() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1118,8 +1168,14 @@ pub fn struct_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nvnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ])
@@ -1129,8 +1185,14 @@ pub fn struct_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_align_nvnr() -> ToDataFrame<StructFlattenEventDataFrame> {
     ToDataFrame(StructFlattenEvent::to_dataframe(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ]))
@@ -1153,9 +1215,18 @@ pub fn struct_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_1vnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1163,7 +1234,10 @@ pub fn struct_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_list_split_nv1r() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
     ])
 }
@@ -1172,8 +1246,14 @@ pub fn struct_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_nvnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ])
@@ -1183,8 +1263,14 @@ pub fn struct_list_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_list_align_nvnr() -> ToDataFrame<StructListEventDataFrame> {
     ToDataFrame(StructListEvent::to_dataframe(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ]))
@@ -1201,7 +1287,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_flatten_align_located_rows_have_values() {
         let df = StructFlattenEvent::to_dataframe(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructFlattenEvent::Other { id: 2 },
         ]);
         // origin is present at row 0 (Located), absent at row 1 (Other)
@@ -1221,8 +1310,14 @@ mod struct_field_tests {
     #[ignore = "requires R runtime (calls into_data_frame)"]
     fn test_struct_flatten_split_located_has_correct_count() {
         let split = StructFlattenEvent::to_dataframe_split(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-            StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
+            StructFlattenEvent::Located {
+                id: 2,
+                origin: Point { x: 3.0, y: 4.0 },
+            },
             StructFlattenEvent::Other { id: 3 },
         ]);
         // split returns a list of per-variant data frames
@@ -1233,7 +1328,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_list_align_origin_is_some() {
         let df = StructListEvent::to_dataframe(vec![
-            StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructListEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructListEvent::Other { id: 2 },
         ]);
         // origin is the list-column holding Option<Point>
@@ -1344,9 +1442,18 @@ pub fn nested_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_1vnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ])
 }
 
@@ -1354,7 +1461,10 @@ pub fn nested_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nv1r() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1363,8 +1473,14 @@ pub fn nested_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nvnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ])
@@ -1374,7 +1490,10 @@ pub fn nested_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
     ]))
 }
 
@@ -1382,9 +1501,18 @@ pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ]))
 }
 
@@ -1392,7 +1520,10 @@ pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ]))
 }
@@ -1401,8 +1532,14 @@ pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nvnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ]))
@@ -1425,9 +1562,18 @@ pub fn nested_factor_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_1vnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1435,7 +1581,10 @@ pub fn nested_factor_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nv1r() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ])
 }
@@ -1444,8 +1593,14 @@ pub fn nested_factor_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nvnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ])
@@ -1454,19 +1609,30 @@ pub fn nested_factor_split_nvnr() -> List {
 /// 1v1r align (as_factor): single Move row.
 #[miniextendr]
 pub fn nested_factor_align_1v1r() -> ToDataFrame<NestedFactorEventDataFrame> {
-    ToDataFrame(NestedFactorEvent::to_dataframe(vec![NestedFactorEvent::Move {
-        id: 1,
-        dir: Direction::North,
-    }]))
+    ToDataFrame(NestedFactorEvent::to_dataframe(vec![
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+    ]))
 }
 
 /// 1vNr align (as_factor): multiple Move rows.
 #[miniextendr]
 pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1474,7 +1640,10 @@ pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ]))
 }
@@ -1483,8 +1652,14 @@ pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nvnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ]))
@@ -1507,9 +1682,18 @@ pub fn nested_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_1vnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1517,7 +1701,10 @@ pub fn nested_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_list_split_nv1r() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ])
 }
@@ -1526,8 +1713,14 @@ pub fn nested_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_nvnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ])
@@ -1546,9 +1739,18 @@ pub fn nested_list_align_1v1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1556,7 +1758,10 @@ pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ]))
 }
@@ -1565,8 +1770,14 @@ pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nvnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ]))
@@ -1594,9 +1805,15 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_companion_struct_shape() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
-            NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+            NestedFlattenEvent::Tracked {
+                id: 3,
+                status: Status::Err { code: 404 },
+            },
         ]);
         assert_eq!(df.id[0], Some(1i32));
         assert_eq!(df.id[1], Some(2i32));
@@ -1616,11 +1833,8 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_status_payload_columns() {
         // Verify inner Status companion struct has the expected column layout.
-        let inner_df = Status::to_dataframe(vec![
-            Status::Ok,
-            Status::Err { code: 404 },
-            Status::Ok,
-        ]);
+        let inner_df =
+            Status::to_dataframe(vec![Status::Ok, Status::Err { code: 404 }, Status::Ok]);
         // `code` column: None for Ok rows, Some(i32) for Err rows.
         assert!(inner_df.code[0].is_none()); // Ok has no code
         assert_eq!(inner_df.code[1], Some(404i32));
@@ -1630,7 +1844,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_factor_align_col_types() {
         let df = NestedFactorEvent::to_dataframe(vec![
-            NestedFactorEvent::Move { id: 1, dir: Direction::North },
+            NestedFactorEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedFactorEvent::Stop { id: 2 },
         ]);
         // The companion struct has id: Vec<Option<i32>> and dir: Vec<Option<Direction>>
@@ -1653,7 +1870,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_list_align_col_types() {
         let df = NestedListEvent::to_dataframe(vec![
-            NestedListEvent::Move { id: 1, dir: Direction::North },
+            NestedListEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedListEvent::Stop { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));
@@ -1664,7 +1884,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_align_col_types() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));

--- a/rpkg/src/rust/dataframe_struct_flatten_test.rs
+++ b/rpkg/src/rust/dataframe_struct_flatten_test.rs
@@ -214,9 +214,18 @@ pub fn flat_basic_1row() -> ToDataFrame<FlatLocatedDataFrame> {
 #[miniextendr]
 pub fn flat_basic_nrow() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocated::to_dataframe(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -246,11 +255,17 @@ pub fn flat_mixed_inner_types() -> ToDataFrame<FlatTaggedDataFrame> {
     ToDataFrame(FlatTagged::to_dataframe(vec![
         FlatTagged {
             id: 1,
-            owner: FlatPerson { name: "Ada".to_string(), age: 30 },
+            owner: FlatPerson {
+                name: "Ada".to_string(),
+                age: 30,
+            },
         },
         FlatTagged {
             id: 2,
-            owner: FlatPerson { name: "Linus".to_string(), age: 50 },
+            owner: FlatPerson {
+                name: "Linus".to_string(),
+                age: 50,
+            },
         },
     ]))
 }
@@ -266,16 +281,28 @@ pub fn flat_renamed_inner() -> ToDataFrame<FlatRenamedDataFrame> {
 #[miniextendr]
 pub fn flat_skip_inner() -> ToDataFrame<FlatSkipDataFrame> {
     ToDataFrame(FlatSkip::to_dataframe(vec![
-        FlatSkip { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatSkip { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatSkip {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatSkip {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
 #[miniextendr]
 pub fn flat_as_list_inner() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsList::to_dataframe(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -406,7 +433,10 @@ const _: () = {
     fn _shape_mixed_inner_types() {
         let _ = FlatTaggedDataFrame {
             id: vec![1],
-            owner: vec![FlatPerson { name: "x".to_string(), age: 1 }],
+            owner: vec![FlatPerson {
+                name: "x".to_string(),
+                age: 1,
+            }],
         };
     }
 
@@ -454,9 +484,7 @@ const _: () = {
     // `Vec<List>` column provides the row-count). This verifies that `par_len_field`
     // codegen correctly omits `_len` for this shape and the struct compiles.
     fn _shape_only_as_list() {
-        let _ = FlatOnlyAsListDataFrame {
-            data: vec![],
-        };
+        let _ = FlatOnlyAsListDataFrame { data: vec![] };
     }
 };
 
@@ -470,9 +498,18 @@ const _: () = {
 #[miniextendr]
 pub fn flat_basic_par() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocatedDataFrame::from_rows_par(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -501,8 +538,14 @@ pub fn flat_two_struct_fields_par() -> ToDataFrame<FlatSegmentDataFrame> {
 #[miniextendr]
 pub fn flat_as_list_par() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsListDataFrame::from_rows_par(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -514,11 +557,17 @@ pub fn flat_nested_par() -> ToDataFrame<FlatNestedDataFrame> {
     ToDataFrame(FlatNestedDataFrame::from_rows_par(vec![
         FlatNested {
             id: 1,
-            inner: FlatInner { a: 10.0, sub: FlatSubInner { depth: 100.0 } },
+            inner: FlatInner {
+                a: 10.0,
+                sub: FlatSubInner { depth: 100.0 },
+            },
         },
         FlatNested {
             id: 2,
-            inner: FlatInner { a: 20.0, sub: FlatSubInner { depth: 200.0 } },
+            inner: FlatInner {
+                a: 20.0,
+                sub: FlatSubInner { depth: 200.0 },
+            },
         },
     ]))
 }
@@ -539,7 +588,10 @@ mod par_tests {
             (0..100)
                 .map(|i| FlatLocated {
                     id: i,
-                    origin: FlatPoint { x: i as f64, y: (i as f64) * 2.0 },
+                    origin: FlatPoint {
+                        x: i as f64,
+                        y: (i as f64) * 2.0,
+                    },
                 })
                 .collect()
         };

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -175,9 +175,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // Flatten path: struct-typed field expands to prefixed columns.
     let flatten_rows = vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 4 },
     ];
     let _ = StructFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -185,9 +191,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // as_list path: struct-typed field kept as opaque list-column.
     let list_rows = vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
         StructListEvent::Other { id: 4 },
     ];
     let _ = StructListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -207,9 +219,15 @@ pub fn gc_stress_dataframe_nested_enum() {
     // Flatten path: nested payload-bearing DataFrameRow enum expands to prefixed columns.
     // Uses Status (Ok / Err { code }) so status_variant + status_code columns are exercised.
     let flatten_rows = vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 4 },
     ];
     let _ = NestedFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -217,9 +235,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_factor path: unit-only enum field stored as factor column.
     let factor_rows = vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
         NestedFactorEvent::Stop { id: 2 },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 4 },
     ];
     let _ = NestedFactorEvent::to_dataframe(factor_rows.clone()).into_sexp();
@@ -227,9 +251,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_list path: enum field kept as opaque list-column.
     let list_rows = vec![
-        NestedListEvent::Move { id: 1, dir: Direction::South },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::South,
+        },
         NestedListEvent::Stop { id: 2 },
-        NestedListEvent::Move { id: 3, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 4 },
     ];
     let _ = NestedListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -256,7 +286,10 @@ pub fn gc_stress_native_sexp_altrep() {
     let sexp = native_sexp_altrep_new(values);
 
     // Verify that it is indeed ALTREP.
-    assert!(sexp.is_altrep(), "native_sexp_altrep_new should return an ALTREP SEXP");
+    assert!(
+        sexp.is_altrep(),
+        "native_sexp_altrep_new should return an ALTREP SEXP"
+    );
 
     // Force element access (exercises the Elt path) via the SexpExt trait.
     let n = sexp.len();

--- a/rpkg/src/rust/jiff_adapter_tests.rs
+++ b/rpkg/src/rust/jiff_adapter_tests.rs
@@ -250,8 +250,7 @@ pub fn jiff_zoned_vec_new(zdts: Vec<String>) -> SEXP {
                 .unwrap_or_else(|e| panic!("invalid zoned datetime at index {i} ({s:?}): {e}"))
         })
         .collect();
-    let vec = JiffZonedVec::new(parsed)
-        .unwrap_or_else(|e| panic!("{e}"));
+    let vec = JiffZonedVec::new(parsed).unwrap_or_else(|e| panic!("{e}"));
     vec.into_posixct_sexp()
 }
 
@@ -527,7 +526,9 @@ pub fn jiff_timestamp_as_millisecond(ts: Timestamp) -> f64 {
 static ELT_COUNTER: OnceLock<Arc<AtomicUsize>> = OnceLock::new();
 
 fn elt_counter() -> Arc<AtomicUsize> {
-    ELT_COUNTER.get_or_init(|| Arc::new(AtomicUsize::new(0))).clone()
+    ELT_COUNTER
+        .get_or_init(|| Arc::new(AtomicUsize::new(0)))
+        .clone()
 }
 
 #[derive(miniextendr_api::AltrepReal)]

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -164,7 +164,6 @@ mod decimal_adapter_tests;
 mod default_tests;
 mod display_fromstr_tests;
 mod doc_attr_tests;
-mod multi_para_doc_demo;
 mod dots_tests;
 #[cfg(feature = "either")]
 mod either_adapter_tests;
@@ -205,9 +204,10 @@ mod match_arg_impl_tests;
 mod match_arg_tests;
 mod misc_tests;
 mod missing_tests;
-mod native_sexp_altrep_fixture;
+mod multi_para_doc_demo;
 #[cfg(feature = "nalgebra")]
 mod nalgebra_adapter_tests;
+mod native_sexp_altrep_fixture;
 #[cfg(feature = "ndarray")]
 mod ndarray_tests;
 #[cfg(feature = "num-complex")]


### PR DESCRIPTION
Closes #484.

## Summary

- `classify_field_type` now returns `syn::Result<FieldTypeKind<'_>>` instead of the bare kind; all unrecognised wrapper types with generic args (`Option<T>`, `Cow<T>`, `Rc<T>`, `Arc<T>`, `RefCell<T>`, `Cell<T>`, `Mutex<T>`, `RwLock<T>`) produce a compile error pointing at the field type with a `#[dataframe(as_list)]` hint.
- All `as_list`-annotated callers use `.ok()` to swallow the error (opt-in makes wrapper types valid opaque list-columns); all other callers propagate via `?`.
- Two UI compile-fail tests added (`derive_dataframe_option_field`, `derive_dataframe_arc_field`); one positive test struct (`WithOptMapAsList`) confirms the escape hatch compiles and runs.
- `docs/DATAFRAME.md` updated: "Detection caveats" section rewritten to document the new hard errors, the `as_list` opt-out, and the remaining type-alias gap (tracked as #604).

## Test plan

- [x] `just check` — green
- [x] `just clippy` — green
- [x] `just fmt` — clean
- [x] CI `clippy_default` (`cargo clippy --workspace --all-targets --locked -- -D warnings`) — green locally
- [x] CI `clippy_all` (full feature list from `.github/workflows/ci.yml`) — green locally
- [x] `cargo test -p miniextendr-macros` — 308 passed (includes new UI compile-fail tests)
- [x] `Option<HashMap<String, i32>>` field without `as_list` → compile error with `as_list` hint
- [x] `Arc<String>` field without `as_list` → compile error with `as_list` hint
- [x] `Option<HashMap<String, i32>>` with `#[dataframe(as_list)]` → compiles, 2-row DataFrame with `counts` list-column

## Deferred

- #604 — type alias detection (`type Counts = HashMap<…>; field: Counts` still produces confusing downstream error; proc macros cannot resolve aliases without typeck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)