### PR TITLE
docs(minirextendr): clarify miniextendr.yml is optional / non-load-bearing (#313)

### DIFF
--- a/minirextendr/R/config.R
+++ b/minirextendr/R/config.R
@@ -7,6 +7,27 @@
 #' is required to read the file; if unavailable, defaults are returned
 #' with a warning.
 #'
+#' @section Is `miniextendr.yml` load-bearing?:
+#'
+#' `miniextendr.yml` is **optional project metadata**, not a build-time
+#' configuration source. Downstream packages may keep it, edit it, or
+#' delete it without changing how their package compiles or runs. The
+#' parsed values are consumed by:
+#'
+#' - `miniextendr-cli config` — display only.
+#' - [miniextendr_sync()] — `features`, `strict`, `coerce`, `rust_version`
+#'   feed a cache-invalidation hash. Editing the file invalidates the
+#'   sync cache; it does not change codegen or runtime behaviour.
+#'
+#' Specifically, `class_system`, `strict`, and `coerce` in this file do
+#' **not** become Rust-side defaults. Codegen behaviour is controlled by
+#' `#[miniextendr(...)]` attributes on each item; the per-package Cargo
+#' feature set is controlled by `src/rust/Cargo.toml` (and optionally
+#' `tools/detect-features.R`); neither layer reads `miniextendr.yml`.
+#'
+#' If unsure: leave it where [use_miniextendr()] scaffolded it, or
+#' delete it — both are safe.
+#'
 #' @param path Path to the project root (default: current directory).
 #' @return A list of configuration values.
 #' @export

--- a/minirextendr/inst/templates/miniextendr.yml
+++ b/minirextendr/inst/templates/miniextendr.yml
@@ -1,5 +1,16 @@
-# miniextendr project configuration
-# See ?miniextendr_config for all options
+# miniextendr project configuration (optional)
+#
+# This file is parsed by minirextendr but is NOT load-bearing for codegen
+# or runtime behaviour. Editing values here changes:
+#   - what `miniextendr-cli config` prints
+#   - the sync-cache hash key (see ?miniextendr_sync)
+#
+# It does NOT change Rust-side defaults — those come from
+# `#[miniextendr(...)]` attributes per item — and it does NOT control
+# which Cargo features are enabled (see src/rust/Cargo.toml or
+# tools/detect-features.R). Safe to delete.
+#
+# See ?miniextendr_config for all keys and defaults.
 
 class_system: env
 strict: false

--- a/minirextendr/man/miniextendr_config.Rd
+++ b/minirextendr/man/miniextendr_config.Rd
@@ -18,3 +18,27 @@ Falls back to defaults for any missing keys. The \code{yaml} package
 is required to read the file; if unavailable, defaults are returned
 with a warning.
 }
+\section{Is \code{miniextendr.yml} load-bearing?}{
+
+
+\code{miniextendr.yml} is \strong{optional project metadata}, not a build-time
+configuration source. Downstream packages may keep it, edit it, or
+delete it without changing how their package compiles or runs. The
+parsed values are consumed by:
+\itemize{
+\item \verb{miniextendr-cli config} — display only.
+\item \code{\link[=miniextendr_sync]{miniextendr_sync()}} — \code{features}, \code{strict}, \code{coerce}, \code{rust_version}
+feed a cache-invalidation hash. Editing the file invalidates the
+sync cache; it does not change codegen or runtime behaviour.
+}
+
+Specifically, \code{class_system}, \code{strict}, and \code{coerce} in this file do
+\strong{not} become Rust-side defaults. Codegen behaviour is controlled by
+\verb{#[miniextendr(...)]} attributes on each item; the per-package Cargo
+feature set is controlled by \code{src/rust/Cargo.toml} (and optionally
+\code{tools/detect-features.R}); neither layer reads \code{miniextendr.yml}.
+
+If unsure: leave it where \code{\link[=use_miniextendr]{use_miniextendr()}} scaffolded it, or
+delete it — both are safe.
+}
+


### PR DESCRIPTION
## Summary

- Document that `miniextendr.yml` is **optional project metadata**, not a build-time configuration source — answering the integrator's question in #313.
- Add a new `@section Is miniextendr.yml load-bearing?` to `?miniextendr_config`.
- Update the template's header comments to say the same thing in-line.

## Investigation

Searched the entire repo for consumers of `miniextendr_config` / `miniextendr.yml`:

| Layer | Consumer | What it does with the values |
|---|---|---|
| CLI | `miniextendr-cli/src/commands/config.rs` | Reads + prints (display only) |
| R | `minirextendr/R/sync.R:62` | Hashes `features` / `strict` / `coerce` / `rust_version` into the sync-cache key (cache invalidation) |
| Rust runtime / macros | — | None |
| `rpkg/src/` | — | None |

So `class_system`, `strict`, `coerce` set in `miniextendr.yml` **do not** become Rust-side defaults. Codegen behaviour is controlled by `#[miniextendr(...)]` attributes per item; per-package Cargo features come from `src/rust/Cargo.toml` (and optionally `tools/detect-features.R`).

## Test plan

- [x] `devtools::document("minirextendr")` regenerates `miniextendr_config.Rd` with the new section
- [x] Template comment renders as a visible header banner in scaffolded packages

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)