### PR TITLE
docs(connection): lock in CString-field lifetime contract (#534)

### DIFF
--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -930,7 +930,18 @@ impl RCustomConnection {
             let boxed_state = Box::new(state);
             let state_ptr = Box::into_raw(boxed_state).cast::<c_void>();
 
-            // Create the R connection object
+            // Create the R connection object.
+            //
+            // SAFETY: self.{description,mode,class_name} are owned `CString`
+            // field bindings on the builder, alive for the entirety of this
+            // call. R `strcpy`s them into its own malloc'd buffers inside
+            // `init_con` (r-source `src/main/connections.c` ~line 710) and
+            // frees those copies in `con_close1`; we only need the borrow
+            // to outlive this single FFI call. Do not refactor the builder
+            // to hold `&str` views or to compute these via
+            // `CString::new(...).as_ptr()` without a binding — that would
+            // free the temporary before R reads it (silent UAF, not caught
+            // by basic tests because R has already copied the bytes by then).
             let mut conn_ptr: Rconnection = std::ptr::null_mut();
             let sexp = crate::ffi::R_new_custom_connection(
                 self.description.as_ptr(),


### PR DESCRIPTION
## Summary

- Add a SAFETY block at `RCustomConnection::build`'s `R_new_custom_connection` call site documenting why the three `CString` field bindings (`description` / `mode` / `class_name`) are load-bearing.

## Why

`R_new_custom_connection` is documented in r-source `src/main/connections.c` to `strcpy` the three `char *` pointers into its own malloc'd buffers inside `init_con` (~line 710). The Rust call site is correct today because the builder holds owned `CString` fields whose `.as_ptr()` stays valid for the duration of the single FFI call.

A future refactor that:

- holds `&str` views, or
- computes inline `CString::new(...).as_ptr()` without a let-binding,

would compile fine but silently UAF: R has already copied the bytes by the time the test observes any output, so a basic round-trip test would not catch the bug. The SAFETY comment locks that invariant so the next person to touch this code sees it.

## Test plan

- [x] `cargo check -p miniextendr-api --features connections` passes.
- [x] No functional change — comment only.

Closes #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)