### PR TITLE
fix(connections): make custom-connection tests pass

### DIFF
--- a/.claude/skills/miniextendr-connections/SKILL.md
+++ b/.claude/skills/miniextendr-connections/SKILL.md
@@ -11,7 +11,7 @@ R's connection system provides an I/O abstraction used by `file()`, `url()`, `gz
 
 - "How do I create a custom R connection in Rust?"
 - "What is `RConnectionImpl`?"
-- "Why does my connection start closed and have to be explicitly opened?"
+- "Why is my connection returned already-open, and where does the open callback get invoked?"
 - "How do panics inside connection callbacks get handled?"
 - "What is `catch_connection_panic`?"
 - "What is the connections ABI version check?"
@@ -26,22 +26,24 @@ The `connections` feature in miniextendr is gated for this reason. Before using 
 
 The API requires R >= 4.3.0. Use `check_runtime_connections_support()` for a runtime probe.
 
-### Connections start in CLOSED state
+### Connections from `RCustomConnection::build` are returned open
 
-`R_new_custom_connection` creates the connection in a closed state (`isopen = FALSE`). After building the connection SEXP, you must explicitly invoke the `open` callback to put it into an open state before returning it to R callers who expect an open connection.
+`R_new_custom_connection` (R's underlying C entry point) returns a connection in the CLOSED state (`isopen = FALSE`) with `text = TRUE` regardless of mode. `RCustomConnection::build` papers over both:
 
-The builder's `.build(impl)` method does not automatically call `open`. If you want an auto-opened connection:
+- The mode string is parsed for `'b'` to infer `text`; explicit `.text(...)` still wins.
+- The `open` callback is invoked before the SEXP is returned. R's own auto-open path (used by `readLines` / `scan` / etc.) sees `isopen == TRUE` and short-circuits, so there is no double-open.
 
 ```rust
 let conn_sexp = RCustomConnection::new()
     .description("my conn")
+    .mode("r+b")
     .can_read(true)
+    .can_write(true)
     .build(MyConnectionImpl { /* ... */ });
-// conn_sexp is CLOSED here. Open it:
-unsafe { open_connection(conn_sexp)? };
+// conn_sexp is already OPEN. readLines / writeBin / seek all work.
 ```
 
-`open_connection` is a helper that calls the connection's registered `open` trampoline through R's internal dispatch. See `miniextendr-api/src/connection.rs` for the implementation.
+If your `RConnectionImpl::open` returns `false`, the boxed state is dropped via the destroy trampoline and `build` returns `SEXP::nil()`. Make sure `open` returns `true` on success.
 
 ### `RConnectionImpl` trait
 
@@ -116,7 +118,7 @@ Panics inside `RConnectionImpl` methods are caught by `catch_connection_panic`. 
 
 ## Common pitfalls
 
-- **Connection starts CLOSED**: `R_new_custom_connection` creates in closed state. Always call the open callback explicitly after `build()` if you want an already-open connection. Returning a closed connection to R code that calls `readLines()` on it immediately will produce an "connection is not open" error.
+- **Underlying API starts CLOSED with `text = TRUE`**: `R_new_custom_connection` returns a closed connection with `text = TRUE` regardless of mode. `RCustomConnection::build` opens it for you and infers `text` from the mode string before returning, so this is invisible to callers — but if you ever bypass the builder and call `R_new_custom_connection` directly, you need to handle both yourself.
 
 - **Panics are silently absorbed**: unlike `#[miniextendr]` functions (which use the tagged-SEXP error transport to surface Rust panics as R errors), connection trampolines use the fallback-value pattern. A panic in `read()` returns `0` bytes — the R caller sees a short read, not an error. Design your `RConnectionImpl` to return error signals through return values, not panics.
 

--- a/miniextendr-api/CLAUDE.md
+++ b/miniextendr-api/CLAUDE.md
@@ -27,7 +27,7 @@ Runtime crate — FFI, ExternalPtr, ALTREP, worker thread, error/condition trans
 - **PROTECT discipline against R-devel GC** — `SEXP::scalar_string` and `scalar_logical(true)` allocate fresh STRSXP/LGLSXP; protect across `SET_VECTOR_ELT`/`SETATTRIB`. R-devel's GC is more aggressive — `make_rust_condition_value` crossed the threshold in PR #344 commit `af6b4875` (recursive gc + segfault at small offsets). R-release passing ≠ safe.
 - **`#[macro_export]` collides with same-named modules at crate root** — `pub mod error`/`pub mod condition` shadow `error!`/`condition!` macros under `use miniextendr_api::{error, condition}`. Invoke via fully-qualified path; `message!` / `warning!` have no module conflict.
 - **`R_GetCCallable` throws on miss** — does NOT return NULL. Force DLL load via `NAMESPACE importFrom(...)`.
-- **`R_new_custom_connection` creates connections CLOSED** (`isopen = FALSE`); explicitly call the `open` callback after building.
+- **`R_new_custom_connection` creates connections CLOSED with `text = TRUE`** — `RCustomConnection::build` papers over both (infers `text` from mode, invokes the `open` trampoline before returning). If you bypass the builder, you must handle both yourself or `writeBin`/`writeLines`/`seek` will fail and binary modes will reject `readBin`/`writeBin`.
 - **Pointer provenance for ExternalPtr** — cache `*mut T` via `&mut T` / `downcast_mut` / `Box::into_raw`. Never write through a `*mut` derived from `&T` / `downcast_ref` — UB under Stacked Borrows.
 
 ## Features

--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -611,12 +611,22 @@ pub trait RConnectionImpl: Sized + 'static {
         0
     }
 
-    /// Formatted print (vfprintf-style).
+    /// Formatted print (`vfprintf`-style).
     ///
-    /// This is rarely needed - R typically uses `write` for output.
-    /// Return the number of characters written, or -1 on error.
+    /// R calls into this through `Rconn_printf` from `writeLines`, `cat`,
+    /// sink dispatch, and similar. The default implementation returns `-1`
+    /// to signal "delegate to the standard format-and-write path," in
+    /// which case the framework formats the args into a fixed buffer via
+    /// the host `vsnprintf` and forwards the bytes to [`write`](Self::write).
     ///
-    /// The default returns -1 (not implemented).
+    /// Override this only if you need a custom output path that bypasses
+    /// [`write`](Self::write) (e.g., to stream into a pre-encoded sink).
+    /// Return the number of bytes written on success, or `-1` on error.
+    ///
+    /// # Safety
+    ///
+    /// `fmt` is a null-terminated C string from R. `ap` is the `va_list`
+    /// of R's printf-style call; treat it as opaque and pass to libc.
     fn vfprintf(&mut self, _fmt: *const c_char, _ap: *mut c_void) -> i32 {
         -1
     }
@@ -768,7 +778,64 @@ simple_trampoline!(fgetc_trampoline, c_int, fallback = -1 => fgetc());
 simple_trampoline!(seek_trampoline, f64, fallback = -1.0, where_: f64, origin: c_int, rw: c_int => seek(where_, origin, rw));
 simple_trampoline!(truncate_trampoline, (), fallback = () => truncate());
 simple_trampoline!(flush_trampoline, c_int, fallback = -1 => flush());
-simple_trampoline!(vfprintf_trampoline, c_int, fallback = -1, fmt: *const c_char, ap: *mut c_void => vfprintf(fmt, ap));
+
+// libc::vsnprintf — the host C library's printf-into-buffer entry point.
+// Used by the default `vfprintf_trampoline` to format R's printf-style
+// callsites (e.g. `Rconn_printf` in `do_writelines`) into a byte buffer,
+// which is then forwarded to the user's `write` callback.
+unsafe extern "C" {
+    fn vsnprintf(s: *mut c_char, n: usize, format: *const c_char, ap: *mut c_void) -> c_int;
+}
+
+/// vfprintf callback trampoline.
+///
+/// R calls this through `Rconn_printf` from `do_writelines`, `cat`, sink
+/// dispatch, and similar. We must NOT return a negative value — R treats
+/// that as a write error and raises `"Error writing to connection"`.
+///
+/// We format the printf-style args into a stack buffer via the host
+/// `vsnprintf`, then forward the resulting bytes to the user's `write`
+/// callback. This mirrors R's own `dummy_vfprintf` (used by most stock
+/// connection types) and means users almost never need to override
+/// [`RConnectionImpl::vfprintf`] manually — implementing `write` is enough.
+///
+/// If the formatted output exceeds the buffer, we still write the
+/// truncated portion and return the truncated length. Long writes through
+/// `Rconn_printf` are rare on custom connections; users who need
+/// unbounded text output can override [`RConnectionImpl::vfprintf`].
+unsafe extern "C-unwind" fn vfprintf_trampoline<T: RConnectionImpl>(
+    conn: *mut Rconn,
+    fmt: *const c_char,
+    ap: *mut c_void,
+) -> c_int {
+    catch_connection_panic(-1, || {
+        // Give user impls first crack — if they return >= 0 we honor that.
+        // The default impl returns -1, which we interpret as "fall back to
+        // the standard format-and-write path below."
+        let state = unsafe { get_state::<T>(conn) };
+        let user_result = state.vfprintf(fmt, ap);
+        if user_result >= 0 {
+            return user_result;
+        }
+
+        // Standard fallback: vsnprintf into a stack buffer, then write.
+        const BUFSIZE: usize = 10_000;
+        let mut buf = [0u8; BUFSIZE];
+        let res = unsafe { vsnprintf(buf.as_mut_ptr().cast::<c_char>(), BUFSIZE, fmt, ap) };
+        if res < 0 {
+            return -1;
+        }
+        let written_len = (res as usize).min(BUFSIZE.saturating_sub(1));
+        if written_len == 0 {
+            return res;
+        }
+        let bytes_written = state.write(&buf[..written_len]);
+        if bytes_written < written_len {
+            return -1;
+        }
+        res
+    })
+}
 // endregion
 
 // region: RCustomConnection builder
@@ -901,7 +968,11 @@ impl RCustomConnection {
 
     /// Set whether the connection is blocking.
     ///
-    /// Default is `true`.
+    /// Default is `true`. R's underlying `R_new_custom_connection` defaults
+    /// this to FALSE, which makes `readLines` push back the final incomplete
+    /// line on EOF (silently dropping a trailing line without `\n`). Most
+    /// in-memory Rust impls want synchronous blocking behavior, so we
+    /// flip the default to match R's stock `file()` connections.
     pub fn blocking(mut self, blocking: bool) -> Self {
         self.blocking = Some(blocking);
         self
@@ -945,6 +1016,14 @@ impl RCustomConnection {
         // connection that rejects `readBin` / `writeBin`.
         let text_default = !self.mode.as_bytes().contains(&b'b');
         let text = self.text.unwrap_or(text_default);
+
+        // Default `blocking = true`. R's `init_con` defaults blocking to
+        // FALSE, but for in-memory / synchronous custom connections that
+        // is wrong — non-blocking text connections push back the final
+        // incomplete line on EOF, so `readLines` silently drops a trailing
+        // line without a `\n`. R's stock `file()`/`url()` paths flip this
+        // to TRUE later in their own builders; we do the same.
+        let blocking = self.blocking.unwrap_or(true);
 
         unsafe {
             // Box the state
@@ -1024,13 +1103,11 @@ impl RCustomConnection {
                     Rboolean::FALSE
                 };
             }
-            if let Some(blocking) = self.blocking {
-                (*conn).blocking = if blocking {
-                    Rboolean::TRUE
-                } else {
-                    Rboolean::FALSE
-                };
-            }
+            (*conn).blocking = if blocking {
+                Rboolean::TRUE
+            } else {
+                Rboolean::FALSE
+            };
 
             // Open the connection. `R_new_custom_connection` returns a
             // connection in CLOSED state (`isopen = FALSE`). R auto-opens

--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -909,9 +909,22 @@ impl RCustomConnection {
 
     /// Build the connection with the given state.
     ///
-    /// Returns an R connection SEXP that can be returned to R.
+    /// Returns an **open** R connection SEXP that can be returned to R.
     /// The state is boxed and stored in the connection's `private` field.
     /// It will be automatically dropped when the connection is destroyed.
+    ///
+    /// `R_new_custom_connection` returns the connection in a CLOSED state
+    /// with `text = TRUE` as defaults. This builder fixes both:
+    /// - `text` is inferred from the mode string when not explicitly set
+    ///   (`'b'` in the mode → binary; otherwise text). This matches the
+    ///   behavior of R's built-in `file()` / `url()` connections.
+    /// - The `open` callback is invoked before returning, so the resulting
+    ///   SEXP is immediately usable for `readLines` / `writeBin` / `seek`
+    ///   without relying on R's per-call auto-open path (which doesn't
+    ///   fire for write/seek operations).
+    ///
+    /// If the `open` callback fails, the boxed state is dropped via the
+    /// destroy trampoline and `SEXP::nil()` is returned.
     ///
     /// # Panics
     ///
@@ -924,6 +937,14 @@ impl RCustomConnection {
     pub fn build<T: RConnectionImpl>(self, state: T) -> SEXP {
         // Verify API version
         check_connections_version();
+
+        // Infer text vs binary from the mode string when the caller did not
+        // explicitly set `text`. R's `R_new_custom_connection` defaults
+        // `text = TRUE` regardless of mode, so a builder like
+        // `.mode("r+b")` without `.text(false)` would land as a text
+        // connection that rejects `readBin` / `writeBin`.
+        let text_default = !self.mode.as_bytes().contains(&b'b');
+        let text = self.text.unwrap_or(text_default);
 
         unsafe {
             // Box the state
@@ -976,14 +997,12 @@ impl RCustomConnection {
             (*conn).fflush = Some(flush_trampoline::<T>);
             (*conn).vfprintf = Some(vfprintf_trampoline::<T>);
 
-            // Set optional flags
-            if let Some(text) = self.text {
-                (*conn).text = if text {
-                    Rboolean::TRUE
-                } else {
-                    Rboolean::FALSE
-                };
-            }
+            // Set text/binary mode (always overrides R's default of TRUE).
+            (*conn).text = if text {
+                Rboolean::TRUE
+            } else {
+                Rboolean::FALSE
+            };
             if let Some(can_read) = self.can_read {
                 (*conn).canread = if can_read {
                     Rboolean::TRUE
@@ -1011,6 +1030,23 @@ impl RCustomConnection {
                 } else {
                     Rboolean::FALSE
                 };
+            }
+
+            // Open the connection. `R_new_custom_connection` returns a
+            // connection in CLOSED state (`isopen = FALSE`). R auto-opens
+            // on some paths (e.g. `readLines`) but not on `writeBin` /
+            // `writeLines` / direct `seek`, which would then bail with
+            // "Error writing to connection". Pre-open here so callers get
+            // a uniformly usable connection. R's auto-open path sees
+            // `isopen == TRUE` and short-circuits — no double-open.
+            let opened = open_trampoline::<T>(conn);
+            if !matches!(opened, Rboolean::TRUE) {
+                // Open failed — tear down via the destroy trampoline,
+                // which drops the boxed state and nulls out `private`.
+                if let Some(destroy) = (*conn).destroy {
+                    destroy(conn);
+                }
+                return SEXP::nil();
             }
 
             sexp

--- a/rpkg/tests/testthat/test-connections.R
+++ b/rpkg/tests/testthat/test-connections.R
@@ -4,21 +4,11 @@
 
 skip_if_missing_feature("connections")
 
-# Custom connection tests (string_input, counter, memory, cursor, uppercase, rot13)
-# are skipped pending a fix for pre-existing lifecycle bugs in RCustomConnection
-# (see GitHub issue #568). The new standard-stream and null-connection tests
-# below do not have this skip and should always run when the `connections` feature
-# is present.
-skip_custom_conn_bug <- function() {
-  skip("pre-existing custom connection bug (see #568)")
-}
-
 # =============================================================================
 # String input connection
 # =============================================================================
 
 test_that("string_input_connection reads multi-line content", {
-  skip_custom_conn_bug()
   con <- string_input_connection("line1\nline2\nline3")
   on.exit(close(con))
   lines <- readLines(con)
@@ -27,7 +17,6 @@ test_that("string_input_connection reads multi-line content", {
 })
 
 test_that("string_input_connection reads single line", {
-  skip_custom_conn_bug()
   con <- string_input_connection("hello")
   on.exit(close(con))
   lines <- readLines(con)
@@ -36,7 +25,6 @@ test_that("string_input_connection reads single line", {
 })
 
 test_that("string_input_connection reads empty string", {
-  skip_custom_conn_bug()
   con <- string_input_connection("")
   on.exit(close(con))
   lines <- readLines(con)
@@ -48,7 +36,6 @@ test_that("string_input_connection reads empty string", {
 # =============================================================================
 
 test_that("counter_connection generates sequential integers", {
-  skip_custom_conn_bug()
   con <- counter_connection(1L, 5L)
   on.exit(close(con))
   lines <- readLines(con)
@@ -56,7 +43,6 @@ test_that("counter_connection generates sequential integers", {
 })
 
 test_that("counter_connection with single value", {
-  skip_custom_conn_bug()
   con <- counter_connection(42L, 42L)
   on.exit(close(con))
   lines <- readLines(con)
@@ -68,7 +54,6 @@ test_that("counter_connection with single value", {
 # =============================================================================
 
 test_that("memory_connection write then read roundtrip", {
-  skip_custom_conn_bug()
   con <- memory_connection()
   on.exit(close(con))
   writeLines("Hello, World!", con)
@@ -78,7 +63,6 @@ test_that("memory_connection write then read roundtrip", {
 })
 
 test_that("memory_connection write multiple lines", {
-  skip_custom_conn_bug()
   con <- memory_connection()
   on.exit(close(con))
   writeLines(c("foo", "bar", "baz"), con)
@@ -92,7 +76,6 @@ test_that("memory_connection write multiple lines", {
 # =============================================================================
 
 test_that("uppercase_connection transforms to uppercase", {
-  skip_custom_conn_bug()
   con <- uppercase_connection("hello world")
   on.exit(close(con))
   lines <- readLines(con)
@@ -100,7 +83,6 @@ test_that("uppercase_connection transforms to uppercase", {
 })
 
 test_that("uppercase_connection preserves non-alpha characters", {
-  skip_custom_conn_bug()
   con <- uppercase_connection("abc 123 !@#")
   on.exit(close(con))
   lines <- readLines(con)
@@ -112,7 +94,6 @@ test_that("uppercase_connection preserves non-alpha characters", {
 # =============================================================================
 
 test_that("rot13_connection encodes text", {
-  skip_custom_conn_bug()
   con <- rot13_connection("hello")
   on.exit(close(con))
   lines <- readLines(con)
@@ -120,7 +101,6 @@ test_that("rot13_connection encodes text", {
 })
 
 test_that("rot13 double-application returns original", {
-  skip_custom_conn_bug()
   # ROT13 is its own inverse
   con1 <- rot13_connection("hello world")
   on.exit(close(con1), add = TRUE)
@@ -138,7 +118,6 @@ test_that("rot13 double-application returns original", {
 # =============================================================================
 
 test_that("empty_cursor_connection binary roundtrip", {
-  skip_custom_conn_bug()
   con <- empty_cursor_connection()
   on.exit(close(con))
   data <- as.raw(1:10)
@@ -149,7 +128,6 @@ test_that("empty_cursor_connection binary roundtrip", {
 })
 
 test_that("cursor_connection reads pre-filled data", {
-  skip_custom_conn_bug()
   data <- charToRaw("Hello")
   con <- cursor_connection(data)
   on.exit(close(con))


### PR DESCRIPTION
Pre-existing `RCustomConnection::build` bugs caused all 12 custom-connection tests in `rpkg/tests/testthat/test-connections.R` to skip via `skip_custom_conn_bug()`. This PR fixes the underlying issues so the tests run end-to-end with `FAIL 0`.

## Root causes fixed

`R_new_custom_connection` (R's stable C entry point) returns a connection with a defaults block that is wrong for nearly every custom impl:

```
isopen   = FALSE
text     = TRUE     (regardless of mode)
blocking = FALSE
canread  = canwrite = TRUE  /* "in principle" */
vfprintf = null_vfprintf   (raises "Error writing to connection")
```

`RCustomConnection::build` now papers over each of these:

1. **Pre-open.** R auto-opens on some paths (`readLines`) but not on `writeBin` / `writeLines` / direct `seek`. The builder invokes the registered `open` trampoline before returning, with destroy-on-failure cleanup. R's later auto-open path sees `isopen == TRUE` and short-circuits — no double-open.
2. **Text inference.** `text` is inferred from the mode string when the caller didn't set `.text(...)`. `'b'` in mode → binary (`text = FALSE`); else text. Matches R's stock `file()` behavior.
3. **`vfprintf` fallback.** Our trampoline now mirrors R's own `dummy_vfprintf`: format the args via the host `vsnprintf` into a 10 KiB stack buffer, then forward the bytes to the user's `write` callback. The trait method still exists for custom impls that want to override.
4. **Blocking default.** Default `blocking = true`. `do_readLines` treats `text && !blocking` as a non-blocking text stream and pushes back the final incomplete line on EOF, silently dropping a trailing line without `\n`. The builder now matches R's `file()` / `url()`.

## Diff shape

- `miniextendr-api/src/connection.rs`: ~95 lines of changes inside `RCustomConnection::build`, the `vfprintf_trampoline`, and the `vfprintf` trait docstring.
- `rpkg/tests/testthat/test-connections.R`: drop `skip_custom_conn_bug` shim + 12 call sites (-22 LoC).
- Doc updates: `.claude/skills/miniextendr-connections/SKILL.md` and `miniextendr-api/CLAUDE.md` reflect that `build()` returns an open, mode-aware connection.

## Test plan

- [x] `cargo check -p miniextendr-api --features connections` — passes.
- [x] `just rcmdinstall` — clean install.
- [x] `just devtools-test` — `FAIL 0 | WARN 7 | SKIP 16 | PASS 5912`. The 7 warnings are R's expected `incomplete final line found on '<conn>'` for tests whose inputs intentionally lack trailing `\n`.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- [ ] CI to run `clippy_all` with the curated feature set.

Closes #568

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>