### PR TITLE
fix(wrappers): ignore source-position churn in wrapper-gen compare (#528)

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -914,9 +914,20 @@ pub fn write_r_wrappers_to_file(path: &str) {
         content = result;
     }
 
-    // Only write if content changed (avoids unnecessary NAMESPACE/man regeneration)
+    // Only write if content changed (avoids unnecessary NAMESPACE/man regeneration).
+    //
+    // "Semantic equality" means equal after stripping source-position suffixes from
+    // the source-attribution comments emitted by the `#[miniextendr]` proc-macro:
+    //
+    //   # Generated from Rust fn `foo` (lib.rs:42:8)
+    //                                           ^^^^^ positional suffix — ignored here
+    //
+    // These positions shift whenever any unrelated Rust source above a wrapper is
+    // edited. The NOTE and the file rewrite should only fire when the actual
+    // wrapper code, exports, or docstrings change — not when line numbers move.
+    // The written file still carries the real line:col for jump-to-source.
     let existing = std::fs::read_to_string(path).unwrap_or_default();
-    if existing == content {
+    if wrappers_semantically_equal(&existing, &content) {
         return;
     }
 
@@ -932,6 +943,142 @@ pub fn write_r_wrappers_to_file(path: &str) {
         eprintln!("NOTE: {filename} changed — run devtools::document() to update NAMESPACE.");
         eprintln!();
     }
+}
+
+/// Returns `true` when `a` and `b` are equal after normalising away
+/// `(<file>.rs:LINE:COL)` positional suffixes in source-attribution comments.
+///
+/// The `#[miniextendr]` proc-macro emits comments of the form:
+/// ```r
+/// # Generated from Rust fn `foo` (lib.rs:42:8)
+/// ```
+/// The `42:8` part shifts whenever unrelated code above the wrapper is edited,
+/// producing spurious wrapper-file rewrites and misleading NOTEs. Normalisation
+/// replaces `(lib.rs:42:8)` → `(lib.rs:_:_)` for the comparison only; the
+/// file on disk still carries the real positions.
+///
+/// A match requires `(` + one or more non-`()`/non-newline chars + `.rs:` +
+/// ASCII digits + `:` + ASCII digits + `)`. Malformed or non-`.rs` patterns
+/// are left untouched.
+fn wrappers_semantically_equal(a: &str, b: &str) -> bool {
+    normalize_source_locs(a) == normalize_source_locs(b)
+}
+
+/// Replace every `(<stem>.rs:LINE:COL)` occurrence with `(<stem>.rs:_:_)`.
+///
+/// Returns a [`std::borrow::Cow::Borrowed`] slice when no replacements are
+/// needed (zero-allocation fast path for the common case where the file has
+/// never been written or is truly unchanged).
+fn normalize_source_locs(s: &str) -> std::borrow::Cow<'_, str> {
+    // Fast path: bail early if there is no `.rs:` anywhere in the string.
+    if !s.contains(".rs:") {
+        return std::borrow::Cow::Borrowed(s);
+    }
+
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(len);
+    let mut pos = 0usize;
+    let mut any_replaced = false;
+
+    while pos < len {
+        // Look for the next `(`.
+        let Some(open) = memchr(bytes, pos, b'(') else {
+            break;
+        };
+
+        // After `(`, scan for `.rs:` without crossing `)` or `(` or a newline.
+        let inner_start = open + 1;
+        let Some(dot_rs) = find_substr(bytes, inner_start, b".rs:") else {
+            // No `.rs:` at all in the rest of the string — copy remainder and stop.
+            out.push_str(&s[pos..]);
+            return std::borrow::Cow::Owned(out);
+        };
+
+        // Make sure `.rs:` precedes any closing `)`, `(`, or newline (no nesting).
+        let intervening = &bytes[inner_start..dot_rs];
+        if intervening
+            .iter()
+            .any(|&b| b == b')' || b == b'(' || b == b'\n')
+        {
+            // Guard crossed; copy up to and including `(` and continue after it.
+            out.push_str(&s[pos..=open]);
+            pos = open + 1;
+            continue;
+        }
+
+        // After `.rs:`, consume digits for LINE.
+        let after_colon1 = dot_rs + 4; // skip `.rs:`
+        let Some(colon2) = scan_digits(bytes, after_colon1) else {
+            // Not digits after `.rs:` — not a source-attribution pattern.
+            out.push_str(&s[pos..=open]);
+            pos = open + 1;
+            continue;
+        };
+        if colon2 >= len || bytes[colon2] != b':' {
+            out.push_str(&s[pos..=open]);
+            pos = open + 1;
+            continue;
+        }
+
+        // After the second `:`, consume digits for COL.
+        let after_colon2 = colon2 + 1;
+        let Some(close_pos) = scan_digits(bytes, after_colon2) else {
+            out.push_str(&s[pos..=open]);
+            pos = open + 1;
+            continue;
+        };
+        if close_pos >= len || bytes[close_pos] != b')' {
+            out.push_str(&s[pos..=open]);
+            pos = open + 1;
+            continue;
+        }
+
+        // We have a match: `(stem.rs:LINE:COL)` — emit `(stem.rs:_:_)`.
+        any_replaced = true;
+        out.push_str(&s[pos..inner_start]); // text before inner_start (includes `(`)
+        out.push_str(&s[inner_start..dot_rs + 3]); // `stem.rs` (without the colon)
+        out.push_str(":_:_)");
+        pos = close_pos + 1; // skip past the closing `)`
+    }
+
+    if !any_replaced {
+        return std::borrow::Cow::Borrowed(s);
+    }
+
+    out.push_str(&s[pos..]);
+    std::borrow::Cow::Owned(out)
+}
+
+/// Find the first occurrence of `needle` in `haystack[from..]`.
+/// Returns the absolute index in `haystack`, or `None`.
+#[inline]
+fn find_substr(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    let window = haystack.get(from..)?;
+    window
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|rel| from + rel)
+}
+
+/// Find the first byte equal to `needle` in `haystack[from..]`.
+/// Returns the absolute index, or `None`.
+#[inline]
+fn memchr(haystack: &[u8], from: usize, needle: u8) -> Option<usize> {
+    haystack[from..]
+        .iter()
+        .position(|&b| b == needle)
+        .map(|rel| from + rel)
+}
+
+/// Advance past a run of ASCII digits starting at `haystack[from]`.
+/// Returns the absolute index of the first non-digit byte, or `None` if
+/// there are no digits at `from` (empty run is not valid).
+#[inline]
+fn scan_digits(haystack: &[u8], from: usize) -> Option<usize> {
+    let start = haystack.get(from..)?;
+    let count = start.iter().take_while(|&&b| b.is_ascii_digit()).count();
+    if count == 0 { None } else { Some(from + count) }
 }
 // endregion
 
@@ -1203,5 +1350,92 @@ mod tests {
         let output = resolve_class_refs(input, &entries);
         assert_eq!(output, "inherit = Parent, class = S7::class_any");
     }
+
+    // region: normalize_source_locs unit tests (#528)
+
+    #[test]
+    fn normalize_source_locs_noop_on_plain_text() {
+        // No `.rs:N:M` pattern — should return the input string unchanged (Borrowed).
+        let input = "# just a comment\nfoo <- function() {}\n";
+        let result = normalize_source_locs(input);
+        assert_eq!(result.as_ref(), input);
+        // Verify it's the zero-allocation borrowed path.
+        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn normalize_source_locs_single_attribution() {
+        let input = "# Generated from Rust fn `foo` (lib.rs:42:8)";
+        let result = normalize_source_locs(input);
+        assert_eq!(
+            result.as_ref(),
+            "# Generated from Rust fn `foo` (lib.rs:_:_)"
+        );
+    }
+
+    #[test]
+    fn normalize_source_locs_multiple_attributions() {
+        let input = concat!(
+            "# (conversions.rs:1:5)\n",
+            "foo <- function() {}\n",
+            "# (conversions.rs:158:8)\n",
+            "bar <- function() {}\n",
+        );
+        let result = normalize_source_locs(input);
+        assert_eq!(
+            result.as_ref(),
+            concat!(
+                "# (conversions.rs:_:_)\n",
+                "foo <- function() {}\n",
+                "# (conversions.rs:_:_)\n",
+                "bar <- function() {}\n",
+            )
+        );
+    }
+
+    #[test]
+    fn normalize_source_locs_does_not_match_extra_colon() {
+        // `(lib.rs:1:5:6)` — four components — is NOT a valid attribution; leave alone.
+        let input = "(lib.rs:1:5:6)";
+        let result = normalize_source_locs(input);
+        // The pattern `(lib.rs:1:5` matches, but then we expect `)` after the col
+        // digits and find `:` instead — so it should NOT be replaced.
+        assert_eq!(result.as_ref(), input);
+    }
+
+    #[test]
+    fn normalize_source_locs_does_not_match_without_parens() {
+        // Bare `lib.rs:1:5` without surrounding parens — leave untouched.
+        let input = "lib.rs:1:5";
+        let result = normalize_source_locs(input);
+        assert_eq!(result.as_ref(), input);
+        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn wrappers_semantically_equal_position_only_diff() {
+        // Two wrappers identical except for line:col are semantically equal.
+        let old = "# Generated from Rust fn `foo` (lib.rs:42:8)\nfoo <- function() {}\n";
+        let new = "# Generated from Rust fn `foo` (lib.rs:99:8)\nfoo <- function() {}\n";
+        assert!(wrappers_semantically_equal(old, new));
+    }
+
+    #[test]
+    fn wrappers_semantically_equal_content_diff() {
+        // A real semantic change (different function body) is NOT equal.
+        let old = "# Generated from Rust fn `foo` (lib.rs:42:8)\nfoo <- function() { 1L }\n";
+        let new = "# Generated from Rust fn `foo` (lib.rs:42:8)\nfoo <- function() { 2L }\n";
+        assert!(!wrappers_semantically_equal(old, new));
+    }
+
+    #[test]
+    fn wrappers_semantically_equal_both_position_and_content_diff() {
+        // Both positions and content differ — still NOT equal.
+        let old = "# Generated from Rust fn `foo` (lib.rs:1:1)\nfoo <- function() { 1L }\n";
+        let new = "# Generated from Rust fn `bar` (lib.rs:9:1)\nbar <- function() { 2L }\n";
+        assert!(!wrappers_semantically_equal(old, new));
+    }
+
+    // endregion
 }
 // endregion

--- a/rpkg/src/rust/columnar_option_none_tests.rs
+++ b/rpkg/src/rust/columnar_option_none_tests.rs
@@ -132,9 +132,18 @@ pub fn test_columnar_opt_u64_all_none_single() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_all_none_multi() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: None },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: None },
+        WithOptU64 {
+            name: "a".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -213,9 +222,18 @@ pub fn test_columnar_opt_bytes_all_none() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptU64 { name: "a".into(), stored: Some(42) },
-        WithOptU64 { name: "b".into(), stored: None },
-        WithOptU64 { name: "c".into(), stored: Some(99) },
+        WithOptU64 {
+            name: "a".into(),
+            stored: Some(42),
+        },
+        WithOptU64 {
+            name: "b".into(),
+            stored: None,
+        },
+        WithOptU64 {
+            name: "c".into(),
+            stored: Some(99),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -226,7 +244,10 @@ pub fn test_columnar_opt_u64_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptString { id: 1, label: Some("hello".into()) },
+        WithOptString {
+            id: 1,
+            label: Some("hello".into()),
+        },
         WithOptString { id: 2, label: None },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -242,8 +263,14 @@ pub fn test_columnar_opt_string_mixed() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
     let rows = vec![
-        WithOptBytes { id: 1, data: Some(vec![1u8, 2, 3]) },
-        WithOptBytes { id: 2, data: Some(vec![4u8, 5]) },
+        WithOptBytes {
+            id: 1,
+            data: Some(vec![1u8, 2, 3]),
+        },
+        WithOptBytes {
+            id: 2,
+            data: Some(vec![4u8, 5]),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -259,8 +286,14 @@ pub fn test_columnar_bytes_with_values() -> ColumnarDataFrame {
 #[miniextendr]
 pub fn test_columnar_bytes_and_opt_none() -> ColumnarDataFrame {
     let rows = vec![
-        WithBytesAndOpt { raw: vec![1u8, 2], stored: None },
-        WithBytesAndOpt { raw: vec![3u8], stored: None },
+        WithBytesAndOpt {
+            raw: vec![1u8, 2],
+            stored: None,
+        },
+        WithBytesAndOpt {
+            raw: vec![3u8],
+            stored: None,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -278,11 +311,17 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
     let rows = vec![
         WithFlattenedOptField {
             id: 1,
-            inner: InnerWithOpt { size: None, name: "a".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "a".into(),
+            },
         },
         WithFlattenedOptField {
             id: 2,
-            inner: InnerWithOpt { size: None, name: "b".into() },
+            inner: InnerWithOpt {
+                size: None,
+                name: "b".into(),
+            },
         },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
@@ -297,10 +336,7 @@ pub fn test_columnar_flatten_all_none() -> ColumnarDataFrame {
 /// @export
 #[miniextendr]
 pub fn test_columnar_enum_all_none() -> ColumnarDataFrame {
-    let rows = vec![
-        EventWithOptX::A { x: None },
-        EventWithOptX::A { x: None },
-    ];
+    let rows = vec![EventWithOptX::A { x: None }, EventWithOptX::A { x: None }];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
 
@@ -352,7 +388,10 @@ pub fn test_columnar_schema_upgrade_scalar() -> ColumnarDataFrame {
 pub fn test_columnar_schema_upgrade_nested() -> ColumnarDataFrame {
     let rows = vec![
         WithOptPoint { id: 1, point: None },
-        WithOptPoint { id: 2, point: Some(InnerStruct { x: 1.0, y: 2.0 }) },
+        WithOptPoint {
+            id: 2,
+            point: Some(InnerStruct { x: 1.0, y: 2.0 }),
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }
@@ -400,7 +439,10 @@ pub fn test_columnar_schema_upgrade_multi_none_first() -> ColumnarDataFrame {
 pub fn test_columnar_compound_different_shapes() -> ColumnarDataFrame {
     let rows = vec![
         EventDifferentNested::A { value: 1.0 },
-        EventDifferentNested::B { value: 2.0, extra: 3.0 },
+        EventDifferentNested::B {
+            value: 2.0,
+            extra: 3.0,
+        },
     ];
     ColumnarDataFrame::from_rows(&rows).expect("from_rows")
 }

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -235,10 +235,7 @@ pub struct WithSlicePinned<'a> {
 // This enum uses only owned types to verify the enum expand path compiles.
 #[derive(Clone, Debug, DataFrameRow)]
 pub enum WithLifetimeEnumOwned {
-    Row {
-        label: String,
-        value: f64,
-    },
+    Row { label: String, value: f64 },
 }
 
 // Test enum with skip

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -28,13 +28,8 @@ use miniextendr_api::{DataFrameRow, IntoList, List, miniextendr};
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum VecOpaqueEvent {
-    Items {
-        label: String,
-        items: Vec<i32>,
-    },
-    NoItems {
-        label: String,
-    },
+    Items { label: String, items: Vec<i32> },
+    NoItems { label: String },
 }
 
 fn vec_opaque_payload(label: &str, items: Vec<i32>) -> VecOpaqueEvent {
@@ -93,13 +88,8 @@ pub fn vec_opaque_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum HashSetEvent {
-    Tagged {
-        id: i32,
-        tags: HashSet<String>,
-    },
-    Untagged {
-        id: i32,
-    },
+    Tagged { id: i32, tags: HashSet<String> },
+    Untagged { id: i32 },
 }
 
 fn hashset_payload(id: i32, tags: &[&str]) -> HashSetEvent {
@@ -158,13 +148,8 @@ pub fn hashset_split_nvnr() -> List {
 #[derive(Clone, Debug, DataFrameRow)]
 #[dataframe(align, tag = "_type")]
 pub enum BTreeSetEvent {
-    Cats {
-        label: String,
-        cats: BTreeSet<i32>,
-    },
-    NoCats {
-        label: String,
-    },
+    Cats { label: String, cats: BTreeSet<i32> },
+    NoCats { label: String },
 }
 
 fn btreeset_payload(label: &str, cats: &[i32]) -> BTreeSetEvent {
@@ -514,16 +499,25 @@ pub enum BorrowedStrEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_str_split_1v1r() -> List {
-    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named { id: 1, name: "alice" }];
+    let data: Vec<BorrowedStrEvent<'static>> = vec![BorrowedStrEvent::Named {
+        id: 1,
+        name: "alice",
+    }];
     BorrowedStrEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_str_split_1vnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Named { id: 2, name: "bob" },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
 }
@@ -531,7 +525,10 @@ pub fn borrowed_str_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_str_split_nv1r() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -540,9 +537,15 @@ pub fn borrowed_str_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'static>> {
     ToDataFrame(BorrowedStrEvent::to_dataframe(vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ]))
 }
@@ -550,9 +553,15 @@ pub fn borrowed_str_align_nvnr() -> ToDataFrame<BorrowedStrEventDataFrame<'stati
 #[miniextendr]
 pub fn borrowed_str_split_nvnr() -> List {
     let data: Vec<BorrowedStrEvent<'static>> = vec![
-        BorrowedStrEvent::Named { id: 1, name: "alice" },
+        BorrowedStrEvent::Named {
+            id: 1,
+            name: "alice",
+        },
         BorrowedStrEvent::Bare { id: 2 },
-        BorrowedStrEvent::Named { id: 3, name: "carol" },
+        BorrowedStrEvent::Named {
+            id: 3,
+            name: "carol",
+        },
         BorrowedStrEvent::Bare { id: 4 },
     ];
     BorrowedStrEvent::to_dataframe_split(data)
@@ -571,17 +580,28 @@ pub enum BorrowedSliceEvent<'a> {
 
 #[miniextendr]
 pub fn borrowed_slice_split_1v1r() -> List {
-    let data: Vec<BorrowedSliceEvent<'static>> =
-        vec![BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] }];
+    let data: Vec<BorrowedSliceEvent<'static>> = vec![BorrowedSliceEvent::Buffer {
+        label: "a".into(),
+        data: &[1.0, 2.0, 3.0],
+    }];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
 
 #[miniextendr]
 pub fn borrowed_slice_split_1vnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
-        BorrowedSliceEvent::Buffer { label: "b".into(), data: &[4.0] },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "b".into(),
+            data: &[4.0],
+        },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[],
+        },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
 }
@@ -589,7 +609,10 @@ pub fn borrowed_slice_split_1vnr() -> List {
 #[miniextendr]
 pub fn borrowed_slice_split_nv1r() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -598,9 +621,15 @@ pub fn borrowed_slice_split_nv1r() -> List {
 #[miniextendr]
 pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'static>> {
     ToDataFrame(BorrowedSliceEvent::to_dataframe(vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ]))
 }
@@ -608,9 +637,15 @@ pub fn borrowed_slice_align_nvnr() -> ToDataFrame<BorrowedSliceEventDataFrame<'s
 #[miniextendr]
 pub fn borrowed_slice_split_nvnr() -> List {
     let data: Vec<BorrowedSliceEvent<'static>> = vec![
-        BorrowedSliceEvent::Buffer { label: "a".into(), data: &[1.0, 2.0, 3.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "a".into(),
+            data: &[1.0, 2.0, 3.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "b".into() },
-        BorrowedSliceEvent::Buffer { label: "c".into(), data: &[4.0] },
+        BorrowedSliceEvent::Buffer {
+            label: "c".into(),
+            data: &[4.0],
+        },
         BorrowedSliceEvent::NoBuffer { label: "d".into() },
     ];
     BorrowedSliceEvent::to_dataframe_split(data)
@@ -1025,7 +1060,10 @@ mod tests {
             df.tally_keys[0].as_deref(),
             Some(vec!["a".to_string(), "z".to_string()].as_slice())
         );
-        assert_eq!(df.tally_values[0].as_deref(), Some(vec![1i32, 3i32].as_slice()));
+        assert_eq!(
+            df.tally_values[0].as_deref(),
+            Some(vec![1i32, 3i32].as_slice())
+        );
     }
 
     #[test]
@@ -1099,9 +1137,18 @@ pub fn struct_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_1vnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1109,7 +1156,10 @@ pub fn struct_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nv1r() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1118,8 +1168,14 @@ pub fn struct_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_flatten_split_nvnr() -> List {
     StructFlattenEvent::to_dataframe_split(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ])
@@ -1129,8 +1185,14 @@ pub fn struct_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_flatten_align_nvnr() -> ToDataFrame<StructFlattenEventDataFrame> {
     ToDataFrame(StructFlattenEvent::to_dataframe(vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructFlattenEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 3 },
         StructFlattenEvent::Other { id: 4 },
     ]))
@@ -1153,9 +1215,18 @@ pub fn struct_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_1vnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
     ])
 }
 
@@ -1163,7 +1234,10 @@ pub fn struct_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn struct_list_split_nv1r() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
     ])
 }
@@ -1172,8 +1246,14 @@ pub fn struct_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn struct_list_split_nvnr() -> List {
     StructListEvent::to_dataframe_split(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ])
@@ -1183,8 +1263,14 @@ pub fn struct_list_split_nvnr() -> List {
 #[miniextendr]
 pub fn struct_list_align_nvnr() -> ToDataFrame<StructListEventDataFrame> {
     ToDataFrame(StructListEvent::to_dataframe(vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-        StructListEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
+        StructListEvent::Located {
+            id: 2,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructListEvent::Other { id: 3 },
         StructListEvent::Other { id: 4 },
     ]))
@@ -1201,7 +1287,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_flatten_align_located_rows_have_values() {
         let df = StructFlattenEvent::to_dataframe(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructFlattenEvent::Other { id: 2 },
         ]);
         // origin is present at row 0 (Located), absent at row 1 (Other)
@@ -1221,8 +1310,14 @@ mod struct_field_tests {
     #[ignore = "requires R runtime (calls into_data_frame)"]
     fn test_struct_flatten_split_located_has_correct_count() {
         let split = StructFlattenEvent::to_dataframe_split(vec![
-            StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
-            StructFlattenEvent::Located { id: 2, origin: Point { x: 3.0, y: 4.0 } },
+            StructFlattenEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
+            StructFlattenEvent::Located {
+                id: 2,
+                origin: Point { x: 3.0, y: 4.0 },
+            },
             StructFlattenEvent::Other { id: 3 },
         ]);
         // split returns a list of per-variant data frames
@@ -1233,7 +1328,10 @@ mod struct_field_tests {
     #[test]
     fn test_struct_list_align_origin_is_some() {
         let df = StructListEvent::to_dataframe(vec![
-            StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+            StructListEvent::Located {
+                id: 1,
+                origin: Point { x: 1.0, y: 2.0 },
+            },
             StructListEvent::Other { id: 2 },
         ]);
         // origin is the list-column holding Option<Point>
@@ -1344,9 +1442,18 @@ pub fn nested_flatten_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_1vnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ])
 }
 
@@ -1354,7 +1461,10 @@ pub fn nested_flatten_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nv1r() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ])
 }
@@ -1363,8 +1473,14 @@ pub fn nested_flatten_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_flatten_split_nvnr() -> List {
     NestedFlattenEvent::to_dataframe_split(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ])
@@ -1374,7 +1490,10 @@ pub fn nested_flatten_split_nvnr() -> List {
 #[miniextendr]
 pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
     ]))
 }
 
@@ -1382,9 +1501,18 @@ pub fn nested_flatten_align_1v1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 500 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 500 },
+        },
     ]))
 }
 
@@ -1392,7 +1520,10 @@ pub fn nested_flatten_align_1vnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
     ]))
 }
@@ -1401,8 +1532,14 @@ pub fn nested_flatten_align_nv1r() -> ToDataFrame<NestedFlattenEventDataFrame> {
 #[miniextendr]
 pub fn nested_flatten_align_nvnr() -> ToDataFrame<NestedFlattenEventDataFrame> {
     ToDataFrame(NestedFlattenEvent::to_dataframe(vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
-        NestedFlattenEvent::Tracked { id: 2, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
+        NestedFlattenEvent::Tracked {
+            id: 2,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 3 },
         NestedFlattenEvent::Other { id: 4 },
     ]))
@@ -1425,9 +1562,18 @@ pub fn nested_factor_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_1vnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1435,7 +1581,10 @@ pub fn nested_factor_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nv1r() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ])
 }
@@ -1444,8 +1593,14 @@ pub fn nested_factor_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_factor_split_nvnr() -> List {
     NestedFactorEvent::to_dataframe_split(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ])
@@ -1454,19 +1609,30 @@ pub fn nested_factor_split_nvnr() -> List {
 /// 1v1r align (as_factor): single Move row.
 #[miniextendr]
 pub fn nested_factor_align_1v1r() -> ToDataFrame<NestedFactorEventDataFrame> {
-    ToDataFrame(NestedFactorEvent::to_dataframe(vec![NestedFactorEvent::Move {
-        id: 1,
-        dir: Direction::North,
-    }]))
+    ToDataFrame(NestedFactorEvent::to_dataframe(vec![
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+    ]))
 }
 
 /// 1vNr align (as_factor): multiple Move rows.
 #[miniextendr]
 pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::South },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1474,7 +1640,10 @@ pub fn nested_factor_align_1vnr() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::West },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedFactorEvent::Stop { id: 2 },
     ]))
 }
@@ -1483,8 +1652,14 @@ pub fn nested_factor_align_nv1r() -> ToDataFrame<NestedFactorEventDataFrame> {
 #[miniextendr]
 pub fn nested_factor_align_nvnr() -> ToDataFrame<NestedFactorEventDataFrame> {
     ToDataFrame(NestedFactorEvent::to_dataframe(vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
-        NestedFactorEvent::Move { id: 2, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedFactorEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 3 },
         NestedFactorEvent::Stop { id: 4 },
     ]))
@@ -1507,9 +1682,18 @@ pub fn nested_list_split_1v1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_1vnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ])
 }
 
@@ -1517,7 +1701,10 @@ pub fn nested_list_split_1vnr() -> List {
 #[miniextendr]
 pub fn nested_list_split_nv1r() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ])
 }
@@ -1526,8 +1713,14 @@ pub fn nested_list_split_nv1r() -> List {
 #[miniextendr]
 pub fn nested_list_split_nvnr() -> List {
     NestedListEvent::to_dataframe_split(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ])
@@ -1546,9 +1739,18 @@ pub fn nested_list_align_1v1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::South },
-        NestedListEvent::Move { id: 3, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::South,
+        },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
     ]))
 }
 
@@ -1556,7 +1758,10 @@ pub fn nested_list_align_1vnr() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 2 },
     ]))
 }
@@ -1565,8 +1770,14 @@ pub fn nested_list_align_nv1r() -> ToDataFrame<NestedListEventDataFrame> {
 #[miniextendr]
 pub fn nested_list_align_nvnr() -> ToDataFrame<NestedListEventDataFrame> {
     ToDataFrame(NestedListEvent::to_dataframe(vec![
-        NestedListEvent::Move { id: 1, dir: Direction::North },
-        NestedListEvent::Move { id: 2, dir: Direction::East },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
+        NestedListEvent::Move {
+            id: 2,
+            dir: Direction::East,
+        },
         NestedListEvent::Stop { id: 3 },
         NestedListEvent::Stop { id: 4 },
     ]))
@@ -1594,9 +1805,15 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_companion_struct_shape() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
-            NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+            NestedFlattenEvent::Tracked {
+                id: 3,
+                status: Status::Err { code: 404 },
+            },
         ]);
         assert_eq!(df.id[0], Some(1i32));
         assert_eq!(df.id[1], Some(2i32));
@@ -1616,11 +1833,8 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_status_payload_columns() {
         // Verify inner Status companion struct has the expected column layout.
-        let inner_df = Status::to_dataframe(vec![
-            Status::Ok,
-            Status::Err { code: 404 },
-            Status::Ok,
-        ]);
+        let inner_df =
+            Status::to_dataframe(vec![Status::Ok, Status::Err { code: 404 }, Status::Ok]);
         // `code` column: None for Ok rows, Some(i32) for Err rows.
         assert!(inner_df.code[0].is_none()); // Ok has no code
         assert_eq!(inner_df.code[1], Some(404i32));
@@ -1630,7 +1844,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_factor_align_col_types() {
         let df = NestedFactorEvent::to_dataframe(vec![
-            NestedFactorEvent::Move { id: 1, dir: Direction::North },
+            NestedFactorEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedFactorEvent::Stop { id: 2 },
         ]);
         // The companion struct has id: Vec<Option<i32>> and dir: Vec<Option<Direction>>
@@ -1653,7 +1870,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_list_align_col_types() {
         let df = NestedListEvent::to_dataframe(vec![
-            NestedListEvent::Move { id: 1, dir: Direction::North },
+            NestedListEvent::Move {
+                id: 1,
+                dir: Direction::North,
+            },
             NestedListEvent::Stop { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));
@@ -1664,7 +1884,10 @@ mod nested_enum_field_tests {
     #[test]
     fn test_nested_flatten_align_col_types() {
         let df = NestedFlattenEvent::to_dataframe(vec![
-            NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+            NestedFlattenEvent::Tracked {
+                id: 1,
+                status: Status::Ok,
+            },
             NestedFlattenEvent::Other { id: 2 },
         ]);
         assert_eq!(df.id[0], Some(1i32));

--- a/rpkg/src/rust/dataframe_struct_flatten_test.rs
+++ b/rpkg/src/rust/dataframe_struct_flatten_test.rs
@@ -214,9 +214,18 @@ pub fn flat_basic_1row() -> ToDataFrame<FlatLocatedDataFrame> {
 #[miniextendr]
 pub fn flat_basic_nrow() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocated::to_dataframe(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -246,11 +255,17 @@ pub fn flat_mixed_inner_types() -> ToDataFrame<FlatTaggedDataFrame> {
     ToDataFrame(FlatTagged::to_dataframe(vec![
         FlatTagged {
             id: 1,
-            owner: FlatPerson { name: "Ada".to_string(), age: 30 },
+            owner: FlatPerson {
+                name: "Ada".to_string(),
+                age: 30,
+            },
         },
         FlatTagged {
             id: 2,
-            owner: FlatPerson { name: "Linus".to_string(), age: 50 },
+            owner: FlatPerson {
+                name: "Linus".to_string(),
+                age: 50,
+            },
         },
     ]))
 }
@@ -266,16 +281,28 @@ pub fn flat_renamed_inner() -> ToDataFrame<FlatRenamedDataFrame> {
 #[miniextendr]
 pub fn flat_skip_inner() -> ToDataFrame<FlatSkipDataFrame> {
     ToDataFrame(FlatSkip::to_dataframe(vec![
-        FlatSkip { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatSkip { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatSkip {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatSkip {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
 #[miniextendr]
 pub fn flat_as_list_inner() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsList::to_dataframe(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -406,7 +433,10 @@ const _: () = {
     fn _shape_mixed_inner_types() {
         let _ = FlatTaggedDataFrame {
             id: vec![1],
-            owner: vec![FlatPerson { name: "x".to_string(), age: 1 }],
+            owner: vec![FlatPerson {
+                name: "x".to_string(),
+                age: 1,
+            }],
         };
     }
 
@@ -454,9 +484,7 @@ const _: () = {
     // `Vec<List>` column provides the row-count). This verifies that `par_len_field`
     // codegen correctly omits `_len` for this shape and the struct compiles.
     fn _shape_only_as_list() {
-        let _ = FlatOnlyAsListDataFrame {
-            data: vec![],
-        };
+        let _ = FlatOnlyAsListDataFrame { data: vec![] };
     }
 };
 
@@ -470,9 +498,18 @@ const _: () = {
 #[miniextendr]
 pub fn flat_basic_par() -> ToDataFrame<FlatLocatedDataFrame> {
     ToDataFrame(FlatLocatedDataFrame::from_rows_par(vec![
-        FlatLocated { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatLocated { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
-        FlatLocated { id: 3, origin: FlatPoint { x: 5.0, y: 6.0 } },
+        FlatLocated {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatLocated {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
+        FlatLocated {
+            id: 3,
+            origin: FlatPoint { x: 5.0, y: 6.0 },
+        },
     ]))
 }
 
@@ -501,8 +538,14 @@ pub fn flat_two_struct_fields_par() -> ToDataFrame<FlatSegmentDataFrame> {
 #[miniextendr]
 pub fn flat_as_list_par() -> ToDataFrame<FlatAsListDataFrame> {
     ToDataFrame(FlatAsListDataFrame::from_rows_par(vec![
-        FlatAsList { id: 1, origin: FlatPoint { x: 1.0, y: 2.0 } },
-        FlatAsList { id: 2, origin: FlatPoint { x: 3.0, y: 4.0 } },
+        FlatAsList {
+            id: 1,
+            origin: FlatPoint { x: 1.0, y: 2.0 },
+        },
+        FlatAsList {
+            id: 2,
+            origin: FlatPoint { x: 3.0, y: 4.0 },
+        },
     ]))
 }
 
@@ -514,11 +557,17 @@ pub fn flat_nested_par() -> ToDataFrame<FlatNestedDataFrame> {
     ToDataFrame(FlatNestedDataFrame::from_rows_par(vec![
         FlatNested {
             id: 1,
-            inner: FlatInner { a: 10.0, sub: FlatSubInner { depth: 100.0 } },
+            inner: FlatInner {
+                a: 10.0,
+                sub: FlatSubInner { depth: 100.0 },
+            },
         },
         FlatNested {
             id: 2,
-            inner: FlatInner { a: 20.0, sub: FlatSubInner { depth: 200.0 } },
+            inner: FlatInner {
+                a: 20.0,
+                sub: FlatSubInner { depth: 200.0 },
+            },
         },
     ]))
 }
@@ -539,7 +588,10 @@ mod par_tests {
             (0..100)
                 .map(|i| FlatLocated {
                     id: i,
-                    origin: FlatPoint { x: i as f64, y: (i as f64) * 2.0 },
+                    origin: FlatPoint {
+                        x: i as f64,
+                        y: (i as f64) * 2.0,
+                    },
                 })
                 .collect()
         };

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -175,9 +175,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // Flatten path: struct-typed field expands to prefixed columns.
     let flatten_rows = vec![
-        StructFlattenEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructFlattenEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructFlattenEvent::Other { id: 2 },
-        StructFlattenEvent::Located { id: 3, origin: Point { x: 3.0, y: 4.0 } },
+        StructFlattenEvent::Located {
+            id: 3,
+            origin: Point { x: 3.0, y: 4.0 },
+        },
         StructFlattenEvent::Other { id: 4 },
     ];
     let _ = StructFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -185,9 +191,15 @@ pub fn gc_stress_dataframe_struct() {
 
     // as_list path: struct-typed field kept as opaque list-column.
     let list_rows = vec![
-        StructListEvent::Located { id: 1, origin: Point { x: 1.0, y: 2.0 } },
+        StructListEvent::Located {
+            id: 1,
+            origin: Point { x: 1.0, y: 2.0 },
+        },
         StructListEvent::Other { id: 2 },
-        StructListEvent::Located { id: 3, origin: Point { x: 5.0, y: 6.0 } },
+        StructListEvent::Located {
+            id: 3,
+            origin: Point { x: 5.0, y: 6.0 },
+        },
         StructListEvent::Other { id: 4 },
     ];
     let _ = StructListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -207,9 +219,15 @@ pub fn gc_stress_dataframe_nested_enum() {
     // Flatten path: nested payload-bearing DataFrameRow enum expands to prefixed columns.
     // Uses Status (Ok / Err { code }) so status_variant + status_code columns are exercised.
     let flatten_rows = vec![
-        NestedFlattenEvent::Tracked { id: 1, status: Status::Ok },
+        NestedFlattenEvent::Tracked {
+            id: 1,
+            status: Status::Ok,
+        },
         NestedFlattenEvent::Other { id: 2 },
-        NestedFlattenEvent::Tracked { id: 3, status: Status::Err { code: 404 } },
+        NestedFlattenEvent::Tracked {
+            id: 3,
+            status: Status::Err { code: 404 },
+        },
         NestedFlattenEvent::Other { id: 4 },
     ];
     let _ = NestedFlattenEvent::to_dataframe(flatten_rows.clone()).into_sexp();
@@ -217,9 +235,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_factor path: unit-only enum field stored as factor column.
     let factor_rows = vec![
-        NestedFactorEvent::Move { id: 1, dir: Direction::North },
+        NestedFactorEvent::Move {
+            id: 1,
+            dir: Direction::North,
+        },
         NestedFactorEvent::Stop { id: 2 },
-        NestedFactorEvent::Move { id: 3, dir: Direction::East },
+        NestedFactorEvent::Move {
+            id: 3,
+            dir: Direction::East,
+        },
         NestedFactorEvent::Stop { id: 4 },
     ];
     let _ = NestedFactorEvent::to_dataframe(factor_rows.clone()).into_sexp();
@@ -227,9 +251,15 @@ pub fn gc_stress_dataframe_nested_enum() {
 
     // as_list path: enum field kept as opaque list-column.
     let list_rows = vec![
-        NestedListEvent::Move { id: 1, dir: Direction::South },
+        NestedListEvent::Move {
+            id: 1,
+            dir: Direction::South,
+        },
         NestedListEvent::Stop { id: 2 },
-        NestedListEvent::Move { id: 3, dir: Direction::West },
+        NestedListEvent::Move {
+            id: 3,
+            dir: Direction::West,
+        },
         NestedListEvent::Stop { id: 4 },
     ];
     let _ = NestedListEvent::to_dataframe(list_rows.clone()).into_sexp();
@@ -256,7 +286,10 @@ pub fn gc_stress_native_sexp_altrep() {
     let sexp = native_sexp_altrep_new(values);
 
     // Verify that it is indeed ALTREP.
-    assert!(sexp.is_altrep(), "native_sexp_altrep_new should return an ALTREP SEXP");
+    assert!(
+        sexp.is_altrep(),
+        "native_sexp_altrep_new should return an ALTREP SEXP"
+    );
 
     // Force element access (exercises the Elt path) via the SexpExt trait.
     let n = sexp.len();

--- a/rpkg/src/rust/jiff_adapter_tests.rs
+++ b/rpkg/src/rust/jiff_adapter_tests.rs
@@ -250,8 +250,7 @@ pub fn jiff_zoned_vec_new(zdts: Vec<String>) -> SEXP {
                 .unwrap_or_else(|e| panic!("invalid zoned datetime at index {i} ({s:?}): {e}"))
         })
         .collect();
-    let vec = JiffZonedVec::new(parsed)
-        .unwrap_or_else(|e| panic!("{e}"));
+    let vec = JiffZonedVec::new(parsed).unwrap_or_else(|e| panic!("{e}"));
     vec.into_posixct_sexp()
 }
 
@@ -527,7 +526,9 @@ pub fn jiff_timestamp_as_millisecond(ts: Timestamp) -> f64 {
 static ELT_COUNTER: OnceLock<Arc<AtomicUsize>> = OnceLock::new();
 
 fn elt_counter() -> Arc<AtomicUsize> {
-    ELT_COUNTER.get_or_init(|| Arc::new(AtomicUsize::new(0))).clone()
+    ELT_COUNTER
+        .get_or_init(|| Arc::new(AtomicUsize::new(0)))
+        .clone()
 }
 
 #[derive(miniextendr_api::AltrepReal)]

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -164,7 +164,6 @@ mod decimal_adapter_tests;
 mod default_tests;
 mod display_fromstr_tests;
 mod doc_attr_tests;
-mod multi_para_doc_demo;
 mod dots_tests;
 #[cfg(feature = "either")]
 mod either_adapter_tests;
@@ -205,9 +204,10 @@ mod match_arg_impl_tests;
 mod match_arg_tests;
 mod misc_tests;
 mod missing_tests;
-mod native_sexp_altrep_fixture;
+mod multi_para_doc_demo;
 #[cfg(feature = "nalgebra")]
 mod nalgebra_adapter_tests;
+mod native_sexp_altrep_fixture;
 #[cfg(feature = "ndarray")]
 mod ndarray_tests;
 #[cfg(feature = "num-complex")]


### PR DESCRIPTION
Closes #528.

## Summary

- Add `normalize_source_locs`: a zero-dependency, zero-allocation-on-no-match hand-rolled scanner that replaces `(<stem>.rs:LINE:COL)` with `(<stem>.rs:_:_)` in source-attribution comments emitted by the `#[miniextendr]` proc-macro.
- Add `wrappers_semantically_equal`: wraps the normalised comparison; used in `write_r_wrappers_to_file` so both the disk write and the `NOTE: wrappers changed` message are suppressed when the only diff is line/column positions shifting due to unrelated edits above a wrapper.
- Seven unit tests covering: no-op (borrowed fast path), single replacement, multiple replacements, malformed patterns (extra colon segment, bare `file.rs:N:M` without parens), position-only diff (semantically equal), and content diff (not equal).
- Fix pre-existing `cargo fmt` failures in `rpkg/src/rust/*.rs` (struct literal formatting).
- No new crate dependencies. Written output is **byte-identical** to before — only the comparison is normalised; on-disk content retains real line:col for jump-to-source.

## Test plan

- [x] `just check` — green
- [x] `just clippy` — green
- [x] `just fmt` — clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default) — green
- [x] `cargo clippy ... --features rayon,...,jiff -- -D warnings` (clippy_all, full CI feature list) — green
- [x] `cargo test -p miniextendr-api` — 379 passed, 7 new tests included
- [x] `R CMD INSTALL rpkg` (R 4.5, rv library) — installed without `NOTE: wrappers changed`
- [x] Re-ran `R CMD INSTALL` on already-installed package — wrappers file mtime unchanged (1779028933 before and after), no NOTE emitted
- [ ] `just devtools-test` — in progress (R version mismatch in worktree; install confirmed working)

## Acceptance test recipe

To verify the position-churn fix end-to-end:
1. Edit a Rust file above a `#[miniextendr]` fn to shift line numbers (e.g., add a blank line above `pub fn conv_usize_arg`).
2. Re-run `just rcmdinstall`.
3. Confirm no `NOTE: miniextendr-wrappers.R changed` in output and no diff to `R/miniextendr-wrappers.R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)