### PR TITLE
fix(connections): make RCustomConnection::build return a usable connection

### DIFF
--- a/.claude/skills/miniextendr-connections/SKILL.md
+++ b/.claude/skills/miniextendr-connections/SKILL.md
@@ -11,7 +11,7 @@ R's connection system provides an I/O abstraction used by `file()`, `url()`, `gz
 
 - "How do I create a custom R connection in Rust?"
 - "What is `RConnectionImpl`?"
-- "Why does my connection start closed and have to be explicitly opened?"
+- "Why does my connection start closed?" (it doesn't — `build()` pre-opens it)
 - "How do panics inside connection callbacks get handled?"
 - "What is `catch_connection_panic`?"
 - "What is the connections ABI version check?"
@@ -26,22 +26,23 @@ The `connections` feature in miniextendr is gated for this reason. Before using 
 
 The API requires R >= 4.3.0. Use `check_runtime_connections_support()` for a runtime probe.
 
-### Connections start in CLOSED state
+### Connections returned by `build()` are already open
 
-`R_new_custom_connection` creates the connection in a closed state (`isopen = FALSE`). After building the connection SEXP, you must explicitly invoke the `open` callback to put it into an open state before returning it to R callers who expect an open connection.
+`R_new_custom_connection` itself creates connections in a closed state (`isopen = FALSE`) and defaults `text = TRUE` regardless of the mode string. `RCustomConnection::build()` (and the `RConnectionIo` adapters that funnel through it) corrects both:
 
-The builder's `.build(impl)` method does not automatically call `open`. If you want an auto-opened connection:
+- `text` is inferred from the mode string when `.text(...)` wasn't called: any `'b'` in the mode means binary, otherwise text.
+- The `open` trampoline is invoked before `build()` returns. R's auto-open machinery sees `isopen == TRUE` on the first use and short-circuits, so there is no double-open.
+
+If your `RConnectionImpl::open` returns `false`, `build()` runs the destroy trampoline to release the boxed state and returns `R_NilValue`.
 
 ```rust
 let conn_sexp = RCustomConnection::new()
     .description("my conn")
+    .mode("rb")
     .can_read(true)
     .build(MyConnectionImpl { /* ... */ });
-// conn_sexp is CLOSED here. Open it:
-unsafe { open_connection(conn_sexp)? };
+// conn_sexp is OPEN here, ready for readBin/writeBin/seek.
 ```
-
-`open_connection` is a helper that calls the connection's registered `open` trampoline through R's internal dispatch. See `miniextendr-api/src/connection.rs` for the implementation.
 
 ### `RConnectionImpl` trait
 
@@ -116,7 +117,7 @@ Panics inside `RConnectionImpl` methods are caught by `catch_connection_panic`. 
 
 ## Common pitfalls
 
-- **Connection starts CLOSED**: `R_new_custom_connection` creates in closed state. Always call the open callback explicitly after `build()` if you want an already-open connection. Returning a closed connection to R code that calls `readLines()` on it immediately will produce an "connection is not open" error.
+- **`R_new_custom_connection` starts CLOSED, but `build()` opens for you**: the raw R API leaves new connections with `isopen = FALSE`. `RCustomConnection::build()` invokes the open callback before returning, so callers always get an open connection. If you carry an `RConnectionImpl` through some other path that calls `R_new_custom_connection` directly without going through `build()`, you must explicitly open it yourself before R-side operations like `writeBin`/`writeLines`/`seek`.
 
 - **Panics are silently absorbed**: unlike `#[miniextendr]` functions (which use the tagged-SEXP error transport to surface Rust panics as R errors), connection trampolines use the fallback-value pattern. A panic in `read()` returns `0` bytes — the R caller sees a short read, not an error. Design your `RConnectionImpl` to return error signals through return values, not panics.
 

--- a/miniextendr-api/CLAUDE.md
+++ b/miniextendr-api/CLAUDE.md
@@ -27,7 +27,7 @@ Runtime crate — FFI, ExternalPtr, ALTREP, worker thread, error/condition trans
 - **PROTECT discipline against R-devel GC** — `SEXP::scalar_string` and `scalar_logical(true)` allocate fresh STRSXP/LGLSXP; protect across `SET_VECTOR_ELT`/`SETATTRIB`. R-devel's GC is more aggressive — `make_rust_condition_value` crossed the threshold in PR #344 commit `af6b4875` (recursive gc + segfault at small offsets). R-release passing ≠ safe.
 - **`#[macro_export]` collides with same-named modules at crate root** — `pub mod error`/`pub mod condition` shadow `error!`/`condition!` macros under `use miniextendr_api::{error, condition}`. Invoke via fully-qualified path; `message!` / `warning!` have no module conflict.
 - **`R_GetCCallable` throws on miss** — does NOT return NULL. Force DLL load via `NAMESPACE importFrom(...)`.
-- **`R_new_custom_connection` creates connections CLOSED** (`isopen = FALSE`); explicitly call the `open` callback after building.
+- **`R_new_custom_connection` creates connections CLOSED** (`isopen = FALSE`) and defaults `text = TRUE`. `RCustomConnection::build()` pre-opens and infers `text` from the mode string ('b' → binary), so callers get a usable connection. Going around `build()` requires explicit `open()` + `text` correction.
 - **Pointer provenance for ExternalPtr** — cache `*mut T` via `&mut T` / `downcast_mut` / `Box::into_raw`. Never write through a `*mut` derived from `&T` / `downcast_ref` — UB under Stacked Borrows.
 
 ## Features

--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -477,6 +477,35 @@ pub struct Rconn {
 }
 // endregion
 
+// region: libc bindings for default vfprintf implementation
+
+// We hand-bind `vsnprintf` rather than pulling in the `libc` crate because
+// (a) this is the only libc symbol we need and (b) miniextendr already
+// hand-binds the rest of its C ABI surface in `crate::ffi`. The signature
+// matches POSIX/glibc/musl/macOS/Win32 (`_vsnprintf` is also exported as
+// `vsnprintf` since Windows 7).
+unsafe extern "C" {
+    fn vsnprintf(buf: *mut c_char, len: usize, format: *const c_char, ap: *mut c_void) -> c_int;
+}
+
+/// Wrapper so the trait method's `unsafe` block has a stable name.
+///
+/// # Safety
+///
+/// Inherits the contract of `vsnprintf`: `buf` must be writable for `len`
+/// bytes, `format` must be a NUL-terminated C string, `ap` must be a
+/// valid `va_list` matching `format`.
+#[inline]
+unsafe fn ffi_vsnprintf(
+    buf: *mut c_char,
+    len: usize,
+    format: *const c_char,
+    ap: *mut c_void,
+) -> c_int {
+    unsafe { vsnprintf(buf, len, format, ap) }
+}
+// endregion
+
 // region: RConnectionImpl trait - user-facing trait for implementing connections
 
 /// Trait for implementing custom R connections.
@@ -613,12 +642,39 @@ pub trait RConnectionImpl: Sized + 'static {
 
     /// Formatted print (vfprintf-style).
     ///
-    /// This is rarely needed - R typically uses `write` for output.
-    /// Return the number of characters written, or -1 on error.
+    /// R's `Rconn_printf` (used by `writeLines`, `cat`, `message`, etc.)
+    /// always routes through `con->vfprintf`. The default implementation
+    /// uses libc `vsnprintf` to format into a stack buffer and delegates
+    /// to [`write`](Self::write) — so anything that implements `write`
+    /// gets working `writeLines`/`cat`/`message` for free. Output larger
+    /// than the 4 KiB stack buffer is truncated; override this method if
+    /// you need to support very large single `Rconn_printf` payloads.
     ///
-    /// The default returns -1 (not implemented).
-    fn vfprintf(&mut self, _fmt: *const c_char, _ap: *mut c_void) -> i32 {
-        -1
+    /// Return the number of bytes written, or -1 on error.
+    ///
+    /// # Safety
+    ///
+    /// `fmt` must be a NUL-terminated C string. `ap` must be a valid
+    /// `va_list` whose pending arguments match `fmt`'s conversion
+    /// specifiers. R's `Rconn_printf` upholds both for the default impl;
+    /// only override if you can guarantee them for your custom format.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn vfprintf(&mut self, fmt: *const c_char, ap: *mut c_void) -> i32 {
+        // SAFETY: `fmt` and `ap` come from R's `Rconn_printf` and obey the
+        // standard `vsnprintf` contract. `vsnprintf` writes at most `len`
+        // bytes (including NUL) into `buf`. The `va_list` is consumed by
+        // this single call, which is why we can't trivially re-run with a
+        // larger buffer on overflow — keep the stack buffer ample.
+        const STACK_BUF: usize = 4096;
+        let mut stack = [0u8; STACK_BUF];
+        let needed =
+            unsafe { ffi_vsnprintf(stack.as_mut_ptr().cast::<c_char>(), STACK_BUF, fmt, ap) };
+        if needed < 0 {
+            return -1;
+        }
+        let written = (needed as usize).min(STACK_BUF.saturating_sub(1));
+        let wrote = self.write(&stack[..written]);
+        wrote as i32
     }
 }
 // endregion
@@ -869,7 +925,11 @@ impl RCustomConnection {
 
     /// Set whether this is a text connection (vs binary).
     ///
-    /// If not set, R infers from the mode string.
+    /// If not set, [`build`](Self::build) infers from the mode string: any
+    /// `'b'` in the mode means binary (`text = false`), otherwise text
+    /// (`text = true`). This overrides R's `R_new_custom_connection`
+    /// default of `text = TRUE`, which would otherwise leave binary
+    /// connections mis-flagged.
     pub fn text(mut self, is_text: bool) -> Self {
         self.text = Some(is_text);
         self
@@ -901,7 +961,12 @@ impl RCustomConnection {
 
     /// Set whether the connection is blocking.
     ///
-    /// Default is `true`.
+    /// Default is `true`. (R's `init_con` actually defaults to `FALSE`, but
+    /// `do_readLines` reflexively calls `con->seek(con, -1.0, 1, 1)` on
+    /// non-blocking seekable connections to "re-position" them — and any
+    /// `seek` impl that doesn't treat negative `where` as a `tell` will
+    /// reset its read cursor on every `readLines` call. The builder
+    /// overrides R's default to keep the common case usable.)
     pub fn blocking(mut self, blocking: bool) -> Self {
         self.blocking = Some(blocking);
         self
@@ -909,9 +974,22 @@ impl RCustomConnection {
 
     /// Build the connection with the given state.
     ///
-    /// Returns an R connection SEXP that can be returned to R.
-    /// The state is boxed and stored in the connection's `private` field.
-    /// It will be automatically dropped when the connection is destroyed.
+    /// Returns an R connection SEXP that can be returned to R. The connection
+    /// is returned **open** — `build` invokes the implementation's `open`
+    /// callback before returning, so callers (and R-side code) can read or
+    /// write immediately. If `open` returns `false`, `build` runs the destroy
+    /// trampoline to release the boxed state and returns `R_NilValue`.
+    ///
+    /// `R_new_custom_connection` itself creates connections in a closed state
+    /// (`isopen = FALSE`), defaults `text` to `TRUE`, and defaults `blocking`
+    /// to `FALSE`. The builder corrects all three: `text` is inferred from the
+    /// mode string when not explicitly set (modes containing `'b'` → binary,
+    /// otherwise text), `blocking` defaults to `true` to avoid the
+    /// `do_readLines` re-position footgun (see [`blocking`](Self::blocking)),
+    /// and the open callback is invoked after callbacks and flags are wired.
+    ///
+    /// The state is boxed and stored in the connection's `private` field. It
+    /// will be automatically dropped when the connection is destroyed.
     ///
     /// # Panics
     ///
@@ -976,14 +1054,21 @@ impl RCustomConnection {
             (*conn).fflush = Some(flush_trampoline::<T>);
             (*conn).vfprintf = Some(vfprintf_trampoline::<T>);
 
-            // Set optional flags
-            if let Some(text) = self.text {
-                (*conn).text = if text {
-                    Rboolean::TRUE
-                } else {
-                    Rboolean::FALSE
-                };
-            }
+            // Set text flag. `R_new_custom_connection` defaults `text = TRUE`
+            // regardless of the mode string, which leaves binary connections
+            // mis-flagged when the caller didn't explicitly thread `.text(...)`
+            // through (e.g. `RConnectionIo` adapters with `.mode("r+b")`).
+            // Infer from the mode string when not explicitly set: any `'b'`
+            // in the mode means binary, otherwise text. This matches R's
+            // own mode-string parsing in `file()` / `gzfile()`.
+            let text = self
+                .text
+                .unwrap_or_else(|| !self.mode.as_bytes().contains(&b'b'));
+            (*conn).text = if text {
+                Rboolean::TRUE
+            } else {
+                Rboolean::FALSE
+            };
             if let Some(can_read) = self.can_read {
                 (*conn).canread = if can_read {
                     Rboolean::TRUE
@@ -1005,12 +1090,45 @@ impl RCustomConnection {
                     Rboolean::FALSE
                 };
             }
-            if let Some(blocking) = self.blocking {
-                (*conn).blocking = if blocking {
-                    Rboolean::TRUE
-                } else {
-                    Rboolean::FALSE
-                };
+            // Set blocking flag. `init_con` defaults this to FALSE, which is
+            // a footgun: `do_readLines` re-positions non-blocking seekable
+            // connections by calling `con->seek(con, -1.0, 1, 1)` (a query
+            // disguised as a value seek). Implementations that don't treat
+            // a negative `where` as a "tell" silently reset position to 0
+            // on every `readLines` call. Blocking custom connections are
+            // the common case (the impl runs on the R thread anyway), so
+            // default to TRUE and let callers opt into FALSE via
+            // `.blocking(false)`.
+            let blocking = self.blocking.unwrap_or(true);
+            (*conn).blocking = if blocking {
+                Rboolean::TRUE
+            } else {
+                Rboolean::FALSE
+            };
+
+            // Open the connection. `R_new_custom_connection` returns the
+            // connection in a closed state (`isopen = FALSE`). R auto-opens
+            // on some code paths (e.g. `readLines`) but not on others
+            // (`writeBin`, `writeLines`, direct `seek`), so callers that
+            // skip pre-opening hit "Error writing to connection" on the
+            // first write call. Pre-opening here makes `.build()` return a
+            // usable connection in every code path; R's auto-open machinery
+            // sees `isopen == TRUE` and short-circuits, so there is no
+            // double-open.
+            //
+            // SAFETY: `open` was just set above to `Some(open_trampoline::<T>)`.
+            let opened = (*conn).open.expect("open trampoline was set above")(conn);
+            if opened != Rboolean::TRUE {
+                // Open failed. Tear down the boxed state via the destroy
+                // trampoline (which also nulls `private`) and return nil.
+                // R itself will not have signalled here — the open trampoline
+                // absorbs panics into `Rboolean::FALSE`, and an
+                // `RConnectionImpl::open` returning `false` is the trait's
+                // documented failure signal.
+                if let Some(destroy) = (*conn).destroy {
+                    destroy(conn);
+                }
+                return SEXP::nil();
             }
 
             sexp

--- a/rpkg/tests/testthat/test-connections.R
+++ b/rpkg/tests/testthat/test-connections.R
@@ -4,21 +4,11 @@
 
 skip_if_missing_feature("connections")
 
-# Custom connection tests (string_input, counter, memory, cursor, uppercase, rot13)
-# are skipped pending a fix for pre-existing lifecycle bugs in RCustomConnection
-# (see GitHub issue #568). The new standard-stream and null-connection tests
-# below do not have this skip and should always run when the `connections` feature
-# is present.
-skip_custom_conn_bug <- function() {
-  skip("pre-existing custom connection bug (see #568)")
-}
-
 # =============================================================================
 # String input connection
 # =============================================================================
 
 test_that("string_input_connection reads multi-line content", {
-  skip_custom_conn_bug()
   con <- string_input_connection("line1\nline2\nline3")
   on.exit(close(con))
   lines <- readLines(con)
@@ -27,7 +17,6 @@ test_that("string_input_connection reads multi-line content", {
 })
 
 test_that("string_input_connection reads single line", {
-  skip_custom_conn_bug()
   con <- string_input_connection("hello")
   on.exit(close(con))
   lines <- readLines(con)
@@ -36,7 +25,6 @@ test_that("string_input_connection reads single line", {
 })
 
 test_that("string_input_connection reads empty string", {
-  skip_custom_conn_bug()
   con <- string_input_connection("")
   on.exit(close(con))
   lines <- readLines(con)
@@ -48,7 +36,6 @@ test_that("string_input_connection reads empty string", {
 # =============================================================================
 
 test_that("counter_connection generates sequential integers", {
-  skip_custom_conn_bug()
   con <- counter_connection(1L, 5L)
   on.exit(close(con))
   lines <- readLines(con)
@@ -56,7 +43,6 @@ test_that("counter_connection generates sequential integers", {
 })
 
 test_that("counter_connection with single value", {
-  skip_custom_conn_bug()
   con <- counter_connection(42L, 42L)
   on.exit(close(con))
   lines <- readLines(con)
@@ -68,7 +54,6 @@ test_that("counter_connection with single value", {
 # =============================================================================
 
 test_that("memory_connection write then read roundtrip", {
-  skip_custom_conn_bug()
   con <- memory_connection()
   on.exit(close(con))
   writeLines("Hello, World!", con)
@@ -78,7 +63,6 @@ test_that("memory_connection write then read roundtrip", {
 })
 
 test_that("memory_connection write multiple lines", {
-  skip_custom_conn_bug()
   con <- memory_connection()
   on.exit(close(con))
   writeLines(c("foo", "bar", "baz"), con)
@@ -92,7 +76,6 @@ test_that("memory_connection write multiple lines", {
 # =============================================================================
 
 test_that("uppercase_connection transforms to uppercase", {
-  skip_custom_conn_bug()
   con <- uppercase_connection("hello world")
   on.exit(close(con))
   lines <- readLines(con)
@@ -100,7 +83,6 @@ test_that("uppercase_connection transforms to uppercase", {
 })
 
 test_that("uppercase_connection preserves non-alpha characters", {
-  skip_custom_conn_bug()
   con <- uppercase_connection("abc 123 !@#")
   on.exit(close(con))
   lines <- readLines(con)
@@ -112,7 +94,6 @@ test_that("uppercase_connection preserves non-alpha characters", {
 # =============================================================================
 
 test_that("rot13_connection encodes text", {
-  skip_custom_conn_bug()
   con <- rot13_connection("hello")
   on.exit(close(con))
   lines <- readLines(con)
@@ -120,7 +101,6 @@ test_that("rot13_connection encodes text", {
 })
 
 test_that("rot13 double-application returns original", {
-  skip_custom_conn_bug()
   # ROT13 is its own inverse
   con1 <- rot13_connection("hello world")
   on.exit(close(con1), add = TRUE)
@@ -138,7 +118,6 @@ test_that("rot13 double-application returns original", {
 # =============================================================================
 
 test_that("empty_cursor_connection binary roundtrip", {
-  skip_custom_conn_bug()
   con <- empty_cursor_connection()
   on.exit(close(con))
   data <- as.raw(1:10)
@@ -149,7 +128,6 @@ test_that("empty_cursor_connection binary roundtrip", {
 })
 
 test_that("cursor_connection reads pre-filled data", {
-  skip_custom_conn_bug()
   data <- charToRaw("Hello")
   con <- cursor_connection(data)
   on.exit(close(con))


### PR DESCRIPTION
<!-- TODO: replace with author framing paragraph in your own voice -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Fix three latent bugs in `RCustomConnection::build` that surfaced when PR #569 enabled `connections` in `tools/detect-features.R`, finally letting the 12 custom-connection tests in `rpkg/tests/testthat/test-connections.R` actually run:
  - **Pre-open the connection.** `R_new_custom_connection` returns connections with `isopen = FALSE`. R only auto-opens for some code paths (e.g. `readLines`), so `writeBin` / `writeLines` / direct `seek` hit "Error writing to connection". `build()` now calls `open_trampoline::<T>` after wiring callbacks/flags, with destroy-on-failure cleanup if `RConnectionImpl::open` returns `false`.
  - **Infer `text` from the mode string.** R's `R_new_custom_connection` defaults `text = TRUE` regardless of mode. The builder previously only overrode this when `.text(...)` was explicitly threaded through, so binary `RConnectionIo` adapters (`.mode("r+b")`) ended up text-flagged. Now `text` defaults to `false` whenever the mode contains `'b'`.
  - **Default `blocking = true`.** `init_con` defaults `blocking = FALSE`, which triggers `do_readLines`'s "re-position non-blocking seekable" branch: R calls `con->seek(con, -1.0, 1, 1)` before each read, and any `seek` impl that doesn't treat negative `where` as a `tell` resets its read cursor on every `readLines`. The builder now defaults blocking to `true`; callers can opt back into non-blocking with `.blocking(false)`.
- Replace the trait's default `vfprintf` (returned `-1`, which `Rconn_printf` translates to "Error writing to connection") with a `vsnprintf` -> `write` adapter, so any `RConnectionImpl` providing `write` now gets working `writeLines` / `cat` / `message` for free. Override the method for >4 KiB single-call payloads.
- Drop the `skip_custom_conn_bug()` helper and its 12 call sites from `rpkg/tests/testthat/test-connections.R`; all 12 tests now run and pass with the above fixes.
- Update the connections skill and `miniextendr-api/CLAUDE.md` to reflect the new `build()` contract.
- Closes #568.

## Test plan
- [ ] `just configure && just rcmdinstall`
- [ ] `just devtools-test` -- `test-connections.R` reports `[ FAIL 0 | WARN 7 | SKIP 16 | PASS 5912 ]` (the 7 WARNs are R's "incomplete final line" notices for test inputs without trailing newlines, not testthat failures)
- [ ] `cargo test --workspace --all-targets --features connections`
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [ ] `cargo clippy --workspace --all-targets --locked --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,default-strict,default-coerce,default-r6,default-worker,jiff -- -D warnings`

## Notes
- The plan in the issue body anticipated only the two named bugs (CLOSED-state and text-default). Two more surfaced during validation: the `blocking = FALSE` default (caused `string_input_connection` / `uppercase_connection` / `rot13_connection` `readLines` to read the same first line forever via the `do_readLines` re-seek path), and the `vfprintf` default returning `-1` (caused `memory_connection` `writeLines` to error). Both are fixed inline rather than punted to follow-ups, per the "no out-of-scope" policy.
- The `do_readLines` re-seek behavior was tracked down with eprintln-instrumented `MemoryBuffer` -- prints were removed before commit. Root cause is documented in the `blocking()` builder method doc so future readers don't get bitten the same way.
- The default `vfprintf` uses libc `vsnprintf` directly via a hand-bound extern (no `libc` crate dep) since this is the only libc symbol we need. Output larger than the 4 KiB stack buffer is truncated; the doc calls this out and points to overriding the method.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>