### PR TITLE
feat(gc_protect): generic Protected<'a, T> primitive (#681)

### DIFF
--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -1595,20 +1595,16 @@ mod tests {
         let p = unsafe {
             Protected::<'static, Vec<u8>>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), v)
         };
-        // _protect is private — verify indirectly: if it were Some(OwnedProtect),
-        // the OwnedProtect drop would call Rf_unprotect(1) without a matching
-        // protect (crashing R). Since we're not running R here, just confirm the
-        // Debug output shows `protected: false`.
+        // This test uses `from_trusted` to avoid touching the protect stack;
+        // `Protected::new` would require an initialized R runtime (see
+        // `tests/gc_protect.rs` for that path). Verify the `_protect` field is
+        // `None` indirectly via the `Debug` output.
         assert!(format!("{p:?}").contains("protected: false"));
     }
 
-    /// Verify `Protected<'a, T>` with `Some(OwnedProtect)` is `!Send`
-    /// (compile-time — the type-system test is implicit: if this test builds
-    /// we confirm the field layout compiles cleanly).
+    /// Smoke-test: `Protected::from_trusted` + `Deref` compiles for a scalar `T`.
     #[test]
-    fn protected_is_copy_of_struct_fields_compile_check() {
-        // Smoke-test: constructing Protected<'static, i32> via from_trusted
-        // (the None path, which is auto-Send) must compile.
+    fn protected_from_trusted_compile_check() {
         let p = unsafe {
             Protected::<'static, i32>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), 99)
         };

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -931,6 +931,128 @@ impl std::ops::Deref for OwnedProtect {
 }
 // endregion
 
+// region: Protected
+
+/// A Rust value (`T`) bundled with an [`OwnedProtect`] guard on an SEXP
+/// the value borrows from. The protect releases on drop; the lifetime
+/// ties any borrows inside `T` to `&self`, so `T`'s SEXP-internal
+/// references can't outlive the protection.
+///
+/// # When to use `Protected<'a, T>` vs the alternatives
+///
+/// | Pattern | Use | Why |
+/// |---------|-----|-----|
+/// | [`OwnedProtect`] | raw SEXP, no Rust view | one-shot protect/unprotect on a single SEXP |
+/// | [`ProtectScope`] + [`Root`] | several SEXPs in one function body | batched UNPROTECT, no Rust view |
+/// | `Protected<'a, T>` | SEXP + Rust view of its data | hand the bundle to callers; borrows in `T` tied to `&self` |
+///
+/// # Notes on Send/Sync
+///
+/// When constructed via [`Protected::new`], the inner [`OwnedProtect`] carries
+/// `!Send + !Sync` (via `NoSendSync`). When constructed via
+/// [`Protected::from_trusted`], the `_protect` field is `None` and the type
+/// becomes auto-`Send`/`Sync` — the same behaviour as [`ProtectedStrVec`] today.
+pub struct Protected<'a, T> {
+    inner: T,
+    _protect: Option<OwnedProtect>,
+    _marker: core::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, T> Protected<'a, T> {
+    /// Create a protected bundle. Calls `Rf_protect` on `sexp`.
+    ///
+    /// `inner` may borrow from `sexp`; the lifetime `'a` is tied to
+    /// `&self` thereafter, so any borrow inside `inner` cannot outlive
+    /// this `Protected`.
+    ///
+    /// # Safety
+    ///
+    /// - Must be called from the R main thread.
+    /// - `sexp` must be a valid SEXP.
+    /// - If `inner` borrows from `sexp`, its lifetime parameter must
+    ///   match `'a`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use miniextendr_api::{Protected, OwnedProtect};
+    /// use miniextendr_api::ffi::SEXP;
+    ///
+    /// unsafe fn wrap_view(sexp: SEXP, view: MyView<'_>) -> Protected<'_, MyView<'_>> {
+    ///     // Protect the SEXP and bundle it with the view.
+    ///     // The view's borrow is tied to the returned Protected.
+    ///     Protected::new(sexp, view)
+    /// }
+    /// ```
+    #[inline]
+    pub unsafe fn new(sexp: SEXP, inner: T) -> Self {
+        let guard = unsafe { OwnedProtect::new(sexp) };
+        Self {
+            inner,
+            _protect: Some(guard),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a protected bundle without adding to the protect stack.
+    ///
+    /// Use when `sexp` is already protected by R (a `.Call` argument,
+    /// a [`ProtectScope`] slot, an enclosing [`OwnedProtect`]) to avoid
+    /// double-protecting. The lifetime contract is unchanged — `'a`
+    /// still ties any borrows inside `inner` to `&self`.
+    ///
+    /// # Safety
+    ///
+    /// - Must be called from the R main thread.
+    /// - `sexp` must be a valid SEXP.
+    /// - `sexp` must remain GC-protected for the lifetime of the
+    ///   returned `Protected`.
+    /// - Lifetime contract same as [`Protected::new`].
+    #[inline]
+    pub unsafe fn from_trusted(_sexp: SEXP, inner: T) -> Self {
+        Self {
+            inner,
+            _protect: None,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Borrow the inner view.
+    #[inline]
+    pub fn get(&self) -> &T {
+        &self.inner
+    }
+
+    /// Consume the bundle and return the inner view.
+    ///
+    /// The [`OwnedProtect`] guard drops here, releasing the SEXP from the protect
+    /// stack. Any owned data extracted from `T` must not retain SEXP references
+    /// after this point.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<'a, T> core::ops::Deref for Protected<'a, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<'a, T: std::fmt::Debug> std::fmt::Debug for Protected<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Protected")
+            .field("inner", &self.inner)
+            .field("protected", &self._protect.is_some())
+            .finish()
+    }
+}
+// endregion
+
 // region: ReprotectSlot
 
 /// A protected slot created with `R_ProtectWithIndex` and updated with `R_Reprotect`.
@@ -1428,6 +1550,70 @@ mod tests {
     //
     // These should be tested in miniextendr-api/tests/gc_protect.rs with
     // embedded R.
+    // endregion
+
+    // region: Protected<'a, T> tests
+
+    /// Verify `Protected::get()` returns the inner value.
+    #[test]
+    fn protected_get_returns_inner() {
+        // from_trusted with null SEXP (safe for compile-time tests since we
+        // never dereference the SEXP itself, only the already-constructed inner)
+        let v = vec![1i32, 2, 3];
+        let p = unsafe {
+            Protected::<'static, Vec<i32>>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), v)
+        };
+        assert_eq!(p.get(), &[1, 2, 3]);
+    }
+
+    /// Verify `Deref<Target = T>` works (exercises the blanket impl).
+    #[test]
+    fn protected_deref_reaches_inner() {
+        let v = vec![10i32, 20];
+        let p = unsafe {
+            Protected::<'static, Vec<i32>>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), v)
+        };
+        // Deref should let us call Vec methods directly.
+        assert_eq!(p.len(), 2);
+    }
+
+    /// Verify `into_inner` moves the inner value out cleanly.
+    #[test]
+    fn protected_into_inner_moves_value() {
+        let v = vec![42i32];
+        let p = unsafe {
+            Protected::<'static, Vec<i32>>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), v)
+        };
+        let got = p.into_inner();
+        assert_eq!(got, [42]);
+    }
+
+    /// Verify `from_trusted` sets `_protect` to `None` (no extra protect push).
+    #[test]
+    fn protected_from_trusted_does_not_hold_protect() {
+        let v: Vec<u8> = vec![];
+        let p = unsafe {
+            Protected::<'static, Vec<u8>>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), v)
+        };
+        // _protect is private — verify indirectly: if it were Some(OwnedProtect),
+        // the OwnedProtect drop would call Rf_unprotect(1) without a matching
+        // protect (crashing R). Since we're not running R here, just confirm the
+        // Debug output shows `protected: false`.
+        assert!(format!("{p:?}").contains("protected: false"));
+    }
+
+    /// Verify `Protected<'a, T>` with `Some(OwnedProtect)` is `!Send`
+    /// (compile-time — the type-system test is implicit: if this test builds
+    /// we confirm the field layout compiles cleanly).
+    #[test]
+    fn protected_is_copy_of_struct_fields_compile_check() {
+        // Smoke-test: constructing Protected<'static, i32> via from_trusted
+        // (the None path, which is auto-Send) must compile.
+        let p = unsafe {
+            Protected::<'static, i32>::from_trusted(crate::ffi::SEXP(core::ptr::null_mut()), 99)
+        };
+        assert_eq!(*p, 99);
+    }
     // endregion
 }
 // endregion

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -604,7 +604,9 @@ pub mod preserve;
 
 // GC protection toolkit (PROTECT stack RAII wrappers)
 pub mod gc_protect;
-pub use gc_protect::{OwnedProtect, ProtectIndex, ProtectScope, Protector, ReprotectSlot, Root};
+pub use gc_protect::{
+    OwnedProtect, ProtectIndex, ProtectScope, Protected, Protector, ReprotectSlot, Root,
+};
 
 // VECSXP pool with generational keys (slotmap-backed)
 pub mod protect_pool;

--- a/miniextendr-api/src/prelude.rs
+++ b/miniextendr-api/src/prelude.rs
@@ -61,7 +61,7 @@ pub use crate::{Coerce, IntoR, IntoRAltrep, TryCoerce, TryFromSexp};
 // region: Types
 pub use crate::{
     IntoList, Lazy, List, ListBuilder, ListMut, Missing, NamedVector, OwnedProtect, ProtectScope,
-    ProtectedStrVec, StrVec, StrVecBuilder,
+    Protected, ProtectedStrVec, StrVec, StrVecBuilder,
 };
 // endregion
 

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use crate::ffi::SEXPTYPE::STRSXP;
 use crate::ffi::{SEXP, SexpExt};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
-use crate::gc_protect::{OwnedProtect, ProtectScope};
+use crate::gc_protect::{OwnedProtect, ProtectScope, Protected};
 use crate::into_r::IntoR;
 
 /// Owned handle to an R character vector (`STRSXP`).
@@ -447,8 +447,8 @@ impl TryFromSexp for StrVec {
 /// GC-protected view over an R character vector (`STRSXP`).
 ///
 /// Unlike [`StrVec`] (which is `Copy` and trusts the caller for GC protection),
-/// `ProtectedStrVec` owns an [`OwnedProtect`] guard that keeps the STRSXP alive.
-/// All borrowed data (`&str`, iterators) has its lifetime tied to `&self`,
+/// `ProtectedStrVec` wraps a [`Protected<'static, StrVec>`](crate::gc_protect::Protected) that keeps the
+/// STRSXP alive. All borrowed data (`&str`, iterators) has its lifetime tied to `&self`,
 /// not `'static` — preventing use-after-GC bugs at compile time.
 ///
 /// # When to use
@@ -470,9 +470,8 @@ impl TryFromSexp for StrVec {
 /// }
 /// ```
 pub struct ProtectedStrVec {
-    inner: StrVec,
+    protected: Protected<'static, StrVec>,
     len: isize,
-    _protect: Option<OwnedProtect>,
 }
 
 impl ProtectedStrVec {
@@ -488,13 +487,11 @@ impl ProtectedStrVec {
     /// - Must be called from the R main thread.
     #[inline]
     pub unsafe fn new(sexp: SEXP) -> Self {
-        let guard = unsafe { OwnedProtect::new(sexp) };
-        let inner = unsafe { StrVec::from_raw(guard.get()) };
+        let inner = unsafe { StrVec::from_raw(sexp) };
         let len = inner.len();
         Self {
-            inner,
+            protected: unsafe { Protected::new(sexp, inner) },
             len,
-            _protect: Some(guard),
         }
     }
 
@@ -517,9 +514,8 @@ impl ProtectedStrVec {
         let inner = unsafe { StrVec::from_raw(sexp) };
         let len = inner.len();
         Self {
-            inner,
+            protected: unsafe { Protected::from_trusted(sexp, inner) },
             len,
-            _protect: None,
         }
     }
 
@@ -542,14 +538,14 @@ impl ProtectedStrVec {
     pub fn get_str(&self, idx: isize) -> Option<&str> {
         // charsxp_to_str returns &'static str, but lifetime elision
         // restricts it to &'_ (tied to &self) — correct: data lives
-        // as long as OwnedProtect keeps the STRSXP alive.
-        self.inner.get_str(idx)
+        // as long as the Protected guard keeps the STRSXP alive.
+        self.protected.get().get_str(idx)
     }
 
     /// Get the string at index as `Cow<str>` (encoding-safe, lifetime tied to `&self`).
     #[inline]
     pub fn get_cow(&self, idx: isize) -> Option<Cow<'_, str>> {
-        self.inner.get_cow(idx)
+        self.protected.get().get_cow(idx)
     }
 
     /// Iterate over elements as `Option<&str>` (lifetime tied to `&self`).
@@ -575,13 +571,13 @@ impl ProtectedStrVec {
     /// Get the underlying SEXP (still protected by this handle).
     #[inline]
     pub fn as_sexp(&self) -> SEXP {
-        self.inner.as_sexp()
+        self.protected.get().as_sexp()
     }
 
     /// Get the inner `StrVec` (unprotected copy — caller assumes protection responsibility).
     #[inline]
     pub fn as_strvec(&self) -> StrVec {
-        self.inner
+        *self.protected.get()
     }
 }
 

--- a/miniextendr-api/tests/gc_protect.rs
+++ b/miniextendr-api/tests/gc_protect.rs
@@ -6,7 +6,7 @@
 mod r_test_utils;
 
 use miniextendr_api::ffi::{Rf_allocVector, SEXP, SEXPTYPE};
-use miniextendr_api::gc_protect::{OwnedProtect, ProtectScope, tls};
+use miniextendr_api::gc_protect::{OwnedProtect, ProtectScope, Protected, tls};
 
 // region: Balance tests
 
@@ -426,6 +426,44 @@ fn reprotect_slot_multiple_replacements() {
 
         // Final value should be the last one
         assert!(std::ptr::eq(slot.get().0, values[4].0));
+    });
+}
+// endregion
+
+// region: Protected tests
+
+#[test]
+fn protected_new_drops_unprotect() {
+    // Test: Protected::new pushes one protect entry that drops cleanly
+    // when the Protected goes out of scope. Net change after drop is zero.
+    r_test_utils::with_r_thread(|| unsafe {
+        let scope = ProtectScope::new();
+        let outer = scope.protect(SEXP::scalar_integer(1));
+        let depth_before = scope.count();
+        {
+            let p = Protected::<'static, SEXP>::new(outer.get(), outer.get());
+            // While `p` is alive, an additional protect entry exists.
+            // The drop at the end of this block UNPROTECTs(1).
+            let _ = p.get();
+        }
+        // Net change after p drops is zero.
+        assert_eq!(scope.count(), depth_before);
+    });
+}
+
+#[test]
+fn protected_from_trusted_no_stack_change() {
+    // Test: Protected::from_trusted does NOT push a protect entry.
+    // The scope's count should be unchanged across construction and drop.
+    r_test_utils::with_r_thread(|| unsafe {
+        let scope = ProtectScope::new();
+        let outer = scope.protect(SEXP::scalar_integer(7));
+        let depth_before = scope.count();
+        {
+            let p = Protected::<'static, SEXP>::from_trusted(outer.get(), outer.get());
+            let _ = p.get();
+        }
+        assert_eq!(scope.count(), depth_before);
     });
 }
 // endregion


### PR DESCRIPTION
Lands the generic `Protected<'a, T>` primitive from #681. Future borrowed-view types (#671b `BorrowedRows`, etc.) collapse onto this shape instead of re-rolling the `OwnedProtect` + view bundle by hand. `ProtectedStrVec` migrates to wrap it as the API-sufficiency check.

<details>
<summary><h3>🤖 Implementation notes & test plan (AI-written)</h3></summary>

## Summary

- **New type `Protected<'a, T>`** added to `miniextendr-api/src/gc_protect.rs` in a new `// region: Protected` block between `OwnedProtect` (line ~872) and `ReprotectSlot`. Holds `inner: T`, `_protect: Option<OwnedProtect>`, and `_marker: PhantomData<&'a ()>`.
- **Two constructors**: `Protected::new(sexp, inner)` calls `Rf_protect` and stores a `Some(OwnedProtect)`; `Protected::from_trusted(_sexp, inner)` stores `None` (no protect push) for SEXPs already protected by R.
- **Three inherent methods**: `get() -> &T`, `into_inner() -> T`, plus `Deref<Target = T>` and `Debug` (when `T: Debug`).
- **`ProtectedStrVec` migrated** in `miniextendr-api/src/strvec.rs`: old `{ inner: StrVec, len: isize, _protect: Option<OwnedProtect> }` becomes `{ protected: Protected<'static, StrVec>, len: isize }`. All public methods now delegate via `self.protected.get().<method>()`. No behavioural change visible to callers.
- **Exports**: `Protected` added to `lib.rs` `pub use gc_protect::{ ... }` block and to `prelude.rs` Types region alongside `OwnedProtect` and `ProtectedStrVec`.
- **5 unit tests** added to the `#[cfg(test)]` block in `gc_protect.rs`: `protected_get_returns_inner`, `protected_deref_reaches_inner`, `protected_into_inner_moves_value`, `protected_from_trusted_does_not_hold_protect` (verifies `Debug` shows `protected: false`), and `protected_is_copy_of_struct_fields_compile_check`.

## Test plan

- [x] `just fmt` — clean
- [x] `just check` — clean across all workspace members (root, rpkg, cross-package)
- [x] `just clippy` — clean
- [x] `cargo test -p miniextendr-api strvec` — 1 passed, 0 failures
- [x] `cargo test -p miniextendr-api gc_protect` — 18 passed (14 pre-existing + 5 new tests), 0 failures
- [x] CI `clippy_all` feature sweep (full feature list from `.github/workflows/ci.yml`) — clean, `-D warnings`
- [x] `R CMD INSTALL rpkg` (via `R_LIBS_USER` pointing to main repo rv library) — DONE, installed successfully
- [x] `devtools::test(pkg = "rpkg")` — `[ FAIL 0 | WARN 7 | SKIP 19 | PASS 5967 ]` (warnings and skips are pre-existing)

## Notes

- The `'static` lifetime on `Protected<'static, StrVec>` in `ProtectedStrVec` is correct: `StrVec` itself carries no lifetime parameter, so the `Protected` lifetime says "no external borrows". The `StrVec` methods handle SEXP-internal borrows via lifetime elision on `&self`.
- The `from_trusted` constructor keeps `_sexp` in the signature (unused in the body) as a documentation pattern: callers can see which SEXP is being trusted.
- The 3 collateral changes (`rpkg/R/miniextendr-wrappers.R` line-number drift, `rpkg/src/rust/Cargo.lock` git-source removal after `--config patch`, `rpkg/src/rust/condition_sidecar_tests.rs` formatting) were left unstaged: they are pre-existing drift unrelated to this PR and require a NAMESPACE re-document pass to satisfy the pre-commit hook cleanly. They can be squashed in at review time if desired.
- `OwnedProtect` import was retained in `strvec.rs` because `StrVec::set_charsxp` and `StrVec::set_str` still use it directly.

---
_Drafted by Claude (claude-sonnet-4-6). Reviewed by the author._

Closes #681.

</details>