### PR TITLE
fix(minirextendr): scaffold tools/lock-shape-check.R (#567)

### DIFF
--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -271,6 +271,14 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
     bullet_created(file.path(rpkg_name, "tools", script), "Copied")
   }
 
+  # tools/lock-shape-check.R is referenced by configure.ac's
+  # AC_CONFIG_COMMANDS([lock-shape-check]) block; without it, configure
+  # fails in tarball mode with "cannot open file 'tools/lock-shape-check.R'".
+  lock_check_src <- template_path("lock-shape-check.R", subdir = file.path("rpkg", "tools"))
+  lock_check_dest <- usethis::proj_path(rpkg_name, "tools", "lock-shape-check.R")
+  fs::file_copy(lock_check_src, lock_check_dest, overwrite = TRUE)
+  bullet_created(file.path(rpkg_name, "tools", "lock-shape-check.R"), "Copied")
+
   invisible(TRUE)
 }
 

--- a/minirextendr/R/use-configure.R
+++ b/minirextendr/R/use-configure.R
@@ -101,6 +101,14 @@ use_miniextendr_config_scripts <- function(path = ".") {
     bullet_created(file.path("tools", script), "Copied")
   }
 
+  # tools/lock-shape-check.R is referenced by configure.ac's
+  # AC_CONFIG_COMMANDS([lock-shape-check]) block; without it, configure
+  # fails in tarball mode with "cannot open file 'tools/lock-shape-check.R'".
+  lock_check_src <- template_path("lock-shape-check.R", subdir = "tools")
+  lock_check_dest <- usethis::proj_path("tools", "lock-shape-check.R")
+  fs::file_copy(lock_check_src, lock_check_dest, overwrite = TRUE)
+  bullet_created(file.path("tools", "lock-shape-check.R"), "Copied")
+
   invisible(TRUE)
 }
 


### PR DESCRIPTION
## Summary

- Copy `tools/lock-shape-check.R` during scaffolding (both standalone and monorepo paths) so `configure.ac`'s `AC_CONFIG_COMMANDS([lock-shape-check])` finds the file in tarball-install mode.
- Without the file, scaffolded packages fail at `bash ./configure` with `cannot open file 'tools/lock-shape-check.R': No such file or directory`, leading to a cascade of test failures across `test-scaffold-smoke.R` and `test-templates.R`.

## What was missing

`use_miniextendr_config_scripts()` copies `config.guess` / `config.sub` from `inst/scripts/`, but the `tools/lock-shape-check.R` referenced by `configure.ac` was never copied to scaffolded packages. The file already exists in both `inst/templates/rpkg/tools/` and `inst/templates/monorepo/rpkg/tools/` — it was just never installed.

This PR appends a single `fs::file_copy` to each scaffolder path:

- `minirextendr/R/use-configure.R` → `use_miniextendr_config_scripts()` (standalone)
- `minirextendr/R/create.R` → `create_rpkg_subdirectory()` (monorepo)

## Test plan

- [x] Manual repro pre-fix: `usethis::create_package` + `use_miniextendr` → `bash ./configure` fails with `cannot open file 'tools/lock-shape-check.R'`.
- [x] `just minirextendr-test`: configure stage now clears in the 3 originally-failing scaffold tests; PASS jumped 420 → 423.
- [x] Lock-shape-check appears in scaffolded `tools/`; configure logs `lock-shape OK`.

## Follow-ups (out of scope for this PR — separate defects unmasked by clearing the configure failure)

- #631 — standalone scaffold + vendor + `cargo check --offline` trips linkme checksum drift
- #632 — test-templates tarball-install path fails (missing pre-generated `R/<pkg>-wrappers.R`)
- #633 — test-templates cargo-dep scenario fails (vendor missing transitive `itertools`)
- #634 — `check_native_package('cli')` bindgen invocation fails on cli headers (pre-existing, unrelated)

Closes #567 for the lock-shape-check.R defect; remaining failures are tracked as the follow-ups above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)