### PR TITLE
fix(serde): round-trip Vec<Vec<scalar>> with length-1 inner vecs

### DIFF
--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -797,9 +797,7 @@ impl<'de> de::Deserializer<'de> for VectorElementDeserializer {
     /// a sequence and we hold a single scalar, we yield it as a 1-element
     /// sequence.
     fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_seq(VectorElementSeqAccess {
-            de: Some(self),
-        })
+        visitor.visit_seq(VectorElementSeqAccess { de: Some(self) })
     }
 
     fn deserialize_tuple<V: Visitor<'de>>(

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -788,10 +788,73 @@ impl<'de> de::Deserializer<'de> for VectorElementDeserializer {
         }
     }
 
+    /// Treat a coalesced scalar element as a 1-element sequence.
+    ///
+    /// `SeqSerializer::end()` coalesces `Vec<T>` with length-1 scalar elements
+    /// into a flat atomic vector. That makes `Vec<Vec<scalar>>` with all
+    /// length-1 inner vecs serialize to the same flat atomic vector as
+    /// `Vec<scalar>`. To round-trip correctly, when the target type asks for
+    /// a sequence and we hold a single scalar, we yield it as a 1-element
+    /// sequence.
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_seq(VectorElementSeqAccess {
+            de: Some(self),
+        })
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        if len != 1 {
+            return Err(RSerdeError::LengthMismatch {
+                expected: len,
+                actual: 1,
+            });
+        }
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_tuple(len, visitor)
+    }
+
     serde::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf
-        option unit unit_struct newtype_struct seq tuple tuple_struct map struct
+        option unit unit_struct newtype_struct map struct
         enum identifier ignored_any
+    }
+}
+
+/// SeqAccess that yields a single `VectorElementDeserializer` then None.
+///
+/// Used when a scalar element of a coalesced atomic vector must round-trip
+/// as a 1-element sequence (the inverse of `SeqSerializer::end()` coalescing).
+struct VectorElementSeqAccess {
+    de: Option<VectorElementDeserializer>,
+}
+
+impl<'de> SeqAccess<'de> for VectorElementSeqAccess {
+    type Error = RSerdeError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        match self.de.take() {
+            Some(de) => seed.deserialize(de).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(if self.de.is_some() { 1 } else { 0 })
     }
 }
 

--- a/miniextendr-api/tests/serde_nested_vec.rs
+++ b/miniextendr-api/tests/serde_nested_vec.rs
@@ -1,0 +1,140 @@
+//! Regression tests for nested-Vec serde round-tripping.
+//!
+//! `SeqSerializer::end()` calls `List::from_scalars_or_list`, which coalesces
+//! length-1 same-typed scalars into an R atomic vector. That means
+//! `Vec<Vec<i32>>` with all-length-1 inner vecs serializes to a flat INTSXP.
+//! Without symmetric handling on the deserializer side, the inner
+//! `deserialize_seq` is called on a scalar `VectorElementDeserializer` and
+//! fails with "invalid type: integer N, expected a sequence".
+//!
+//! These tests exercise the round-trip for that and related shapes.
+
+mod r_test_utils;
+
+use miniextendr_api::serde::{from_r, to_r};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct WithNestedVecUsize {
+    nested: Vec<Vec<usize>>,
+}
+
+#[test]
+fn nested_vec_usize_all_singletons() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecUsize {
+            nested: vec![vec![56], vec![73], vec![158]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecUsize = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[test]
+fn nested_vec_usize_singleton_outer() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecUsize {
+            nested: vec![vec![42]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecUsize = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[test]
+fn nested_vec_usize_mixed_lengths() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecUsize {
+            nested: vec![vec![1], vec![2, 3], vec![4, 5, 6]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecUsize = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[test]
+fn nested_vec_usize_empty_inner() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecUsize {
+            nested: vec![vec![], vec![1], vec![]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecUsize = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct WithNestedVecF64 {
+    nested: Vec<Vec<f64>>,
+}
+
+#[test]
+fn nested_vec_f64_all_singletons() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecF64 {
+            nested: vec![vec![1.5], vec![2.5], vec![3.5]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecF64 = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct WithNestedVecString {
+    nested: Vec<Vec<String>>,
+}
+
+#[test]
+fn nested_vec_string_all_singletons() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithNestedVecString {
+            nested: vec![
+                vec!["a".to_string()],
+                vec!["b".to_string()],
+                vec!["c".to_string()],
+            ],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithNestedVecString = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct WithTriplyNested {
+    deep: Vec<Vec<Vec<i32>>>,
+}
+
+#[test]
+fn triply_nested_vec_all_singletons() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithTriplyNested {
+            deep: vec![vec![vec![1]], vec![vec![2]]],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithTriplyNested = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct WithTupleOfScalars {
+    pairs: Vec<(i32, i32)>,
+}
+
+#[test]
+fn vec_of_tuple_pairs_roundtrips() {
+    r_test_utils::with_r_thread(|| {
+        let value = WithTupleOfScalars {
+            pairs: vec![(1, 2), (3, 4), (5, 6)],
+        };
+        let sexp = to_r(&value).expect("serialize");
+        let back: WithTupleOfScalars = from_r(sexp).expect("deserialize");
+        assert_eq!(back, value);
+    });
+}

--- a/miniextendr-api/tests/serde_nested_vec.rs
+++ b/miniextendr-api/tests/serde_nested_vec.rs
@@ -9,6 +9,8 @@
 //!
 //! These tests exercise the round-trip for that and related shapes.
 
+#![cfg(feature = "serde")]
+
 mod r_test_utils;
 
 use miniextendr_api::serde::{from_r, to_r};


### PR DESCRIPTION
## Summary
- Fix a `from_r` deserialization failure for `Vec<Vec<T>>` (and `Vec<Vec<Vec<T>>>`, etc.) where every inner `Vec` has length 1.
- Add `tests/serde_nested_vec.rs` covering nested-vec round-trips for `usize` / `f64` / `String` / triply nested / tuple-pair / mixed-length / empty-inner shapes.

## Root cause
`SeqSerializer::end()` calls `List::from_scalars_or_list`, which coalesces all-length-1 same-typed scalar elements into a single atomic vector. So `Vec<Vec<i32>>` with inner vecs of length 1 serializes to a flat `INTSXP` — the same shape as `Vec<i32>`.

On the deserialization side, `VectorElementDeserializer` forwarded `seq`/`tuple`/`tuple_struct` to `deserialize_any`, which only knows how to emit scalars. When serde then asked an inner `Vec<T>` element to deserialize from the resulting `i32`/`f64`/etc. scalar, the `SeqVisitor` reported `invalid type: integer N, expected a sequence` and the round-trip blew up.

## Fix
Implement `deserialize_seq` / `deserialize_tuple` / `deserialize_tuple_struct` on `VectorElementDeserializer` so a scalar element is yielded as a 1-element sequence (via a new `VectorElementSeqAccess`). That mirrors the serializer's coalescing and makes nested-vec round-trips lossless.

## Discovery
Found while porting [hyperion](https://github.com/A2-ai/empyrean) — an R package binding NONMEM model parsing — to miniextendr. The `nonmem::Model` struct has `omega_initial_values: Vec<Vec<usize>>` and `tokens: Vec<Token>` whose serialized inner shape depends on the input model file. For some real inputs (e.g. `run-duplicate-omega-names.mod`), every inner `Vec` happened to have length 1, so `to_r` → `from_r` failed deterministically with `Failed to deserialize Model: invalid type: integer 56, expected a sequence`.

## Test plan
- [x] New `tests/serde_nested_vec.rs`: 5 of 8 tests fail on `main`, all 8 pass after the fix.
- [x] `cargo test -p miniextendr-api --features "serde,serde_json"`: 424 passed, 248 ignored, no regressions.