### PR TITLE
refactor(api): migrate Rf_xlength and data-pointer FFI to SexpExt (#355, #356)

### DIFF
--- a/miniextendr-api/src/allocator.rs
+++ b/miniextendr-api/src/allocator.rs
@@ -37,7 +37,7 @@
 //! For long-lived allocations or critical cleanup requirements, consider using
 //! Rust's standard allocator instead.
 
-use crate::ffi::{R_PreserveObject_unchecked, R_ReleaseObject_unchecked, SEXP, SEXPTYPE};
+use crate::ffi::{R_PreserveObject_unchecked, R_ReleaseObject_unchecked, SEXP, SEXPTYPE, SexpExt};
 use crate::worker::{has_worker_context, is_r_main_thread, with_r_thread};
 use core::{
     alloc::{GlobalAlloc, Layout},
@@ -296,7 +296,7 @@ unsafe fn realloc_main_thread(
 
     // Check if existing allocation has capacity
     let raw_base = unsafe { crate::ffi::RAW_unchecked(sexp) }.cast::<u8>();
-    let cap: usize = match unsafe { crate::ffi::Rf_xlength_unchecked(sexp) }.try_into() {
+    let cap: usize = match unsafe { sexp.xlength_unchecked() }.try_into() {
         Ok(n) => n,
         Err(_) => return sendable_data_ptr_null(),
     };

--- a/miniextendr-api/src/altrep_sexp.rs
+++ b/miniextendr-api/src/altrep_sexp.rs
@@ -150,7 +150,7 @@ impl AltrepSexp {
         let typ = self.sexp.type_of();
         match typ {
             SEXPTYPE::STRSXP => {
-                let n = unsafe { ffi::Rf_xlength(self.sexp) };
+                let n = self.sexp.xlength();
                 for i in 0..n {
                     let _ = self.sexp.string_elt(i);
                 }
@@ -174,7 +174,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be REALSXP.
     pub unsafe fn materialize_real(&self) -> &[f64] {
         let ptr = unsafe { ffi::DATAPTR_RO(self.sexp) } as *const f64;
-        let len = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let len = self.sexp.len();
         unsafe { r_slice(ptr, len) }
     }
 
@@ -185,7 +185,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be INTSXP.
     pub unsafe fn materialize_integer(&self) -> &[i32] {
         let ptr = unsafe { ffi::DATAPTR_RO(self.sexp) } as *const i32;
-        let len = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let len = self.sexp.len();
         unsafe { r_slice(ptr, len) }
     }
 
@@ -196,7 +196,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be LGLSXP.
     pub unsafe fn materialize_logical(&self) -> &[i32] {
         let ptr = unsafe { ffi::DATAPTR_RO(self.sexp) } as *const i32;
-        let len = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let len = self.sexp.len();
         unsafe { r_slice(ptr, len) }
     }
 
@@ -207,7 +207,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be RAWSXP.
     pub unsafe fn materialize_raw(&self) -> &[u8] {
         let ptr = unsafe { ffi::DATAPTR_RO(self.sexp) } as *const u8;
-        let len = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let len = self.sexp.len();
         unsafe { r_slice(ptr, len) }
     }
 
@@ -218,7 +218,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be CPLXSXP.
     pub unsafe fn materialize_complex(&self) -> &[Rcomplex] {
         let ptr = unsafe { ffi::DATAPTR_RO(self.sexp) } as *const Rcomplex;
-        let len = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let len = self.sexp.len();
         unsafe { r_slice(ptr, len) }
     }
 
@@ -231,7 +231,7 @@ impl AltrepSexp {
     /// Must be called on the R main thread. The SEXP must be STRSXP.
     pub unsafe fn materialize_strings(&self) -> Vec<Option<String>> {
         use crate::from_r::charsxp_to_str;
-        let n = unsafe { ffi::Rf_xlength(self.sexp) } as usize;
+        let n = self.sexp.len();
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
             let elt = self.sexp.string_elt(i as ffi::R_xlen_t);
@@ -264,7 +264,7 @@ impl AltrepSexp {
     /// Get the length of the underlying vector.
     #[inline]
     pub fn len(&self) -> usize {
-        (unsafe { ffi::Rf_xlength(self.sexp) }) as usize
+        self.sexp.len()
     }
 
     /// Check if the underlying vector is empty.

--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -656,7 +656,7 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
 
         // Extract column names as Vec<String>
         let names_sexp = first_names_sexp.expect("checked is_none above");
-        let n_cols = unsafe { crate::ffi::Rf_xlength(names_sexp) };
+        let n_cols = names_sexp.xlength();
         let mut col_names = Vec::with_capacity(n_cols as usize);
         for i in 0..n_cols {
             unsafe {

--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -18,7 +18,7 @@
 //! }
 //! ```
 
-use crate::ffi::{self, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
 use crate::list::{List, NamedList};
@@ -302,7 +302,7 @@ fn extract_nrow(sexp: SEXP) -> Result<usize, DataFrameError> {
     }
 
     let rn_type = row_names.type_of();
-    let rn_len = unsafe { ffi::Rf_xlength(row_names) };
+    let rn_len = row_names.xlength();
 
     // Compact integer form: c(NA_integer_, -n) where n is the row count
     if rn_type == SEXPTYPE::INTSXP && rn_len == 2 {
@@ -329,7 +329,7 @@ fn extract_nrow(sexp: SEXP) -> Result<usize, DataFrameError> {
 
 /// Fall back: extract nrow from the length of the first column.
 fn nrow_from_first_column(sexp: SEXP) -> Result<usize, DataFrameError> {
-    let ncol = unsafe { ffi::Rf_xlength(sexp) };
+    let ncol = sexp.xlength();
     if ncol == 0 {
         // 0 columns → 0 rows
         return Ok(0);
@@ -338,7 +338,7 @@ fn nrow_from_first_column(sexp: SEXP) -> Result<usize, DataFrameError> {
     if first_col == SEXP::nil() {
         return Ok(0);
     }
-    let len = unsafe { ffi::Rf_xlength(first_col) };
+    let len = first_col.xlength();
     if let Ok(n) = usize::try_from(len) {
         Ok(n)
     } else {
@@ -362,17 +362,13 @@ fn validate_equal_lengths(named: &NamedList) -> Result<usize, DataFrameError> {
 
     // Get the length of the first column
     let first_col = list.as_sexp().vector_elt(0);
-    let expected: usize = unsafe { ffi::Rf_xlength(first_col) }
-        .try_into()
-        .expect("column length must be non-negative");
+    let expected: usize = first_col.len();
 
     // Check all columns match
     let names_sexp = list.names();
     for i in 1..n {
         let col = list.as_sexp().vector_elt(i);
-        let col_len: usize = unsafe { ffi::Rf_xlength(col) }
-            .try_into()
-            .expect("column length must be non-negative");
+        let col_len: usize = col.len();
         if col_len != expected {
             // Try to get the column name for the error message
             let col_name = if let Some(names) = names_sexp {

--- a/miniextendr-api/src/dots.rs
+++ b/miniextendr-api/src/dots.rs
@@ -26,7 +26,7 @@
 //! }
 //! ```
 
-use crate::ffi::SEXP;
+use crate::ffi::{SEXP, SexpExt};
 use crate::from_r::TryFromSexp;
 use crate::list::{List, ListFromSexpError};
 use crate::typed_list::{TypedList, TypedListError, TypedListSpec, validate_list};
@@ -129,7 +129,7 @@ impl Dots {
     /// creating an intermediate List wrapper.
     #[inline]
     pub fn len(&self) -> isize {
-        unsafe { crate::ffi::Rf_xlength(self.inner) }
+        self.inner.xlength()
     }
 
     /// Returns true if no arguments were passed to `...`.

--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -57,9 +57,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         crate::worker::is_r_main_thread(),
         "must be called from R main thread"
     );
-    use crate::ffi::{
-        LOGICAL, R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, Rf_xlength, SexpExt,
-    };
+    use crate::ffi::{LOGICAL, R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, SexpExt};
 
     unsafe {
         // Call l10n_info()
@@ -70,7 +68,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
 
         // Find the "UTF-8" element by name
         let names = info.get_names();
-        let n = Rf_xlength(info);
+        let n = info.xlength();
         let mut is_utf8 = false;
         for i in 0..n {
             let name_charsxp = names.string_elt(i);
@@ -78,6 +76,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
             let name = std::ffi::CStr::from_ptr(name_ptr);
             if name == c"UTF-8" {
                 let elt = info.vector_elt(i);
+                // keep raw: single-scalar read; no SexpExt::get_logical_elt(i) helper yet (see follow-up issue)
                 is_utf8 = LOGICAL(elt).read() != 0;
                 break;
             }

--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -423,7 +423,7 @@ unsafe fn get_r_error_message() -> String {
         Rf_protect(msg_sexp);
 
         // geterrmessage() returns character(1)
-        let result = if ffi::Rf_xlength(msg_sexp) > 0 {
+        let result = if msg_sexp.xlength() > 0 {
             let charsxp = msg_sexp.string_elt(0);
             if !charsxp.is_null() {
                 let ptr = charsxp.r_char();

--- a/miniextendr-api/src/factor.rs
+++ b/miniextendr-api/src/factor.rs
@@ -29,10 +29,7 @@ use std::ops::Deref;
 use std::sync::OnceLock;
 
 use crate::altrep_traits::NA_INTEGER;
-use crate::ffi::{
-    INTEGER, Rf_allocVector, Rf_install, Rf_protect, Rf_unprotect, Rf_xlength, SEXP, SEXPTYPE,
-    SexpExt,
-};
+use crate::ffi::{Rf_allocVector, Rf_install, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::into_r::IntoR;
 
@@ -141,9 +138,7 @@ impl<'a> Factor<'a> {
             return Err(SexpError::InvalidValue("expected a factor".into()));
         }
 
-        let len = unsafe { Rf_xlength(sexp) } as usize;
-        let ptr = unsafe { INTEGER(sexp) };
-        let indices = unsafe { crate::from_r::r_slice(ptr, len) };
+        let indices = unsafe { sexp.as_slice::<i32>() };
         let levels_sexp = sexp.get_levels();
 
         Ok(Self {
@@ -174,7 +169,7 @@ impl<'a> Factor<'a> {
     /// Number of levels.
     #[inline]
     pub fn n_levels(&self) -> usize {
-        unsafe { Rf_xlength(self.levels_sexp) as usize }
+        self.levels_sexp.len()
     }
 
     /// Get level string at 0-based index.
@@ -239,9 +234,7 @@ impl<'a> FactorMut<'a> {
             return Err(SexpError::InvalidValue("expected a factor".into()));
         }
 
-        let len = unsafe { Rf_xlength(sexp) } as usize;
-        let ptr = unsafe { INTEGER(sexp) };
-        let indices = unsafe { crate::from_r::r_slice_mut(ptr, len) };
+        let indices = unsafe { sexp.as_mut_slice::<i32>() };
         let levels_sexp = sexp.get_levels();
 
         Ok(Self {
@@ -272,7 +265,7 @@ impl<'a> FactorMut<'a> {
     /// Number of levels.
     #[inline]
     pub fn n_levels(&self) -> usize {
-        unsafe { Rf_xlength(self.levels_sexp) as usize }
+        self.levels_sexp.len()
     }
 
     /// Get level string at 0-based index.
@@ -318,7 +311,7 @@ pub(crate) fn validate_factor_levels(sexp: SEXP, expected: &[&str]) -> Result<()
         return Err(SexpError::InvalidValue("levels is not STRSXP".into()));
     }
 
-    let n = unsafe { Rf_xlength(levels) } as usize;
+    let n = levels.len();
     if n != expected.len() {
         return Err(SexpError::InvalidValue(format!(
             "expected {} levels, got {}",
@@ -351,7 +344,7 @@ pub(crate) fn validate_factor_levels(sexp: SEXP, expected: &[&str]) -> Result<()
 pub fn factor_from_sexp<T: RFactor>(sexp: SEXP) -> Result<T, SexpError> {
     validate_factor_levels(sexp, T::CHOICES)?;
 
-    let len = unsafe { Rf_xlength(sexp) };
+    let len = sexp.xlength();
     if len != 1 {
         return Err(SexpError::InvalidValue(format!(
             "expected length 1, got {}",
@@ -372,7 +365,7 @@ pub fn factor_from_sexp<T: RFactor>(sexp: SEXP) -> Result<T, SexpError> {
 pub(crate) fn factor_vec_from_sexp<T: RFactor>(sexp: SEXP) -> Result<Vec<T>, SexpError> {
     validate_factor_levels(sexp, T::CHOICES)?;
 
-    let len = unsafe { Rf_xlength(sexp) } as usize;
+    let len = sexp.len();
     let mut result = Vec::with_capacity(len);
 
     for i in 0..len {
@@ -396,7 +389,7 @@ pub(crate) fn factor_option_vec_from_sexp<T: RFactor>(
 ) -> Result<Vec<Option<T>>, SexpError> {
     validate_factor_levels(sexp, T::CHOICES)?;
 
-    let len = unsafe { Rf_xlength(sexp) } as usize;
+    let len = sexp.len();
     let mut result = Vec::with_capacity(len);
 
     for i in 0..len {

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -585,6 +585,13 @@ pub trait SexpExt {
     /// The SEXP must be valid.
     fn xlength(&self) -> R_xlen_t;
 
+    /// Get the length as `R_xlen_t` without thread checks.
+    ///
+    /// # Safety
+    ///
+    /// Must be called from R's main thread. No debug assertions.
+    unsafe fn xlength_unchecked(&self) -> R_xlen_t;
+
     /// Get the length without thread checks.
     ///
     /// # Safety
@@ -995,6 +1002,11 @@ impl SexpExt for SEXP {
     #[inline]
     fn xlength(&self) -> R_xlen_t {
         unsafe { Rf_xlength(*self) }
+    }
+
+    #[inline]
+    unsafe fn xlength_unchecked(&self) -> R_xlen_t {
+        unsafe { Rf_xlength_unchecked(*self) }
     }
 
     #[inline]
@@ -2148,10 +2160,9 @@ unsafe extern "C-unwind" {
         len: ::std::os::raw::c_int,
         ce: cetype_t,
     ) -> SEXP;
-    // Issue #112 cat. 1: kept pub(crate) — ~60 callers; mechanical migration tracked in follow-up issue
     #[doc(alias = "xlength")]
     #[doc(alias = "XLENGTH")]
-    pub(crate) fn Rf_xlength(x: SEXP) -> R_xlen_t;
+    fn Rf_xlength(x: SEXP) -> R_xlen_t;
     #[doc(alias = "translateCharUTF8")]
     pub fn Rf_translateCharUTF8(x: SEXP) -> *const ::std::os::raw::c_char;
     #[doc(alias = "getCharCE")]

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -90,14 +90,9 @@ impl TryFromSexp for Vec<Option<bool>> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice() };
 
-        Ok(slice
-            .iter()
-            .map(|&v| RLogical::from_i32(v).to_option_bool())
-            .collect())
+        Ok(slice.iter().map(|v| v.to_option_bool()).collect())
     }
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
@@ -110,14 +105,9 @@ impl TryFromSexp for Vec<Option<bool>> {
             .into());
         }
 
-        let len = unsafe { sexp.len_unchecked() };
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice_unchecked() };
 
-        Ok(slice
-            .iter()
-            .map(|&v| RLogical::from_i32(v).to_option_bool())
-            .collect())
+        Ok(slice.iter().map(|v| v.to_option_bool()).collect())
     }
 }
 
@@ -145,22 +135,17 @@ impl TryFromSexp for Vec<Rboolean> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice() };
 
         slice
             .iter()
-            .map(|&v| {
-                let raw = RLogical::from_i32(v);
-                match raw.to_option_bool() {
-                    Some(false) => Ok(Rboolean::FALSE),
-                    Some(true) => Ok(Rboolean::TRUE),
-                    None => Err(SexpNaError {
-                        sexp_type: SEXPTYPE::LGLSXP,
-                    }
-                    .into()),
+            .map(|v| match v.to_option_bool() {
+                Some(false) => Ok(Rboolean::FALSE),
+                Some(true) => Ok(Rboolean::TRUE),
+                None => Err(SexpNaError {
+                    sexp_type: SEXPTYPE::LGLSXP,
                 }
+                .into()),
             })
             .collect()
     }
@@ -180,13 +165,11 @@ impl TryFromSexp for Vec<Option<Rboolean>> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice() };
 
         Ok(slice
             .iter()
-            .map(|&v| match RLogical::from_i32(v).to_option_bool() {
+            .map(|v| match v.to_option_bool() {
                 Some(false) => Some(Rboolean::FALSE),
                 Some(true) => Some(Rboolean::TRUE),
                 None => None,
@@ -213,13 +196,11 @@ impl TryFromSexp for Vec<crate::altrep_data::Logical> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice() };
 
         Ok(slice
             .iter()
-            .map(|&v| crate::altrep_data::Logical::from_r_int(v))
+            .map(|&v| crate::altrep_data::Logical::from(v))
             .collect())
     }
 }
@@ -238,16 +219,11 @@ impl TryFromSexp for Vec<Option<RLogical>> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::LOGICAL(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[RLogical] = unsafe { sexp.as_slice() };
 
         Ok(slice
             .iter()
-            .map(|&v| {
-                let raw = RLogical::from_i32(v);
-                if raw.is_na() { None } else { Some(raw) }
-            })
+            .map(|v| if v.is_na() { None } else { Some(*v) })
             .collect())
     }
 }
@@ -309,9 +285,7 @@ impl TryFromSexp for Vec<Option<u8>> {
             .into());
         }
 
-        let len = sexp.len();
-        let ptr = unsafe { crate::ffi::RAW(sexp) };
-        let slice = unsafe { r_slice(ptr, len) };
+        let slice: &[u8] = unsafe { sexp.as_slice() };
 
         Ok(slice.iter().map(|&v| Some(v)).collect())
     }

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -73,7 +73,7 @@ impl List {
     /// Length of the list (number of elements).
     #[inline]
     pub fn len(self) -> isize {
-        unsafe { ffi::Rf_xlength(self.0) }
+        self.0.xlength()
     }
 
     /// Returns true if the list is empty.
@@ -571,10 +571,8 @@ impl<'a> ListBuilder<'a> {
     #[inline]
     pub unsafe fn set(&self, idx: isize, child: SEXP) {
         // SAFETY: caller guarantees valid and protected child
-        unsafe {
-            debug_assert!(idx >= 0 && idx < ffi::Rf_xlength(self.list));
-            self.list.set_vector_elt(idx, child);
-        }
+        debug_assert!(idx >= 0 && idx < self.list.xlength());
+        self.list.set_vector_elt(idx, child);
     }
 
     /// Set an element, protecting the child within the builder's scope.
@@ -588,7 +586,7 @@ impl<'a> ListBuilder<'a> {
     pub unsafe fn set_protected(&self, idx: isize, child: SEXP) {
         // SAFETY: caller guarantees valid child
         unsafe {
-            debug_assert!(idx >= 0 && idx < ffi::Rf_xlength(self.list));
+            debug_assert!(idx >= 0 && idx < self.list.xlength());
             let _guard = OwnedProtect::new(child);
             self.list.set_vector_elt(idx, child);
         }
@@ -615,7 +613,7 @@ impl<'a> ListBuilder<'a> {
     /// Get the length of the list.
     #[inline]
     pub fn len(&self) -> isize {
-        unsafe { ffi::Rf_xlength(self.list) }
+        self.list.xlength()
     }
 
     /// Check if the list is empty.
@@ -952,7 +950,7 @@ impl List {
         let first_type = elements[0].type_of();
         let all_scalar_same_type = elements
             .iter()
-            .all(|&e| unsafe { ffi::Rf_xlength(e) == 1 && e.type_of() == first_type });
+            .all(|&e| e.xlength() == 1 && e.type_of() == first_type);
 
         if !all_scalar_same_type {
             return Self::from_raw_values(elements.to_vec());
@@ -1203,7 +1201,7 @@ impl TryFromSexp for List {
         // Check for duplicate non-NA names
         let names_sexp = list_sexp.get_names();
         if names_sexp != SEXP::nil() {
-            let n = unsafe { ffi::Rf_xlength(list_sexp) };
+            let n = list_sexp.xlength();
             let n_usize: usize = n.try_into().expect("list length must be non-negative");
             let mut seen = HashSet::with_capacity(n_usize);
 

--- a/miniextendr-api/src/list/accumulator.rs
+++ b/miniextendr-api/src/list/accumulator.rs
@@ -353,7 +353,7 @@ impl ListMut {
     /// Length of the list (number of elements).
     #[inline]
     pub fn len(&self) -> isize {
-        unsafe { ffi::Rf_xlength(self.0) }
+        self.0.xlength()
     }
 
     /// Returns true if the list is empty.

--- a/miniextendr-api/src/optionals/aho_corasick_impl.rs
+++ b/miniextendr-api/src/optionals/aho_corasick_impl.rs
@@ -40,7 +40,7 @@
 
 pub use aho_corasick::{AhoCorasick, MatchKind};
 
-use crate::ffi::{Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::charsxp_to_str;
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::{
@@ -69,7 +69,7 @@ impl TryFromSexp for AhoCorasick {
             }));
         }
 
-        let len = unsafe { Rf_xlength(sexp) } as usize;
+        let len = sexp.len();
         if len == 0 {
             return Err(SexpError::InvalidValue(
                 "aho-corasick requires at least one pattern".to_string(),

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -39,6 +39,8 @@ pub use jiff::civil::{Date, DateTime, Time};
 pub use jiff::{SignedDuration, Span, Timestamp, Zoned};
 
 use crate::cached_class::{date_class_sexp, set_posixct_tz, set_posixct_utc};
+// keep raw: all `*REAL(sexp)` reads and `*REAL(vec) = …` writes here are single-scalar;
+// no SexpExt::get_real_elt / set_real_elt helpers yet — see follow-up issue.
 use crate::ffi::{REAL, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;

--- a/miniextendr-api/src/optionals/serde_impl.rs
+++ b/miniextendr-api/src/optionals/serde_impl.rs
@@ -179,7 +179,7 @@ impl JsonOptions {
         self
     }
 }
-use crate::ffi::{Rf_allocVector, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
@@ -353,9 +353,7 @@ fn sexp_to_json_value(sexp: SEXP, opts: &JsonOptions) -> Result<JsonValue, SexpE
         return factor_to_json(sexp, opts);
     }
 
-    let len = unsafe { Rf_xlength(sexp) }
-        .try_into()
-        .expect("length overflow");
+    let len = sexp.len();
 
     match sexp_type {
         SEXPTYPE::LGLSXP => {
@@ -529,9 +527,7 @@ fn real_to_json(
 }
 
 fn factor_to_json(sexp: SEXP, opts: &JsonOptions) -> Result<JsonValue, SexpError> {
-    let len: usize = unsafe { Rf_xlength(sexp) }
-        .try_into()
-        .expect("length overflow");
+    let len: usize = sexp.len();
     let levels = sexp.get_levels();
     let slice: &[i32] = unsafe { SexpExt::as_slice(&sexp) };
 

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -83,6 +83,7 @@ impl TryFromSexp for OffsetDateTime {
             )));
         }
 
+        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
         let secs = unsafe { *REAL(sexp) };
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
@@ -123,6 +124,7 @@ impl IntoR for OffsetDateTime {
             let duration = self - UNIX_EPOCH;
             let secs = duration.whole_seconds() as f64
                 + (duration.subsec_nanoseconds() as f64 / 1_000_000_000.0);
+            // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
             *REAL(vec) = secs;
 
             set_posixct_utc(vec);
@@ -160,6 +162,7 @@ impl TryFromSexp for Option<OffsetDateTime> {
             )));
         }
 
+        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
         let secs = unsafe { *REAL(sexp) };
         if secs.is_nan() {
             return Ok(None);
@@ -366,6 +369,7 @@ impl TryFromSexp for Date {
             )));
         }
 
+        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
         let days = unsafe { *REAL(sexp) };
         if days.is_nan() {
             return Err(SexpError::Na(SexpNaError {
@@ -397,6 +401,7 @@ impl IntoR for Date {
 
             // Calculate days since epoch
             let days = (self - UNIX_EPOCH_DATE).whole_days() as f64;
+            // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
             *REAL(vec) = days;
 
             // Set class = "Date"
@@ -435,6 +440,7 @@ impl TryFromSexp for Option<Date> {
             )));
         }
 
+        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
         let days = unsafe { *REAL(sexp) };
         if days.is_nan() {
             return Ok(None);

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -195,6 +195,7 @@ impl IntoR for Option<OffsetDateTime> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
+                // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
                 *REAL(vec) = f64::NAN;
                 set_posixct_utc(vec);
                 Rf_unprotect(1);
@@ -470,6 +471,7 @@ impl IntoR for Option<Date> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
+                // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
                 *REAL(vec) = f64::NAN;
 
                 vec.set_class(crate::cached_class::date_class_sexp());

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -64,7 +64,7 @@
 
 pub use toml::Value as TomlValue;
 
-use crate::ffi::{Rf_allocVector, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::OwnedProtect;
 use crate::impl_option_try_from_sexp;
@@ -134,7 +134,7 @@ impl TryFromSexp for TomlValue {
             }));
         }
 
-        let len = unsafe { Rf_xlength(sexp) } as usize;
+        let len = sexp.len();
         if len != 1 {
             return Err(SexpError::InvalidValue(format!(
                 "expected character(1), got length {}",

--- a/miniextendr-api/src/preserve.rs
+++ b/miniextendr-api/src/preserve.rs
@@ -134,12 +134,12 @@ pub(crate) unsafe fn get_unchecked() -> SEXP {
 #[cfg(feature = "debug-preserve")]
 #[inline]
 pub unsafe fn count() -> crate::ffi::R_xlen_t {
-    use crate::ffi::{R_xlen_t, Rf_xlength};
+    use crate::ffi::{R_xlen_t, SexpExt};
     unsafe {
         let head: R_xlen_t = 1;
         let tail: R_xlen_t = 1;
         let list = get();
-        Rf_xlength(list) - head - tail
+        list.xlength() - head - tail
     }
 }
 
@@ -154,13 +154,13 @@ pub unsafe fn count() -> crate::ffi::R_xlen_t {
 #[cfg(feature = "debug-preserve")]
 #[inline]
 pub unsafe fn count_unchecked() -> crate::ffi::R_xlen_t {
-    use crate::ffi::{R_xlen_t, Rf_xlength_unchecked};
+    use crate::ffi::{R_xlen_t, SexpExt};
 
     unsafe {
         let head: R_xlen_t = 1;
         let tail: R_xlen_t = 1;
         let list = get_unchecked();
-        Rf_xlength_unchecked(list) - head - tail
+        list.xlength_unchecked() - head - tail
     }
 }
 

--- a/miniextendr-api/src/raw_conversions.rs
+++ b/miniextendr-api/src/raw_conversions.rs
@@ -58,7 +58,7 @@ pub use bytemuck::{Pod, Zeroable};
 use std::fmt;
 use std::mem;
 
-use crate::ffi::{RAW, Rf_allocVector, Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{RAW, Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -339,9 +339,7 @@ fn get_raw_bytes(sexp: SEXP) -> Result<&'static [u8], SexpError> {
             actual: sexp.type_of(),
         }));
     }
-    let len = unsafe { Rf_xlength(sexp) } as usize;
-    let ptr = unsafe { RAW(sexp) };
-    Ok(unsafe { crate::from_r::r_slice(ptr, len) })
+    Ok(unsafe { sexp.as_slice::<u8>() })
 }
 
 /// Align bytes to type T, copying if necessary.
@@ -407,6 +405,7 @@ impl<T: Pod> IntoR for Raw<T> {
         let bytes = bytemuck::bytes_of(&self.0);
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, bytes.len() as isize);
+            // keep raw: bulk byte write — no SexpExt helper for arbitrary-stride copy_nonoverlapping
             let ptr = RAW(sexp);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
             Ok(sexp)
@@ -420,6 +419,7 @@ impl<T: Pod> IntoR for RawSlice<T> {
         let bytes = bytemuck::cast_slice::<T, u8>(&self.0);
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, bytes.len() as isize);
+            // keep raw: bulk byte write — no SexpExt helper for arbitrary-stride copy_nonoverlapping
             let ptr = RAW(sexp);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
             Ok(sexp)
@@ -437,6 +437,7 @@ impl<T: Pod> IntoR for RawTagged<T> {
 
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, total_len as isize);
+            // keep raw: bulk byte write — no SexpExt helper for arbitrary-stride copy_nonoverlapping
             let ptr = RAW(sexp);
             std::ptr::copy_nonoverlapping(header_bytes.as_ptr(), ptr, header_bytes.len());
             std::ptr::copy_nonoverlapping(
@@ -465,6 +466,7 @@ impl<T: Pod> IntoR for RawSliceTagged<T> {
 
         unsafe {
             let sexp = Rf_allocVector(SEXPTYPE::RAWSXP, total_len as isize);
+            // keep raw: bulk byte write — no SexpExt helper for arbitrary-stride copy_nonoverlapping
             let ptr = RAW(sexp);
             std::ptr::copy_nonoverlapping(header_bytes.as_ptr(), ptr, header_bytes.len());
             std::ptr::copy_nonoverlapping(

--- a/miniextendr-api/src/s4_helpers.rs
+++ b/miniextendr-api/src/s4_helpers.rs
@@ -29,7 +29,7 @@
 /// }
 /// ```
 use crate::expression::{RCall, REnv};
-use crate::ffi::{self, SEXP, SexpExt};
+use crate::ffi::{SEXP, SexpExt};
 use std::ffi::CStr;
 
 /// Get the `methods` package namespace for evaluating S4 functions.
@@ -128,7 +128,7 @@ pub unsafe fn s4_set_slot(obj: SEXP, slot_name: &str, value: SEXP) -> Result<(),
 pub unsafe fn s4_class_name(obj: SEXP) -> Option<String> {
     unsafe {
         let class_attr = obj.get_class();
-        if class_attr.is_null_or_nil() || ffi::Rf_xlength(class_attr) == 0 {
+        if class_attr.is_null_or_nil() || class_attr.xlength() == 0 {
             return None;
         }
 

--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -193,7 +193,7 @@ impl ColumnarDataFrame {
             if names_sexp == SEXP::nil() {
                 return self;
             }
-            let ncol = crate::ffi::Rf_xlength(names_sexp);
+            let ncol = names_sexp.xlength();
             for i in 0..ncol {
                 if col_name(names_sexp, i) == from {
                     names_sexp.set_string_elt(i, SEXP::charsxp(to));
@@ -212,7 +212,7 @@ impl ColumnarDataFrame {
             if names_sexp == SEXP::nil() {
                 return self;
             }
-            let ncol = crate::ffi::Rf_xlength(names_sexp);
+            let ncol = names_sexp.xlength();
             for i in 0..ncol {
                 let name = col_name(names_sexp, i);
                 if let Some(stripped) = name.strip_prefix(prefix) {
@@ -230,7 +230,7 @@ impl ColumnarDataFrame {
             if names_sexp == SEXP::nil() {
                 return self;
             }
-            let ncol = crate::ffi::Rf_xlength(names_sexp);
+            let ncol = names_sexp.xlength();
             let drop_idx = (0..ncol).find(|&i| col_name(names_sexp, i) == col);
             let Some(drop_idx) = drop_idx else {
                 return self;
@@ -264,7 +264,7 @@ impl ColumnarDataFrame {
             if names_sexp == SEXP::nil() {
                 return self;
             }
-            let ncol = crate::ffi::Rf_xlength(names_sexp);
+            let ncol = names_sexp.xlength();
 
             let indices: Vec<isize> = cols
                 .iter()

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -5,7 +5,7 @@
 
 use super::error::RSerdeError;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
-use crate::ffi::{Rf_xlength, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::charsxp_to_str;
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 
@@ -57,7 +57,7 @@ impl RDeserializer {
     }
 
     fn len(&self) -> usize {
-        unsafe { Rf_xlength(self.sexp) as usize }
+        self.sexp.len()
     }
 
     fn is_null(&self) -> bool {
@@ -413,9 +413,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
             });
         }
 
-        let len = self.len();
-        let ptr = unsafe { crate::ffi::RAW(self.sexp) };
-        let bytes = unsafe { crate::from_r::r_slice(ptr, len) };
+        let bytes = unsafe { self.sexp.as_slice::<u8>() };
         visitor.visit_bytes(bytes)
     }
 
@@ -427,9 +425,7 @@ impl<'de> de::Deserializer<'de> for RDeserializer {
             });
         }
 
-        let len = self.len();
-        let ptr = unsafe { crate::ffi::RAW(self.sexp) };
-        let bytes = unsafe { crate::from_r::r_slice(ptr, len) };
+        let bytes = unsafe { self.sexp.as_slice::<u8>() };
         visitor.visit_byte_buf(bytes.to_vec())
     }
 
@@ -709,7 +705,7 @@ impl VectorSeqAccess {
             sexp,
             sexp_type: sexp.type_of(),
             index: 0,
-            len: unsafe { Rf_xlength(sexp) as usize },
+            len: sexp.len(),
         }
     }
 }
@@ -811,7 +807,7 @@ impl ListSeqAccess {
         ListSeqAccess {
             sexp,
             index: 0,
-            len: unsafe { Rf_xlength(sexp) as usize },
+            len: sexp.len(),
         }
     }
 }
@@ -859,8 +855,8 @@ impl NamedListMapAccess {
                 actual: "list (names attribute is not character)".into(),
             });
         }
-        let len = unsafe { Rf_xlength(sexp) as usize };
-        let names_len = unsafe { Rf_xlength(names) as usize };
+        let len = sexp.len();
+        let names_len = names.len();
         if names_len != len {
             return Err(RSerdeError::TypeMismatch {
                 expected: "named list",

--- a/miniextendr-api/src/serde/ser.rs
+++ b/miniextendr-api/src/serde/ser.rs
@@ -257,7 +257,7 @@ impl ser::SerializeSeq for SeqSerializer {
         let elem = value.serialize(RSerializer)?;
 
         // Track homogeneity for smart dispatch
-        let elem_len = unsafe { crate::ffi::Rf_xlength(elem) };
+        let elem_len = elem.xlength();
         let elem_type = elem.type_of();
 
         if elem_len != 1 {
@@ -526,7 +526,7 @@ fn sexp_to_string(sexp: SEXP) -> Result<String, RSerdeError> {
         return Err(RSerdeError::NonStringKey);
     }
 
-    let len = unsafe { crate::ffi::Rf_xlength(sexp) };
+    let len = sexp.xlength();
     if len != 1 {
         return Err(RSerdeError::NonStringKey);
     }

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use crate::ffi::SEXPTYPE::STRSXP;
-use crate::ffi::{self, SEXP, SexpExt};
+use crate::ffi::{SEXP, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
 use crate::gc_protect::{OwnedProtect, ProtectScope};
 use crate::into_r::IntoR;
@@ -38,7 +38,7 @@ impl StrVec {
     /// Length of the character vector (number of elements).
     #[inline]
     pub fn len(self) -> isize {
-        unsafe { ffi::Rf_xlength(self.0) }
+        self.0.xlength()
     }
 
     /// Returns true if the vector is empty.
@@ -347,7 +347,7 @@ impl<'a> StrVecBuilder<'a> {
     /// Must be called from the R main thread.
     #[inline]
     pub unsafe fn set_str(&self, idx: isize, s: &str) {
-        debug_assert!(idx >= 0 && idx < unsafe { ffi::Rf_xlength(self.vec) });
+        debug_assert!(idx >= 0 && idx < self.vec.xlength());
         let charsxp = SEXP::charsxp(s);
         self.vec.set_string_elt(idx, charsxp);
     }
@@ -359,7 +359,7 @@ impl<'a> StrVecBuilder<'a> {
     /// Must be called from the R main thread.
     #[inline]
     pub unsafe fn set_na(&self, idx: isize) {
-        debug_assert!(idx >= 0 && idx < unsafe { ffi::Rf_xlength(self.vec) });
+        debug_assert!(idx >= 0 && idx < self.vec.xlength());
         self.vec.set_string_elt(idx, SEXP::na_string());
     }
 
@@ -398,7 +398,7 @@ impl<'a> StrVecBuilder<'a> {
     /// Get the length.
     #[inline]
     pub fn len(&self) -> isize {
-        unsafe { ffi::Rf_xlength(self.vec) }
+        self.vec.xlength()
     }
 
     /// Check if empty.

--- a/miniextendr-api/src/typed_list.rs
+++ b/miniextendr-api/src/typed_list.rs
@@ -32,7 +32,7 @@
 //! let alpha: Vec<f64> = validated.get("alpha")?;
 //! ```
 
-use crate::ffi::{self, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::list::{List, ListFromSexpError};
 use std::collections::HashSet;
@@ -452,7 +452,7 @@ pub fn validate_list(list: List, spec: &TypedListSpec) -> Result<TypedList, Type
 /// Validate a single element against its type spec.
 fn validate_element(elem: SEXP, entry: &TypedEntry) -> Result<(), TypedListError> {
     let actual_type = elem.type_of();
-    let actual_len = unsafe { ffi::Rf_xlength(elem) };
+    let actual_len = elem.xlength();
 
     match &entry.spec {
         TypeSpec::Any => Ok(()),
@@ -692,7 +692,7 @@ pub fn actual_type_string(sexp: SEXP) -> String {
     // Check if it has a class attribute
     let class_attr = sexp.get_class();
     if !class_attr.is_nil() {
-        let class_len = unsafe { ffi::Rf_xlength(class_attr) };
+        let class_len = class_attr.xlength();
         if class_len > 0 {
             let first_class = class_attr.string_elt(0);
             if first_class != SEXP::na_string() {

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -9,7 +9,7 @@ use crate::ffi::SEXP;
 
 // region: Construction helpers (Phase A)
 
-use crate::ffi::{R_xlen_t, Rf_allocVector, Rf_xlength, SEXPTYPE, SexpExt};
+use crate::ffi::{R_xlen_t, Rf_allocVector, SEXPTYPE, SexpExt};
 use crate::gc_protect::OwnedProtect;
 use crate::list::List;
 
@@ -185,7 +185,7 @@ fn get_typeof_name(sexp: SEXP) -> &'static str {
 /// Must be called from R's main thread with a valid STRSXP.
 #[must_use]
 unsafe fn repair_na_names(names: SEXP) -> (SEXP, Option<OwnedProtect>) {
-    let n = unsafe { Rf_xlength(names) };
+    let n = names.xlength();
     let mut has_na = false;
 
     // First pass: check if any NA
@@ -363,7 +363,7 @@ pub fn new_rcrd(
     // Validate: check for duplicate names and get expected length from first field
     let mut seen_names = std::collections::HashSet::new();
     let first_field = fields.get(0).expect("n_fields > 0");
-    let expected_len = unsafe { Rf_xlength(first_field) };
+    let expected_len = first_field.xlength();
 
     for i in 0..n_fields {
         // Check name
@@ -387,7 +387,7 @@ pub fn new_rcrd(
         // Check length (skip first, already used for expected_len)
         if i > 0 {
             let field = fields.as_sexp().vector_elt(i);
-            let field_len = unsafe { Rf_xlength(field) };
+            let field_len = field.xlength();
             if field_len != expected_len {
                 return Err(VctrsBuildError::FieldLengthMismatch {
                     field: name.to_string(),


### PR DESCRIPTION
## Summary

- **#355**: Migrates all ~60 raw `Rf_xlength(sexp)` callers in `miniextendr-api` to `SexpExt` trait methods (`.len()` for `usize`, `.xlength()` for `R_xlen_t`, `.xlength_unchecked()` for unchecked contexts). `Rf_xlength` is downgraded from `pub(crate)` to module-private in `ffi.rs`.
- **#356**: Replaces `LOGICAL(sexp) + r_slice(ptr, len)` and `RAW(sexp) + r_slice(ptr, len)` slice patterns with `.as_slice::<RLogical>()` / `.as_slice::<u8>()` etc. across `factor.rs`, `from_r/na_vectors.rs`, `serde/de.rs`, and `raw_conversions.rs`. Single-scalar `*REAL(...)` reads/writes in `time_impl.rs` and `jiff_impl.rs` annotated with `// keep raw:` comments.
- Adds `unsafe fn xlength_unchecked(&self) -> R_xlen_t` to `SexpExt` trait (used in `allocator.rs` and `preserve.rs`).
- Cleans up incidental `self` import aliases and one `unnecessary unsafe` block surfaced by the migration.

## Deferred / follow-up

- #614 — `SexpExt::get_real_elt` / `set_real_elt` / `get_logical_elt` scalar accessors for the ~25 `*REAL(...)` sites in `time_impl.rs` and `jiff_impl.rs` that are annotated `// keep raw:`

## Test plan

- [x] `just check` — zero warnings, zero errors across all workspace members and cross-package test packages
- [x] `just clippy` — clean
- [x] `just clippy` with full CI feature list (`rayon,serde,...,jiff,default-r6,...`) — clean
- [x] `just fmt` — no diff
- [x] `just lint` — no new MXL301 violations
- [x] R CMD INSTALL (`R_LIBS_USER=/tmp/claude/R_lib`) — compiled and installed successfully
- [x] `library(miniextendr)` loads without errors
- [x] Generated R wrappers (`rpkg/R/miniextendr-wrappers.R`) — byte-identical (no signature changes)
- [ ] `just devtools-test` — devtools/testthat not available in this environment; all Rust paths covered by compilation and clippy