### PR TITLE
docs(skills): tooling skills (#168, #164, #173)

### DIFF
--- a/.claude/skills/miniextendr-build/SKILL.md
+++ b/.claude/skills/miniextendr-build/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: miniextendr-build
+description: Use when debugging configure.ac failures, Makevars issues, Cargo.lock mismatches, vendor tarball problems, build mode confusion, or the cdylib-to-staticlib double-link pipeline. Also use when changing a Makevars value, diagnosing a latch-leak, understanding the bash-vs-sh configure requirement, or working with m4 quoting in configure.ac.
+---
+
+# miniextendr Build System
+
+miniextendr bridges R's package build system and Cargo via a configure script,
+Makevars template, and a double-link pipeline that generates R wrappers during
+the build itself. This skill covers the full build pipeline and the install-mode
+latch that switches between source and CRAN tarball builds.
+
+## When to use this skill
+
+- "Why does `./configure` fail but `bash ./configure` work?"
+- "My build picks the tarball vendor when it shouldn't."
+- "I'm getting a Cargo.lock mismatch error."
+- "I changed a Makevars value — what's the regen flow?"
+- "What are the cdylib and staticlib builds and why are there two?"
+- "Where does `.cargo/config.toml` come from?"
+- "What is the install-mode latch and how does it leak?"
+- "How do I add a cargo feature flag to the build?"
+- "What are the m4 quoting pitfalls in configure.ac?"
+
+## Key concepts
+
+### The double-link pipeline
+
+The most unusual aspect of the build: two sequential cargo invocations produce
+two different artifacts, and R wrapper generation happens between them.
+
+```
+configure.ac  →  configure  →  src/Makevars
+                                    |
+             cargo rustc --crate-type staticlib  (warm cache first)
+                                    |
+             cargo rustc --crate-type cdylib
+                                    |
+                   Makevars: dyn.load cdylib in R
+                                    |
+             miniextendr_write_wrappers()    ← miniextendr-api/src/registry.rs
+             miniextendr_write_wasm_registry()
+                                    |
+                   R/miniextendr-wrappers.R  (generated, do not hand-edit)
+                                    |
+                        final .so  (links staticlib)
+```
+
+The cdylib phase boots enough of the Rust runtime inside R to walk the
+`MX_R_WRAPPERS` distributed_slice (declared in `miniextendr-api/src/registry.rs`)
+and emit the R-side `.Call()` wrappers. The staticlib phase then relinks the
+same code as the final installed shared object. `miniextendr_write_wrappers`
+lives in `miniextendr-api/src/registry.rs` — not in miniextendr-engine.
+
+`stub.c` provides the minimal C translation unit that R's build system requires.
+It declares `extern const char miniextendr_force_link`, which references a symbol
+emitted by `miniextendr_init!()`. With `codegen-units = 1` in `Cargo.toml`, this
+pulls the entire user crate out of the staticlib archive, carrying all
+`#[distributed_slice]` entries — no `-force_load` or `--whole-archive` needed
+in user packages.
+
+### configure.ac mechanics
+
+#### `bash ./configure`, not `./configure`
+
+The generated configure script uses `#!/bin/sh` as its shebang (required by
+autoconf's portability model). The `AC_CONFIG_COMMANDS` blocks write
+`.cargo/config.toml` inline by emitting shell commands via `echo`. Under some
+shells invoked as `sh`, the passthrough of those commands produces spurious
+errors or mis-executes. Invoking the script explicitly with `bash` avoids the
+problem on all platforms. Always use `bash ./configure` or the `just configure`
+recipe.
+
+This is a shell-passthrough issue with `AC_CONFIG_COMMANDS`, not a dash
+incompatibility — macOS `/bin/sh` is bash. The symptom is spurious failures in
+the `cargo-config` or `unpack-vendor-tarball` command blocks.
+
+#### What configure does, in order
+
+1. Verifies `DESCRIPTION` and `NAMESPACE` exist (guards against running from
+   the monorepo root instead of `rpkg/`).
+2. Self-repair: if `inst/vendor.tar.xz` is absent, no `.git` ancestor exists,
+   and `cargo-revendor` is on PATH, invokes `cargo revendor` to produce the
+   tarball. Skipped in git-tracked source trees to keep `just configure` fast.
+3. Detects install mode from `[ -f inst/vendor.tar.xz ]`.
+4. Discovers `cargo`, `rustc`, `sed`. Enforces rustc 1.85+ (edition 2024).
+5. Detects webR/wasm32 via `CC=emcc`.
+6. Resolves monorepo siblings by walking parent directories for
+   `miniextendr-api/Cargo.toml`.
+7. Writes `src/Makevars` from `src/Makevars.in` via `AC_CONFIG_FILES`.
+8. Writes `src/miniextendr-win.def` from `src/win.def.in` via `AC_CONFIG_FILES`.
+9. Writes `src/rust/.cargo/config.toml` **inline** via `AC_CONFIG_COMMANDS`
+   (three variants: tarball / source+monorepo / source-only). There is no
+   `.in` template for this file — configure emits it directly.
+10. Unpacks `inst/vendor.tar.xz` in tarball mode.
+11. Validates Cargo.lock shape and compatibility.
+
+#### m4 quoting pitfalls
+
+m4 treats `[` and `]` as quoting characters throughout `configure.ac`. Literal
+brackets in shell code or sed expressions inside `AC_CONFIG_COMMANDS` must be
+escaped as `@<:@` (for `[`) and `@:>@` (for `]`). This applies everywhere in
+the file, not only in m4 macro arguments. Forgetting this in a sed character
+class produces silent wrong output or m4 parse errors.
+
+Also: inside `AC_CONFIG_COMMANDS`, `$1` is empty (it refers to the command
+name, not a shell positional). Use `$0` or avoid `sh -c` constructs.
+
+#### PACKAGE_NAME vs PACKAGE_TARNAME
+
+`PACKAGE_NAME` preserves dots (e.g., `producer.pkg`). `PACKAGE_TARNAME`
+lowercases and normalizes. When deriving C or Rust identifiers (e.g.,
+`CARGO_STATICLIB_NAME`), configure converts both hyphens and dots to
+underscores. If only hyphens are replaced, package names with dots produce
+broken symbol names.
+
+### .in templates that exist on disk
+
+`AC_CONFIG_FILES` in `configure.ac` drives substitution for:
+
+- `rpkg/src/Makevars.in` → `rpkg/src/Makevars`
+- `rpkg/src/win.def.in` → `rpkg/src/miniextendr-win.def`
+
+The `configure` script itself is generated from `rpkg/configure.ac` by running
+`autoconf`. If you edit `configure.ac`, re-run `autoconf` from the `rpkg/`
+directory to regenerate `configure`.
+
+`rpkg/src/stub.c` is static — no substitution, no `.in` counterpart.
+
+`rpkg/src/rust/.cargo/config.toml` is written inline by `AC_CONFIG_COMMANDS`
+in configure.ac. There is no `cargo-config.toml.in` file in the repository.
+Do not edit `config.toml` directly; re-run `bash ./configure` to regenerate it.
+
+### The install-mode latch
+
+`rpkg/inst/vendor.tar.xz` is the single signal that flips configure into
+tarball (CRAN offline) mode.
+
+| Mode | Triggered when | What configure writes to .cargo/config.toml |
+|------|----------------|---------------------------------------------|
+| Source (monorepo) | tarball absent, `.git` ancestor found, monorepo siblings detected | `[patch."git+url"]` → local workspace crates |
+| Source (standalone) | tarball absent, no monorepo siblings | `[build] target-dir = ...` only; cargo follows git URL |
+| Tarball | tarball present | `[source.crates-io] replace-with = "vendored-sources"` + git-source replacements + `[source.vendored-sources] directory = ...` |
+
+The tarball has been gitignored since 2026-04-18. CI regenerates it per-build
+via `just vendor`. Locally, `just r-cmd-build` and `just r-cmd-check` produce
+the tarball transiently and trap-clean on exit.
+
+Three layered triggers converge on the latch:
+1. Maintainer's explicit `just vendor` / `miniextendr_vendor()`.
+2. `bootstrap.R` (invoked by pkgbuild during `devtools::build()`, `rcmdcheck`,
+   `r-lib/actions/check-r-package`) — runs configure in a staging directory
+   that has no `.git` ancestor, triggering auto-vendor.
+3. End-user install of a tarball that shipped without vendored dependencies —
+   configure auto-vendors at install time.
+
+CRAN's offline build farm does not have `cargo-revendor`, so the auto-vendor
+branch is short-circuited there. A maintainer who ships a tarball without
+`inst/vendor.tar.xz` inside fails CRAN's offline check loudly; this is the
+intended canary. There is no `NOT_CRAN`, `FORCE_VENDOR`, or `PREPARE_CRAN`
+escape — see `docs/CRAN_COMPATIBILITY.md`.
+
+### The latch leak (#441)
+
+If `inst/vendor.tar.xz` is present during local development (left behind by a
+failed `just r-cmd-build` or `just r-cmd-check` that did not trap-clean),
+configure switches to tarball mode. In that mode:
+
+- `.cargo/config.toml` contains `[source.vendored-sources]` instead of
+  `[patch."git+url"]`.
+- Edits to `miniextendr-api`, `miniextendr-macros`, or `miniextendr-lint` are
+  silently ignored — cargo resolves those crates from the stale tarball, not
+  the working tree.
+- Cargo.lock mismatches may appear when the tarball lock diverges from the
+  current workspace state.
+
+Recipes that produce the tarball (`just r-cmd-build`, `just r-cmd-check`,
+`just devtools-build`) trap-clean on exit. Recipes that consume configure state
+(`just rcmdinstall`, `just devtools-test`, `just devtools-load`,
+`just devtools-install`) refuse to run if the tarball is present.
+
+Detection: `minirextendr_doctor()` reports both stale-latch and missing
+`.cargo/config.toml`.
+
+Fix: `just clean-vendor-leak` (safe, idempotent). Then re-run `just configure`.
+
+Regression test: `just test-bootstrap-vendor`.
+
+## How it works
+
+### Makevars.in and the double-link
+
+`rpkg/src/Makevars.in` defines `make` rules for both cargo invocations. The
+key targets are:
+
+- `$(SHLIB)` — depends on `$(CARGO_AR)` (the staticlib archive).
+- `$(CARGO_AR)` — invokes `cargo build --lib --profile $(CARGO_PROFILE)`.
+  This is the staticlib. A `FORCE_CARGO` phony target ensures cargo is always
+  invoked so that cargo's own incremental logic decides what to rebuild.
+- `$(WRAPPERS_R)` — depends on `$(CARGO_CDYLIB)` in source mode. In tarball
+  mode, the pre-shipped `R/*-wrappers.R` is used and the cdylib build is
+  skipped (the 10–30 s cdylib build is a no-op in tarball installs). Set
+  `MINIEXTENDR_FORCE_WRAPPER_GEN` to override for debugging.
+- `$(CARGO_CDYLIB)` — invokes `cargo rustc --crate-type cdylib`.
+
+In tarball mode, Makevars also scrubs `vendor/`, `rust-target/`, and
+`.cargo/` after a successful build to save installed-package size.
+
+### configure → cargo feature flags
+
+`configure` auto-detects optional features via `tools/detect-features.R`. The
+result is passed to cargo as `--features=$(CARGO_FEATURES)` via `Makevars`.
+Override with the `CARGO_FEATURES` environment variable.
+
+### macOS tar and xattrs
+
+When producing `inst/vendor.tar.xz` on macOS, set `COPYFILE_DISABLE=1` to
+suppress Apple extended attribute metadata. PAX headers injected by macOS tar
+cause warnings on Linux/Windows GNU tar and can confuse the unpacking step in
+configure.
+
+### cargo-revendor standalone workspace
+
+`cargo-revendor/` is excluded from the main miniextendr workspace (see root
+`Cargo.toml`). Build and test it via `just revendor-build` / `just revendor-test`.
+It is the tool that vendors, strips, and compresses the dependency tree into
+`inst/vendor.tar.xz`. `--freeze` mode resolves `Cargo.toml` against `vendor/`
+only (no network). Windows paths in the generated `config.toml` must use
+forward slashes; the `\\?\` prefix from `canonicalize()` must be stripped.
+
+## Decision trees
+
+### I changed a Makevars value — what is the regen flow?
+
+1. Edit `rpkg/src/Makevars.in` (not `rpkg/src/Makevars`).
+2. `cd rpkg && bash ./configure` (or `just configure` from the monorepo root).
+3. Verify `rpkg/src/Makevars` reflects your change.
+4. Commit `Makevars.in`. Do not commit the generated `Makevars` — it is
+   generated at install time and its path depends on the local system.
+
+If the generated `configure` script itself needs to change, edit
+`rpkg/configure.ac` and run `autoconf` in `rpkg/` to regenerate `configure`.
+
+### Build is picking tarball mode when it shouldn't
+
+1. Check: `ls rpkg/inst/vendor.tar.xz` — if present, the latch is tripped.
+2. Run: `just clean-vendor-leak`.
+3. Run: `just configure`.
+4. Verify: `cat rpkg/src/rust/.cargo/config.toml` shows `[patch."git+url"]`
+   entries (monorepo) or only `[build] target-dir` (standalone).
+5. If `config.toml` is missing entirely: `minirextendr_doctor()` detects this
+   condition; run `bash ./configure` to regenerate.
+
+### Cargo.lock mismatch during build
+
+Source mode (no tarball):
+- Cargo rewrites the lock freely. Mismatches are tolerated.
+
+Tarball mode:
+- configure runs `tools/lock-shape-check.R` to verify the lock is in
+  tarball-shape (no `checksum =` lines, no path-based framework-crate sources).
+- If the check fails, the Cargo.lock in the tarball drifted from the vendored
+  sources. Run `just vendor` from a clean source state to regenerate.
+
+### Why is my configure failing with an error in AC_CONFIG_COMMANDS?
+
+Almost always one of:
+- Called as `./configure` instead of `bash ./configure` — the `#!/bin/sh`
+  passthrough produces spurious errors in `AC_CONFIG_COMMANDS`.
+- m4 quoting issue: literal `[` or `]` inside a `AC_CONFIG_COMMANDS` block
+  without `@<:@` / `@:>@` escaping. Check the configure.ac line that defines
+  the failing command.
+- `$1` used inside `AC_CONFIG_COMMANDS` — it is empty there. Use `$0` or
+  eliminate the reference.
+
+## Key files
+
+- `rpkg/configure.ac` — autoconf source for install-mode detection and cargo
+  config generation.
+- `rpkg/configure` — generated configure script (do not edit; regenerate with
+  `autoconf` in `rpkg/`).
+- `rpkg/src/Makevars.in` — Makevars template driving the double-link pipeline.
+- `rpkg/src/win.def.in` → `rpkg/src/miniextendr-win.def` — Windows symbol
+  export definitions.
+- `rpkg/src/stub.c` — static C translation unit; declares `miniextendr_force_link`.
+- `rpkg/src/rust/.cargo/config.toml` — generated inline by configure; three
+  variants per install mode. No `.in` template exists for this file.
+- `rpkg/tools/` — `Rscript`-invoked helpers for configure (lock-shape-check.R,
+  detect-features.R, etc.).
+- `miniextendr-api/src/registry.rs` — `miniextendr_write_wrappers` cdylib
+  entry + `collect_r_wrappers` ordering logic.
+- `cargo-revendor/` — standalone vendoring tool (separate workspace).
+- `docs/CRAN_COMPATIBILITY.md` — vendoring requirements and offline build
+  verification.
+- `docs/RELEASE_WORKFLOW.md` — AlmaLinux 8 / macOS arm64 release CI details.
+
+## Common pitfalls
+
+- **Never edit generated files directly.** `rpkg/src/Makevars`,
+  `rpkg/src/miniextendr-win.def`, and `rpkg/src/rust/.cargo/config.toml` are
+  all generated by configure. Edit the `.in` templates or `configure.ac` and
+  re-run configure.
+
+- **`configure.ac` must not mutate sources.** Writing to `Cargo.toml`,
+  `Cargo.lock`, or `.rs` files during `./configure` dirties the VCS working
+  tree. Vendoring belongs in `just vendor`, not in configure.
+
+- **`configure.ac` must not call `minirextendr::*`.** Configure runs in a
+  minimal environment where the R library may not be available. Put helpers
+  in `tools/*.R` and invoke via `Rscript tools/foo.R`.
+
+- **`PACKAGE_NAME` includes dots; `PACKAGE_TARNAME` does not.** When deriving
+  C or Rust identifiers, convert both hyphens and dots to underscores.
+
+- **macOS `/bin/sh` is not dash.** The `bash ./configure` requirement is about
+  `AC_CONFIG_COMMANDS` passthrough behavior, not about a dash-incompatible
+  script.
+
+- **`R CMD build --debug` is invalid.** R silently ignores the flag. The
+  `r-cmd-build` justfile recipe passes it; this is a pre-existing harmless quirk.
+
+- **Trap-cleanup in justfile recipes.** Recipes that produce a transient
+  tarball use `trap 'rm -f X' EXIT` joined on one logical shell line (via `\`
+  continuation). A recipe where the trap and the command run as separate `-c`
+  invocations will fire the trap immediately after defining it, before the
+  command runs.
+
+## Related skills
+
+- `miniextendr-architecture` — the install-mode latch, distributed_slice tables,
+  and the double-link pipeline at a higher level.
+- `miniextendr-scaffolding` — minirextendr templates, doctor checks, and the
+  `use_release_workflow()` helper for CI scaffolding.
+- `miniextendr-lint` — the MXL300 / MXL301 rules that `build.rs` enforces
+  during `cargo check`.
+- `miniextendr-getting-started` — end-user walkthrough of `bash ./configure &&
+  R CMD INSTALL .`.

--- a/.claude/skills/miniextendr-lint/SKILL.md
+++ b/.claude/skills/miniextendr-lint/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: miniextendr-lint
+description: Use when a lint rule (MXL###) fires during cargo build or cargo check, when you want to understand what a specific rule checks and why it exists, when adding a new lint rule, or when diagnosing a build.rs static analysis failure. Also use when MINIEXTENDR_LINT=0 is being considered.
+---
+
+# miniextendr-lint
+
+miniextendr-lint is a build-time static analysis tool that runs automatically
+during `cargo build` and `cargo check`. It walks your crate's source tree,
+evaluates `#[cfg(feature = "...")]` gates, and checks for correctness problems
+that would otherwise produce confusing runtime errors, silent misbehavior, or
+codegen failures. Every MXL rule has a specific safety or correctness reason;
+violations are always bugs to fix, never to silence.
+
+## When to use this skill
+
+- "I'm getting an MXL### error — what does it mean?"
+- "Why does the build say MXL300 when I call Rf_error?"
+- "How do I add a new lint rule?"
+- "How does the lint walk feature-gated modules?"
+- "Can I turn the lint off temporarily?"
+- "What is the relationship between the lint and miniextendr-macros?"
+
+## Key concepts
+
+### How the lint runs
+
+miniextendr-lint is invoked from a downstream crate's `build.rs`, via an
+integration hook in `miniextendr-api`. It does not run as a `cargo check`
+plugin or proc-macro; it runs as a normal build script. The linting occurs at
+`cargo build` / `cargo check` time, before compilation, by parsing source files
+with the `syn` crate.
+
+Disable temporarily with `MINIEXTENDR_LINT=0 cargo check`. This is an escape
+hatch for exploration; violations must still be fixed before the code is
+committed. The policy from `CLAUDE.md` is explicit: "Fix warnings you see: no
+known issues."
+
+### Module-tree walking and cfg evaluation
+
+`miniextendr-lint/src/crate_index.rs` resolves `mod foo;` declarations into
+file paths, following the same rules as `rustc`: a bare `mod foo;` maps to
+`foo.rs` or `foo/mod.rs`. When a module is guarded with `#[cfg(feature = "...")]`,
+the walker evaluates whether that feature is active for the current build before
+deciding to visit the module. This means linting correctly skips dead code and
+only flags live paths. Do not re-implement cfg evaluation in new rules; use the
+utilities from `crate_index.rs`.
+
+### Shared parser layer
+
+The lint shares its parser layer with `miniextendr-macros`. Since the retirement
+of `miniextendr-macros-core` as a separate crate, the shared parsing lives
+inside `miniextendr-macros` and is consumed directly by `miniextendr-lint` as a
+workspace dependency. New rules that need to parse `#[miniextendr]` attributes
+should use the same parser types rather than duplicating parsing logic.
+
+## MXL rule catalogue
+
+### Trait and impl rules
+
+**MXL008** — Trait-impl class-system compat with inherent impl.
+An impl block decorated for trait-ABI class systems must be compatible with the
+corresponding inherent impl. Triggers when the class-system configuration
+conflicts with the method signatures or receiver types on the inherent impl.
+Fix: align the trait-ABI configuration with the inherent impl structure.
+
+**MXL009** — Multiple impl blocks without distinct labels.
+When a type has more than one `#[miniextendr]` impl block, each must carry a
+`label = "..."` attribute to disambiguate R class names. Without labels the
+codegen produces duplicate identifiers.
+Fix: add `#[miniextendr(label = "my_label")]` to each impl block.
+
+**MXL010** — Duplicate labels on impl blocks.
+Two impl blocks on the same type share the same `label = "..."` value.
+Fix: assign unique labels to each block.
+
+### Export and visibility rules
+
+**MXL106** — Non-`pub` function that would receive `@export`.
+A function is marked `#[miniextendr]` but is not `pub`. Without `pub`, the
+function is not part of the crate's public API; exporting it from R would
+create a dangling entry point.
+Fix: add `pub`, or add `#[miniextendr(noexport)]` if the function is
+intentionally internal.
+
+**MXL203** — Redundant `internal` + `noexport`.
+Both `internal` and `noexport` appear on the same item. These are not additive;
+`noexport` alone is sufficient to suppress R-side export.
+Fix: remove the redundant attribute.
+
+### Parameter rules
+
+**MXL110** — Parameter name is an R reserved word.
+An argument name to a `#[miniextendr]` function collides with an R keyword or
+built-in (`if`, `else`, `for`, `function`, `NULL`, `NA`, etc.). The generated
+R wrapper would be syntactically invalid.
+Fix: rename the parameter.
+
+### Codegen-compatibility rules
+
+**MXL111** — `s4_*` method name on an `#[miniextendr(s4)]` impl.
+The S4 class codegen auto-prefixes generated method names with `s4_`. Writing
+`s4_my_method` in Rust produces `s4_s4_my_method` in R.
+Fix: drop the `s4_` prefix from the Rust method name; the codegen adds it.
+
+**MXL112** — Explicit lifetime parameter on a `#[miniextendr]` fn or impl block.
+An `extern "C-unwind" #[no_mangle]` function is incompatible with any generic
+parameter, including lifetime parameters. The codegen rejects lifetime params
+at macro-expansion time; the lint catches them before expansion.
+Fix: replace `&str` with `String`, `&[T]` with `Vec<T>`, etc. Lifetime elision
+on `&str` / `&[T]` arguments works fine — the lint only fires on explicit
+`<'a>` annotations.
+
+**MXL120** — Invalid vctrs constructor or receiver.
+A vctrs constructor returns `Self` or a named type (must return `SEXP`), or a
+vctrs impl block includes an instance-method receiver (`&self`, `self: &ExternalPtr<Self>`, etc.).
+Mirrors the hard error in `miniextendr-macros`.
+Fix: change the return type to `SEXP` and ensure no instance methods are on the
+vctrs impl.
+
+**MXL302** — Non-doc attribute interrupts a `///` doc-comment stream.
+A `#[cfg(...)]`, `#[deprecated]`, or similar non-doc attribute appears between
+`///` comment lines on a `#[miniextendr]` item. The macro resets multiline
+continuation context at the interruption, so trailing prose after the attribute
+will not continue the preceding `@examples` / `@details` / `@return` block.
+Fix: move all `///` comments above any non-doc attributes.
+
+### FFI safety rules (most-commonly-tripped)
+
+**MXL300** — Direct `Rf_error` or `Rf_errorcall` call.
+Calling the R error longjmp functions directly bypasses the
+`with_r_unwind_protect_error_in_r` transport that runs Rust destructors before
+jumping. The tagged-SEXP payload (Box allocated in `make_rust_error_value`) is
+leaked on the R longjmp path when `Rf_error` is called inside
+`with_r_unwind_protect_error_in_r` — approximately 8 bytes per error invocation.
+The framework converts `panic!()` to R errors correctly.
+Fix: replace `Rf_error(...)` / `Rf_errorcall(...)` with `panic!(...)`.
+
+**MXL301** — `_unchecked` FFI call outside a known-safe context.
+The `#[r_ffi_checked]` attribute generates both checked and `*_unchecked`
+variants of each R API entry point. The checked variant asserts that the caller
+is on the R main thread. The `*_unchecked` variant skips this assertion.
+Calling `*_unchecked` outside a context where the main-thread property is
+already established is a logic error.
+Safe contexts where `*_unchecked` is valid: ALTREP callbacks, inside
+`with_r_unwind_protect`, inside `with_r_thread` blocks.
+Fix: either move the call into a safe context, or switch to the checked variant.
+
+## How it works
+
+### Adding a new rule
+
+1. Create a new file under `miniextendr-lint/src/rules/` (e.g., `my_rule.rs`).
+2. Register the rule in `miniextendr-lint/src/rules.rs`.
+3. Add the `MXL###` code to `miniextendr-lint/src/lint_code.rs`.
+4. Use helpers from `miniextendr-lint/src/helpers.rs` for common AST predicates.
+5. Do not re-implement cfg evaluation — call into `crate_index.rs` utilities.
+
+## Decision trees
+
+### My lint is firing — silence or fix?
+
+Always fix. The project policy (CLAUDE.md) is "no known issues." Every MXL
+rule prevents a real safety or correctness defect. `MINIEXTENDR_LINT=0` is an
+exploration escape hatch only; committed code must be clean.
+
+### Which context makes `*_unchecked` calls safe?
+
+- Inside an ALTREP callback registered via the ALTREP bridge? Safe.
+- Inside `with_r_unwind_protect { ... }`? Safe.
+- Inside `with_r_thread { ... }`? Safe.
+- Anywhere else, including global init, background threads, or standalone
+  functions? Unsafe — use the checked variant.
+
+## Key files
+
+- `miniextendr-lint/src/lib.rs` — entrypoint and module-tree walker
+- `miniextendr-lint/src/crate_index.rs` — `mod` resolution + cfg evaluation
+- `miniextendr-lint/src/rules.rs` — rule dispatcher
+- `miniextendr-lint/src/rules/rf_error.rs` — MXL300
+- `miniextendr-lint/src/rules/ffi_unchecked.rs` — MXL301
+- `miniextendr-lint/src/rules/lifetime_param.rs` — MXL112
+- `miniextendr-lint/src/rules/impl_validation.rs` — MXL008 / MXL009 / MXL010 / MXL111
+- `miniextendr-lint/src/rules/fn_visibility.rs` — MXL106
+- `miniextendr-lint/src/lint_code.rs` — MXL code registry
+- `miniextendr-lint/src/helpers.rs` — shared AST predicates
+- `miniextendr-lint/CLAUDE.md` — authoritative rule catalogue
+
+## Common pitfalls
+
+- **MXL300 fires on `_unchecked` FFI, not just user code.** The lint visits all
+  reachable modules, including internal FFI shims. If you see MXL300 on a path
+  you didn't write, it is still a bug — the call should go through `panic!()`.
+
+- **MXL112 does not fire on lifetime elision.** `fn foo(x: &str)` is fine —
+  the macro infers the conversion internally. Only explicit `<'a>` annotations
+  trigger MXL112.
+
+- **Cfg-gated modules are only linted when the feature is active.** If a rule
+  does not fire during normal `cargo check` but fires in CI with a large feature
+  set, the affected code is in a feature-gated module that was not active
+  locally. Reproduce with the CI feature list from `.github/workflows/ci.yml`.
+
+- **`miniextendr-macros-core` is retired.** The issue tracker (#168) references
+  it; that crate no longer exists. Shared parsing now lives inside
+  `miniextendr-macros` and is consumed directly.
+
+## Related skills
+
+- `miniextendr-macros` — the proc-macro side of attribute parsing and codegen
+  that the lint validates against.
+- `miniextendr-ffi` — `#[r_ffi_checked]`, `_unchecked` variants, and the
+  threading model that MXL301 enforces.
+- `miniextendr-build` — how `build.rs` integration runs the lint at
+  `cargo build` / `cargo check` time.

--- a/.claude/skills/miniextendr-scaffolding/SKILL.md
+++ b/.claude/skills/miniextendr-scaffolding/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: miniextendr-scaffolding
+description: Use when creating a new R package with a Rust backend via minirextendr, upgrading an existing package's scaffold, diagnosing a broken setup with minirextendr_doctor(), maintaining or syncing templates between rpkg and minirextendr/inst/templates/, adding configure-time feature detection, or using use_release_workflow() for CRAN CI scaffolding.
+---
+
+# miniextendr Scaffolding (minirextendr)
+
+minirextendr is the pure-R scaffolding helper that generates new R packages
+with miniextendr Rust backends. It writes `configure.ac`, `Makevars.in`,
+`Cargo.toml`, `lib.rs`, `stub.c`, and related boilerplate so users never
+touch the build plumbing directly. It also maintains the template sync
+pipeline, doctor checks, and release-workflow scaffolding.
+
+## When to use this skill
+
+- "How do I create a new R package with Rust using miniextendr?"
+- "How do I upgrade an existing package scaffold to a newer miniextendr version?"
+- "minirextendr_doctor() is reporting a problem — how do I fix it?"
+- "I changed rpkg — how do I sync the templates?"
+- "What is `just templates-approve` / `just templates-check`?"
+- "How does configure-time feature detection work?"
+- "I need to scaffold release CI for AlmaLinux 8 / macOS arm64."
+- "What is the difference between `use_miniextendr()` and `create_miniextendr_package()`?"
+
+## Key concepts
+
+### minirextendr vs miniextendr
+
+- **minirextendr** — pure-R scaffolding helper. Generates project structure.
+  Installed once; users run `use_miniextendr()` to set up a package and never
+  invoke minirextendr again during normal development.
+- **miniextendr** — the runtime framework and macro system that the scaffolded
+  Rust crate links against. End users add it as a Cargo dependency.
+
+Cross-link: see `miniextendr-getting-started` for the end-user walkthrough.
+
+### Template system
+
+Templates live in `minirextendr/inst/templates/`. They are derived from `rpkg/`
+(the canonical live example) with an approved delta recorded in
+`patches/templates.patch`. The approved delta captures standalone-project
+differences: templates may include extra logic for checking monorepo siblings
+before applying path overrides, or running `cargo vendor` for transitive deps
+in a non-monorepo context.
+
+Templates use mustache-style substitution at scaffolding time (not autoconf
+`@VAR@` substitution). The scaffolding functions call
+`minirextendr::use_template()` / `render.R` to interpolate package name,
+author, and other values into the emitted files.
+
+The two template subtrees are:
+- `minirextendr/inst/templates/rpkg/` — scaffolds a new package from scratch.
+- `minirextendr/inst/templates/monorepo/` — scaffold variants for monorepo use.
+
+### Source direction: rpkg → templates (never the reverse)
+
+`rpkg/` is the master source. Always edit `rpkg/` first, port the change to
+`minirextendr/inst/templates/`, then lock the delta with `just templates-approve`.
+Never edit templates to change behavior that should live in `rpkg/`.
+
+### `use_template()` and the silent-skip trap
+
+`usethis::write_over()` silently skips overwriting a file in non-interactive
+mode. `minirextendr::use_template()` (in `minirextendr/R/render.R`) deletes the
+target file first, ensuring that `upgrade_miniextendr_package()` actually
+overwrites existing scaffold files rather than leaving stale versions in place.
+
+## How it works
+
+### Scaffolding API
+
+Key functions in `minirextendr/R/create.R`:
+
+- `use_miniextendr()` — main entry point for adding Rust scaffolding to an
+  existing R package or a newly created one. Detects an existing `DESCRIPTION`
+  and adds files without overwriting existing R code.
+- `create_miniextendr_package(path, ...)` — creates a new package skeleton and
+  calls `use_miniextendr()` on it.
+
+Both functions emit: `configure.ac`, `configure` (generated), `src/Makevars.in`,
+`src/stub.c`, `src/rust/Cargo.toml`, `src/rust/src/lib.rs`, and `.gitignore`
+updates.
+
+After scaffolding, the user runs `bash ./configure && R CMD INSTALL .` to build.
+
+### Upgrading an existing package
+
+`upgrade_miniextendr_package()` in `minirextendr/R/upgrade.R` overwrites all
+scaffold files with the latest templates. Because `use_template()` deletes the
+target before writing, the upgrade is unconditional — all scaffold-managed
+files are refreshed.
+
+Edits made directly to scaffold-managed files (e.g., `configure.ac`,
+`Makevars.in`) will be overwritten. Put project-specific logic in `tools/*.R`
+and hook it from configure via `Rscript tools/foo.R`.
+
+### Template sync workflow (contributor-facing)
+
+When `rpkg/` changes in a way that should propagate to end-user packages:
+
+1. Make the change in `rpkg/` first.
+2. Port the change to `minirextendr/inst/templates/`.
+3. Run `just templates-check` to see unexpected drift (non-zero exit = drift
+   detected).
+4. Run `just templates-approve` to regenerate `patches/templates.patch` with
+   the new delta as the approved baseline.
+5. Commit `rpkg/` changes, the template changes, and `patches/templates.patch`
+   together.
+
+`patches/templates.patch` records the approved delta between `rpkg/` and
+`inst/templates/`. CI runs `just templates-check` to verify no unexpected
+drift has accumulated.
+
+### minirextendr_doctor()
+
+`minirextendr/R/doctor.R` — detects two common broken states:
+
+1. **Stale-latch**: `inst/vendor.tar.xz` is present in a development context
+   where it should have been trap-cleaned. Causes configure to switch to
+   tarball mode, silently ignoring monorepo path overrides. Fix:
+   `just clean-vendor-leak`.
+
+2. **Missing `.cargo/config.toml`**: configure was not run (or ran before the
+   tarball was removed). Fix: `bash ./configure` (or `just configure`).
+
+Run `minirextendr_doctor()` from R when a build behaves unexpectedly — it is
+the first diagnostic step for any configure or cargo resolution issue.
+
+### Configure-time feature detection
+
+`minirextendr/R/feature-detect-configure.R` implements a system for probing
+optional R package dependencies at configure time and enabling corresponding
+cargo features.
+
+- `add_feature_rule(feature, package, ...)` — registers a detection rule
+  mapping a cargo feature to an R package. If the R package is installed at
+  configure time, the feature is enabled.
+- `use_configure_feature_detection()` — scaffolds the detection machinery into
+  a package's `tools/detect-features.R`.
+
+The detected feature list is passed to cargo via `CARGO_FEATURES` in `Makevars`.
+Users can also override `CARGO_FEATURES` directly in their environment.
+
+### Vendoring helpers
+
+`minirextendr/R/vendor.R` (and `minirextendr/R/vendor-lib.R`):
+
+- `miniextendr_vendor()` — R-side entry point equivalent to `just vendor`.
+  Runs `cargo-revendor` to produce `inst/vendor.tar.xz`.
+- `strip_toml_sections()` — strips `[[bench]]`, `[[test]]`, and
+  `[dev-dependencies]` sections from vendored `Cargo.toml` files when the
+  corresponding directories are absent in scaffolded packages. Without
+  stripping, cargo fails to resolve the vendored tree because the referenced
+  bench/test directories do not exist.
+
+### use_release_workflow()
+
+`minirextendr/R/use-release-workflow.R` scaffolds a known-good release CI
+workflow template for R packages targeting CRAN on AlmaLinux 8 (the default
+CRAN Linux build platform) and macOS arm64. Created to resolve #448 — the
+AlmaLinux 8 and macOS arm64 combination has build environment quirks that
+require pinning the macOS SDK and CRAN-provided library prefixes. See
+`docs/RELEASE_WORKFLOW.md` for the full set of requirements.
+
+### `just` is maintainer-only
+
+Scaffolded packages must build via `configure.ac` / `tools/*.R` / standard R
+mechanisms (`R CMD INSTALL`, `devtools::install()`). Never put `just` in
+scaffolded package instructions or templates. If a template requires `just`, fix
+the template.
+
+## Decision trees
+
+### Starting a new package
+
+1. Install minirextendr: `install.packages("minirextendr")` or
+   `remotes::install_github("A2-ai/minirextendr")`.
+2. `usethis::create_package("mypkg")` — creates the R package skeleton.
+3. `minirextendr::use_miniextendr()` — from the package root, adds Rust
+   scaffolding.
+4. Write Rust functions with `#[miniextendr]` in `src/rust/src/lib.rs`.
+5. `bash ./configure && R CMD INSTALL .` — builds and installs.
+
+### Upgrading an existing package
+
+1. `minirextendr::upgrade_miniextendr_package()` — refreshes all
+   scaffold-managed files from the latest templates.
+2. Run `bash ./configure && R CMD INSTALL .` to rebuild.
+3. If configure-time behavior changed (e.g., new feature detection), also run
+   `minirextendr::use_configure_feature_detection()` to update `tools/`.
+
+### Diagnosing a broken setup
+
+1. `minirextendr_doctor()` from R — reports stale tarball or missing
+   `.cargo/config.toml`.
+2. If stale tarball: `just clean-vendor-leak` (monorepo) or manually
+   `rm rpkg/inst/vendor.tar.xz` (standalone).
+3. `bash ./configure` to regenerate `Makevars` and `.cargo/config.toml`.
+4. If still broken: check `miniextendr-build` skill for detailed pipeline
+   diagnostics.
+
+### Template drift detected in CI
+
+1. Identify which files drifted: `just templates-check` output lists them.
+2. If the drift is intentional (rpkg changed, templates should follow):
+   port the change to `inst/templates/` and run `just templates-approve`.
+3. If the drift is unintentional (templates were edited directly):
+   revert the template edits and make the change in `rpkg/` first.
+
+## Key files
+
+- `minirextendr/R/create.R` — `use_miniextendr()` and
+  `create_miniextendr_package()` entry points.
+- `minirextendr/R/upgrade.R` — `upgrade_miniextendr_package()`.
+- `minirextendr/R/doctor.R` — `minirextendr_doctor()` health checks.
+- `minirextendr/R/render.R` — `use_template()` (delete-then-write wrapper).
+- `minirextendr/R/vendor.R` — `miniextendr_vendor()` and related helpers.
+- `minirextendr/R/vendor-lib.R` — `strip_toml_sections()`.
+- `minirextendr/R/feature-detect-configure.R` — `add_feature_rule()`,
+  `use_configure_feature_detection()`.
+- `minirextendr/R/use-release-workflow.R` — `use_release_workflow()`.
+- `minirextendr/inst/templates/` — scaffolding template files.
+- `patches/templates.patch` — approved rpkg → templates delta.
+- `docs/RELEASE_WORKFLOW.md` — release CI details for AlmaLinux 8 / macOS arm64.
+
+## Common pitfalls
+
+- **Never edit templates to fix something that should be fixed in rpkg.**
+  Templates are derived, not authoritative. The delta should be small and
+  intentional; unreviewed drift accumulates and breaks `just templates-check`.
+
+- **`upgrade_miniextendr_package()` overwrites scaffold files.** Put
+  project-specific logic in `tools/*.R`, not in `configure.ac` or
+  `Makevars.in` directly. Scaffold-managed files are always refreshed.
+
+- **`bootstrap.R` is the auto-vendor trigger.** When devtools or pkgbuild
+  invokes `R CMD build` on a source tree, `bootstrap.R` runs configure in a
+  staging directory with no `.git` ancestor. If `cargo-revendor` is on PATH,
+  auto-vendor fires. This is expected and correct behavior, not a bug.
+
+- **Regression tests in `minirextendr/tests/testthat/` grep function source.**
+  These tests use `deparse(body())` to check that template strings appear
+  literally in function bodies. Inlining a helper just to pass such a test is
+  implementation theater — fix the test or accept the indirection.
+
+- **`configure.ac` must not call `minirextendr::*`.** Configure runs in a
+  minimal environment at install time. Template-generated configure scripts
+  follow the same rule; any configure-time R logic must go in `tools/*.R`.
+
+## Related skills
+
+- `miniextendr-getting-started` — end-user walkthrough from empty package to
+  callable Rust function.
+- `miniextendr-build` — configure.ac mechanics, install-mode latch, and
+  Makevars pipeline in detail.
+- `miniextendr-architecture` — the install-mode latch and the cdylib-to-staticlib
+  double-link.


### PR DESCRIPTION
## Summary

PR-E of Flight 14. Three skills covering lint / build / scaffolding tooling.

- `miniextendr-lint` — MXL rule catalogue (300 / 301 / 112 + all others), build.rs invocation, `MINIEXTENDR_LINT=0` opt-out, shared parser layer note.
- `miniextendr-build` — cdylib→staticlib pipeline, configure.ac (`bash` requirement explained as AC_CONFIG_COMMANDS passthrough, not dash incompatibility), install-mode latch via `inst/vendor.tar.xz`, the latch leak (#441) and detection. Verified `cargo-config.toml.in` does not exist; configure writes inline via AC_CONFIG_COMMANDS.
- `miniextendr-scaffolding` — minirextendr templates (rpkg-derived, mustache substitution), sync workflow (`just templates-approve` / `just templates-check`), `minirextendr_doctor()`, `use_release_workflow()`, vendoring helpers, feature-detection API.

Verified file paths against actual repo state — confirmed `cargo-config.toml.in` does not exist in `rpkg/src/rust/` (configure.ac writes the file inline). Wrapper writer correctly attributed to `miniextendr-api/src/registry.rs`.

## Closes

- #168, #164, #173

## Test plan

- [ ] All referenced file paths exist in the repo.
- [ ] Frontmatter `description:` has "Use when..." triggers in all three files.
- [ ] No emoji, no inlined code blocks >20 lines.
- [ ] Cross-skill refs are slug-only.
- [ ] No misattribution to miniextendr-engine.
- [ ] No false claim that macOS `/bin/sh` is dash.
- [ ] No claim that `cargo-config.toml.in` exists.

Generated with [Claude Code](https://claude.com/claude-code)