### PR TITLE
refactor(api): migrate scalar SexpExt accessors at time/jiff/encoding sites (closes #614)

### DIFF
--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -57,7 +57,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         crate::worker::is_r_main_thread(),
         "must be called from R main thread"
     );
-    use crate::ffi::{LOGICAL, R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, SexpExt};
+    use crate::ffi::{R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, SexpExt};
 
     unsafe {
         // Call l10n_info()
@@ -76,8 +76,7 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
             let name = std::ffi::CStr::from_ptr(name_ptr);
             if name == c"UTF-8" {
                 let elt = info.vector_elt(i);
-                // keep raw: single-scalar read; no SexpExt::get_logical_elt(i) helper yet (see follow-up issue)
-                is_utf8 = LOGICAL(elt).read() != 0;
+                is_utf8 = elt.logical_elt(0) != 0;
                 break;
             }
         }

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -39,9 +39,7 @@ pub use jiff::civil::{Date, DateTime, Time};
 pub use jiff::{SignedDuration, Span, Timestamp, Zoned};
 
 use crate::cached_class::{date_class_sexp, set_posixct_tz, set_posixct_utc};
-// keep raw: all `*REAL(sexp)` reads and `*REAL(vec) = …` writes here are single-scalar;
-// no SexpExt::get_real_elt / set_real_elt helpers yet — see follow-up issue.
-use crate::ffi::{REAL, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -70,7 +68,7 @@ impl TryFromSexp for Timestamp {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -99,7 +97,7 @@ impl IntoR for Timestamp {
             Rf_protect(vec);
             let secs =
                 self.as_second() as f64 + (self.subsec_nanosecond() as f64 / 1_000_000_000.0);
-            *REAL(vec) = secs;
+            vec.set_real_elt(0, secs);
             set_posixct_utc(vec);
             Rf_unprotect(1);
             vec
@@ -132,7 +130,7 @@ impl TryFromSexp for Option<Timestamp> {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Ok(None);
         }
@@ -159,7 +157,7 @@ impl IntoR for Option<Timestamp> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
                 set_posixct_utc(vec);
                 Rf_unprotect(1);
                 vec
@@ -314,7 +312,7 @@ impl TryFromSexp for Date {
                 sexp.len()
             )));
         }
-        let days = unsafe { *REAL(sexp) };
+        let days = sexp.real_elt(0);
         if days.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -344,7 +342,7 @@ impl IntoR for Date {
             Rf_protect(vec);
             // Date::since(epoch) → Span of days
             let span = self.since(unix_epoch_date()).unwrap_or_default();
-            *REAL(vec) = span.get_days() as f64;
+            vec.set_real_elt(0, span.get_days() as f64);
             vec.set_class(date_class_sexp());
             Rf_unprotect(1);
             vec
@@ -377,7 +375,7 @@ impl TryFromSexp for Option<Date> {
                 sexp.len()
             )));
         }
-        let days = unsafe { *REAL(sexp) };
+        let days = sexp.real_elt(0);
         if days.is_nan() {
             return Ok(None);
         }
@@ -406,7 +404,7 @@ impl IntoR for Option<Date> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
                 vec.set_class(date_class_sexp());
                 Rf_unprotect(1);
                 vec
@@ -562,7 +560,7 @@ impl TryFromSexp for Zoned {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -611,7 +609,10 @@ impl IntoR for Zoned {
             let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
             Rf_protect(vec);
             let ts = self.timestamp();
-            *REAL(vec) = ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0);
+            vec.set_real_elt(
+                0,
+                ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0),
+            );
             let iana = self.time_zone().iana_name().unwrap_or("UTC");
             set_posixct_tz(vec, iana);
             Rf_unprotect(1);
@@ -645,7 +646,7 @@ impl TryFromSexp for Option<Zoned> {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Ok(None);
         }
@@ -667,7 +668,7 @@ impl IntoR for Option<Zoned> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
                 set_posixct_utc(vec);
                 Rf_unprotect(1);
                 vec
@@ -919,7 +920,7 @@ impl TryFromSexp for SignedDuration {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -944,7 +945,7 @@ impl IntoR for SignedDuration {
         unsafe {
             let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
             Rf_protect(vec);
-            *REAL(vec) = self.as_secs_f64();
+            vec.set_real_elt(0, self.as_secs_f64());
             set_difftime_secs_class(vec);
             Rf_unprotect(1);
             vec
@@ -977,7 +978,7 @@ impl TryFromSexp for Option<SignedDuration> {
                 sexp.len()
             )));
         }
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Ok(None);
         }
@@ -1001,7 +1002,7 @@ impl IntoR for Option<SignedDuration> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
                 set_difftime_secs_class(vec);
                 Rf_unprotect(1);
                 vec

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -51,7 +51,7 @@
 pub use time::{Date, OffsetDateTime};
 
 use crate::cached_class::set_posixct_utc;
-use crate::ffi::{REAL, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::ffi::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 
@@ -83,8 +83,7 @@ impl TryFromSexp for OffsetDateTime {
             )));
         }
 
-        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -124,8 +123,7 @@ impl IntoR for OffsetDateTime {
             let duration = self - UNIX_EPOCH;
             let secs = duration.whole_seconds() as f64
                 + (duration.subsec_nanoseconds() as f64 / 1_000_000_000.0);
-            // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
-            *REAL(vec) = secs;
+            vec.set_real_elt(0, secs);
 
             set_posixct_utc(vec);
 
@@ -162,8 +160,7 @@ impl TryFromSexp for Option<OffsetDateTime> {
             )));
         }
 
-        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
-        let secs = unsafe { *REAL(sexp) };
+        let secs = sexp.real_elt(0);
         if secs.is_nan() {
             return Ok(None);
         }
@@ -195,8 +192,7 @@ impl IntoR for Option<OffsetDateTime> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
                 set_posixct_utc(vec);
                 Rf_unprotect(1);
                 vec
@@ -370,8 +366,7 @@ impl TryFromSexp for Date {
             )));
         }
 
-        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
-        let days = unsafe { *REAL(sexp) };
+        let days = sexp.real_elt(0);
         if days.is_nan() {
             return Err(SexpError::Na(SexpNaError {
                 sexp_type: SEXPTYPE::REALSXP,
@@ -402,8 +397,7 @@ impl IntoR for Date {
 
             // Calculate days since epoch
             let days = (self - UNIX_EPOCH_DATE).whole_days() as f64;
-            // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
-            *REAL(vec) = days;
+            vec.set_real_elt(0, days);
 
             // Set class = "Date"
             vec.set_class(crate::cached_class::date_class_sexp());
@@ -441,8 +435,7 @@ impl TryFromSexp for Option<Date> {
             )));
         }
 
-        // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
-        let days = unsafe { *REAL(sexp) };
+        let days = sexp.real_elt(0);
         if days.is_nan() {
             return Ok(None);
         }
@@ -471,8 +464,7 @@ impl IntoR for Option<Date> {
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
                 Rf_protect(vec);
-                // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
-                *REAL(vec) = f64::NAN;
+                vec.set_real_elt(0, f64::NAN);
 
                 vec.set_class(crate::cached_class::date_class_sexp());
 


### PR DESCRIPTION
## Summary

Sweeps the remaining `// keep raw:` single-scalar `*REAL(sexp)` reads,
`*REAL(vec) = …` writes, and `LOGICAL(elt).read()` patterns from the
`time` / `jiff` / `encoding` modules onto the safe `SexpExt` scalar
accessors that already exist on the trait.

- `miniextendr-api/src/optionals/time_impl.rs` — 8 sites
- `miniextendr-api/src/optionals/jiff_impl.rs` — 16 sites (plus module-level comment)
- `miniextendr-api/src/encoding.rs` — 1 site (`LOGICAL(elt).read()` in `miniextendr_assert_utf8_locale`)

## API

The `real_elt` / `set_real_elt` / `logical_elt` / `set_logical_elt`
helpers requested in the issue **already exist** on `SexpExt`:

- declarations: `miniextendr-api/src/ffi.rs:876-896`
- implementations: `miniextendr-api/src/ffi.rs:1402-1437`

They wrap `REAL_ELT` / `SET_REAL_ELT` / `LOGICAL_ELT` (the ALTREP-aware
public R API). So this PR is purely a call-site sweep — no new public
API surface.

## Mechanical changes

For each affected site:

```rust
- // keep raw: single-scalar read; no SexpExt::get_real_elt helper yet (see follow-up issue)
- let secs = unsafe { *REAL(sexp) };
+ let secs = sexp.real_elt(0);

- // keep raw: single-scalar write; no SexpExt::set_real_elt helper yet (see follow-up issue)
- *REAL(vec) = f64::NAN;
+ vec.set_real_elt(0, f64::NAN);

- // keep raw: single-scalar read; no SexpExt::get_logical_elt(i) helper yet (see follow-up issue)
- is_utf8 = LOGICAL(elt).read() != 0;
+ is_utf8 = elt.logical_elt(0) != 0;
```

`REAL` is dropped from `time_impl.rs`'s and `jiff_impl.rs`'s imports
(no longer referenced), and `LOGICAL` is dropped from `encoding.rs`.

## Test plan

- [x] `cargo check -p miniextendr-api --features time,jiff` — clean
- [x] `cargo check -p miniextendr-api --features time,jiff,nonapi` — clean
- [ ] CI green

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)