### PR TITLE
feat(configure): mirror R's LTO flag into CARGO_PROFILE_<P>_LTO

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -470,6 +470,26 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- LTO: mirror R's --enable-lto into cargo profile LTO ----
+dnl R's `--enable-lto` substitutes a value into the LTO make variable
+dnl (typically `-flto`, but users can pass `LTO=-flto=thin` etc).
+dnl We map the flag space onto cargo's profile.lto values:
+dnl   -flto=thin              -> "thin"
+dnl   -flto=fat | -flto=full  -> "fat"
+dnl   -flto* (anything else)  -> "thin"  (conservative)
+dnl   empty                   -> ""      (no emission)
+CARGO_ENV_PROFILE_LTO=""
+_r_lto=`"${R_HOME}/bin/R" CMD config LTO 2>/dev/null`
+case "$_r_lto" in
+  *-flto=thin*)              CARGO_ENV_PROFILE_LTO="thin" ;;
+  *-flto=fat*|*-flto=full*)  CARGO_ENV_PROFILE_LTO="fat"  ;;
+  *-flto*)                   CARGO_ENV_PROFILE_LTO="thin" ;;
+  *)                         CARGO_ENV_PROFILE_LTO=""     ;;
+esac
+if test -n "$CARGO_ENV_PROFILE_LTO"; then
+  AC_MSG_NOTICE([R LTO flag           = $_r_lto (cargo profile lto: $CARGO_ENV_PROFILE_LTO)])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -583,6 +603,10 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_PROFILE_LTO"; then
+      CARGO_ENV_PROFILE_UPPER=`echo "$CARGO_PROFILE" | tr 'a-z' 'A-Z'`
+      echo "CARGO_PROFILE_${CARGO_ENV_PROFILE_UPPER}_LTO = \"$CARGO_ENV_PROFILE_LTO\""
+    fi
     echo ""
   }
 
@@ -655,6 +679,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_PROFILE_LTO="$CARGO_ENV_PROFILE_LTO"
+ CARGO_PROFILE="$CARGO_PROFILE"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -522,6 +522,26 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- LTO: mirror R's --enable-lto into cargo profile LTO ----
+dnl R's `--enable-lto` substitutes a value into the LTO make variable
+dnl (typically `-flto`, but users can pass `LTO=-flto=thin` etc).
+dnl We map the flag space onto cargo's profile.lto values:
+dnl   -flto=thin              -> "thin"
+dnl   -flto=fat | -flto=full  -> "fat"
+dnl   -flto* (anything else)  -> "thin"  (conservative)
+dnl   empty                   -> ""      (no emission)
+CARGO_ENV_PROFILE_LTO=""
+_r_lto=`"${R_HOME}/bin/R" CMD config LTO 2>/dev/null`
+case "$_r_lto" in
+  *-flto=thin*)              CARGO_ENV_PROFILE_LTO="thin" ;;
+  *-flto=fat*|*-flto=full*)  CARGO_ENV_PROFILE_LTO="fat"  ;;
+  *-flto*)                   CARGO_ENV_PROFILE_LTO="thin" ;;
+  *)                         CARGO_ENV_PROFILE_LTO=""     ;;
+esac
+if test -n "$CARGO_ENV_PROFILE_LTO"; then
+  AC_MSG_NOTICE([R LTO flag           = $_r_lto (cargo profile lto: $CARGO_ENV_PROFILE_LTO)])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -635,6 +655,10 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_PROFILE_LTO"; then
+      CARGO_ENV_PROFILE_UPPER=`echo "$CARGO_PROFILE" | tr 'a-z' 'A-Z'`
+      echo "CARGO_PROFILE_${CARGO_ENV_PROFILE_UPPER}_LTO = \"$CARGO_ENV_PROFILE_LTO\""
+    fi
     echo ""
   }
 
@@ -707,6 +731,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_PROFILE_LTO="$CARGO_ENV_PROFILE_LTO"
+ CARGO_PROFILE="$CARGO_PROFILE"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-17 13:14:25
+--- a/monorepo/rpkg/bootstrap.R	2026-05-19 21:12:56
++++ b/monorepo/rpkg/bootstrap.R	2026-05-19 21:12:56
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-17 13:41:31
-+++ b/monorepo/rpkg/configure.ac	2026-05-17 13:23:10
+--- a/monorepo/rpkg/configure.ac	2026-05-20 00:48:16
++++ b/monorepo/rpkg/configure.ac	2026-05-20 00:50:24
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -367,20 +367,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -500,4 +478,5 @@
+@@ -520,4 +498,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -716,5 +695,5 @@
+@@ -742,5 +721,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -732,13 +711,22 @@
+@@ -758,13 +737,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -406,8 +406,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-17 13:41:31
-+++ b/rpkg/configure.ac	2026-05-17 13:21:51
+--- a/rpkg/configure.ac	2026-05-20 00:48:16
++++ b/rpkg/configure.ac	2026-05-20 00:49:45
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -589,20 +589,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -500,4 +530,5 @@
+@@ -520,4 +550,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -716,5 +747,5 @@
+@@ -742,5 +773,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -732,13 +763,22 @@
+@@ -758,13 +789,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2720,6 +2720,19 @@ esac
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+CARGO_ENV_PROFILE_LTO=""
+_r_lto=`"${R_HOME}/bin/R" CMD config LTO 2>/dev/null`
+case "$_r_lto" in
+  *-flto=thin*)              CARGO_ENV_PROFILE_LTO="thin" ;;
+  *-flto=fat*|*-flto=full*)  CARGO_ENV_PROFILE_LTO="fat"  ;;
+  *-flto*)                   CARGO_ENV_PROFILE_LTO="thin" ;;
+  *)                         CARGO_ENV_PROFILE_LTO=""     ;;
+esac
+if test -n "$CARGO_ENV_PROFILE_LTO"; then
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: R LTO flag           = $_r_lto (cargo profile lto: $CARGO_ENV_PROFILE_LTO)" >&5
+printf '%s\n' "$as_me: R LTO flag           = $_r_lto (cargo profile lto: $CARGO_ENV_PROFILE_LTO)" >&6;}
+fi
+
 
 as_dir=src/rust/.cargo; as_fn_mkdir_p
 
@@ -3410,6 +3423,8 @@ IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_PROFILE_LTO="$CARGO_ENV_PROFILE_LTO"
+ CARGO_PROFILE="$CARGO_PROFILE"
  SED="$SED"
 IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"
  R_HOME="$R_HOME"
@@ -3888,6 +3903,10 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
     fi
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
+    fi
+    if test -n "$CARGO_ENV_PROFILE_LTO"; then
+      CARGO_ENV_PROFILE_UPPER=`echo "$CARGO_PROFILE" | tr 'a-z' 'A-Z'`
+      echo "CARGO_PROFILE_${CARGO_ENV_PROFILE_UPPER}_LTO = \"$CARGO_ENV_PROFILE_LTO\""
     fi
     echo ""
   }

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -492,6 +492,26 @@ dnl when R's values differ — otherwise we'd just add noise to the config.
 CARGO_ENV_R_AR=`"${R_HOME}/bin/R" CMD config AR 2>/dev/null`
 CARGO_ENV_R_RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB 2>/dev/null`
 
+dnl --- LTO: mirror R's --enable-lto into cargo profile LTO ----
+dnl R's `--enable-lto` substitutes a value into the LTO make variable
+dnl (typically `-flto`, but users can pass `LTO=-flto=thin` etc).
+dnl We map the flag space onto cargo's profile.lto values:
+dnl   -flto=thin              -> "thin"
+dnl   -flto=fat | -flto=full  -> "fat"
+dnl   -flto* (anything else)  -> "thin"  (conservative)
+dnl   empty                   -> ""      (no emission)
+CARGO_ENV_PROFILE_LTO=""
+_r_lto=`"${R_HOME}/bin/R" CMD config LTO 2>/dev/null`
+case "$_r_lto" in
+  *-flto=thin*)              CARGO_ENV_PROFILE_LTO="thin" ;;
+  *-flto=fat*|*-flto=full*)  CARGO_ENV_PROFILE_LTO="fat"  ;;
+  *-flto*)                   CARGO_ENV_PROFILE_LTO="thin" ;;
+  *)                         CARGO_ENV_PROFILE_LTO=""     ;;
+esac
+if test -n "$CARGO_ENV_PROFILE_LTO"; then
+  AC_MSG_NOTICE([R LTO flag           = $_r_lto (cargo profile lto: $CARGO_ENV_PROFILE_LTO)])
+fi
+
 dnl Individual env-derivation variables are propagated to AC_CONFIG_COMMANDS
 dnl via the trailing variable-pass list, and the [env] block body is composed
 dnl inline inside that shell context. Pre-composing here and passing a single
@@ -604,6 +624,10 @@ AC_CONFIG_COMMANDS([cargo-config],
     if test -n "$CARGO_ENV_R_RANLIB" && test "$CARGO_ENV_R_RANLIB" != "ranlib"; then
       echo "RANLIB_$CARGO_ENV_RUST_TARGET = \"$CARGO_ENV_R_RANLIB\""
     fi
+    if test -n "$CARGO_ENV_PROFILE_LTO"; then
+      CARGO_ENV_PROFILE_UPPER=`echo "$CARGO_PROFILE" | tr 'a-z' 'A-Z'`
+      echo "CARGO_PROFILE_${CARGO_ENV_PROFILE_UPPER}_LTO = \"$CARGO_ENV_PROFILE_LTO\""
+    fi
     echo ""
   }
 
@@ -676,6 +700,8 @@ AC_CONFIG_COMMANDS([cargo-config],
  CARGO_ENV_RUST_TARGET_UPPER="$CARGO_ENV_RUST_TARGET_UPPER"
  CARGO_ENV_R_AR="$CARGO_ENV_R_AR"
  CARGO_ENV_R_RANLIB="$CARGO_ENV_R_RANLIB"
+ CARGO_ENV_PROFILE_LTO="$CARGO_ENV_PROFILE_LTO"
+ CARGO_PROFILE="$CARGO_PROFILE"
  SED="$SED"])
 
 dnl ---- 3) Cargo.lock shape check (tarball mode only) ----


### PR DESCRIPTION
<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- When R is built with `--enable-lto`, `R CMD config LTO` returns a non-empty `-flto*` value (semantics per R source `.r-svn/configure.ac:364-410`). Probe it during configure and emit a matching `CARGO_PROFILE_<PROFILE>_LTO` key into the `[env]` table in `src/rust/.cargo/config.toml`. Map the flag space onto cargo's profile.lto values: `-flto=thin` → `"thin"`, `-flto=fat`/`-flto=full` → `"fat"`, any other `-flto*` → `"thin"` (conservative). LTO off (default) → no emission, no notice — baseline CI runners untouched.
- **Why `CARGO_PROFILE_<P>_LTO` and not `RUSTFLAGS`-shape (Option A from the original issue body):** `rpkg/src/Makevars.in` already exports `RUSTFLAGS="$(ENV_RUSTFLAGS) $$LINK_ARGS"` on the cargo invocation. Cargo's precedence ("first non-empty source wins, no merging") means a `RUSTFLAGS`-shaped key in `[env]` is *silently shadowed* by the Makevars prefix and never reaches rustc. `CARGO_PROFILE_<P>_<KEY>` is read at profile-lookup time independently of `RUSTFLAGS`, so it actually takes effect.
- Profile-keyed: derived from `$CARGO_PROFILE` (uppercased). Default is `release` → emits `CARGO_PROFILE_RELEASE_LTO`. `CARGO_PROFILE=dev` → `CARGO_PROFILE_DEV_LTO`. R's `LTO` flag is release-shaped so this matches user intent without surprising dev iteration.
- Shell env still wins (`[env]` is no-force), so users can opt out per build: `CARGO_PROFILE_RELEASE_LTO=off R CMD INSTALL .` if a transitive dep chokes under thin LTO.
- Three configure.ac edits, mirrored byte-for-byte across `rpkg/configure.ac`, `minirextendr/inst/templates/rpkg/configure.ac`, and `minirextendr/inst/templates/monorepo/rpkg/configure.ac`:
  1. LTO probe block right after the AR/RANLIB derivation (sets `CARGO_ENV_PROFILE_LTO` + emits an `AC_MSG_NOTICE` only when LTO is on).
  2. New conditional emission inside `emit_env_block` before the trailing `echo ""`.
  3. Two new entries (`CARGO_ENV_PROFILE_LTO`, `CARGO_PROFILE`) on the variable-pass list for `AC_CONFIG_COMMANDS([cargo-config], …)`.
- `rpkg/configure` regenerated via `autoconf`; `patches/templates.patch` refreshed via `just templates-approve` (`just templates-check` green).

Closes #597.

## Test plan
- [x] Baseline (LTO off): `bash ./configure` → no `R LTO flag` notice, no `CARGO_PROFILE_RELEASE_LTO` in emitted `[env]` table.
- [x] Mock R with `R CMD config LTO` returning `-flto=thin`: notice fires, `CARGO_PROFILE_RELEASE_LTO = "thin"` lands in `[env]`.
- [x] Mock R with `-flto=fat`: emits `"fat"`.
- [x] `just templates-check` (green — patch matches both templates after rpkg edits).
- [ ] Verify on a Linux CI runner where R may actually carry `--enable-lto` (none of the local hosts have an LTO-built R; tested via mock R_HOME shim).

## Non-goals (deferred via follow-up issues)
- No `RUSTFLAGS`-shape emission (deliberate; see above).
- No `CFLAGS`/`CXXFLAGS` propagation — that's #598's surface.
- No CI matrix job with `--enable-lto` R (rebuilding R from source in CI is expensive); will file a follow-up for "cheap CI coverage of LTO-built R" if the LTO path needs guard testing.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>
