### PR TITLE
docs(release-workflow): document rpkg_subdir monorepo flow + YAML insertion rule

### DIFF
--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -283,3 +283,28 @@ The template targets AlmaLinux 8 (RHEL 8 family — common in enterprise release
 pipelines) and macOS arm64 (`macos-14`). Extend it with additional steps for
 your package's specific setup (R package installation, cargo caching, upload
 steps, etc.).
+
+## Monorepo layouts (`rpkg_subdir`)
+
+If the R package lives in a subdirectory of a Cargo workspace (the layout this
+repo uses — `rpkg/` under the workspace root), `bash ./configure` and `R CMD
+build` must run from inside that subdirectory. Pass `rpkg_subdir` to inject
+`working-directory:` on every relevant step:
+
+```r
+minirextendr::use_release_workflow(rpkg_subdir = "rpkg")
+```
+
+When `rpkg_subdir = NULL` (default) the call attempts auto-detection via
+`detect_project_type()`; pass `auto_detect_subdir = FALSE` to force standalone
+mode on a confirmed single-package layout.
+
+**Why the `working-directory:` key precedes `run:`** — the build step uses a
+`run: |` block scalar (`R CMD build .` + `R CMD check ...`). YAML resolves the
+scalar's content by the indent of its first line, so any same-indent line that
+follows `run: |` is absorbed into the scalar text instead of becoming a sibling
+mapping key. `release_workflow_insert_workdir()` inserts `working-directory:`
+*before* the matched `run:` line so it stays a peer of `run:`. The structural
+test in `minirextendr/tests/testthat/test-monorepo-gaps.R` parses the patched
+workflow with `yaml::read_yaml()` and asserts every configure and build step
+exposes `working-directory: <subdir>` as a real key.


### PR DESCRIPTION
## Summary

Follow-up to PR #648, which fixed a bug in `release_workflow_insert_workdir()` (`working-directory:` inserted *after* `run: |` was absorbed into the build step's block scalar). The flag flipped to "this contract was never documented" — \`docs/RELEASE_WORKFLOW.md\` covered the six platform gotchas but never mentioned the monorepo \`rpkg_subdir\` option at all.

This adds a short "Monorepo layouts" section that:

- Documents \`use_release_workflow(rpkg_subdir = "rpkg")\` for the layout this repo uses
- Explains the auto-detect vs explicit-subdir flow
- States the YAML insertion contract (\`working-directory:\` before \`run:\` — block-scalar absorption)
- Points at the structural YAML test that prevents the regression silently re-landing

Generates 1:1 to \`site/content/manual/release-workflow.md\` via \`scripts/docs-to-site.sh\`.

## Test plan

- [x] \`scripts/docs-to-site.sh\` runs clean and propagates the new section to \`site/content/manual/release-workflow.md\` (gitignored, generated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)