### PR TITLE
docs(skills): type system skills (#162, #163, #169)

### DIFF
--- a/.claude/skills/miniextendr-conversions/SKILL.md
+++ b/.claude/skills/miniextendr-conversions/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: miniextendr-conversions
+description: Use when the user asks about converting between R and Rust types, how TryFromSexp or IntoR work, what NA handling looks like, how strict mode differs from normal coercion, why Vec<i32> from an empty R vector panics, or how bool, Option<T>, or large integer types behave across the R-Rust boundary.
+---
+
+# miniextendr Type Conversions
+
+The conversion layer is the interface between R's SEXP values and Rust types.
+Every argument a `#[miniextendr]` function receives goes through `TryFromSexp`;
+every return value goes through `IntoR`. Getting these right is prerequisite
+knowledge for working on any function that crosses the R-Rust boundary.
+
+## When to use this skill
+
+- "How do I receive a `Vec<i32>` from R?"
+- "What happens when R passes NA to a `i32` argument?"
+- "My `i64` return value is becoming a double in R — why?"
+- "What is strict mode and when do I use it?"
+- "Why does converting from an empty R vector panic?"
+- "How do I handle logical NA (three-state true/false/NA)?"
+- "What types does `Option<T>` accept?"
+- "How do I add a new conversion type?"
+- "Why can't I use `bool` where R uses logical vectors?"
+- "What does `Coerce` vs `TryCoerce` mean?"
+
+## Key concepts
+
+### TryFromSexp — R to Rust
+
+`TryFromSexp` is the trait that converts an incoming SEXP to a Rust type.
+It lives in `miniextendr-api/src/from_r.rs`. The generated C wrapper calls
+`try_from_sexp` for each argument before invoking the user's function.
+
+The trait has two methods:
+- `try_from_sexp(sexp: SEXP)` — checked path, runs debug thread assertions.
+- `try_from_sexp_unchecked(sexp: SEXP)` — unchecked path for ALTREP callbacks
+  and other contexts where the thread is already known.
+
+### IntoR — Rust to R
+
+`IntoR` converts a Rust value into a SEXP after the user's function returns.
+It lives in `miniextendr-api/src/into_r.rs`. The trait is infallible by
+convention for scalar types (using `std::convert::Infallible` as the error
+type), but fallible for types that can fail (such as strings exceeding R's
+i32 length limit — `IntoRError` is the error type for those).
+
+### Coerce and TryCoerce — R-side type coercion
+
+`Coerce<R>` (infallible) and `TryCoerce<R>` (fallible) sit between R native
+types and Rust non-native types. They live in `miniextendr-api/src/coerce.rs`.
+These are not exposed directly to function authors; `TryFromSexp` impls use
+them internally for the "coerced scalar" types (see below).
+
+### Three conversion modes
+
+The full matrix is in `docs/CONVERSION_MATRIX.md`. The three modes are:
+
+**Normal mode** — each Rust type accepts exactly one R type. `i32` only
+accepts `INTSXP`; `f64` only accepts `REALSXP`. A type mismatch produces a
+`SexpTypeError`.
+
+**Coerce mode** — sub-integer types (`i8`, `i16`, `u16`, `u32`, `f32`) and
+large integer types (`i64`, `u64`, `isize`, `usize`) accept multiple R types:
+`INTSXP`, `REALSXP`, `RAWSXP`, and `LGLSXP`. The value is extracted as the
+R native type then converted to the Rust type via `TryCoerce`. This is the
+default for these types — no attribute is needed.
+
+**Strict mode** — activated via `#[miniextendr(strict)]` on the function.
+Large integer types (`i64`, `u64`, `isize`, `usize`) are restricted to
+`INTSXP` and `REALSXP` only; `RAWSXP` and `LGLSXP` are rejected. On output,
+values that do not fit in i32 cause a panic (which becomes an R error via the
+framework's error transport) instead of silently widening to `REALSXP`. Strict
+mode is implemented in `miniextendr-api/src/strict.rs`.
+
+### NA handling
+
+R NA values are type-specific sentinel values:
+
+- `NA_integer_` = `i32::MIN`. This value is excluded from the valid range for
+  `i32` — receiving it via `TryFromSexp` returns `SexpError::Na`. If you need
+  NA-aware integer handling, use `Option<i32>`.
+- `NA_real_` is a specific NaN bit pattern (not the same as `f64::is_nan()`).
+  `f64` receives it as the NA_real_ NaN; `Option<f64>` maps it to `None`.
+- `NA_logical` is a third state for logicals — neither true nor false.
+  Use `RLogical` (not `bool`) to represent it. `bool` treats NA as an error.
+- `NA_character_` causes an error for `String` / `&str`. Use
+  `Option<String>` / `Option<&str>` to accept it as `None`.
+
+`Option<T>` maps both NA and NULL to `None` for all wrapped types.
+
+On output, `Option<T>` produces NA (not NULL) for `None` when T is a scalar
+type. `Option<Vec<T>>` produces NULL.
+
+### bool is not RNativeType
+
+R represents logical values as i32 (three-state: 0=FALSE, 1=TRUE, `NA_integer_`=NA).
+Rust `bool` is two-state and has no `IntoR`/`TryFromSexp` implementation via
+the `RNativeType` blanket. Instead, `bool` has separate explicit impls:
+- `TryFromSexp for bool` — accepts LGLSXP, fails on NA.
+- `IntoR for bool` — emits `1_i32` or `0_i32` as LGLSXP.
+
+If you need NA-aware logical handling, use `RLogical` (which carries
+`RLogical::True`, `RLogical::False`, `RLogical::Na`).
+
+### Empty-vector pointer trap
+
+R returns a sentinel pointer (`0x1`, not null) for the data pointer of
+zero-length vectors (e.g., `LOGICAL(integer(0))`). Rust 1.93+ validates
+pointer alignment even for `len == 0` in `slice::from_raw_parts`, so passing
+R's sentinel directly causes a precondition-check abort.
+
+All slice construction inside miniextendr goes through `r_slice()` and
+`r_slice_mut()`, defined in `miniextendr-api/src/from_r.rs`. These helpers
+return `&[]` / `&mut []` when `len == 0` without dereferencing the pointer.
+If you add a custom `TryFromSexp` impl that calls `slice::from_raw_parts`
+directly, you must handle this case. Never call `from_raw_parts` with R's
+raw data pointer without first checking `len > 0`.
+
+### Large integer types: smart widening vs strict
+
+By default, `i64`, `u64`, `isize`, and `usize` use smart widening on output:
+- Value fits in `(i32::MIN, i32::MAX]` → `INTSXP`
+- Value outside that range → `REALSXP` (may lose precision above 2^53)
+- `i32::MIN` is always excluded from `INTSXP` because it is `NA_integer_`
+
+With `#[miniextendr(strict)]`, out-of-range values panic instead of widening
+to `REALSXP`. The strict helpers are in `miniextendr-api/src/strict.rs`:
+`checked_into_sexp_i64`, `checked_into_sexp_u64`, and the vector variants.
+
+## How it works
+
+### Normal call path
+
+1. `#[miniextendr]` generates a C wrapper. For each argument, it calls
+   `TryFromSexp::try_from_sexp(sexp)` (or the `_unchecked` variant in
+   appropriate contexts).
+2. Conversion failures become panics, which the `with_r_unwind_protect`
+   boundary converts into R errors via the tagged-SEXP transport in
+   `miniextendr-api/src/error_value.rs`.
+3. The user's function runs with native Rust types.
+4. The return value is converted via `IntoR::into_sexp()` and returned
+   to R.
+
+For the macro code that generates this glue, see:
+- `miniextendr-macros/src/rust_conversion_builder.rs` — argument conversion
+  code generation.
+- `miniextendr-macros/src/return_type_analysis.rs` — return type analysis
+  (strict-aware).
+
+### Adding a new conversion type
+
+The six-step checklist from `miniextendr-api/CLAUDE.md`:
+1. `from_r.rs` — implement `TryFromSexp`.
+2. `into_r.rs` — implement `IntoR`.
+3. `coerce.rs` — implement `Coerce<R>` or `TryCoerce<R>` if needed.
+4. Update serde docs (if the type participates in serde).
+5. Add an rpkg fixture function so the type is exercised under
+   `gctorture(TRUE)`.
+6. Run `just vendor-sync-check` to confirm vendored copies are in sync.
+
+`bool` is not `RNativeType` (R uses i32 for logicals), so it needs separate
+impls. The proc-macro handles `Box<[T]>` generically — no macro changes are
+needed when adding a new element type.
+
+## Decision trees
+
+### Which type do I use for a function argument?
+
+```
+Do you need NA-awareness?
+  Yes → Option<T>: maps NA and NULL to None.
+  No:
+    Is the value a scalar?
+      Yes — what R type?
+        INTSXP → i32 (exact) or i64/u64 (coerced)
+        REALSXP → f64 (exact) or f32/i64/u64 (coerced)
+        LGLSXP → bool (error on NA) or RLogical (NA-aware)
+        STRSXP → &str (borrowed, no alloc) or String (owned)
+        RAWSXP → u8
+      No (vector)?
+        Vec<i32>, Vec<f64>, Vec<u8>, Vec<bool>, Vec<String>, Vec<RLogical>
+        Vec<Option<T>> for NA-aware variants
+        &[T] for borrowed read-only slices (no copying)
+Do you want multi-source coercion (INTSXP or REALSXP or RAWSXP)?
+  Yes → use i8, i16, u16, u32, f32, i64, u64, isize, usize (coerce mode)
+```
+
+### Strict mode or not?
+
+Use `#[miniextendr(strict)]` when:
+- The function explicitly contracts that all values fit in R's integer range.
+- You want a user-facing error rather than silent precision loss for large i64.
+
+Avoid strict mode when:
+- The function handles large integers that may legitimately exceed i32::MAX.
+- You want R users to pass either integer or numeric vectors without a strict
+  type contract.
+
+### What does Option do?
+
+- `Option<i32>` input: accepts `NA_integer_` → `None`; accepts non-NA integer
+  → `Some(val)`.
+- `Option<i32>` output: `None` → `NA_integer_`; `Some(v)` → integer scalar.
+- `Option<Vec<i32>>` output: `None` → NULL (`R_NilValue`).
+
+## Key files
+
+- `miniextendr-api/src/from_r.rs` — `TryFromSexp` trait and all built-in
+  implementations. Also contains `r_slice` / `r_slice_mut` (the empty-vector
+  pointer helpers), `SexpError`, `SexpTypeError`, `SexpLengthError`,
+  `SexpNaError`.
+- `miniextendr-api/src/into_r.rs` — `IntoR` trait and all built-in
+  implementations. Submodules for large integers, collections, Result.
+- `miniextendr-api/src/coerce.rs` — `Coerce<R>` and `TryCoerce<R>` traits
+  used internally by the coerce-mode `TryFromSexp` impls.
+- `miniextendr-api/src/strict.rs` — `checked_into_sexp_i64`,
+  `checked_into_sexp_u64`, `checked_into_sexp_isize`, `checked_into_sexp_usize`,
+  and their vector variants.
+- `docs/CONVERSION_MATRIX.md` — the authoritative R type × Rust type
+  reference table covering all three modes in both directions.
+- `miniextendr-macros/src/rust_conversion_builder.rs` — proc-macro code that
+  generates the `TryFromSexp` call sites in C wrappers.
+- `miniextendr-macros/src/return_type_analysis.rs` — proc-macro code that
+  selects normal vs strict `IntoR` call sites based on the function attribute.
+
+## Common pitfalls
+
+- **i32::MIN is NA_integer_**: passing `i32::MIN` from R as an `i32` argument
+  returns `SexpError::Na`, not a large negative number. Use `Option<i32>` to
+  accept it explicitly as `None`. On output, never return `i32::MIN` from a
+  function expecting a valid integer — R will display it as `NA`.
+
+- **bool does not have a blanket RNativeType impl**: if you write a generic
+  function over `T: RNativeType`, it will not cover `bool`. That is intentional
+  — R's logical type is three-state (TRUE/FALSE/NA). Use `RLogical` for the
+  full three-state representation.
+
+- **Coerce-mode types silently accept LGLSXP**: `i64` from an LGLSXP is legal
+  in normal (non-strict) mode. If you want to enforce that only numeric R values
+  are accepted, add `#[miniextendr(strict)]`.
+
+- **Empty vector sentinel causes precondition abort in Rust 1.93+**: never call
+  `slice::from_raw_parts` with a raw R data pointer without checking `len > 0`
+  first. Use `r_slice()` / `r_slice_mut()` from `from_r.rs` instead.
+
+- **NA_real_ is a specific NaN bit pattern**: `f64::is_nan()` returns `true`
+  for all NaN values including `0.0/0.0`. Use `is_na_real()` from `from_r.rs`
+  to distinguish R's NA from regular NaN.
+
+- **Option<Vec<T>> returns NULL, not NA**: on output, `None` for a vector
+  `Option<Vec<T>>` produces `R_NilValue` (R's NULL), not a length-1 NA vector.
+  Scalar `Option<i32>` produces `NA_integer_`. The distinction matters for
+  downstream R code that uses `is.null()` vs `is.na()`.
+
+## Related skills
+
+- `miniextendr-getting-started` — how to write and register a first function.
+- `miniextendr-macros` — how `#[miniextendr]` attribute parsing selects strict
+  vs normal mode and how `TryFromSexp` call sites are generated.
+- `miniextendr-serde` — alternative path for complex types via serde's
+  Serialize/Deserialize instead of hand-rolled TryFromSexp/IntoR.
+- `miniextendr-ffi` — thread safety, `_unchecked` FFI variants, and the
+  MXL300/MXL301 lint rules that govern when unchecked conversions are legal.
+- `miniextendr-altrep` — ALTREP vectors, which use `r_slice` / `r_slice_mut`
+  directly inside ALTREP callbacks.

--- a/.claude/skills/miniextendr-externalptr/SKILL.md
+++ b/.claude/skills/miniextendr-externalptr/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: miniextendr-externalptr
+description: Use when the user asks about ExternalPtr, how Rust structs are stored as R objects, TypedExternal, Box<Box<dyn Any>> storage, pointer provenance for cached_ptr, the release_any finalizer, sidecar field accessors, the TYPE_NAME_CSTR vs TYPE_ID_CSTR distinction, or how to pass an ExternalPtr across crate or package boundaries.
+---
+
+# miniextendr ExternalPtr
+
+`ExternalPtr<T>` is how Rust-owned data lives in R's heap as an
+`EXTPTRSXP`. Understanding its storage layout, type-safety model, pointer
+provenance rules, and the sidecar accessor codegen quirks is necessary for
+any work that exposes Rust structs to R code.
+
+## When to use this skill
+
+- "How do I expose a Rust struct to R?"
+- "What is ExternalPtr and how does it work?"
+- "What is TypedExternal and why do I need it?"
+- "How is type safety enforced across package boundaries?"
+- "What is the Box<Box<dyn Any>> layout and why?"
+- "What is cached_ptr and how must I handle its provenance?"
+- "How are sidecar field accessors generated?"
+- "Why does adding `.call = match.call()` to a sidecar wrapper break at runtime?"
+- "How do I cross a crate boundary with an ExternalPtr?"
+- "What is the release_any finalizer?"
+
+## Key concepts
+
+### Storage layout: Box<Box<dyn Any>>
+
+`ExternalPtr<T>` stores `Box<Box<dyn Any>>` in two levels:
+
+1. **Inner box** (`Box<T>` cast to `Box<dyn Any>`): owns the Rust value.
+   The `Any` vtable carries `T`'s `drop` and `TypeId`. This is the fat pointer.
+2. **Outer box** (`Box<Box<dyn Any>>`): wraps the fat pointer in a second
+   allocation. Its raw pointer (`*mut Box<dyn Any>`) is a thin pointer that
+   fits in R's `R_ExternalPtrAddr` field.
+
+The indirection exists because R's `EXTPTRSXP` stores a single `void*` pointer.
+A `Box<dyn Any>` fat pointer is two words (data + vtable) and does not fit in
+a `void*`. The outer box reduces it to a single thin pointer.
+
+On finalization, `release_any` receives the SEXP, reads the thin pointer from
+`R_ExternalPtrAddr`, reconstructs `Box<Box<dyn Any>>` by dropping both boxes,
+and the `Any` vtable dispatches to T's `Drop` implementation. No generic
+parameter on `release_any` is needed because the vtable carries it.
+
+### cached_ptr and pointer provenance
+
+`ExternalPtr<T>` caches a `NonNull<T>` in its `cached_ptr` field. This allows
+`as_ref()` / `as_mut()` to skip the `R_ExternalPtrAddr` FFI call on every
+access.
+
+The critical constraint: **`cached_ptr` must have mutable provenance**.
+
+When constructing `ExternalPtr::new(x)`:
+1. The value is placed in a `Box<T>` via `Box::new(x)`.
+2. `Box::into_raw(box_t)` yields a `*mut T` with mutable provenance.
+   This raw pointer is stored as `cached_ptr`.
+3. The same allocation is then re-wrapped as `Box<dyn Any>` and placed in the
+   outer `Box<Box<dyn Any>>`.
+
+The mutable-provenance constraint means you must never derive `cached_ptr` from
+a `&T` reference or from `downcast_ref`. Those yield shared-reference provenance;
+writing through them later is undefined behavior under the Stacked Borrows model.
+The correct paths are `Box::into_raw`, `downcast_mut`, or `ptr::from_mut`.
+
+See `miniextendr-api/src/externalptr.rs` (the `ExternalPtr::new` implementation
+around line 353) for the concrete construction sequence that preserves provenance.
+
+### TypedExternal trait
+
+`TypedExternal` provides R-visible type identification. Two constants are required:
+
+- `TYPE_NAME_CSTR: &'static [u8]` — short display name for the R tag slot
+  (shown when you print an ExternalPtr in R). Example: `b"MyData\0"`.
+- `TYPE_ID_CSTR: &'static [u8]` — namespaced type ID stored in the `prot`
+  list's index-0 slot. Format: `"crate_name@crate_version::module_path::TypeName\0"`.
+  The crate name and version mean that two types with the same name from
+  different crates (or different versions of the same crate) are distinct
+  identities and will not be confused.
+
+`TypedExternal` is implemented manually or via `#[derive(ExternalPtr)]`. The
+derive macro generates both constants from the type's name and module path using
+`module_path!()` and `env!("CARGO_PKG_NAME")`.
+
+### Type safety: Any::downcast, not R symbols
+
+`TypedExternal` constants provide display names and error messages. They are
+not the mechanism for type safety. The authoritative type check is
+`Any::downcast_ref::<T>()` / `Any::downcast_mut::<T>()`, which uses Rust's
+`TypeId`. An ExternalPtr wrapping `MyStruct` can only be downcast to
+`MyStruct` — not to any other type with the same name or layout.
+
+This means type safety survives across package boundaries without requiring a
+shared header file or agreed-upon name string.
+
+### IntoExternalPtr marker trait
+
+`IntoExternalPtr: TypedExternal` is a marker trait that gives a type a blanket
+`IntoR` implementation. When a type derives `#[derive(ExternalPtr)]`, it
+implements both `TypedExternal` and `IntoExternalPtr`, which means it can be
+returned directly from a `#[miniextendr]` function:
+
+```rust
+#[derive(ExternalPtr)]
+struct MyData { value: i32 }
+
+#[miniextendr]
+fn create_data(v: i32) -> MyData {
+    MyData { value: v }  // Wrapped automatically via IntoExternalPtr blanket
+}
+```
+
+### The release_any finalizer
+
+`release_any` is defined in `miniextendr-api/src/externalptr.rs` as a
+non-generic `extern "C-unwind"` function registered with
+`R_RegisterCFinalizerEx`. When R's GC collects an `EXTPTRSXP`:
+
+1. `release_any` reads `R_ExternalPtrAddr(sexp)` as `*mut Box<dyn Any>`.
+2. It calls `R_ClearExternalPtr(sexp)` to prevent double-finalization.
+3. It reconstructs `Box<Box<dyn Any>>` from the raw pointer and drops it.
+4. The drop chain runs: outer Box drops → inner Box<dyn Any> drops → T's
+   `Drop` runs via the vtable.
+
+Because `Box<dyn Any>` carries the vtable, `release_any` handles every
+`ExternalPtr<T>` type with one concrete function. No generic finalizer per
+type is needed.
+
+### Sidecar field accessors
+
+The `#[r_data]` annotation on struct fields inside a `#[derive(ExternalPtr)]`
+struct enables R-side accessor generation. These accessors are called sidecar
+slots and they have a fundamentally different C wrapper signature from normal
+`#[miniextendr]` functions.
+
+**Normal `#[miniextendr]` C wrappers** (via `c_wrapper_builder.rs`) prepend
+`__miniextendr_call: SEXP` as the first parameter and register with `numArgs`
+counting that slot.
+
+**Sidecar accessor C wrappers** (generated in `miniextendr-macros/src/externalptr_derive.rs`)
+do not have the `__miniextendr_call` slot:
+- Getter: `(x: SEXP) -> SEXP`, registered with `numArgs: 1`.
+- Setter: `(x: SEXP, value: SEXP) -> SEXP`, registered with `numArgs: 2`.
+
+The R-side wrappers for sidecar accessors are generated as standalone
+`Type_get_field()` / `Type_set_field()` functions (environment class system
+default) or as active bindings (R6) or property accessors (S7). These wrappers
+call `.Call(C_Type_get_field, self$.ptr)` directly — they do not pass a `.call`
+argument.
+
+Adding `.call = match.call()` to a sidecar R wrapper causes an "Incorrect
+number of arguments" error at runtime because the C wrapper expects `numArgs`
+arguments, not `numArgs + 1`. This was the root cause of a PR #344 regression
+that was subsequently reverted.
+
+Three field tiers are supported in sidecar slots:
+- Raw SEXP — direct SEXP storage, no conversion.
+- Zero-overhead scalars (`i32`, `f64`, `bool`, `u8`) — stored directly in R
+  memory, read/written without copying.
+- Conversion types — uses `IntoR` / `TryFromSexp` round-trip.
+
+### Cross-package ABI
+
+`ExternalPtr<T>` values can cross package boundaries when both packages depend
+on the same `miniextendr-api` version and the same `TypedExternal` impl (i.e.,
+from the same producer crate). The cross-package handoff mechanism is
+`mx_abi` in `miniextendr-api/src/mx_abi.rs`. This provides `mx_wrap`,
+`mx_get`, `mx_query`, and `mx_abi_register` — thin wrappers around
+`R_MakeExternalPtr` / `R_ExternalPtrAddr` that are shared via
+`R_GetCCallable`.
+
+The `tests/cross-package/` directory contains `producer.pkg` and `consumer.pkg`
+that exercise this path end-to-end.
+
+## How it works
+
+### Creating an ExternalPtr
+
+```
+ExternalPtr::new(value)
+  1. Box::new(value)  →  *mut T  (mutable provenance, saved as cached_ptr)
+  2. Box::from_raw(raw) as Box<dyn Any>  →  fat ptr carrying Any vtable
+  3. Box::into_raw(Box::new(inner))  →  *mut Box<dyn Any>  (thin ptr)
+  4. with_r_thread { R_MakeExternalPtr(thin_ptr, tag_sym, prot_list) }
+  5. R_RegisterCFinalizerEx(sexp, release_any, TRUE)
+  6. Return ExternalPtr { sexp, cached_ptr, _marker }
+```
+
+`ExternalPtr::new` uses `with_r_thread` so it can be called safely from the
+worker thread. The SEXP creation and finalizer registration happen on R's main
+thread; the Rust allocation happens on the calling thread.
+
+### Accessing the wrapped value
+
+```rust
+// Shared access
+let ptr = ExternalPtr::wrap_sexp(sexp);   // borrow the EXTPTRSXP
+if let Some(data) = ptr.as_ref() {
+    // data: &MyData — via downcast from Box<dyn Any>
+}
+
+// Mutable access
+if let Some(data) = ptr.as_mut() {
+    // data: &mut MyData
+}
+```
+
+Both `as_ref()` and `as_mut()` use `cached_ptr` rather than calling back into
+R's FFI. Type safety is from `Any::downcast_ref` / `Any::downcast_mut`.
+
+### Choosing the right class system for sidecar fields
+
+The `#[externalptr(...)]` attribute selects the R class system:
+
+| Attribute | Class system | Sidecar R accessor form |
+|-----------|-------------|------------------------|
+| `#[externalptr(env)]` (default) | Environment | `Type_get_field()`, `Type_set_field()` |
+| `#[externalptr(r6)]` | R6 | Active bindings in R6Class |
+| `#[externalptr(s3)]` | S3 | `$.class`, `$<-.class` methods |
+| `#[externalptr(s4)]` | S4 | Slot accessors |
+| `#[externalptr(s7)]` | S7 | Properties via `new_property()` |
+
+## Decision trees
+
+### Type-tagged R object vs pure data?
+
+Returning Rust data to R where R needs to hold it across `.Call` boundaries
+and where the data is opaque to R:
+- Use `ExternalPtr<T>`.
+
+Returning Rust data to R where R needs to inspect, modify, or serialize it:
+- Consider `#[derive(IntoList)]` (converts to a named R list) or
+  `miniextendr-serde` (via serde Serialize/Deserialize).
+
+If the data is array-like and benefits from lazy evaluation:
+- Consider ALTREP (`miniextendr-altrep` skill).
+
+### When to use sidecar fields?
+
+Sidecar fields (`#[r_data]`) are appropriate when a subset of the struct's
+fields should be readable or writable from R without going through a full
+round-trip of serialization. They store R SEXP values alongside the Rust
+data inside the `EXTPTRSXP`.
+
+Use sidecar fields for:
+- Small scalar values that R code needs to read frequently without a Rust
+  function call overhead.
+- R-owned SEXP values (plots, closures, environments) that the Rust struct
+  must retain a reference to without R GC-ing them.
+
+Avoid sidecar fields for:
+- Large data — each sidecar slot is a separate R allocation.
+- Data that changes often and where conversion cost matters.
+
+### Crossing a crate boundary?
+
+If a producer package exports an `ExternalPtr<T>` and a consumer package must
+receive it:
+1. The consumer must have the same `TypedExternal` impl (typically by depending
+   on the producer crate as a library).
+2. The handoff uses `mx_abi`'s `R_GetCCallable`-based protocol
+   (`miniextendr-api/src/mx_abi.rs`).
+3. The `tests/cross-package/` smoke test exercises this path.
+
+## Key files
+
+- `miniextendr-api/src/externalptr.rs` — `ExternalPtr<T>`, `TypedExternal`,
+  `IntoExternalPtr`, `ErasedExternalPtr`, `ExternalSlice<T>`, and the
+  `release_any` finalizer. The `ExternalPtr::new` implementation (around line
+  353) is the canonical reference for the mutable-provenance construction sequence.
+- `miniextendr-macros/src/externalptr_derive.rs` — `#[derive(ExternalPtr)]`
+  proc-macro. Generates `TypedExternal` impls, sidecar accessor C wrappers
+  (`numArgs: 1` getter / `numArgs: 2` setter), and R wrapper fragments.
+- `miniextendr-macros/src/typed_external_macro.rs` — `TYPE_NAME_CSTR` /
+  `TYPE_ID_CSTR` constant generation.
+- `miniextendr-api/src/mx_abi.rs` — cross-package ABI: `mx_wrap`, `mx_get`,
+  `mx_query`, `mx_abi_register`.
+- `tests/cross-package/` — producer/consumer smoke test exercising cross-crate
+  `ExternalPtr` handoff.
+
+## Common pitfalls
+
+- **Deriving cached_ptr from &T or downcast_ref is UB**: the cached pointer
+  must be derived from a mutable path (`Box::into_raw`, `downcast_mut`,
+  `ptr::from_mut`). Writing through a `*mut T` derived from a shared reference
+  is undefined behavior under the Stacked Borrows model. `ExternalPtr::new`
+  preserves this invariant by capturing the `*mut T` from `Box::into_raw`
+  before erasing to `dyn Any`.
+
+- **Sidecar R wrappers must not include .call = match.call()**: sidecar
+  accessors have `numArgs: 1` (getter) or `numArgs: 2` (setter) with no
+  `__miniextendr_call` slot. Adding `.call` to the `.Call()` invocation adds
+  an extra argument and causes "Incorrect number of arguments" at runtime.
+  This is the intentional distinction from `#[miniextendr]` method wrappers.
+
+- **TypedExternal is display, not type safety**: `TYPE_NAME_CSTR` and
+  `TYPE_ID_CSTR` are stored for display and error messages. Type safety is
+  enforced by `Any::downcast`, which uses Rust `TypeId`. Two types with
+  identical `TYPE_ID_CSTR` strings but different `TypeId`s will downcast
+  correctly (they are distinct). Two types with the same Rust `TypeId` from
+  different `TypedExternal` impls are the same type — the string constants are
+  irrelevant to safety.
+
+- **release_any double-finalization guard**: `R_ClearExternalPtr` is called
+  at the start of `release_any` (after the null check) to ensure that if R
+  calls the finalizer twice, the second invocation sees a null pointer and
+  returns early. Do not remove this guard when modifying the finalizer.
+
+- **ExternalPtr is not an R native type**: R cannot coerce an EXTPTRSXP to
+  a vector or use it in vectorized operations. This is an R limitation, not a
+  miniextendr limitation. If you need R-vectorized behavior over Rust data,
+  use ALTREP.
+
+- **Cross-package type safety requires the same crate version**: the `TypeId`
+  in `Any::downcast` is per-compilation. Two separate compilations of the same
+  source file (e.g., different Cargo.lock versions of the producer crate) yield
+  different `TypeId`s. Pin the producer crate version in the consumer's
+  `Cargo.toml` to guarantee compatibility.
+
+## Related skills
+
+- `miniextendr-architecture` — how distributed_slice registration works and
+  where `ExternalPtr` fits in the overall crate graph.
+- `miniextendr-macros` — the `#[miniextendr]` attribute on impl blocks that
+  generates R class wrappers around ExternalPtr types.
+- `miniextendr-conversions` — `TryFromSexp` / `IntoR` used inside sidecar
+  accessor bodies for conversion-type fields.
+- `miniextendr-altrep` — alternative to ExternalPtr when you need R to treat
+  Rust data as a native lazy vector.
+- `miniextendr-ffi` — `#[r_ffi_checked]`, `_unchecked` FFI variants, and the
+  ALTREP callback context where `ExternalPtr` accessors may be called.

--- a/.claude/skills/miniextendr-serde/SKILL.md
+++ b/.claude/skills/miniextendr-serde/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: miniextendr-serde
+description: Use when the user asks about serializing Rust types to R without writing TryFromSexp or IntoR by hand, how serde Serialize/Deserialize maps to R lists and vectors, what RSerializeNative and RDeserializeNative do, how AsSerialize works as a return type, when to reach for serde vs hand-rolled conversions, or how the native serde path differs from serde_json.
+---
+
+# miniextendr Serde Integration
+
+The `serde` feature in `miniextendr-api` provides a direct R serialization
+path: Rust types that implement `serde::Serialize` can be converted to R
+objects, and types that implement `serde::Deserialize` can be reconstructed
+from R objects — without going through an intermediate JSON string.
+
+## When to use this skill
+
+- "How do I convert a Rust struct to an R list without writing IntoR manually?"
+- "What is RSerializeNative?"
+- "What is the AsSerialize wrapper type?"
+- "How does serde NA handling work?"
+- "When should I use serde vs hand-rolling TryFromSexp / IntoR?"
+- "What is the difference between the native serde feature and serde_json?"
+- "How do I serialize a type from an external crate that has no Serialize impl?"
+
+## Key concepts
+
+### Feature gate
+
+The serde integration is behind the `serde` feature:
+
+```toml
+[dependencies]
+miniextendr-api = { version = "...", features = ["serde"] }
+```
+
+The optional `serde_json` feature adds a separate JSON-string path
+(`json_string` submodule). The two features are independent.
+
+### Type mappings
+
+Serialization (Rust to R) and deserialization (R to Rust) use the following
+mappings. The full mapping tables are in `miniextendr-api/src/serde.rs`.
+
+Rust scalar types produce R scalars of the corresponding type. `Vec<primitive>`
+uses smart dispatch: `Vec<i32>` becomes an integer vector, `Vec<f64>` a numeric
+vector, `Vec<bool>` a logical vector, `Vec<String>` a character vector. A
+`Vec<struct>` becomes a list of lists.
+
+Structs serialize as named R lists. `HashMap<String, T>` serializes as a named
+list. Unit enum variants serialize as a character scalar. Data enum variants
+serialize as a tagged list `list(tag = value)`. `Option<T>::None` serializes
+as NA (for primitive types) or as NULL.
+
+### RSerializeNative and RDeserializeNative
+
+`RSerializeNative` and `RDeserializeNative` are adapter traits in
+`miniextendr-api/src/serde/traits.rs`. They have blanket implementations for
+all `serde::Serialize` and `serde::Deserialize` types respectively:
+
+- `T: Serialize` automatically gets `to_r(&self) -> Result<SEXP, String>`.
+- `T: Deserialize` automatically gets `from_r(sexp: SEXP) -> Result<T, String>`.
+
+When you write `#[miniextendr] impl RSerializeNative for MyType {}`, the
+generated R wrapper gets a `to_r()` method that calls `to_r(&self)` on the
+Rust side. Similarly `#[miniextendr] impl RDeserializeNative for MyType {}`
+adds a `from_r(data)` class method.
+
+The convenience functions `to_r<T: Serialize>` and `from_r<T: Deserialize>`
+are also exported from `miniextendr-api/src/serde/traits.rs` for calling
+directly inside Rust code when you do not want the R class method form.
+
+### AsSerialize wrapper
+
+`AsSerialize<T>` (in `miniextendr-api/src/serde/traits.rs`) is a newtype
+wrapper that implements `IntoR` for any `T: Serialize`. This lets you return
+a serializable type from a `#[miniextendr]` function directly, without
+implementing `IntoR` manually or going through a class method:
+
+```rust
+#[miniextendr]
+fn make_point(x: f64, y: f64) -> AsSerialize<Point> {
+    AsSerialize(Point { x, y })
+}
+// Returns list(x = 1.0, y = 2.0) in R
+```
+
+### NA roundtrip
+
+NA values survive the Rust-R-Rust roundtrip through `Option<T>`:
+- `Option<i32>::None` → `NA_integer_` → `Option<i32>::None` on deserialization.
+- `Option<f64>::None` → `NA_real_` → `Option<f64>::None`.
+- Same pattern for `Option<bool>`, `Option<String>`.
+
+### Remote derive for external types
+
+When you need to serialize a type from an external crate that has no
+`Serialize`/`Deserialize` impl, use serde's remote derive pattern:
+define a shadow type mirroring the external type's structure, annotate it
+with `#[serde(remote = "ExternalType")]`, and reference it via
+`#[serde(with = "ShadowType")]` on fields. A worked example for
+`std::time::Duration` is in `miniextendr-api/src/serde.rs`.
+
+### Native serde vs serde_json
+
+| Aspect | Native serde (`serde` feature) | serde_json (`serde_json` feature) |
+|--------|-------------------------------|-----------------------------------|
+| Intermediate | None — direct SEXP | JSON string |
+| Type preservation | Yes (i32 stays integer) | No (all numbers → f64) |
+| NA handling | Full Option<T> support | Limited |
+| Performance | Direct conversion | Extra parse/stringify pass |
+| Interop | R-native only | JSON string compatible with other tools |
+
+Use native serde when round-tripping Rust structs to R and back. Use serde_json
+when you need a JSON string for file I/O or interoperability with non-R systems.
+
+## How it works
+
+The core serialization path is `RSerializer::to_sexp(value)` in
+`miniextendr-api/src/serde/ser.rs`. It implements serde's `Serializer` trait
+and drives the mapping from serde's data model to R SEXPs.
+
+The deserialization path is `RDeserializer::from_sexp_to(sexp)` in
+`miniextendr-api/src/serde/de.rs`. It implements serde's `Deserializer` trait
+and reads R SEXPs through serde's visitor protocol.
+
+The `columnar` submodule (`miniextendr-api/src/serde/columnar.rs`) provides
+`ColumnarDataFrame`, `vec_to_dataframe`, and `vec_to_dataframe_split` for
+converting a `Vec<T: Serialize>` to an R data frame in columnar layout.
+
+## Decision trees
+
+### Serde-derive or hand-rolled conversions?
+
+Use serde (`#[derive(Serialize, Deserialize)]`) when:
+- The type has many fields and you want all of them serializable to R lists
+  without writing each TryFromSexp / IntoR impl by hand.
+- The type is already `Serialize`/`Deserialize` for other purposes (e.g.,
+  writing JSON config files).
+- You need to accept the type as input from R as a named list.
+
+Use hand-rolled `TryFromSexp` / `IntoR` when:
+- The type needs a custom R representation that does not map naturally to a
+  named list (e.g., a packed binary format, an ALTREP vector, or a raw SEXP).
+- Performance is critical and the serde visitor overhead is measurable.
+- The type participates in strict-mode or coerce-mode conversion logic that
+  the serde path does not expose.
+
+### Which serde entry point to use?
+
+- Returning a struct from a `#[miniextendr]` function without a class method:
+  use `AsSerialize<T>` as the return type.
+- Exposing `to_r()` / `from_r()` as class methods on an ExternalPtr type:
+  use `#[miniextendr] impl RSerializeNative for MyType {}` and
+  `#[miniextendr] impl RDeserializeNative for MyType {}`.
+- Calling serde conversion inside Rust code (no R class method):
+  use the free functions `to_r(&value)` and `from_r::<T>(sexp)`.
+- Converting `Vec<T>` to a columnar R data frame:
+  use `vec_to_dataframe(&items)` from the `columnar` submodule.
+
+## Key files
+
+- `miniextendr-api/src/serde.rs` — module doc with full type-mapping tables,
+  smart Vec dispatch explanation, NA roundtrip, remote derive examples, and the
+  native-vs-json comparison. Re-exports: `RSerializer`, `RDeserializer`,
+  `RSerdeError`, `RSerializeNative`, `RDeserializeNative`, `to_r`, `from_r`,
+  `AsSerialize`, `ColumnarDataFrame`.
+- `miniextendr-api/src/serde/traits.rs` — `RSerializeNative`,
+  `RDeserializeNative`, `to_r`, `from_r`, and `AsSerialize<T>`.
+- `miniextendr-api/src/serde/ser.rs` — `RSerializer` (serde Serializer impl).
+- `miniextendr-api/src/serde/de.rs` — `RDeserializer` (serde Deserializer impl).
+- `miniextendr-api/src/serde/columnar.rs` — `ColumnarDataFrame`,
+  `vec_to_dataframe`, `vec_to_dataframe_split`.
+
+## Common pitfalls
+
+- **All-None columns land as LGLSXP**: in `ColumnarDataFrame::from_rows`,
+  columns where every row's `Option<T>` was `None` are stored as a logical NA
+  column (`LGLSXP`), not `list(NULL, NULL, ...)`. R coerces logical NA to the
+  surrounding type on first use (`c(NA, 1L)` → integer vector). Mixed
+  Some/None columns are unaffected.
+
+- **serde_json feature is separate from serde**: enabling `features = ["serde"]`
+  does not enable the JSON-string submodule. The JSON path requires `features =
+  ["serde_json"]`. They can both be enabled simultaneously.
+
+- **AsSerialize panics on serialization failure**: the `IntoR` impl for
+  `AsSerialize<T>` calls `to_r(&self.0).unwrap_or_else(|e| r_stop(...))`.
+  Serialization failures become R errors (via `r_stop`), not Rust panics.
+  If you need explicit error handling, use `to_r` directly.
+
+- **Remote derive requires a shadow type for each external type**: serde's
+  remote derive cannot be applied directly to a type you do not own. You must
+  define a shadow struct/enum that mirrors the layout. See the `Duration`
+  example in `miniextendr-api/src/serde.rs` for the full pattern.
+
+## Related skills
+
+- `miniextendr-conversions` — hand-rolled `TryFromSexp` / `IntoR`: the
+  alternative to serde for custom R representations.
+- `miniextendr-externalptr` — how Rust structs are stored as R objects;
+  `RSerializeNative` and `RDeserializeNative` are typically implemented on
+  ExternalPtr-backed types.
+- `miniextendr-macros` — `#[miniextendr] impl RSerializeNative for T {}` and
+  `#[miniextendr] impl RDeserializeNative for T {}` are processed like any
+  other impl block.


### PR DESCRIPTION
## Summary

PR-C of Flight 14. Three skills covering the conversion / pointer / serde layers.

- `.claude/skills/miniextendr-conversions/SKILL.md` — TryFromSexp, IntoR, Coerce, strict mode, NA handling, empty-vector pointer trap.
- `.claude/skills/miniextendr-externalptr/SKILL.md` — `Box<Box<dyn Any>>` storage layout, pointer provenance rules, TypedExternal display tags, sidecar accessor codegen quirks.
- `.claude/skills/miniextendr-serde/SKILL.md` — R <-> Rust serde flow.

## Closes

- #162, #163, #169

## Test plan

- [x] All referenced file paths verified to exist.
- [x] Frontmatter `description:` has "Use when..." triggers on all three files.
- [x] No emoji, no inlined code >20 lines.
- [x] Cross-skill refs are slug-only.
- [x] `release_any` finalizer verified in source (externalptr.rs line 1474).
- [x] Sidecar `numArgs: 1`/`2` verified in externalptr_derive.rs lines 1029/1039.
- [x] Empty-vector sentinel `r_slice`/`r_slice_mut` verified in from_r.rs lines 115/129.
- [x] `Box<Box<dyn Any>>` storage verified in externalptr.rs module doc and ExternalPtr::new.

Generated with [Claude Code](https://claude.com/claude-code)