### PR TITLE
refactor(macros): unify S4/S7 instance-method prelude emission (closes #619)

### DIFF
--- a/miniextendr-macros/src/method_return_builder.rs
+++ b/miniextendr-macros/src/method_return_builder.rs
@@ -381,6 +381,84 @@ impl MethodReturnBuilder {
         })
     }
 
+    /// Build S7-style method body lines (creates new S7 object with .ptr).
+    ///
+    /// Returns lines suitable for embedding inside an outer `function(...) { ... }`
+    /// block — unlike [`build_s7_inline`](Self::build_s7_inline) which wraps the
+    /// body in its own `{ }` and is intended for callers that emit
+    /// `function(...) <expr>` directly (e.g., S7 `convert` definitions).
+    pub fn build_s7_body(&self) -> Vec<String> {
+        self.build_with_tails(ReturnTails {
+            // error_in_r=true:  ClassName(.ptr = .val)
+            // error_in_r=false: ClassName(.ptr = call_expr)
+            self_tail: Box::new(|indent, call_expr, class_name, eir| {
+                assert!(
+                    !class_name.is_empty(),
+                    "class_name required for ReturnSelf strategy"
+                );
+                if eir {
+                    vec![format!("{}{}(.ptr = .val)", indent, class_name)]
+                } else {
+                    vec![format!("{}{}(.ptr = {})", indent, class_name, call_expr)]
+                }
+            }),
+            chain_tail: Box::new(|indent, call_expr, eir| {
+                if eir {
+                    vec![format!("{}x", indent)]
+                } else {
+                    vec![format!("{}{}", indent, call_expr), format!("{}x", indent)]
+                }
+            }),
+            direct_tail: Box::new(|indent, call_expr, eir| {
+                if eir {
+                    vec![format!("{}.val", indent)]
+                } else {
+                    vec![format!("{}{}", indent, call_expr)]
+                }
+            }),
+        })
+    }
+
+    /// Build S4-style method body lines (uses methods::new() to wrap Self returns).
+    ///
+    /// Returns lines suitable for embedding inside an outer
+    /// `function(...) { ... }` block, mirroring [`build_s7_body`](Self::build_s7_body).
+    pub fn build_s4_body(&self) -> Vec<String> {
+        self.build_with_tails(ReturnTails {
+            self_tail: Box::new(|indent, call_expr, class_name, eir| {
+                assert!(
+                    !class_name.is_empty(),
+                    "class_name required for ReturnSelf strategy"
+                );
+                if eir {
+                    vec![format!(
+                        "{}methods::new(\"{}\", ptr = .val)",
+                        indent, class_name
+                    )]
+                } else {
+                    vec![format!(
+                        "{}methods::new(\"{}\", ptr = {})",
+                        indent, class_name, call_expr
+                    )]
+                }
+            }),
+            chain_tail: Box::new(|indent, call_expr, eir| {
+                if eir {
+                    vec![format!("{}x", indent)]
+                } else {
+                    vec![format!("{}{}", indent, call_expr), format!("{}x", indent)]
+                }
+            }),
+            direct_tail: Box::new(|indent, call_expr, eir| {
+                if eir {
+                    vec![format!("{}.val", indent)]
+                } else {
+                    vec![format!("{}{}", indent, call_expr)]
+                }
+            }),
+        })
+    }
+
     /// Build S7-style return (creates new S7 object with .ptr).
     ///
     /// In error_in_r mode, returns a multi-line block expression.

--- a/miniextendr-macros/src/miniextendr_impl/s4_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s4_class.rs
@@ -160,73 +160,20 @@ pub fn generate_s4_r_wrapper(parsed_impl: &ParsedImpl) -> String {
         }
 
         let strategy = crate::ReturnStrategy::for_method(method);
-        let return_expr = crate::MethodReturnBuilder::new(call)
+        let body_lines = crate::MethodReturnBuilder::new(call)
             .with_strategy(strategy)
             .with_class_name(class_name.clone())
             .with_error_in_r(method.method_attrs.error_in_r)
-            .build_s4_inline();
+            .build_s4_body();
 
-        // Inject r_entry, on.exit, missing param defaults, lifecycle prelude, and precondition checks if present
-        let r_entry = &method.method_attrs.r_entry;
-        let r_on_exit = &method.method_attrs.r_on_exit;
-        let missing = crate::r_wrapper_builder::build_missing_prelude(
-            &method.sig.inputs,
-            &method.param_defaults,
-        );
         let what = format!("{}.{}", method_name, class_name);
-        let lifecycle = method.lifecycle_prelude(&what);
-        let preconditions = crate::r_preconditions::build_precondition_checks(
-            &method.sig.inputs,
-            &std::collections::HashSet::new(),
-        )
-        .static_checks;
-        let match_arg_lines = ctx.match_arg_prelude();
-        let r_post_checks = &method.method_attrs.r_post_checks;
-        if r_entry.is_some()
-            || r_on_exit.is_some()
-            || !missing.is_empty()
-            || lifecycle.is_some()
-            || !preconditions.is_empty()
-            || !match_arg_lines.is_empty()
-            || r_post_checks.is_some()
-        {
-            lines.push(format!(
-                "methods::setMethod(\"{}\", \"{}\", function({}) {{",
-                method_name, class_name, full_params
-            ));
-            if let Some(entry) = r_entry {
-                for line in entry.lines() {
-                    lines.push(format!("  {}", line));
-                }
-            }
-            if let Some(on_exit) = r_on_exit {
-                lines.push(format!("  {}", on_exit.to_r_code()));
-            }
-            for line in &missing {
-                lines.push(format!("  {}", line));
-            }
-            if let Some(prelude) = lifecycle {
-                lines.push(format!("  {}", prelude));
-            }
-            for check in &preconditions {
-                lines.push(format!("  {}", check));
-            }
-            for line in &match_arg_lines {
-                lines.push(format!("  {}", line));
-            }
-            if let Some(post) = r_post_checks {
-                for line in post.lines() {
-                    lines.push(format!("  {}", line));
-                }
-            }
-            lines.push(format!("  {}", return_expr));
-            lines.push("})".to_string());
-        } else {
-            lines.push(format!(
-                "methods::setMethod(\"{}\", \"{}\", function({}) {})",
-                method_name, class_name, full_params, return_expr
-            ));
-        }
+        lines.push(format!(
+            "methods::setMethod(\"{}\", \"{}\", function({}) {{",
+            method_name, class_name, full_params
+        ));
+        ctx.emit_method_prelude(&mut lines, "  ", &what);
+        lines.extend(body_lines);
+        lines.push("})".to_string());
         lines.push(String::new());
     }
 

--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -748,64 +748,19 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
             // Define method using the resolved generic name
             let strategy = crate::ReturnStrategy::for_method(ctx.method);
-            let return_expr = crate::MethodReturnBuilder::new(call.clone())
+            let body_lines = crate::MethodReturnBuilder::new(call.clone())
                 .with_strategy(strategy)
                 .with_class_name(class_name.clone())
                 .with_error_in_r(ctx.method.method_attrs.error_in_r)
-                .build_s7_inline();
+                .build_s7_body();
 
-            // Inject r_entry, on.exit, missing param defaults, lifecycle prelude, precondition checks, match_arg, r_post_checks
             let what = format!("{}.{}", generic_name, class_name);
-            let r_entry = &ctx.method.method_attrs.r_entry;
-            let r_on_exit = &ctx.method.method_attrs.r_on_exit;
-            let missing = ctx.missing_prelude();
-            let lifecycle = ctx.method.lifecycle_prelude(&what);
-            let preconditions = ctx.precondition_checks();
-            let match_arg_lines = ctx.match_arg_prelude();
-            let r_post_checks = &ctx.method.method_attrs.r_post_checks;
-            if r_entry.is_some()
-                || r_on_exit.is_some()
-                || !missing.is_empty()
-                || lifecycle.is_some()
-                || !preconditions.is_empty()
-                || !match_arg_lines.is_empty()
-                || r_post_checks.is_some()
-            {
-                lines.push(format!(
-                    "S7::method({gen_name}, {method_class}) <- function({full_params}) {{"
-                ));
-                if let Some(entry) = r_entry {
-                    for line in entry.lines() {
-                        lines.push(format!("  {line}"));
-                    }
-                }
-                if let Some(on_exit) = r_on_exit {
-                    lines.push(format!("  {}", on_exit.to_r_code()));
-                }
-                for line in &missing {
-                    lines.push(format!("  {line}"));
-                }
-                if let Some(prelude) = lifecycle {
-                    lines.push(format!("  {prelude}"));
-                }
-                for check in &preconditions {
-                    lines.push(format!("  {check}"));
-                }
-                for line in &match_arg_lines {
-                    lines.push(format!("  {line}"));
-                }
-                if let Some(post) = r_post_checks {
-                    for line in post.lines() {
-                        lines.push(format!("  {line}"));
-                    }
-                }
-                lines.push(format!("  {return_expr}"));
-                lines.push("}".to_string());
-            } else {
-                lines.push(format!(
-                    "S7::method({gen_name}, {method_class}) <- function({full_params}) {return_expr}"
-                ));
-            }
+            lines.push(format!(
+                "S7::method({gen_name}, {method_class}) <- function({full_params}) {{"
+            ));
+            ctx.emit_method_prelude(&mut lines, "  ", &what);
+            lines.extend(body_lines);
+            lines.push("}".to_string());
         } else {
             // Create new S7 generic if it doesn't exist
             // Use @rawNamespace to explicitly export the bare generic name.
@@ -863,67 +818,22 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
             // Define method
             let strategy = crate::ReturnStrategy::for_method(ctx.method);
-            let return_expr = crate::MethodReturnBuilder::new(call)
+            let body_lines = crate::MethodReturnBuilder::new(call)
                 .with_strategy(strategy)
                 .with_class_name(class_name.clone())
                 .with_error_in_r(ctx.method.method_attrs.error_in_r)
-                .build_s7_inline();
+                .build_s7_body();
 
             // Use matching formals for method (with or without ...)
             let method_formals = ctx.instance_formals_with_dots(true, !method_attrs.s7.no_dots);
 
-            // Inject r_entry, on.exit, missing param defaults, lifecycle prelude, precondition checks, match_arg, r_post_checks
             let what = format!("{}.{}", generic_name, class_name);
-            let r_entry = &ctx.method.method_attrs.r_entry;
-            let r_on_exit = &ctx.method.method_attrs.r_on_exit;
-            let missing = ctx.missing_prelude();
-            let lifecycle = ctx.method.lifecycle_prelude(&what);
-            let preconditions = ctx.precondition_checks();
-            let match_arg_lines = ctx.match_arg_prelude();
-            let r_post_checks = &ctx.method.method_attrs.r_post_checks;
-            if r_entry.is_some()
-                || r_on_exit.is_some()
-                || !missing.is_empty()
-                || lifecycle.is_some()
-                || !preconditions.is_empty()
-                || !match_arg_lines.is_empty()
-                || r_post_checks.is_some()
-            {
-                lines.push(format!(
-                    "S7::method({generic_name}, {method_class}) <- function({method_formals}) {{"
-                ));
-                if let Some(entry) = r_entry {
-                    for line in entry.lines() {
-                        lines.push(format!("  {line}"));
-                    }
-                }
-                if let Some(on_exit) = r_on_exit {
-                    lines.push(format!("  {}", on_exit.to_r_code()));
-                }
-                for line in &missing {
-                    lines.push(format!("  {line}"));
-                }
-                if let Some(prelude) = lifecycle {
-                    lines.push(format!("  {prelude}"));
-                }
-                for check in &preconditions {
-                    lines.push(format!("  {check}"));
-                }
-                for line in &match_arg_lines {
-                    lines.push(format!("  {line}"));
-                }
-                if let Some(post) = r_post_checks {
-                    for line in post.lines() {
-                        lines.push(format!("  {line}"));
-                    }
-                }
-                lines.push(format!("  {return_expr}"));
-                lines.push("}".to_string());
-            } else {
-                lines.push(format!(
-                    "S7::method({generic_name}, {method_class}) <- function({method_formals}) {return_expr}"
-                ));
-            }
+            lines.push(format!(
+                "S7::method({generic_name}, {method_class}) <- function({method_formals}) {{"
+            ));
+            ctx.emit_method_prelude(&mut lines, "  ", &what);
+            lines.extend(body_lines);
+            lines.push("}".to_string());
         }
         lines.push(String::new());
     }

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s4_basic.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s4_basic.snap
@@ -34,10 +34,10 @@ Counter <- function(value) {
 if (!methods::isGeneric("s4_get")) methods::setGeneric("s4_get", function(x, ...) standardGeneric("s4_get"))
 #' @exportMethod s4_get
 methods::setMethod("s4_get", "Counter", function(x, ...) {
-    .val <- .Call(C_Counter__get, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_Counter__get, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # Counter::increment (1:1)
 #' @name Counter-s4_increment
@@ -47,7 +47,7 @@ methods::setMethod("s4_get", "Counter", function(x, ...) {
 if (!methods::isGeneric("s4_increment")) methods::setGeneric("s4_increment", function(x, ...) standardGeneric("s4_increment"))
 #' @exportMethod s4_increment
 methods::setMethod("s4_increment", "Counter", function(x, ...) {
-    .val <- .Call(C_Counter__increment, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    x
-  })
+  .val <- .Call(C_Counter__increment, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  x
+})

--- a/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_basic.snap
+++ b/miniextendr-macros/src/miniextendr_impl/snapshots/miniextendr_macros__miniextendr_impl__tests__snapshot_s7_basic.snap
@@ -41,10 +41,10 @@ if (!exists("get", mode = "function")) {
   get <- S7::new_generic("get", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(get, Counter) <- function(x, ...) {
-    .val <- .Call(C_Counter__get, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_Counter__get, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Counter::increment (1:1)
 #' @name Counter-increment
@@ -56,10 +56,10 @@ if (!exists("increment", mode = "function")) {
   increment <- S7::new_generic("increment", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(increment, Counter) <- function(x, ...) {
-    .val <- .Call(C_Counter__increment, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    x
-  }
+  .val <- .Call(C_Counter__increment, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  x
+}
 
 # Counter::from_parts (1:1)
 #' @param a (undocumented)

--- a/rpkg/R/miniextendr-wrappers.R
+++ b/rpkg/R/miniextendr-wrappers.R
@@ -3527,10 +3527,10 @@ methods::setClass("S4TraitCounter", slots = c(ptr = "externalptr"))
 #' @aliases s4_get_value,S4TraitCounter-method
 if (!methods::isGeneric("s4_get_value")) methods::setGeneric("s4_get_value", function(x, ...) standardGeneric("s4_get_value"))
 methods::setMethod("s4_get_value", "S4TraitCounter", function(x, ...) {
-    .val <- .Call(C_S4TraitCounter__get_value, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_S4TraitCounter__get_value, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # S4TraitCounter::new_s4trait (241:8)
 #' @title Create a new S4 trait counter
@@ -3574,10 +3574,10 @@ if (!exists("get_value", mode = "function")) {
   get_value <- S7::new_generic("get_value", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(get_value, S7TraitCounter) <- function(x, ...) {
-    .val <- .Call(C_S7TraitCounter__get_value, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7TraitCounter__get_value, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7TraitCounter::new_s7trait (293:8)
 #' @title Create a new S7 trait counter
@@ -3892,10 +3892,10 @@ if (!exists("read_level", mode = "function")) {
   read_level <- S7::new_generic("read_level", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(read_level, ErrorInRS7Gauge) <- function(x, ...) {
-    .val <- .Call(C_ErrorInRS7Gauge__read_level, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_ErrorInRS7Gauge__read_level, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # ErrorInRS7Gauge::set_level (188:12)
 #' @title Set the level -- mutable, chainable
@@ -3911,11 +3911,9 @@ S7::method(set_level, ErrorInRS7Gauge) <- function(x, level, ...) {
     "'level' must be numeric, logical, or raw" = is.numeric(level) || is.logical(level) || is.raw(level),
     "'level' must have length 1" = length(level) == 1L
   )
-  {
-    .val <- .Call(C_ErrorInRS7Gauge__set_level, .call = match.call(), x@.ptr, level)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    x
-  }
+  .val <- .Call(C_ErrorInRS7Gauge__set_level, .call = match.call(), x@.ptr, level)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  x
 }
 
 # ErrorInRS7Gauge::panic_method (194:12)
@@ -3928,10 +3926,10 @@ if (!exists("panic_method", mode = "function")) {
   panic_method <- S7::new_generic("panic_method", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(panic_method, ErrorInRS7Gauge) <- function(x, ...) {
-    .val <- .Call(C_ErrorInRS7Gauge__panic_method, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_ErrorInRS7Gauge__panic_method, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # ErrorInRS7Gauge::failing_result (200:12)
 #' @title Return Result::Err
@@ -3943,10 +3941,10 @@ if (!exists("failing_result", mode = "function")) {
   failing_result <- S7::new_generic("failing_result", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(failing_result, ErrorInRS7Gauge) <- function(x, ...) {
-    .val <- .Call(C_ErrorInRS7Gauge__failing_result, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_ErrorInRS7Gauge__failing_result, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `ErrorInRR6Widget` (error_in_r_tests.rs:135:6)
 #' @title ErrorInRR6Widget R6 Class
@@ -4418,10 +4416,10 @@ CounterTraitS4 <- function(v) {
 #' @aliases s4_get_value,CounterTraitS4-method
 if (!methods::isGeneric("s4_get_value")) methods::setGeneric("s4_get_value", function(x, ...) standardGeneric("s4_get_value"))
 methods::setMethod("s4_get_value", "CounterTraitS4", function(x, ...) {
-    .val <- .Call(C_CounterTraitS4__get_value, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_CounterTraitS4__get_value, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # Generated from Rust impl `CounterTraitS7` (class_system_matrix.rs:138:6)
 #' @title CounterTraitS7 S7 Class
@@ -4462,10 +4460,10 @@ if (!exists("get_value", mode = "function")) {
   get_value <- S7::new_generic("get_value", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(get_value, CounterTraitS7) <- function(x, ...) {
-    .val <- .Call(C_CounterTraitS7__get_value, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_CounterTraitS7__get_value, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `CounterTraitEnv` (class_system_matrix.rs:37:6)
 #' @title CounterTraitEnv  Class
@@ -5705,10 +5703,10 @@ S4MatchArgHolder <- function(mode = c("Fast", "Safe", "Debug")) {
 if (!methods::isGeneric("s4_mode_current")) methods::setGeneric("s4_mode_current", function(x, ...) standardGeneric("s4_mode_current"))
 #' @exportMethod s4_mode_current
 methods::setMethod("s4_mode_current", "S4MatchArgHolder", function(x, ...) {
-    .val <- .Call(C_S4MatchArgHolder__mode_current, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_S4MatchArgHolder__mode_current, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # S4MatchArgHolder::mode_set (169:12)
 #' @name S4MatchArgHolder-s4_mode_set
@@ -5720,11 +5718,9 @@ if (!methods::isGeneric("s4_mode_set")) methods::setGeneric("s4_mode_set", funct
 methods::setMethod("s4_mode_set", "S4MatchArgHolder", function(x, mode = c("Fast", "Safe", "Debug"), ...) {
   mode <- if (is.factor(mode)) as.character(mode) else mode
   mode <- base::match.arg(mode)
-  {
-    .val <- .Call(C_S4MatchArgHolder__mode_set, .call = match.call(), x@ptr, mode)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4MatchArgHolder__mode_set, .call = match.call(), x@ptr, mode)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # Generated from Rust impl `S7MatchArgHolder` (match_arg_impl_tests.rs:100:6)
@@ -5765,10 +5761,10 @@ if (!exists("current", mode = "function")) {
   current <- S7::new_generic("current", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(current, S7MatchArgHolder) <- function(x, ...) {
-    .val <- .Call(C_S7MatchArgHolder__current, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7MatchArgHolder__current, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7MatchArgHolder::set (111:12)
 #' @name S7MatchArgHolder-set
@@ -5782,11 +5778,9 @@ if (!exists("set", mode = "function")) {
 S7::method(set, S7MatchArgHolder) <- function(x, mode = c("Fast", "Safe", "Debug"), ...) {
   mode <- if (is.factor(mode)) as.character(mode) else mode
   mode <- base::match.arg(mode)
-  {
-    .val <- .Call(C_S7MatchArgHolder__set, .call = match.call(), x@.ptr, mode)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7MatchArgHolder__set, .call = match.call(), x@.ptr, mode)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # Generated from Rust impl `R6MatchArgCounter` (match_arg_impl_tests.rs:38:6)
@@ -6998,10 +6992,10 @@ S4Raiser <- function(id) {
 #' @aliases s4_id,S4Raiser-method
 if (!methods::isGeneric("s4_id")) methods::setGeneric("s4_id", function(x, ...) standardGeneric("s4_id"))
 methods::setMethod("s4_id", "S4Raiser", function(x, ...) {
-    .val <- .Call(C_S4Raiser__id, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_S4Raiser__id, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # S4Raiser::raise_error (161:12)
 #' @name S4Raiser-s4_raise_error
@@ -7014,11 +7008,9 @@ methods::setMethod("s4_raise_error", "S4Raiser", function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_error, .call = match.call(), x@ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_error, .call = match.call(), x@ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_error_classed (165:12)
@@ -7034,11 +7026,9 @@ methods::setMethod("s4_raise_error_classed", "S4Raiser", function(x, class, msg,
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_error_classed, .call = match.call(), x@ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_error_classed, .call = match.call(), x@ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_warning (169:12)
@@ -7052,11 +7042,9 @@ methods::setMethod("s4_raise_warning", "S4Raiser", function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_warning, .call = match.call(), x@ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_warning, .call = match.call(), x@ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_warning_classed (173:12)
@@ -7072,11 +7060,9 @@ methods::setMethod("s4_raise_warning_classed", "S4Raiser", function(x, class, ms
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_warning_classed, .call = match.call(), x@ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_warning_classed, .call = match.call(), x@ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_message (177:12)
@@ -7090,11 +7076,9 @@ methods::setMethod("s4_raise_message", "S4Raiser", function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_message, .call = match.call(), x@ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_message, .call = match.call(), x@ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_condition (181:12)
@@ -7108,11 +7092,9 @@ methods::setMethod("s4_raise_condition", "S4Raiser", function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_condition, .call = match.call(), x@ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_condition, .call = match.call(), x@ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Raiser::raise_condition_classed (185:12)
@@ -7128,11 +7110,9 @@ methods::setMethod("s4_raise_condition_classed", "S4Raiser", function(x, class, 
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S4Raiser__raise_condition_classed, .call = match.call(), x@ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Raiser__raise_condition_classed, .call = match.call(), x@ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # Generated from Rust impl `S7Raiser` (condition_class_system_tests.rs:200:6)
@@ -7174,10 +7154,10 @@ if (!exists("s7_id", mode = "function")) {
   s7_id <- S7::new_generic("s7_id", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(s7_id, S7Raiser) <- function(x, ...) {
-    .val <- .Call(C_S7Raiser__s7_id, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_id, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Raiser::s7_raise_error (209:12)
 #' @name S7Raiser-s7_raise_error
@@ -7192,11 +7172,9 @@ S7::method(s7_raise_error, S7Raiser) <- function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_error, .call = match.call(), x@.ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_error, .call = match.call(), x@.ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_error_classed (213:12)
@@ -7214,11 +7192,9 @@ S7::method(s7_raise_error_classed, S7Raiser) <- function(x, class, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_error_classed, .call = match.call(), x@.ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_error_classed, .call = match.call(), x@.ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_warning (217:12)
@@ -7234,11 +7210,9 @@ S7::method(s7_raise_warning, S7Raiser) <- function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_warning, .call = match.call(), x@.ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_warning, .call = match.call(), x@.ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_warning_classed (221:12)
@@ -7256,11 +7230,9 @@ S7::method(s7_raise_warning_classed, S7Raiser) <- function(x, class, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_warning_classed, .call = match.call(), x@.ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_warning_classed, .call = match.call(), x@.ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_message (225:12)
@@ -7276,11 +7248,9 @@ S7::method(s7_raise_message, S7Raiser) <- function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_message, .call = match.call(), x@.ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_message, .call = match.call(), x@.ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_condition (229:12)
@@ -7296,11 +7266,9 @@ S7::method(s7_raise_condition, S7Raiser) <- function(x, msg, ...) {
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_condition, .call = match.call(), x@.ptr, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_condition, .call = match.call(), x@.ptr, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Raiser::s7_raise_condition_classed (233:12)
@@ -7318,11 +7286,9 @@ S7::method(s7_raise_condition_classed, S7Raiser) <- function(x, class, msg, ...)
     "'msg' must be character" = is.character(msg),
     "'msg' must have length 1" = length(msg) == 1L
   )
-  {
-    .val <- .Call(C_S7Raiser__s7_raise_condition_classed, .call = match.call(), x@.ptr, class, msg)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Raiser__s7_raise_condition_classed, .call = match.call(), x@.ptr, class, msg)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # Generated from Rust impl `EnvRaiser` (condition_class_system_tests.rs:248:6)
@@ -8205,10 +8171,10 @@ S4Counter <- function(initial) {
 #' @aliases s4_value,S4Counter-method
 if (!methods::isGeneric("s4_value")) methods::setGeneric("s4_value", function(x, ...) standardGeneric("s4_value"))
 methods::setMethod("s4_value", "S4Counter", function(x, ...) {
-    .val <- .Call(C_S4Counter__value, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_S4Counter__value, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # S4Counter::inc (28:12)
 #' @title Increments the counter by 1 and returns the new value
@@ -8218,10 +8184,10 @@ methods::setMethod("s4_value", "S4Counter", function(x, ...) {
 #' @aliases s4_inc,S4Counter-method
 if (!methods::isGeneric("s4_inc")) methods::setGeneric("s4_inc", function(x, ...) standardGeneric("s4_inc"))
 methods::setMethod("s4_inc", "S4Counter", function(x, ...) {
-    .val <- .Call(C_S4Counter__inc, .call = match.call(), x@ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  })
+  .val <- .Call(C_S4Counter__inc, .call = match.call(), x@ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+})
 
 # S4Counter::add (35:12)
 #' @title Adds the given amount to the counter and returns the new value
@@ -8235,11 +8201,9 @@ methods::setMethod("s4_add", "S4Counter", function(x, amount, ...) {
     "'amount' must be numeric, logical, or raw" = is.numeric(amount) || is.logical(amount) || is.raw(amount),
     "'amount' must have length 1" = length(amount) == 1L
   )
-  {
-    .val <- .Call(C_S4Counter__add, .call = match.call(), x@ptr, amount)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S4Counter__add, .call = match.call(), x@ptr, amount)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 })
 
 # S4Counter::default_counter (41:12)
@@ -8308,10 +8272,10 @@ if (!exists("s7_start", mode = "function")) {
   s7_start <- S7::new_generic("s7_start", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(s7_start, S7Range) <- function(x, ...) {
-    .val <- .Call(C_S7Range__s7_start, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Range__s7_start, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Range::s7_end (101:12)
 #' @title Regular method: returns the end value
@@ -8323,10 +8287,10 @@ if (!exists("s7_end", mode = "function")) {
   s7_end <- S7::new_generic("s7_end", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(s7_end, S7Range) <- function(x, ...) {
-    .val <- .Call(C_S7Range__s7_end, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Range__s7_end, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Shape` (s7_tests.rs:259:6)
 #' @title S7Shape S7 Class
@@ -8369,10 +8333,10 @@ if (!exists("shape_name", mode = "function")) {
   shape_name <- S7::new_generic("shape_name", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(shape_name, S7Shape) <- function(x, ...) {
-    .val <- .Call(C_S7Shape__shape_name, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Shape__shape_name, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Animal` (s7_tests.rs:305:6)
 #' @title S7Animal S7 Class
@@ -8419,10 +8383,10 @@ if (!exists("animal_kind", mode = "function")) {
   animal_kind <- S7::new_generic("animal_kind", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(animal_kind, S7Animal) <- function(x, ...) {
-    .val <- .Call(C_S7Animal__animal_kind, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Animal__animal_kind, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Circle` (s7_tests.rs:280:6)
 #' @title S7Circle S7 Class
@@ -8464,10 +8428,10 @@ if (!exists("circle_area", mode = "function")) {
   circle_area <- S7::new_generic("circle_area", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(circle_area, S7Circle) <- function(x, ...) {
-    .val <- .Call(C_S7Circle__circle_area, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Circle__circle_area, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Config` (s7_tests.rs:118:6)
 #' @title S7Config S7 Class
@@ -8519,10 +8483,10 @@ if (!exists("get_version", mode = "function")) {
   get_version <- S7::new_generic("get_version", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(get_version, S7Config) <- function(x, ...) {
-    .val <- .Call(C_S7Config__get_version, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Config__get_version, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Strict` (s7_tests.rs:169:6)
 #' @title S7Strict S7 Class
@@ -8564,10 +8528,10 @@ if (!exists("strict_length", mode = "function")) {
   strict_length <- S7::new_generic("strict_length", "x", function(x) S7::S7_dispatch())
 }
 S7::method(strict_length, S7Strict) <- function(x) {
-    .val <- .Call(C_S7Strict__strict_length, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Strict__strict_length, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Strict::describe_any (183:12)
 #' @title Method with fallback to class_any
@@ -8579,10 +8543,10 @@ if (!exists("describe_any", mode = "function")) {
   describe_any <- S7::new_generic("describe_any", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(describe_any, S7::class_any) <- function(x, ...) {
-    .val <- .Call(C_S7Strict__describe_any, .call = match.call(), if (inherits(x, "S7_object")) x@.ptr else stop(paste0("expected an S7 object, got ", class(x)[[1]])))
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Strict__describe_any, .call = match.call(), if (inherits(x, "S7_object")) x@.ptr else stop(paste0("expected an S7 object, got ", class(x)[[1]])))
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Celsius` (s7_tests.rs:200:6)
 #' @title S7Celsius S7 Class
@@ -8624,10 +8588,10 @@ if (!exists("value", mode = "function")) {
   value <- S7::new_generic("value", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(value, S7Celsius) <- function(x, ...) {
-    .val <- .Call(C_S7Celsius__value, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Celsius__value, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Counter` (s7_tests.rs:14:6)
 #' @title S7Counter S7 Class
@@ -8669,10 +8633,10 @@ if (!exists("s7_value", mode = "function")) {
   s7_value <- S7::new_generic("s7_value", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(s7_value, S7Counter) <- function(x, ...) {
-    .val <- .Call(C_S7Counter__s7_value, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Counter__s7_value, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Counter::s7_inc (27:12)
 #' @title Increments the counter by 1 and returns the new value
@@ -8684,10 +8648,10 @@ if (!exists("s7_inc", mode = "function")) {
   s7_inc <- S7::new_generic("s7_inc", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(s7_inc, S7Counter) <- function(x, ...) {
-    .val <- .Call(C_S7Counter__s7_inc, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Counter__s7_inc, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Counter::s7_add (33:12)
 #' @title Adds the given amount to the counter and returns the new value
@@ -8703,11 +8667,9 @@ S7::method(s7_add, S7Counter) <- function(x, amount, ...) {
     "'amount' must be numeric, logical, or raw" = is.numeric(amount) || is.logical(amount) || is.raw(amount),
     "'amount' must have length 1" = length(amount) == 1L
   )
-  {
-    .val <- .Call(C_S7Counter__s7_add, .call = match.call(), x@.ptr, amount)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Counter__s7_add, .call = match.call(), x@.ptr, amount)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
 }
 
 # S7Counter::default_counter (39:12)
@@ -8763,10 +8725,10 @@ if (!exists("label", mode = "function")) {
   label <- S7::new_generic("label", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(label, S7PropInner) <- function(x, ...) {
-    .val <- .Call(C_S7PropInner__label, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7PropInner__label, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7PropOuter` (s7_tests.rs:461:6)
 #' @title S7PropOuter S7 Class
@@ -8840,10 +8802,10 @@ if (!exists("value", mode = "function")) {
   value <- S7::new_generic("value", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(value, S7Fahrenheit) <- function(x, ...) {
-    .val <- .Call(C_S7Fahrenheit__value, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Fahrenheit__value, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Fahrenheit::to_celsius (244:12)
 #' @title Convert Fahrenheit to Celsius
@@ -8855,10 +8817,10 @@ if (!exists("to_celsius", mode = "function")) {
   to_celsius <- S7::new_generic("to_celsius", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(to_celsius, S7Fahrenheit) <- function(x, ...) {
-    .val <- .Call(C_S7Fahrenheit__to_celsius, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Fahrenheit__to_celsius, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Fahrenheit::from_celsius (235:12)
 #' @title Convert Fahrenheit from Celsius
@@ -8936,10 +8898,10 @@ if (!exists("shape_kind", mode = "function")) {
   shape_kind <- S7::new_generic("shape_kind", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(shape_kind, Shape) <- function(x, ...) {
-    .val <- .Call(C_S7OverrideShape__shape_kind, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7OverrideShape__shape_kind, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7OverrideCircle` (s7_tests.rs:413:6)
 #' @title S7OverrideCircle S7 Class
@@ -8981,10 +8943,10 @@ if (!exists("override_radius", mode = "function")) {
   override_radius <- S7::new_generic("override_radius", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(override_radius, S7OverrideCircle) <- function(x, ...) {
-    .val <- .Call(C_S7OverrideCircle__override_radius, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7OverrideCircle__override_radius, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7Dog` (s7_tests.rs:332:6)
 #' @title S7Dog S7 Class
@@ -9026,10 +8988,10 @@ if (!exists("dog_breed", mode = "function")) {
   dog_breed <- S7::new_generic("dog_breed", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(dog_breed, S7Dog) <- function(x, ...) {
-    .val <- .Call(C_S7Dog__dog_breed, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Dog__dog_breed, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7Dog::bark (344:12)
 #' @title All dogs bark
@@ -9041,10 +9003,10 @@ if (!exists("bark", mode = "function")) {
   bark <- S7::new_generic("bark", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(bark, S7Dog) <- function(x, ...) {
-    .val <- .Call(C_S7Dog__bark, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7Dog__bark, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `S7GoldenRetriever` (s7_tests.rs:357:6)
 #' @title S7GoldenRetriever S7 Class
@@ -9086,10 +9048,10 @@ if (!exists("retriever_name", mode = "function")) {
   retriever_name <- S7::new_generic("retriever_name", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(retriever_name, S7GoldenRetriever) <- function(x, ...) {
-    .val <- .Call(C_S7GoldenRetriever__retriever_name, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7GoldenRetriever__retriever_name, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # S7GoldenRetriever::color (369:12)
 #' @title Returns the coat color
@@ -9101,10 +9063,10 @@ if (!exists("color", mode = "function")) {
   color <- S7::new_generic("color", "x", function(x, ...) S7::S7_dispatch())
 }
 S7::method(color, S7GoldenRetriever) <- function(x, ...) {
-    .val <- .Call(C_S7GoldenRetriever__color, .call = match.call(), x@.ptr)
-    if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
-    .val
-  }
+  .val <- .Call(C_S7GoldenRetriever__color, .call = match.call(), x@.ptr)
+  if (inherits(.val, "rust_condition_value") && isTRUE(attr(.val, "__rust_condition__"))) return(.miniextendr_raise_condition(.val, sys.call()))
+  .val
+}
 
 # Generated from Rust impl `RngSampler` (rng_tests.rs:90:6)
 #' @title RngSampler  Class


### PR DESCRIPTION
## Summary

Completes the consolidation started in Flight 5C: S4 and S7 instance
methods now use `MethodContext::emit_method_prelude` like the other
five class generators, dropping the inline-vs-block branching that
was kept around to avoid a doubled `{ ... }` wrap.

## What changes

**`miniextendr-macros/src/miniextendr_impl/s4_class.rs`** —
single instance-method emission site. Drops the `if prelude_needed { … } else { inline }`
branch; always emits the block form.

**`miniextendr-macros/src/miniextendr_impl/s7_class.rs`** —
two instance-method sites (external generic + new generic). Same drop.
S7 `convert_from` / `convert_to` keep `build_s7_inline` since they
emit `function(from, to, ...) <return_expr>` inline without an outer
block.

**`miniextendr-macros/src/method_return_builder.rs`** —
new `build_s7_body` / `build_s4_body` methods returning
`Vec<String>` body lines for embedding inside the outer
`function(...) { ... }`. Mirrors the existing `build_r6_body` /
`build_s3_body` pattern. Inline variants are retained for the
\`convert\` sites that need a single-expression body.

## Snapshot diffs

`snapshot_s4_basic` and `snapshot_s7_basic` re-indent the method
body from 4-space (legacy inline-block style) to 2-space (matching
R6 / S3). Functionally identical R code:

\`\`\`r
# before
S7::method(get, Counter) <- function(x, ...) {
    .val <- .Call(C_Counter__get, .call = match.call(), x@.ptr)
    if (inherits(.val, ...) ...) return(...)
    .val
  }

# after
S7::method(get, Counter) <- function(x, ...) {
  .val <- .Call(C_Counter__get, .call = match.call(), x@.ptr)
  if (inherits(.val, ...) ...) return(...)
  .val
}
\`\`\`

## Test plan

- [x] \`cargo test -p miniextendr-macros\` — 316 passed
- [x] \`cargo clippy -p miniextendr-macros --all-targets --locked -- -D warnings\` — clean
- [ ] CI green

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)