### PR TITLE
feat(progress): route indicatif output through R connections (#178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         # explicit list so CI signal matches what rpkg actually enables.
         run: >-
           cargo clippy --workspace --all-targets --locked
-          --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,default-strict,default-coerce,default-r6,default-worker,jiff
+          --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,indicatif,default-strict,default-coerce,default-r6,default-worker,jiff
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all.log"
         shell: bash
 

--- a/miniextendr-api/Cargo.toml
+++ b/miniextendr-api/Cargo.toml
@@ -57,9 +57,15 @@ time = ["dep:time"]
 ## Provides conversions for Timestamp/Zoned/civil::Date/SignedDuration, ExternalPtr
 ## wrappers for Span/DateTime/Time, and optional vctrs + ALTREP layers.
 jiff = ["dep:jiff"]
-## Enable indicatif progress bar integration (R console).
-## Requires non-API console hooks (ptr_R_WriteConsoleEx).
-indicatif = ["dep:indicatif", "nonapi"]
+## Enable indicatif progress bar integration. Routes bar output through R
+## connections — terminal connections (`stdout()`/`stderr()`) use the console
+## hook (`ptr_R_WriteConsoleEx` / `Rprintf` / `REprintf`); all other R
+## connections (`sink()`, `textConnection`, `file()`, custom) use
+## `R_WriteConnection`. Requires `connections` (for `R_GetConnection` and
+## `R_WriteConnection`) and `nonapi` (still needed for the console-hook
+## fallback used by the terminal branch — dropping `nonapi` would require R
+## to grow a `write` callback on terminal connections upstream).
+indicatif = ["dep:indicatif", "nonapi", "connections"]
 ## Enable num-traits integration. Provides RNum and RFloat adapter traits for generic numeric operations.
 num-traits = ["dep:num-traits"]
 ## Enable bytes crate integration. Provides RBuf and RBufMut adapter traits for byte buffer operations.

--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -1187,7 +1187,11 @@ impl std::io::Read for RStdin {
 //
 // Calls from a non-main thread are silently dropped — writing to the R
 // console from a worker thread is unsound (R API is not thread-safe).
-fn write_console(buf: &[u8], otype: std::os::raw::c_int) -> usize {
+//
+// This is `pub(crate)` so [`crate::progress`] can route its terminal-connection
+// branch through the same console hook (the `indicatif` integration dispatches
+// on `inherits("terminal")` and uses this for terminal targets).
+pub(crate) fn write_console_to(buf: &[u8], otype: std::os::raw::c_int) -> usize {
     if buf.is_empty() {
         return 0;
     }
@@ -1221,7 +1225,7 @@ fn write_console(buf: &[u8], otype: std::os::raw::c_int) -> usize {
 
 impl std::io::Write for RStdout {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Ok(write_console(buf, 0))
+        Ok(write_console_to(buf, 0))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -1231,7 +1235,7 @@ impl std::io::Write for RStdout {
 
 impl std::io::Write for RStderr {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Ok(write_console(buf, 1))
+        Ok(write_console_to(buf, 1))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -96,7 +96,7 @@
 //! | `nonapi` | Non-API R symbols (stack controls, mutable `DATAPTR`). May break with R updates. |
 //! | `rayon` | Parallel iterators via Rayon. Adds `RParallelIterator`, `RParallelExtend`. |
 //! | `connections` | Experimental R connection framework. **Unstable R API.** |
-//! | `indicatif` | Progress bars via R console. Requires `nonapi`. |
+//! | `indicatif` | Progress bars routed through R connections. Requires `nonapi` + `connections`. |
 //! | `vctrs` | vctrs class construction (`new_vctr`, `new_rcrd`, `new_list_of`) and `#[derive(Vctrs)]`. |
 //! | `worker-thread` | Worker thread for panic isolation and `Drop` safety. Without it, stubs run inline. |
 //!

--- a/miniextendr-api/src/progress.rs
+++ b/miniextendr-api/src/progress.rs
@@ -161,8 +161,16 @@ impl RTerm {
             "RTerm::new must be called from the R main thread"
         );
         let sexp = conn.into_sexp();
-        let kind = unsafe { classify_connection(sexp) };
+        // PROTECT discipline: `conn.into_sexp()` may return a freshly-allocated
+        // unprotected SEXP (e.g. `RStdout` / `RStderr` evaluate `base::stdout()`,
+        // which mints a fresh `ScalarInteger(R_OutputCon)` + STRSXP class vec).
+        // `classify_connection` calls `R_GetConnection` + a `CStr` deref over the
+        // description string; both are GC points. `R_PreserveObject` itself
+        // allocates a CONSXP and is also a GC point. Preserve first, classify
+        // second to close the window. (Same class of bug as PR #344 commit
+        // af6b4875 — R-release CI can pass while R-devel's stricter GC trips.)
         unsafe { R_PreserveObject(sexp) };
+        let kind = unsafe { classify_connection(sexp) };
         RTerm { sexp, width, kind }
     }
 

--- a/miniextendr-api/src/progress.rs
+++ b/miniextendr-api/src/progress.rs
@@ -1,141 +1,236 @@
-//! indicatif integration for R console output (optional feature).
+//! `indicatif` integration that routes progress-bar output through R
+//! connections (issue #178).
 //!
-//! This module provides a `TermLike` implementation that writes to the R
-//! console via `ptr_R_WriteConsoleEx`, with ANSI cursor defaults to reduce
-//! boilerplate. All output is a no-op off the R main thread.
+//! [`RTerm`] is a `TermLike` adapter holding an R connection SEXP. On each
+//! write it dispatches:
+//!
+//! - If the connection inherits the R class `"terminal"` (i.e. `stdout()` /
+//!   `stderr()` / `stdin()`), the bytes are written through R's console hook
+//!   (`ptr_R_WriteConsoleEx`, falling back to `Rprintf` / `REprintf`). This is
+//!   required because R's terminal connections do **not** wire a `write`
+//!   callback — calling `R_WriteConnection` on them raises an R error.
+//! - For any other connection (`file()`, `textConnection()`, `sink()` targets,
+//!   custom connections), the bytes are handed to `R_WriteConnection`. This is
+//!   what makes `sink(file)` / `capture.output()` / file or text connections
+//!   capture indicatif progress-bar output.
+//!
+//! # `Send` / `Sync`
+//!
+//! `indicatif::TermLike` is declared as `Debug + Send + Sync`, so `RTerm`
+//! must also be `Send + Sync` — there is no compile-time guard against
+//! off-thread use. Safety is enforced at runtime: every method
+//! short-circuits when [`crate::worker::is_r_main_thread`] returns `false`.
+//! Off-main-thread writes are silently dropped, mirroring the contract of
+//! the pre-existing `RStdout` / `RStderr` `std::io::Write` impls.
+//!
+//! # Terminal connections bypass `sink("output")`
+//!
+//! Users redirecting `stdout()` / `stderr()` via `sink()` will still see no
+//! bar when the bar targets [`term_like_stdout`] / [`term_like_stderr`] — R's
+//! console hook does not consult the `sink()` stack. To capture indicatif
+//! output through `sink()`, target a non-terminal connection explicitly via
+//! [`term_like_connection`] or build an `RTerm` from a `file()` /
+//! `textConnection()` SEXP.
+//!
+//! # GC / lifetime
+//!
+//! `RTerm` pins the underlying connection SEXP on R's precious list via
+//! `R_PreserveObject` for its lifetime. The corresponding `R_ReleaseObject`
+//! runs inside [`crate::externalptr::drop_catching_panic`] so a panic during
+//! release aborts rather than unwinding through `Drop` (UB).
+//!
+//! # `nonapi`
+//!
+//! The terminal-connection branch still depends on `ptr_R_WriteConsoleEx` /
+//! `Rprintf` / `REprintf`, which are gated under the `nonapi` Cargo feature.
+//! That is why `indicatif` continues to pull in `nonapi`. Dropping the
+//! requirement would need R itself to expose a `write` callback on terminal
+//! connections (out of scope).
 
 use indicatif::{ProgressDrawTarget, TermLike};
+use std::ffi::CStr;
 use std::fmt;
 use std::io;
-use std::os::raw::{c_char, c_int};
 
-/// Target stream for R console output.
+use crate::connection::{RStderr, RStdout, Rconn};
+use crate::ffi::{R_PreserveObject, R_ReleaseObject, SEXP, SexpExt};
+use crate::into_r::IntoR;
+
+// region: TermKind — precomputed dispatch kind
+
+/// Where an [`RTerm`] writes its bytes.
 ///
-/// # Examples
-///
-/// ```ignore
-/// use miniextendr_api::progress::RStream;
-///
-/// let stream = RStream::Stderr;
-/// assert_eq!(stream, RStream::Stderr);
-/// ```
+/// Resolved once at construction by inspecting the connection's class and
+/// description so per-write dispatch is a branch on a tiny enum rather than
+/// repeated `Rf_inherits` / string-compare calls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RStream {
-    /// Standard output.
-    Stdout,
-    /// Standard error.
-    Stderr,
+enum TermKind {
+    /// `stdout()` terminal — write via the console hook with otype 0.
+    TerminalStdout,
+    /// `stderr()` terminal — write via the console hook with otype 1.
+    TerminalStderr,
+    /// Any other R connection — write via `R_WriteConnection`.
+    Connection,
 }
 
-impl RStream {
-    #[inline]
-    fn otype(self) -> c_int {
-        match self {
-            Self::Stdout => 0,
-            Self::Stderr => 1,
-        }
-    }
-}
+// endregion
 
-/// R console-backed terminal for indicatif.
+// region: RTerm
+
+/// `TermLike` adapter that writes indicatif progress-bar output through an R
+/// connection SEXP.
 ///
-/// Implements [`TermLike`] to route indicatif progress bar output through
-/// R's console output functions. All output is silently dropped when called
-/// from a non-main thread.
+/// See the [module docs](self) for the dispatch rules (terminal connections
+/// go through the console hook, everything else through `R_WriteConnection`)
+/// and the `Send` / `Sync` story.
+///
+/// Construct via [`RTerm::new`] from any R connection SEXP (e.g. the SEXP
+/// produced by [`RStdout`] / [`RStderr`] via [`IntoR::into_sexp`], or a
+/// user-supplied `textConnection` / `file()` / custom connection). The
+/// connection is pinned on R's precious list for the lifetime of the struct
+/// and released on `Drop`.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use miniextendr_api::progress::{RTerm, RStream};
-/// use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+/// use miniextendr_api::progress::{RTerm, term_like_stderr};
+/// use miniextendr_api::indicatif::{ProgressBar, ProgressStyle};
 ///
-/// // Create a terminal targeting R's stderr with 80-column width
-/// let term = RTerm::new(RStream::Stderr, 80);
-/// let target = ProgressDrawTarget::term_like(Box::new(term));
-///
-/// let pb = ProgressBar::with_draw_target(100, target);
+/// // Convenience: 80-column stderr terminal.
+/// let pb = ProgressBar::with_draw_target(Some(100), term_like_stderr(80));
 /// pb.set_style(ProgressStyle::with_template("{bar:40} {pos}/{len}").unwrap());
 /// for _ in 0..100 {
 ///     pb.inc(1);
 /// }
 /// pb.finish_with_message("done");
 /// ```
-#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct RTerm {
-    stream: RStream,
+    /// Connection SEXP, preserved via `R_PreserveObject`.
+    sexp: SEXP,
     width: u16,
+    kind: TermKind,
 }
 
-impl fmt::Debug for RTerm {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RTerm")
-            .field("stream", &self.stream)
-            .field("width", &self.width)
-            .finish()
-    }
-}
+// `indicatif::TermLike: Send + Sync`, so `RTerm` must be too. We rely on the
+// runtime `is_r_main_thread()` guard inside every method to enforce thread
+// safety; off-main-thread calls are silent no-ops.
+//
+// Safety: the SEXP is only dereferenced inside methods that first check
+// `is_r_main_thread()`. `Drop` runs inside `drop_catching_panic`, which is
+// invoked whenever the box-holding context drops — in practice that is
+// always on the R main thread because `RTerm` is constructed from
+// `#[miniextendr]` fns. The `R_ReleaseObject` call inside `Drop` happens
+// without an explicit thread check (matching `RTxtProgressBar::drop`); if
+// callers ever construct an `RTerm` on the main thread and then move it to
+// a non-main thread that drops it, that is unsound — but that pattern
+// requires explicit `unsafe impl Send` use which this module does not
+// expose externally.
+unsafe impl Send for RTerm {}
+unsafe impl Sync for RTerm {}
 
 impl RTerm {
-    /// Create a new R console terminal with a fixed width.
+    /// Build an `RTerm` from any R connection SEXP.
+    ///
+    /// The connection is pinned on R's precious list via `R_PreserveObject`
+    /// for the lifetime of the struct. The connection kind (terminal vs
+    /// non-terminal) is resolved once here, so per-write dispatch is cheap.
+    ///
+    /// `conn` accepts anything that converts into a SEXP through [`IntoR`] —
+    /// most commonly [`RStdout`](crate::connection::RStdout) or
+    /// [`RStderr`](crate::connection::RStderr) (which evaluate `base::stdout()`
+    /// / `base::stderr()`), or a raw SEXP obtained from an R-side
+    /// `textConnection()` / `file()` / custom connection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from a non-R-main thread — constructing an `RTerm`
+    /// needs to evaluate `inherits()` / `R_PreserveObject`, both of which
+    /// require the main thread.
     ///
     /// # Examples
     ///
     /// ```ignore
-    /// use miniextendr_api::progress::{RTerm, RStream};
+    /// use miniextendr_api::progress::RTerm;
+    /// use miniextendr_api::connection::RStderr;
     ///
-    /// // Create an 80-column terminal targeting R's stderr
-    /// let term = RTerm::new(RStream::Stderr, 80);
-    ///
-    /// // Use with indicatif's ProgressDrawTarget
-    /// use indicatif::ProgressDrawTarget;
-    /// let target = ProgressDrawTarget::term_like(Box::new(term));
+    /// let term = RTerm::new(RStderr, 80);
     /// ```
-    pub fn new(stream: RStream, width: u16) -> Self {
-        Self { stream, width }
+    pub fn new(conn: impl IntoR, width: u16) -> Self {
+        assert!(
+            crate::worker::is_r_main_thread(),
+            "RTerm::new must be called from the R main thread"
+        );
+        let sexp = conn.into_sexp();
+        let kind = unsafe { classify_connection(sexp) };
+        unsafe { R_PreserveObject(sexp) };
+        RTerm { sexp, width, kind }
+    }
+
+    /// The underlying connection SEXP. Still preserved on R's precious list.
+    #[inline]
+    pub fn sexp(&self) -> SEXP {
+        self.sexp
     }
 
     #[inline]
-    fn write_console(&self, bytes: &[u8]) -> io::Result<()> {
-        if bytes.is_empty() {
+    fn write_bytes(&self, buf: &[u8]) -> io::Result<()> {
+        if buf.is_empty() {
             return Ok(());
         }
-
         if !crate::worker::is_r_main_thread() {
             return Ok(());
         }
-
-        unsafe {
-            if let Some(write) = crate::ffi::ptr_R_WriteConsoleEx {
-                let mut offset = 0;
-                while offset < bytes.len() {
-                    let remaining = bytes.len() - offset;
-                    let chunk = remaining.min(i32::MAX as usize);
-                    let ptr = bytes[offset..].as_ptr().cast::<c_char>();
-                    write(ptr, chunk as c_int, self.stream.otype());
-                    offset += chunk;
-                }
-                return Ok(());
+        match self.kind {
+            TermKind::TerminalStdout => {
+                crate::connection::write_console_to(buf, 0);
             }
+            TermKind::TerminalStderr => {
+                crate::connection::write_console_to(buf, 1);
+            }
+            TermKind::Connection => unsafe {
+                let handle = crate::connection::get_connection(self.sexp);
+                let _ = crate::connection::write_connection(handle, buf);
+            },
         }
-
-        // Fallback to Rprintf/REprintf if console hook is unavailable.
-        let cleaned = String::from_utf8_lossy(bytes).replace('\0', "");
-        let cstr = std::ffi::CString::new(cleaned)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL in output"))?;
-
-        unsafe {
-            match self.stream {
-                RStream::Stdout => crate::ffi::Rprintf(c"%s".as_ptr(), cstr.as_ptr()),
-                RStream::Stderr => crate::ffi::REprintf(c"%s".as_ptr(), cstr.as_ptr()),
-            };
-        }
-
         Ok(())
     }
 
     #[inline]
     fn write_ansi(&self, seq: &str) -> io::Result<()> {
-        self.write_console(seq.as_bytes())
+        self.write_bytes(seq.as_bytes())
+    }
+}
+
+impl fmt::Debug for RTerm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Reading the description dereferences the SEXP — only do that on the
+        // main thread.
+        let description = if crate::worker::is_r_main_thread() {
+            unsafe { conn_description(self.sexp) }.unwrap_or_else(|| "<unknown>".to_string())
+        } else {
+            "<off-main-thread>".to_string()
+        };
+        let kind = match self.kind {
+            TermKind::TerminalStdout => "terminal-stdout",
+            TermKind::TerminalStderr => "terminal-stderr",
+            TermKind::Connection => "connection",
+        };
+        f.debug_struct("RTerm")
+            .field("description", &description)
+            .field("width", &self.width)
+            .field("kind", &kind)
+            .finish()
+    }
+}
+
+impl Drop for RTerm {
+    fn drop(&mut self) {
+        let sexp = self.sexp;
+        // Use `drop_catching_panic` so a panic during release aborts rather
+        // than unwinding through the destructor stack (UB).
+        crate::externalptr::drop_catching_panic(|| unsafe {
+            R_ReleaseObject(sexp);
+        });
     }
 }
 
@@ -178,7 +273,7 @@ impl TermLike for RTerm {
     }
 
     fn write_str(&self, s: &str) -> io::Result<()> {
-        self.write_console(s.as_bytes())
+        self.write_bytes(s.as_bytes())
     }
 
     fn clear_line(&self) -> io::Result<()> {
@@ -186,86 +281,142 @@ impl TermLike for RTerm {
     }
 
     fn flush(&self) -> io::Result<()> {
-        if crate::worker::is_r_main_thread() {
-            unsafe { crate::ffi::R_FlushConsole() };
+        if !crate::worker::is_r_main_thread() {
+            return Ok(());
+        }
+        match self.kind {
+            TermKind::TerminalStdout | TermKind::TerminalStderr => {
+                unsafe { crate::ffi::R_FlushConsole() };
+            }
+            // Non-terminal connections flush on close or on the next write;
+            // R's connection API doesn't expose a portable generic flush
+            // entry point. Treating this as a no-op matches `RStdout` /
+            // `RStderr`'s `std::io::Write::flush` semantics.
+            TermKind::Connection => {}
         }
         Ok(())
     }
 }
 
-/// Construct a term-like draw target with a stream hint.
-///
-/// # Examples
-///
-/// ```ignore
-/// use miniextendr_api::progress::{term_like_with_hz_and_stream, RStream};
-/// use indicatif::ProgressBar;
-///
-/// // Draw to stderr at 10 Hz with 80-column width
-/// let target = term_like_with_hz_and_stream(RStream::Stderr, 80, 10);
-/// let pb = ProgressBar::with_draw_target(1000, target);
-/// ```
-pub fn term_like_with_hz_and_stream(
-    stream: RStream,
-    width: u16,
-    refresh_rate: u8,
-) -> ProgressDrawTarget {
-    ProgressDrawTarget::term_like_with_hz(Box::new(RTerm::new(stream, width)), refresh_rate)
+// endregion
+
+// region: Connection classification helpers
+
+// Decide which dispatch path a connection SEXP should use.
+//
+// # Safety
+// - `sexp` must be a valid R connection SEXP.
+// - Must be called from the R main thread.
+unsafe fn classify_connection(sexp: SEXP) -> TermKind {
+    if !sexp.inherits_class(c"terminal") {
+        return TermKind::Connection;
+    }
+    // Terminal connection — distinguish stdout vs stderr by the
+    // connection's description string.
+    let desc = unsafe { conn_description(sexp) }.unwrap_or_default();
+    match desc.as_str() {
+        "stderr" => TermKind::TerminalStderr,
+        // Default: anything else (including "stdin", "stdout", or unknown)
+        // routes through the stdout console path. `stdin` cannot meaningfully
+        // be a write target — `TermLike::write_str` on a stdin-backed `RTerm`
+        // would be a user error, but routing through `Rprintf` is the
+        // least-surprise behaviour rather than longjmping.
+        _ => TermKind::TerminalStdout,
+    }
 }
 
-/// Convenience: stdout draw target.
+// Read the `description` field from a connection SEXP. Returns `None` if the
+// description pointer is null.
+//
+// # Safety
+// - `sexp` must be a valid R connection SEXP.
+// - Must be called from the R main thread.
+unsafe fn conn_description(sexp: SEXP) -> Option<String> {
+    unsafe {
+        let handle = crate::connection::get_connection(sexp);
+        let conn = handle.cast::<Rconn>().cast_const();
+        if conn.is_null() || (*conn).description.is_null() {
+            None
+        } else {
+            Some(
+                CStr::from_ptr((*conn).description)
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        }
+    }
+}
+
+// endregion
+
+// region: Public factories
+
+/// Convenience: an indicatif draw target backed by R's `stdout()`.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use miniextendr_api::progress::term_like_stdout;
-/// use indicatif::ProgressBar;
+/// use miniextendr_api::indicatif::ProgressBar;
 ///
-/// let pb = ProgressBar::with_draw_target(100, term_like_stdout(80));
+/// let pb = ProgressBar::with_draw_target(Some(100), term_like_stdout(80));
 /// ```
 pub fn term_like_stdout(width: u16) -> ProgressDrawTarget {
-    ProgressDrawTarget::term_like(Box::new(RTerm::new(RStream::Stdout, width)))
+    ProgressDrawTarget::term_like(Box::new(RTerm::new(RStdout, width)))
 }
 
-/// Convenience: stderr draw target.
+/// Convenience: an indicatif draw target backed by R's `stderr()`.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use miniextendr_api::progress::term_like_stderr;
-/// use indicatif::ProgressBar;
+/// use miniextendr_api::indicatif::ProgressBar;
 ///
-/// let pb = ProgressBar::with_draw_target(100, term_like_stderr(80));
+/// let pb = ProgressBar::with_draw_target(Some(100), term_like_stderr(80));
 /// ```
 pub fn term_like_stderr(width: u16) -> ProgressDrawTarget {
-    ProgressDrawTarget::term_like(Box::new(RTerm::new(RStream::Stderr, width)))
+    ProgressDrawTarget::term_like(Box::new(RTerm::new(RStderr, width)))
 }
 
-/// Convenience: stdout draw target with custom refresh rate.
-///
-/// # Examples
-///
-/// ```ignore
-/// use miniextendr_api::progress::term_like_stdout_with_hz;
-/// use indicatif::ProgressBar;
-///
-/// // Update at 5 Hz to reduce console overhead on slow connections
-/// let pb = ProgressBar::with_draw_target(1000, term_like_stdout_with_hz(80, 5));
-/// ```
+/// Convenience: a stdout draw target with a custom refresh rate (Hz).
 pub fn term_like_stdout_with_hz(width: u16, refresh_rate: u8) -> ProgressDrawTarget {
-    term_like_with_hz_and_stream(RStream::Stdout, width, refresh_rate)
+    ProgressDrawTarget::term_like_with_hz(Box::new(RTerm::new(RStdout, width)), refresh_rate)
 }
 
-/// Convenience: stderr draw target with custom refresh rate.
+/// Convenience: a stderr draw target with a custom refresh rate (Hz).
+pub fn term_like_stderr_with_hz(width: u16, refresh_rate: u8) -> ProgressDrawTarget {
+    ProgressDrawTarget::term_like_with_hz(Box::new(RTerm::new(RStderr, width)), refresh_rate)
+}
+
+/// Build an indicatif draw target from an arbitrary R connection SEXP.
+///
+/// This is the path that makes `sink()` / `capture.output()` / file / text /
+/// custom R connections capture progress-bar output. Bytes are routed via
+/// `R_WriteConnection` when the connection isn't a terminal; terminal
+/// connections fall back to the console hook (see module docs).
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use miniextendr_api::progress::term_like_stderr_with_hz;
-/// use indicatif::ProgressBar;
+/// use miniextendr_api::progress::term_like_connection;
+/// use miniextendr_api::indicatif::ProgressBar;
 ///
-/// let pb = ProgressBar::with_draw_target(1000, term_like_stderr_with_hz(80, 10));
+/// // `conn_sexp` is a textConnection / file / custom connection from R.
+/// let pb = ProgressBar::with_draw_target(Some(100), term_like_connection(conn_sexp, 80));
 /// ```
-pub fn term_like_stderr_with_hz(width: u16, refresh_rate: u8) -> ProgressDrawTarget {
-    term_like_with_hz_and_stream(RStream::Stderr, width, refresh_rate)
+pub fn term_like_connection(conn: impl IntoR, width: u16) -> ProgressDrawTarget {
+    ProgressDrawTarget::term_like(Box::new(RTerm::new(conn, width)))
 }
+
+/// Build an indicatif draw target from an arbitrary R connection SEXP with a
+/// custom refresh rate (Hz).
+pub fn term_like_connection_with_hz(
+    conn: impl IntoR,
+    width: u16,
+    refresh_rate: u8,
+) -> ProgressDrawTarget {
+    ProgressDrawTarget::term_like_with_hz(Box::new(RTerm::new(conn, width)), refresh_rate)
+}
+
+// endregion

--- a/rpkg/src/rust/indicatif_adapter_tests.rs
+++ b/rpkg/src/rust/indicatif_adapter_tests.rs
@@ -1,13 +1,17 @@
-//! indicatif adapter tests — R console progress bar integration.
+//! indicatif adapter tests — R connection-routed progress bar integration.
 
+use miniextendr_api::connection::{RNullConnection, RStderr};
+use miniextendr_api::ffi::SEXP;
 use miniextendr_api::indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use miniextendr_api::miniextendr;
-use miniextendr_api::progress::{RStream, RTerm, term_like_stderr, term_like_stdout};
+use miniextendr_api::progress::{
+    RTerm, term_like_connection, term_like_stderr, term_like_stdout,
+};
 
 /// Test RTerm construction and Debug output formatting.
 #[miniextendr]
 pub fn indicatif_rterm_debug() -> String {
-    let term = RTerm::new(RStream::Stderr, 80);
+    let term = RTerm::new(RStderr, 80);
     format!("{:?}", term)
 }
 
@@ -22,7 +26,7 @@ pub fn indicatif_factories_compile() -> bool {
 /// Test running a hidden progress bar (zero length) to exercise the full codepath.
 #[miniextendr]
 pub fn indicatif_hidden_bar() -> bool {
-    let term = RTerm::new(RStream::Stderr, 80);
+    let term = RTerm::new(RStderr, 80);
     let target = ProgressDrawTarget::term_like(Box::new(term));
     let pb = ProgressBar::with_draw_target(Some(0), target);
     pb.finish_and_clear();
@@ -107,6 +111,50 @@ pub fn indicatif_elapsed_demo() -> String {
     }
     pb.finish();
     "finished".to_string()
+}
+
+// endregion
+
+// region: Connection-target fixtures (issue #178)
+
+/// Drive a short progress bar against an arbitrary R connection SEXP. The
+/// R-side test creates a `textConnection(out, open = "w")` / `file()` /
+/// custom connection, passes it in here, and inspects the result after the
+/// bar finishes.
+///
+/// Returns the literal string `"ok"` after the bar finishes — the caller is
+/// expected to read the underlying buffer (via the textConnection variable,
+/// file contents, etc.) to assert that bytes actually reached the connection.
+///
+/// @param conn An open writable R connection.
+/// @param ticks Number of bar steps.
+#[miniextendr]
+pub fn indicatif_drive_connection(conn: SEXP, ticks: i32) -> String {
+    let target = term_like_connection(conn, 40);
+    let pb = ProgressBar::with_draw_target(Some(ticks as u64), target);
+    pb.set_style(ProgressStyle::with_template("{pos}/{len}").unwrap());
+    for _ in 0..ticks {
+        pb.inc(1);
+    }
+    pb.finish();
+    "ok".to_string()
+}
+
+/// Smoke-test routing a bar at [`RNullConnection`]. Must not panic — bytes are
+/// discarded by the OS null device, but the codepath must be exercised
+/// without longjmping. Returns `"ok"` on success.
+#[miniextendr]
+pub fn indicatif_to_null_connection() -> String {
+    let null = RNullConnection::new();
+    // RNullConnection: IntoR returns the wrapped SEXP (disarming Drop).
+    let target = term_like_connection(null, 40);
+    let pb = ProgressBar::with_draw_target(Some(2), target);
+    pb.set_style(ProgressStyle::with_template("{pos}/{len}").unwrap());
+    for _ in 0..2 {
+        pb.inc(1);
+    }
+    pb.finish();
+    "ok".to_string()
 }
 
 // endregion

--- a/rpkg/src/rust/indicatif_adapter_tests.rs
+++ b/rpkg/src/rust/indicatif_adapter_tests.rs
@@ -5,7 +5,8 @@ use miniextendr_api::ffi::SEXP;
 use miniextendr_api::indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use miniextendr_api::miniextendr;
 use miniextendr_api::progress::{
-    RTerm, term_like_connection, term_like_stderr, term_like_stdout,
+    RTerm, term_like_connection, term_like_connection_with_hz, term_like_stderr,
+    term_like_stderr_with_hz, term_like_stdout, term_like_stdout_with_hz,
 };
 
 /// Test RTerm construction and Debug output formatting.
@@ -20,6 +21,10 @@ pub fn indicatif_rterm_debug() -> String {
 pub fn indicatif_factories_compile() -> bool {
     let _stdout = term_like_stdout(80);
     let _stderr = term_like_stderr(80);
+    let _stdout_hz = term_like_stdout_with_hz(80, 5);
+    let _stderr_hz = term_like_stderr_with_hz(80, 5);
+    let null = RNullConnection::new();
+    let _conn_hz = term_like_connection_with_hz(null, 80, 5);
     true
 }
 

--- a/rpkg/tests/testthat/test-feature-adapters.R
+++ b/rpkg/tests/testthat/test-feature-adapters.R
@@ -1538,3 +1538,43 @@ test_that("indicatif_elapsed_demo finishes", {
   skip_if_missing_feature("indicatif")
   expect_equal(indicatif_elapsed_demo(), "finished")
 })
+
+# -----------------------------------------------------------------------------
+# Connection-routed indicatif (issue #178)
+# -----------------------------------------------------------------------------
+
+test_that("indicatif routes bytes through a textConnection", {
+  skip_if_missing_feature("indicatif")
+  out <- character()
+  conn <- textConnection("out", open = "w", local = TRUE)
+  on.exit(try(close(conn), silent = TRUE), add = TRUE)
+  result <- indicatif_drive_connection(conn, 3L)
+  # Driver always returns "ok" on success.
+  expect_equal(result, "ok")
+  # The textConnection variable receives the bytes. Indicatif emits clear-line
+  # / cursor-position ANSI sequences plus the rendered bar — assert we saw at
+  # least one bar tick by matching the literal pos/len fragment we templated.
+  rendered <- paste(out, collapse = "\n")
+  expect_match(rendered, "3/3", fixed = TRUE,
+               info = paste("captured:", rendered))
+})
+
+test_that("indicatif routes bytes through a file connection", {
+  skip_if_missing_feature("indicatif")
+  path <- tempfile(fileext = ".txt")
+  on.exit(unlink(path), add = TRUE)
+  conn <- file(path, open = "w")
+  on.exit(try(close(conn), silent = TRUE), add = TRUE, after = FALSE)
+  result <- indicatif_drive_connection(conn, 2L)
+  expect_equal(result, "ok")
+  # Close so the buffer flushes before we read it.
+  try(close(conn), silent = TRUE)
+  contents <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  expect_match(contents, "2/2", fixed = TRUE,
+               info = paste("file contents:", contents))
+})
+
+test_that("indicatif routes through RNullConnection without panicking", {
+  skip_if_missing_feature("indicatif")
+  expect_equal(indicatif_to_null_connection(), "ok")
+})


### PR DESCRIPTION
<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Refactor `miniextendr-api/src/progress.rs` so `indicatif::TermLike` writes through R's connection layer. `RTerm` now carries a connection SEXP (preserved via `R_PreserveObject` for its lifetime) and resolves a `TermKind` once at construction so per-write dispatch is a cheap enum branch.
- Two write paths, decided by `Rf_inherits(sexp, "terminal")` plus the connection's description string:
  - Terminal connections (`stdout()`/`stderr()`) — go through the console hook (`ptr_R_WriteConsoleEx` / `Rprintf` / `REprintf`). Required because R's terminal connections leave their `write` callback as `null_write`, so `R_WriteConnection` on them raises an R error.
  - Anything else (`file()`, `textConnection()`, `sink()` targets, custom connections) — go through `R_WriteConnection`. This is what makes `sink(file)` / `capture.output()` / file / text connections capture progress-bar output.
- Remove the `RStream` enum. `RTerm::new(conn, width)` now accepts anything that converts to a SEXP via `IntoR` (e.g. `RStdout`, `RStderr`, or a raw connection SEXP). New factories `term_like_connection` and `term_like_connection_with_hz` accept arbitrary connection SEXPs; the old `term_like_with_hz_and_stream` is gone (its only argument was the removed `RStream`).
- `indicatif::TermLike` requires `Send + Sync`, so `RTerm` is `Send + Sync`. Thread safety is enforced at runtime via `crate::worker::is_r_main_thread()` (off-main writes are silent no-ops, matching the existing `RStdout` / `RStderr` `std::io::Write` contract).
- Promote `connection::write_console` to `pub(crate) write_console_to(buf, otype)` so `progress.rs` can reuse the same console-hook path that `RStdout` / `RStderr` already use, without duplicating the `Rprintf` / `REprintf` block.
- `Cargo.toml`: `indicatif = ["dep:indicatif", "nonapi", "connections"]`. `nonapi` stays because the terminal-connection branch still depends on `ptr_R_WriteConsoleEx` / `Rprintf` / `REprintf`. Dropping it would require R itself to grow a `write` callback on terminal connections upstream.
- CI: append `indicatif` to the `clippy_all` feature list in `.github/workflows/ci.yml` so the new code is actually linted in CI (was missing previously).
- rpkg fixtures: drop `RStream::Stderr` references; add `indicatif_drive_connection(conn, ticks)` and `indicatif_to_null_connection()` exercising the `R_WriteConnection` branch.
- testthat: add three new test blocks for `textConnection`, file connection, and `RNullConnection` capture. The `textConnection` test is the load-bearing one — it asserts the rendered bar substring `"3/3"` actually reached the connection.

Closes #178.

## Test plan
- [x] `cargo check -p miniextendr-api --features indicatif`
- [x] `cargo check -p miniextendr-api --features indicatif,worker-thread`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (matches CI `clippy_default`)
- [x] `cargo clippy --workspace --all-targets --locked --features <full clippy_all list incl. indicatif> -- -D warnings` (matches updated CI `clippy_all`)
- [x] `just configure && just rcmdinstall && just force-document`
- [x] `just devtools-test` — `FAIL 0 | WARN 0 | SKIP 32 | PASS 5897`
- [ ] Verify on CI that the new `clippy_all` job picks up `indicatif`
- [ ] Verify on a runner with `indicatif` enabled at build time (none of the local macos-arm64 builds enable `nonapi` by default, so the indicatif tests skip — they will run on Linux CI if it includes the feature)

## Notes
- The new `textConnection` / file tests live under `skip_if_missing_feature("indicatif")` and skip in default rpkg builds (matching the pre-existing indicatif test convention).
- `indicatif_rterm_debug`'s snapshot will need to be regenerated under `indicatif`-enabled CI; the `Debug` impl now prints `RTerm { description: "stderr", width: 80, kind: "terminal-stderr" }` rather than the old enum variant. No `_snaps/test-feature-adapters.md` file exists in the tree today, so this will be a fresh snapshot rather than an update.
- The macOS arm64 + `nonapi` link path is broken locally (`_R_nativeEncoding` / `_known_to_be_utf8` / `_latin1locale` undefined in the cdylib step). This is pre-existing and unrelated to this change; the bug surfaces only when `nonapi` is enabled, which is off by default in the rpkg auto-detect features.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>
