### PR TITLE
fix(minirextendr): YAML-safe working-directory insertion in release workflow

### DIFF
--- a/minirextendr/R/use-release-workflow.R
+++ b/minirextendr/R/use-release-workflow.R
@@ -113,6 +113,10 @@ use_release_workflow <- function(path = ".", rpkg_subdir = NULL,
 #' @return Modified character vector.
 #' @noRd
 release_workflow_insert_workdir <- function(lines, subdir) {
+  # Insert `working-directory:` *before* the matched `run:` line. Inserting
+  # after breaks the build step: `run: |` starts a block scalar that would
+  # absorb a following same-indent line as text, leaving the step with no
+  # actual `run` value. Same-level sibling keys must precede the block scalar.
   wd_line <- paste0("        working-directory: ", subdir)
   result <- character(0)
   i <- 1L
@@ -124,10 +128,10 @@ release_workflow_insert_workdir <- function(lines, subdir) {
     is_configure_step <- grepl("^        run: bash \\./configure\\s*$", line)
     is_build_step <- grepl("^        run: \\|\\s*$", line) &&
       i < length(lines) && grepl("R CMD build", lines[[i + 1L]])
-    result <- c(result, line)
     if (is_configure_step || is_build_step) {
       result <- c(result, wd_line)
     }
+    result <- c(result, line)
     i <- i + 1L
   }
   result

--- a/minirextendr/tests/testthat/test-monorepo-gaps.R
+++ b/minirextendr/tests/testthat/test-monorepo-gaps.R
@@ -239,13 +239,16 @@ test_that("B3: release_workflow_insert_workdir() adds working-directory to confi
   )
   result <- minirextendr:::release_workflow_insert_workdir(lines, "rpkg")
 
+  # working-directory is inserted *before* the matched `run:` line. Same-level
+  # sibling keys must precede a `run: |` block scalar — see the comment on
+  # release_workflow_insert_workdir() for the rationale.
   cfg_idx <- which(grepl("run: bash ./configure", result, fixed = TRUE))
   expect_true(length(cfg_idx) > 0)
-  expect_match(result[[cfg_idx + 1L]], "working-directory: rpkg")
+  expect_match(result[[cfg_idx - 1L]], "working-directory: rpkg")
 
   build_idx <- which(grepl("run: |", result, fixed = TRUE))
   expect_true(length(build_idx) > 0)
-  expect_match(result[[build_idx + 1L]], "working-directory: rpkg")
+  expect_match(result[[build_idx - 1L]], "working-directory: rpkg")
 })
 
 test_that("B3: use_release_workflow() with rpkg_subdir inserts working-directory", {
@@ -332,6 +335,56 @@ test_that("B3: use_release_workflow() standalone auto-detect (no Cargo.toml) is 
   lines <- readLines(dest, warn = FALSE)
   wd_lines <- grep("working-directory:", lines, value = TRUE)
   expect_equal(length(wd_lines), 0L)
+})
+
+# B3-yaml: structural YAML verification — guards against template drift that
+# would silently break release_workflow_insert_workdir()'s line-string matcher.
+# We use yaml::read_yaml() for *verification only* (no round-trip write — that
+# would lose the 50+ inline comments in the template). If this test fails, the
+# template's job/step structure has shifted; update either the matcher or this
+# assertion accordingly. See #524.
+test_that("B3: patched workflow parses as YAML with working-directory on each configure + build step", {
+  skip_if_not_installed("yaml")
+  tmp <- withr::local_tempdir()
+
+  use_release_workflow(path = tmp, rpkg_subdir = "rpkg")
+  dest <- file.path(tmp, ".github", "workflows", "r-release.yml")
+
+  parsed <- yaml::read_yaml(dest)
+  expect_true("jobs" %in% names(parsed),
+              info = "Top-level `jobs:` key missing — template structure changed")
+
+  # Collect every step across all jobs. Each step is a list; we look for steps
+  # whose `run` value mentions `bash ./configure` or `R CMD build`, and assert
+  # they have `working-directory: rpkg` set.
+  configure_steps <- list()
+  build_steps <- list()
+  for (job_name in names(parsed$jobs)) {
+    steps <- parsed$jobs[[job_name]]$steps %||% list()
+    for (step in steps) {
+      run_val <- step$run %||% ""
+      if (grepl("bash \\./configure", run_val)) {
+        configure_steps[[length(configure_steps) + 1L]] <- step
+      }
+      if (grepl("R CMD build", run_val)) {
+        build_steps[[length(build_steps) + 1L]] <- step
+      }
+    }
+  }
+
+  expect_true(length(configure_steps) > 0,
+              info = "No `bash ./configure` step found in any job")
+  expect_true(length(build_steps) > 0,
+              info = "No `R CMD build` step found in any job")
+
+  for (step in configure_steps) {
+    expect_identical(step[["working-directory"]], "rpkg",
+                     info = "configure step missing or has wrong working-directory")
+  }
+  for (step in build_steps) {
+    expect_identical(step[["working-directory"]], "rpkg",
+                     info = "build step missing or has wrong working-directory")
+  }
 })
 
 # endregion ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes a structural bug in `release_workflow_insert_workdir()` where `working-directory:` was inserted **after** `run: |` for the build step. The block-scalar absorbed the new line as part of the run text, leaving the step with no actual `run` field (silently broken in CI).
- Moves insertion *before* the matched `run:` line so the new key is a same-level sibling.
- Adds a YAML structural guardrail test that parses the patched workflow and asserts every configure + build step carries `working-directory: rpkg`. No round-trip write — the template has 50+ inline comments that would be lost.

## Detail

`run: |` opens a block scalar whose content boundary is set by the indent of its first content line. The previous insertion order was:

```yaml
      - name: Build and check
        run: |
        working-directory: rpkg       # ← absorbed as part of the run text
          R CMD build .
          R CMD check ...
```

`yaml::read_yaml()` saw `working-directory: rpkg\n  R CMD build .\n  R CMD check ...` as the run value, with no sibling `working-directory` key. GitHub Actions would run the step with no command. The fix places the key first:

```yaml
      - name: Build and check
        working-directory: rpkg
        run: |
          R CMD build .
          R CMD check ...
```

The unit test for `release_workflow_insert_workdir()` was adjusted to expect the new ordering. New `B3-yaml` test in `test-monorepo-gaps.R` asserts the parsed YAML matches structural expectations across both jobs.

I considered the full structural-patch refactor proposed in the issue but it would have to round-trip through `yaml::write_yaml()` and lose the template's inline comments — a real regression. The verification-only test plus the targeted fix addresses the same risk (template drift breaks the matcher → tests fail loudly).

Closes #524.

## Test plan

- [x] `R -e 'devtools::test_active_file("minirextendr/tests/testthat/test-monorepo-gaps.R")'` — 34 PASS / 0 FAIL
- [ ] CI sync + standard checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)