### PR TITLE
ci(sync-checks): catch stale R wrappers / NAMESPACE / man drift (#602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,23 @@ jobs:
       - name: Install cargo-revendor
         run: cargo install --path cargo-revendor
 
-      - name: Configure and vendor
-        run: |
-          just configure
-          just vendor
+      - name: Install R packages (devtools, roxygen2)
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: rpkg
+          extra-packages: any::devtools, any::roxygen2
+          needs: check
+
+      - name: Configure (dev mode — no vendor tarball yet)
+        run: just configure
+
+      - name: Check R wrappers / NAMESPACE / man sync
+        # MUST run in dev mode (no inst/vendor.tar.xz yet) — tarball mode
+        # short-circuits wrapper generation and expects pre-shipped files.
+        run: just wrappers-sync-check
+
+      - name: Vendor
+        run: just vendor
 
       - name: Check vendor sync
         run: just vendor-sync-check

--- a/justfile
+++ b/justfile
@@ -1026,6 +1026,34 @@ vendor-sync-check:
 lint-sync-check:
     cargo check --manifest-path=miniextendr-lint/Cargo.toml
 
+# Verify committed R wrappers / NAMESPACE / man are in sync with #[miniextendr]
+# Rust source. Catches the failure mode where a Rust-side edit ships without
+# the corresponding regenerated `R/miniextendr-wrappers.R` / NAMESPACE / man/
+# (the pre-commit hook only fires when wrappers.R is itself staged, missing
+# the inverse case — see #602).
+[script("bash")]
+wrappers-sync-check: _assert-no-vendor-leak configure
+    set -euo pipefail
+
+    R CMD INSTALL rpkg >/dev/null
+    Rscript -e 'devtools::document("rpkg")' >/dev/null
+
+    paths=(
+      "rpkg/R/miniextendr-wrappers.R"
+      "rpkg/NAMESPACE"
+      "rpkg/man"
+      "rpkg/src/rust/wasm_registry.rs"
+    )
+
+    if ! git diff --exit-code -- "${paths[@]}"; then
+      echo ""
+      echo "Generated R wrappers / NAMESPACE / man drift from #[miniextendr] Rust source."
+      echo "Run 'just rcmdinstall && just force-document' and commit the regenerated files."
+      exit 1
+    fi
+
+    echo "Wrappers sync check passed."
+
 # Show diff between workspace and vendored crates
 [script("bash")]
 vendor-sync-diff:


### PR DESCRIPTION
## Summary

- Add `wrappers-sync-check` justfile recipe and wire it into the existing `sync-checks` CI job.
- Catches the failure mode where a Rust-side edit to a `#[miniextendr]` function ships without the corresponding regenerated `R/miniextendr-wrappers.R` / `NAMESPACE` / `man/` files.

## Why

Pre-existing guards have a blind spot:
- `.githooks/pre-commit` only fires when `*-wrappers.R` is itself staged — misses Rust-only edits that should have but didn't regenerate wrappers.
- The `sync-checks` CI job ran vendor / templates / lint sync but had no equivalent for generated R wrappers.

The drift in #589 (`gc_stress_toml_array` missing from `R/miniextendr-wrappers.R` and `NAMESPACE` on main, surfaced by #601 review) would have been caught by this check.

## Recipe

`wrappers-sync-check`:
1. Asserts no leaked vendor tarball (must run in dev mode — tarball mode short-circuits wrapper generation).
2. Runs `R CMD INSTALL rpkg` which regenerates `wrappers.R` + `wasm_registry.rs` via Makevars.
3. Runs `Rscript -e 'devtools::document("rpkg")'` to refresh `NAMESPACE` + `man/`.
4. `git diff --exit-code` on the four generated paths.

## CI integration

- `wrappers-sync-check` runs BEFORE `just vendor` (vendor flips configure to tarball mode).
- `devtools` + `roxygen2` installed via `setup-r-dependencies` (uses the existing `rpkg/` working directory).

## Test plan

- [x] Recipe is locally parseable (`just --show wrappers-sync-check`).
- [x] CI flow validates end-to-end on this PR (sync-checks job runs the new step).
- Future drift: when an author adds/changes `#[miniextendr]` Rust without rerunning `just rcmdinstall && just force-document`, CI fails with the diff and an actionable error message.

Closes #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)