### PR TITLE
test(minirextendr): suppress configure auto-vendor in e2e + cargo-dep tests (#632, #633)

### DIFF
--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -298,6 +298,13 @@ test_that("rpkg scaffolding builds and functions work end-to-end", {
     usethis::use_package_doc()
   }))
 
+  # Same auto-vendor suppression as the cargo-dep test below: a `.git`
+  # marker inside `pkg_path` makes configure.ac skip auto-vendor and stay
+  # in source mode. Without this, `devtools::document()` below fails
+  # because tarball-mode Makevars expects a pre-generated wrappers.R that
+  # this fresh scaffold doesn't have yet (#632).
+  dir.create(file.path(pkg_path, ".git"))
+
   suppressMessages({
     miniextendr_autoconf(path = pkg_path)
     miniextendr_configure(path = pkg_path)

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -335,6 +335,15 @@ test_that("rpkg scaffolding with external cargo dependency works", {
     usethis::use_package_doc()
   }))
 
+  # Mark the scaffolded package as a "developer source tree" so
+  # configure.ac's auto-vendor block (active when no .git ancestor is
+  # found) is skipped. We add this AFTER usethis::create_package so it
+  # doesn't trigger usethis's nested-project challenge. Without this,
+  # configure auto-vendors and locks the package into tarball mode,
+  # which then requires pre-generated R wrappers and refuses to resolve
+  # newly-added Cargo deps like itertools at build time (#633).
+  dir.create(file.path(pkg_path, ".git"))
+
   suppressMessages({
     miniextendr_autoconf(path = pkg_path)
     miniextendr_configure(path = pkg_path)


### PR DESCRIPTION
## Summary

Two sibling test failures in `minirextendr/tests/testthat/test-templates.R` share the same root cause: configure.ac's auto-vendor block (active when no `.git` ancestor is found + `cargo-revendor` on PATH) fires on the first `./configure` call in the tempdir-scaffolded test packages and locks them into tarball mode. The tests then can't proceed:

- **End-to-end test (#632)**: tarball mode refuses to generate `R/<pkg>-wrappers.R`, so `devtools::document()` fails.
- **Cargo-dep test (#633)**: a subsequently-added `itertools` dep can't be resolved against the stale vendored directory.

## Fix

Create a `.git` marker inside `pkg_path` after `usethis::create_package` (placing it earlier triggers usethis's nested-project challenge) so `configure.ac`'s walk-up detects a "developer source tree" and skips auto-vendor. Both tests stay in source mode, exactly as the cargo-dep test's original "Reconfigure in source mode — itertools will be fetched by cargo during build" comment intended.

## Test plan

- [x] `R45 -e 'devtools::test("minirextendr", filter = "templates")'`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 55 ]` (was `FAIL 2` before either fix; `FAIL 1` after only the cargo-dep fix).
- [ ] Both tests are gated by `skip_e2e()` / `skip_on_ci()`, so this is a dev-machine-only verification path; CI will not exercise it.

Closes #632. Closes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)