### PR TITLE
feat(configure): propagate ABI-only CFLAGS/CXXFLAGS into cargo [env]

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -470,6 +470,38 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- CFLAGS / CXXFLAGS: ABI-only allowlist from R config ----
+dnl Cargo applies CFLAGS_<target> and CXXFLAGS_<target> to *every* transitive
+dnl C/C++ build script (cc, cmake, etc.). R's raw CFLAGS contain R-specific
+dnl -I paths, R-private defines, and warning flags that have no business in
+dnl cargo deps. We allowlist a small set of ABI-affecting flags; everything
+dnl else is stripped. See issue #598 for the full rationale table.
+CARGO_ENV_ABI_CFLAGS=""
+CARGO_ENV_ABI_CXXFLAGS=""
+
+_r_cflags=`"${R_HOME}/bin/R" CMD config CFLAGS 2>/dev/null`
+_r_cxxflags=`"${R_HOME}/bin/R" CMD config CXXFLAGS 2>/dev/null`
+
+dnl Allowlist regex. Keep ABI-affecting flags only:
+dnl   -march=, -mtune=, -mfpmath=, -mfpu=, -mfloat-abi=, -mabi=, -m{sse,avx,ssse,pclmul,aes},
+dnl   -pthread, -D_REENTRANT, -fopenmp[=…]
+dnl No character classes are used (no `[...]`), so no m4 bracket escaping needed.
+_abi_allow_re='^-march=|^-mtune=|^-mfpmath=|^-mfpu=|^-mfloat-abi=|^-mabi=|^-msse|^-mavx|^-mssse|^-mpclmul|^-maes|^-pthread$|^-D_REENTRANT$|^-fopenmp'
+
+if test -n "$_r_cflags"; then
+  CARGO_ENV_ABI_CFLAGS=`echo "$_r_cflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+if test -n "$_r_cxxflags"; then
+  CARGO_ENV_ABI_CXXFLAGS=`echo "$_r_cxxflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+
+if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+  AC_MSG_NOTICE([cargo CFLAGS_<target>  = $CARGO_ENV_ABI_CFLAGS])
+fi
+if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+  AC_MSG_NOTICE([cargo CXXFLAGS_<target>= $CARGO_ENV_ABI_CXXFLAGS])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -583,6 +615,12 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+      echo "CFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CFLAGS\""
+    fi
+    if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+      echo "CXXFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CXXFLAGS\""
+    fi
     echo ""
   }
 
@@ -655,6 +693,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_ABI_CFLAGS="$CARGO_ENV_ABI_CFLAGS"
+ CARGO_ENV_ABI_CXXFLAGS="$CARGO_ENV_ABI_CXXFLAGS"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -522,6 +522,38 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- CFLAGS / CXXFLAGS: ABI-only allowlist from R config ----
+dnl Cargo applies CFLAGS_<target> and CXXFLAGS_<target> to *every* transitive
+dnl C/C++ build script (cc, cmake, etc.). R's raw CFLAGS contain R-specific
+dnl -I paths, R-private defines, and warning flags that have no business in
+dnl cargo deps. We allowlist a small set of ABI-affecting flags; everything
+dnl else is stripped. See issue #598 for the full rationale table.
+CARGO_ENV_ABI_CFLAGS=""
+CARGO_ENV_ABI_CXXFLAGS=""
+
+_r_cflags=`"${R_HOME}/bin/R" CMD config CFLAGS 2>/dev/null`
+_r_cxxflags=`"${R_HOME}/bin/R" CMD config CXXFLAGS 2>/dev/null`
+
+dnl Allowlist regex. Keep ABI-affecting flags only:
+dnl   -march=, -mtune=, -mfpmath=, -mfpu=, -mfloat-abi=, -mabi=, -m{sse,avx,ssse,pclmul,aes},
+dnl   -pthread, -D_REENTRANT, -fopenmp[=…]
+dnl No character classes are used (no `[...]`), so no m4 bracket escaping needed.
+_abi_allow_re='^-march=|^-mtune=|^-mfpmath=|^-mfpu=|^-mfloat-abi=|^-mabi=|^-msse|^-mavx|^-mssse|^-mpclmul|^-maes|^-pthread$|^-D_REENTRANT$|^-fopenmp'
+
+if test -n "$_r_cflags"; then
+  CARGO_ENV_ABI_CFLAGS=`echo "$_r_cflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+if test -n "$_r_cxxflags"; then
+  CARGO_ENV_ABI_CXXFLAGS=`echo "$_r_cxxflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+
+if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+  AC_MSG_NOTICE([cargo CFLAGS_<target>  = $CARGO_ENV_ABI_CFLAGS])
+fi
+if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+  AC_MSG_NOTICE([cargo CXXFLAGS_<target>= $CARGO_ENV_ABI_CXXFLAGS])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -635,6 +667,12 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+      echo "CFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CFLAGS\""
+    fi
+    if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+      echo "CXXFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CXXFLAGS\""
+    fi
     echo ""
   }
 
@@ -707,6 +745,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_ABI_CFLAGS="$CARGO_ENV_ABI_CFLAGS"
+ CARGO_ENV_ABI_CXXFLAGS="$CARGO_ENV_ABI_CXXFLAGS"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
+--- a/monorepo/rpkg/bootstrap.R	2026-05-19 21:13:10
++++ b/monorepo/rpkg/bootstrap.R	2026-05-19 21:13:10
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-17 13:41:31
-+++ b/monorepo/rpkg/configure.ac	2026-05-17 13:23:10
+--- a/monorepo/rpkg/configure.ac	2026-05-20 00:23:16
++++ b/monorepo/rpkg/configure.ac	2026-05-20 00:24:33
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -367,20 +367,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -500,4 +478,5 @@
+@@ -532,4 +510,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -716,5 +695,5 @@
+@@ -756,5 +735,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -732,13 +711,22 @@
+@@ -772,13 +751,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-17 13:41:31
-+++ b/rpkg/configure.ac	2026-05-17 13:21:51
+--- a/rpkg/configure.ac	2026-05-20 00:23:16
++++ b/rpkg/configure.ac	2026-05-20 00:23:57
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -589,20 +589,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -500,4 +530,5 @@
+@@ -532,4 +562,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -716,5 +747,5 @@
+@@ -756,5 +787,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -732,13 +763,22 @@
+@@ -772,13 +803,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2720,6 +2720,30 @@ esac
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+CARGO_ENV_ABI_CFLAGS=""
+CARGO_ENV_ABI_CXXFLAGS=""
+
+_r_cflags=`"${R_HOME}/bin/R" CMD config CFLAGS 2>/dev/null`
+_r_cxxflags=`"${R_HOME}/bin/R" CMD config CXXFLAGS 2>/dev/null`
+
+_abi_allow_re='^-march=|^-mtune=|^-mfpmath=|^-mfpu=|^-mfloat-abi=|^-mabi=|^-msse|^-mavx|^-mssse|^-mpclmul|^-maes|^-pthread$|^-D_REENTRANT$|^-fopenmp'
+
+if test -n "$_r_cflags"; then
+  CARGO_ENV_ABI_CFLAGS=`echo "$_r_cflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+if test -n "$_r_cxxflags"; then
+  CARGO_ENV_ABI_CXXFLAGS=`echo "$_r_cxxflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+
+if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: cargo CFLAGS_<target>  = $CARGO_ENV_ABI_CFLAGS" >&5
+printf '%s\n' "$as_me: cargo CFLAGS_<target>  = $CARGO_ENV_ABI_CFLAGS" >&6;}
+fi
+if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: cargo CXXFLAGS_<target>= $CARGO_ENV_ABI_CXXFLAGS" >&5
+printf '%s\n' "$as_me: cargo CXXFLAGS_<target>= $CARGO_ENV_ABI_CXXFLAGS" >&6;}
+fi
+
 
 as_dir=src/rust/.cargo; as_fn_mkdir_p
 
@@ -3410,6 +3434,8 @@ IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_ABI_CFLAGS="$CARGO_ENV_ABI_CFLAGS"
+ CARGO_ENV_ABI_CXXFLAGS="$CARGO_ENV_ABI_CXXFLAGS"
  SED="$SED"
 IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  R_HOME="$R_HOME"
@@ -3888,6 +3914,12 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
     fi
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+      echo "CFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CFLAGS\""
+    fi
+    if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+      echo "CXXFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CXXFLAGS\""
     fi
     echo ""
   }

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -492,6 +492,38 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- CFLAGS / CXXFLAGS: ABI-only allowlist from R config ----
+dnl Cargo applies CFLAGS_<target> and CXXFLAGS_<target> to *every* transitive
+dnl C/C++ build script (cc, cmake, etc.). R's raw CFLAGS contain R-specific
+dnl -I paths, R-private defines, and warning flags that have no business in
+dnl cargo deps. We allowlist a small set of ABI-affecting flags; everything
+dnl else is stripped. See issue #598 for the full rationale table.
+CARGO_ENV_ABI_CFLAGS=""
+CARGO_ENV_ABI_CXXFLAGS=""
+
+_r_cflags=`"${R_HOME}/bin/R" CMD config CFLAGS 2>/dev/null`
+_r_cxxflags=`"${R_HOME}/bin/R" CMD config CXXFLAGS 2>/dev/null`
+
+dnl Allowlist regex. Keep ABI-affecting flags only:
+dnl   -march=, -mtune=, -mfpmath=, -mfpu=, -mfloat-abi=, -mabi=, -m{sse,avx,ssse,pclmul,aes},
+dnl   -pthread, -D_REENTRANT, -fopenmp[=…]
+dnl No character classes are used (no `[...]`), so no m4 bracket escaping needed.
+_abi_allow_re='^-march=|^-mtune=|^-mfpmath=|^-mfpu=|^-mfloat-abi=|^-mabi=|^-msse|^-mavx|^-mssse|^-mpclmul|^-maes|^-pthread$|^-D_REENTRANT$|^-fopenmp'
+
+if test -n "$_r_cflags"; then
+  CARGO_ENV_ABI_CFLAGS=`echo "$_r_cflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+if test -n "$_r_cxxflags"; then
+  CARGO_ENV_ABI_CXXFLAGS=`echo "$_r_cxxflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'`
+fi
+
+if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+  AC_MSG_NOTICE([cargo CFLAGS_<target>  = $CARGO_ENV_ABI_CFLAGS])
+fi
+if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+  AC_MSG_NOTICE([cargo CXXFLAGS_<target>= $CARGO_ENV_ABI_CXXFLAGS])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -604,6 +636,12 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_ABI_CFLAGS"; then
+      echo "CFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CFLAGS\""
+    fi
+    if test -n "$CARGO_ENV_ABI_CXXFLAGS"; then
+      echo "CXXFLAGS_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_ABI_CXXFLAGS\""
+    fi
     echo ""
   }
 
@@ -676,6 +714,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_ABI_CFLAGS="$CARGO_ENV_ABI_CFLAGS"
+ CARGO_ENV_ABI_CXXFLAGS="$CARGO_ENV_ABI_CXXFLAGS"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----


### PR DESCRIPTION
Closes #598. Follow-up to PR #601 (the initial `[env]` block introduction).

Implements the strict ABI-only allowlist filter on R's `CFLAGS`/`CXXFLAGS` and emits the survivors as `CFLAGS_<target>` / `CXXFLAGS_<target>` in `src/rust/.cargo/config.toml`'s `[env]` table. Every transitive C/C++ build script in the cargo dep graph (`cc`, `cmake`, `bindgen`, ...) now sees R's ABI baseline — and nothing else.

<details>
<summary>AI-written rationale, validation evidence, and the full allowlist table</summary>

## Allowlist (the source of truth)

| Flag family | Decision | Rationale |
|---|---|---|
| `-march=*` | **KEEP** | Instruction-set baseline; ABI-affecting for SIMD intrinsics and vector struct layout. Mismatch → SIGILL or silent miscompiles. |
| `-mtune=*` | **KEEP** | Not strictly ABI but commonly paired with `-march`; harmless if R picked a value. |
| `-mfpmath=*`, `-mfpu=*` | **KEEP** | Float-ABI on 32-bit ARM and some legacy x86 (FPU-vs-SSE) — load-bearing where present. |
| `-msse*`, `-mavx*`, `-mssse*`, `-msse4*`, `-mpclmul`, `-maes` | **KEEP** | Same as `-march`. Matches what conda-forge / vendor channels actually set. |
| `-mabi=*` | **KEEP** | RISC-V / ARM hard-float vs soft-float ABI. Critical where present. |
| `-mfloat-abi=*` | **KEEP** | ARM hard/soft float — explicit ABI. |
| `-pthread` | **KEEP** | Thread-local storage layout / pthread struct sizes on glibc. |
| `-D_REENTRANT` | **KEEP** | Same family as `-pthread`; some platforms use it instead. |
| `-fopenmp`, `-fopenmp=*` | **KEEP** | OpenMP runtime presence affects struct layout and linkage. |
| `-I*` | **DROP** | R-specific include paths. Cargo deps must not see `R.h`/`Rinternals.h` by accident. |
| `-isystem*` | **DROP** | Same. |
| `-D_*` (other than `-D_REENTRANT`) | **DROP** | R-private feature-test macros (`_FORTIFY_SOURCE`, `_FILE_OFFSET_BITS`, ...). |
| `-DNDEBUG` | **DROP** | cargo's release profile handles this via `debug-assertions`. |
| `-W*` | **DROP** | Warning flags are not ABI. `R CMD check --as-cran` already objects to `-W*` in `PKG_CFLAGS`. |
| `-O*` | **DROP** | Optimisation level is a cargo profile concern. |
| `-g*` | **DROP** | Debug info is a cargo profile concern. |
| `-fPIC`, `-fpic` | **DROP** | Cargo already passes the right PIC flag for staticlib/cdylib. |
| `-fstack-protector*` | **DROP** | Hardening, not ABI. |
| `-fdebug-prefix-map=*`, `-ffile-prefix-map=*` | **DROP** | Build-reproducibility flags; meaningless for cargo deps. |
| `-fno-plt`, `-fno-stack-clash-protection`, `-fexceptions` | **DROP** | Codegen knobs, not ABI for staticlib/cdylib boundary. |
| `-arch *` (macOS) | **DROP** | Covered by the `*_<target>` env var name itself. |
| Everything else | **DROP** | Conservative default. |

Allowlist regex (POSIX BRE-friendly, no character classes so no m4 bracket escaping needed):
```
^-march=|^-mtune=|^-mfpmath=|^-mfpu=|^-mfloat-abi=|^-mabi=|^-msse|^-mavx|^-mssse|^-mpclmul|^-maes|^-pthread$|^-D_REENTRANT$|^-fopenmp
```

`-pthread$` and `-D_REENTRANT$` are anchored so they don't match longer prefixes like `-pthread-foo` or `-D_REENTRANTLY` (paranoid, but cheap).

## Filter pipeline

```sh
echo "$_r_cflags" | tr ' ' '\n' | grep -E "$_abi_allow_re" | tr '\n' ' ' | $SED 's/ *$//'
```

Chosen over a single `sed` because (a) sed alternation portability is patchy across BSD/GNU; (b) `grep -E` is universally available and matches one whole token at a time; (c) trailing-space cleanup keeps the emitted TOML tidy.

## Key casing decision

Cargo accepts both `CFLAGS_aarch64-apple-darwin` and `CFLAGS_AARCH64_APPLE_DARWIN` (cc-rs reads both). To stay consistent with the existing `AR_<target>` / `RANLIB_<target>` emission style in `emit_env_block`, we use the hyphenated-lowercase form (`$CARGO_ENV_RUST_TARGET`). Verified empirically — cc-rs's build-script output enumerates **both** forms when probing env:
```
cargo:rerun-if-env-changed=CFLAGS_aarch64_apple_darwin
cargo:rerun-if-env-changed=CFLAGS_aarch64-apple-darwin
```

## Filter unit tests (in-tree, no fixture needed)

Seven synthetic inputs reproduced via the same `tr | grep -E | tr | sed` pipe:

| Input shape | Output |
|---|---|
| Debian/Ubuntu CFLAGS (only `-mtune=generic`) | `-mtune=generic` |
| Conda-forge `-march=nocona -mtune=haswell` | `-march=nocona -mtune=haswell` |
| Rocker `-mavx2 -fopenmp -pthread -D_REENTRANT` | `-mavx2 -fopenmp -pthread -D_REENTRANT` |
| macOS homebrew (only `-I/opt/homebrew/include`) | `` (empty — no key emitted) |
| ARM `-mfloat-abi=hard -mfpu=neon -march=armv7-a` | `-mfloat-abi=hard -mfpu=neon -march=armv7-a` |
| `-D_REENTRANT -D_REENTRANTLY -D_REENTRANT_FOO` | `-D_REENTRANT` (anchored) |
| `-pthread -pthread-foo` | `-pthread` (anchored) |

## End-to-end `cc::Build` propagation evidence

A throwaway `cc-probe` crate (`cargo` + `build.rs` + `cc::Build::new().file("src/foo.c").compile("foo")`) was built three ways with `CC_ENABLE_DEBUG_OUTPUT=1` to capture the `cc` invocation cc-rs actually emits:

**Baseline (no `CFLAGS_*` set)**:
```
[cc-probe 0.0.0] CFLAGS_aarch64-apple-darwin = None
[cc-probe 0.0.0] running: env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "cc" "-O0" "-ffunction-sections" ... "-mmacosx-version-min=26.5" "-Wall" "-Wextra" "-o" ... "-c" "src/foo.c"
```
No `-march=`. cc-rs defaults to `-Wall -Wextra`.

**Override via env var `CFLAGS_aarch64-apple-darwin=-march=armv8.5-a`**:
```
[cc-probe 0.0.0] CFLAGS_aarch64-apple-darwin = Some(-march=armv8.5-a)
[cc-probe 0.0.0] running: env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "cc" "-O0" ... "-mmacosx-version-min=26.5" "-march=armv8.5-a" "-o" ... "-c" "src/foo.c"
```
`-march=armv8.5-a` reaches `cc`. Note `-Wall -Wextra` is replaced by user flags (validates dropping `-W*` from the allowlist — we don't want to re-inject distro warning flags).

**Via the actual code path — `.cargo/config.toml [env]`**:
```toml
[env]
"CFLAGS_aarch64-apple-darwin" = "-march=armv8.5-a -mtune=generic -fopenmp"
```
```
[cc-probe 0.0.0] CFLAGS_aarch64-apple-darwin = Some(-march=armv8.5-a -mtune=generic -fopenmp)
[cc-probe 0.0.0] running: env ... "cc" "-O0" ... "-march=armv8.5-a" "-mtune=generic" "-fopenmp" "-o" ... "-c" "src/foo.c"
```
All three tokens flow through cargo `[env]` → process env → cc-rs shlex → `cc` argv. End-to-end confirmed.

(Cleanup: the `cc-probe` crate lives only at `/tmp/598-fixture/` and is **not** added to the tree. Adding a permanent build-script test in `rpkg/` would entangle the rpkg build with a custom Cargo workspace member that doesn't earn its keep — the filter logic itself is shell, and the propagation is owned by cargo+cc-rs.)

## Configure-time integration test

Synthetic R shim returning CRAN-Debian-style CFLAGS:
```
R CMD config CFLAGS  → -I"/usr/share/R/include" -DNDEBUG -fpic -g -O2 \
  -fdebug-prefix-map=… -fstack-protector-strong -Wformat -Werror=format-security \
  -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -mtune=generic -march=haswell -mavx2 \
  -fopenmp -pthread
```

`R_HOME=/tmp/598-fake-r bash ./configure` →
```
configure: cargo CFLAGS_<target>  = -mtune=generic -march=haswell -mavx2 -fopenmp -pthread
configure: cargo CXXFLAGS_<target>= -mtune=generic -march=haswell -fopenmp
```

Resulting `src/rust/.cargo/config.toml [env]`:
```toml
CFLAGS_aarch64-apple-darwin = "-mtune=generic -march=haswell -mavx2 -fopenmp -pthread"
CXXFLAGS_aarch64-apple-darwin = "-mtune=generic -march=haswell -fopenmp"
```

Real `R CMD config CFLAGS` on this host (homebrew R 4.6 / macOS arm64):
```
$ R CMD config CFLAGS
-I/opt/homebrew/include
```
Filter strips to empty → no `CFLAGS_*` key emitted in the generated config.

## Validation summary

- [x] `just templates-check` — clean (exit 0)
- [x] `bash ./configure` — exit 0 on this host (homebrew R, no CFLAGS_* emitted as expected)
- [x] `bash ./configure` with synthetic CRAN-style CFLAGS shim — emits expected filtered values
- [x] `just rcmdinstall` — `* DONE (miniextendr)` end-to-end
- [x] cc::Build fixture proves `-march=` flows from `[env]` → process env → cc-rs → `cc` argv

## Out of scope (intentionally)

- `LDFLAGS_<target>` (R's `LDFLAGS` would need a similar but different allowlist; defer if/when users surface a real need).
- LTO propagation (#597).
- `force = true` (mirrors PR #601's no-force-floor stance — shell env always wins).
- A permanent in-tree `build.rs` cc-rs regression test (not earning its keep; the throwaway `cc-probe` evidence is in this PR body, and the filter is a tightly-bounded shell pipeline).

## Files touched

- `rpkg/configure.ac` — derivation block (+25 lines), `emit_env_block` extension (+6), variable-pass list (+2).
- `rpkg/configure` — regenerated via `autoconf`.
- `minirextendr/inst/templates/rpkg/configure.ac` — mirror.
- `minirextendr/inst/templates/monorepo/rpkg/configure.ac` — mirror.
- `patches/templates.patch` — regenerated via `just templates-approve` (line-number drift only).

</details>