### PR TITLE
fix(build): skip link_to_r() on wasm32 targets (#482)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -48,12 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # build.rs:64 unconditionally runs `R RHOME`; $RUNNER_TEMP is always a
-      # real directory so Path::new(&r_home).is_dir() passes. cargo check never
-      # links, so the dummy value is sufficient. Same pattern as rust-lint in ci.yml.
-      - name: Set dummy R_HOME
-        run: echo "R_HOME=$RUNNER_TEMP" >> "$GITHUB_ENV"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/miniextendr-api/build.rs
+++ b/miniextendr-api/build.rs
@@ -54,6 +54,16 @@ fn set_stack_size_flags() {
 }
 
 fn link_to_r() {
+    // Skip libR resolution on wasm32 targets (webR / wasm32-unknown-emscripten
+    // and friends). cargo check never links and the toolchain doesn't ship a
+    // host R, so the rest of this function is pure overhead/breakage there.
+    // Must use the env var, not `cfg!(target_arch = "wasm32")`: the cfg refers
+    // to the build script binary's host arch, not the requested cross-compile
+    // target. See issue #482.
+    if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        return;
+    }
+
     // Resolve R home directory.
     let r_home = if let Ok(val) = env::var("R_HOME") {
         val

--- a/miniextendr-engine/build.rs
+++ b/miniextendr-engine/build.rs
@@ -12,6 +12,16 @@ fn main() {
 
 /// Resolves `R_HOME` and emits linker flags for libR.
 fn link_to_r() {
+    // Skip libR resolution on wasm32 targets (webR / wasm32-unknown-emscripten
+    // and friends). cargo check never links and the toolchain doesn't ship a
+    // host R, so the rest of this function is pure overhead/breakage there.
+    // Must use the env var, not `cfg!(target_arch = "wasm32")`: the cfg refers
+    // to the build script binary's host arch, not the requested cross-compile
+    // target. See issue #482.
+    if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        return;
+    }
+
     // Resolve R home directory.
     let r_home = if let Ok(val) = env::var("R_HOME") {
         val


### PR DESCRIPTION
Routes around the unconditional `R RHOME` call in both `miniextendr-api/build.rs` and `miniextendr-engine/build.rs` so `cargo check --target wasm32-unknown-emscripten` works on machines without R installed.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `miniextendr-api/build.rs` and `miniextendr-engine/build.rs`: early `return` from `link_to_r()` when `CARGO_CFG_TARGET_ARCH == "wasm32"`. Must use the env var, not `cfg!(target_arch = "wasm32")` — the cfg resolves to the build-script binary's host arch, not the requested cross-compile target.
- `.github/workflows/webr.yml`: drop the now-redundant `Set dummy R_HOME` step (5 lines + comments) — its only purpose was dodging the panic this guard eliminates.
- `.github/workflows/ci.yml::rust-lint`'s analogous `R_HOME=$RUNNER_TEMP` workaround is intentionally left alone. That job runs on native x86_64 Linux where `link_to_r()` legitimately needs R; the wasm32 guard doesn't help it.

Closes #482.

## Test plan
- [x] `cargo check --workspace --all-targets --locked` on native target
- [ ] CI verification: webR workflow no longer needs the dummy `R_HOME` and `cargo check --target wasm32-unknown-emscripten -p miniextendr-api` succeeds

## Notes
- Both `build.rs` files carried the same broken pattern. PR #481 (wasm32 detection in `configure.ac`) had touched a different file (`rpkg/src/rust/build.rs` template), so the framework-side scripts went uncovered.
- Stack-size flag setup in `set_stack_size_flags()` already falls through to `_ => {}` on emscripten/unknown OS, so no second guard is needed.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>