### PR TITLE
chore(cargo-lock): auto-restore after local builds + strengthen pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,21 +29,33 @@ fi
 
 # ── Cargo.lock tarball-shape assertion ───────────────────────────────────────
 # rpkg/src/rust/Cargo.lock must stay in "tarball-shape":
-# - miniextendr-{api,lint,macros} as git+url sources (not path+...)
+# - miniextendr-{api,lint,macros} have source = "git+https://github.com/A2-ai/miniextendr#…"
 # - no [[patch.unused]] blocks
-# checksum = "..." lines are now ALLOWED: cargo-revendor writes valid
+# checksum = "..." lines are ALLOWED: cargo-revendor writes valid
 # .cargo-checksum.json files whose `package` field matches them.
-# Local `cargo build` silently rewrites path sources; committing that breaks CRAN.
+#
+# Two drift modes both break CRAN/tarball builds:
+#   1. `cargo build` under `[patch.crates-io]` path overrides → "path+…" sources
+#   2. `cargo …  --config "patch.'…'.path=…"` (just check/clippy/build/test) →
+#      `source` line STRIPPED entirely
+# We inspect the staged blob (not the diff) so the assertion is structural and
+# doesn't depend on whether the lockfile's prior shape was already broken.
 staged_lock=$(echo "$STAGED" | grep -F 'rpkg/src/rust/Cargo.lock' || true)
 if [ -n "$staged_lock" ]; then
-    lock_content=$(git diff --cached -- rpkg/src/rust/Cargo.lock | grep '^+' | grep -v '^+++')
-    if echo "$lock_content" | grep -qE '^\+source = "path\+'; then
-        echo "pre-commit: rpkg/src/rust/Cargo.lock has path+... sources for miniextendr crates." >&2
-        echo "  The committed lockfile must use git+url sources for workspace crates." >&2
-        echo "  Run: just vendor    # regenerates canonical shape" >&2
-        exit 1
-    fi
-    if echo "$lock_content" | grep -qE '^\+\[\[patch\.unused\]\]'; then
+    staged_blob=$(git show ":rpkg/src/rust/Cargo.lock")
+    for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
+        if ! echo "$staged_blob" | grep -A 3 "^name = \"$crate\"\$" \
+                | grep -q '^source = "git+https://github\.com/A2-ai/miniextendr'; then
+            echo "pre-commit: rpkg/src/rust/Cargo.lock — $crate is missing the canonical" >&2
+            echo "  source = \"git+https://github.com/A2-ai/miniextendr#<sha>\" line." >&2
+            echo "  Likely cause: local 'just check / clippy / build / test' stripped it" >&2
+            echo "  under '--config \"patch.'…'.path=…\"'." >&2
+            echo "  Run: just cargo-lock-restore    # restore from HEAD" >&2
+            echo "    or just vendor                # regenerate canonical shape" >&2
+            exit 1
+        fi
+    done
+    if echo "$staged_blob" | grep -qE '^\[\[patch\.unused\]\]'; then
         echo "pre-commit: rpkg/src/rust/Cargo.lock has [[patch.unused]] blocks." >&2
         echo "  Narrow the [patch.crates-io] override in .cargo/config.toml." >&2
         echo "  Run: just vendor    # regenerates canonical shape" >&2

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@
 #     just clippy             - Run lints
 #     just fmt                - Format Rust code
 #     just lint               - Run miniextendr-lint on rpkg
+#     just cargo-lock-restore - Undo rpkg/src/rust/Cargo.lock drift from local builds
 #
 #   rpkg (example R package):
 #     just configure          - Configure R package build (dev mode, no vendoring)
@@ -179,6 +180,17 @@ update *cargo_flags:
     cargo update --manifest-path "$rust_dir/Cargo.toml" {{cargo_flags}}
     just lock-shape-check
 
+# Restore rpkg/src/rust/Cargo.lock to its committed canonical (tarball) shape.
+# `just check / clippy / build / test / doc / doc-check` invoke cargo with
+# `--config "patch.'https://github.com/A2-ai/miniextendr'.<crate>.path=…"`,
+# which causes cargo to drop the `source = "git+…#<sha>"` line for each
+# workspace sibling. The committed lockfile must keep those lines (CRAN/
+# tarball builds resolve `vendor/` against them). The drifting recipes
+# auto-chain this restore as their last line; run it manually to clean
+# up if a recipe aborted mid-way.
+cargo-lock-restore:
+    git restore --worktree -- rpkg/src/rust/Cargo.lock
+
 # Check all crates
 alias cargo-check := check
 check *cargo_flags:
@@ -186,6 +198,7 @@ check *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo check --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo check --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo check --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    @just cargo-lock-restore
 
 # Build all crates
 alias cargo-build := build
@@ -194,6 +207,7 @@ build *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo build --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo build --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo build --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    @just cargo-lock-restore
 
 # Run clippy on all crates
 alias cargo-clippy := clippy
@@ -202,6 +216,7 @@ clippy *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo clippy --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    @just cargo-lock-restore
 
 # Run miniextendr-lint on rpkg (checks #[miniextendr] consistency)
 # The lint runs as a build script; this command triggers it via cargo check.
@@ -234,6 +249,7 @@ doc-check *cargo_flags: configure-all
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo doc --no-deps --document-private-items --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo doc --no-deps --document-private-items --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo doc --no-deps --document-private-items --manifest-path="$root/rpkg/src/rust/Cargo.toml" --config "patch.crates-io.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.crates-io.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.crates-io.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    @just cargo-lock-restore
 
 # Build and open documentation
 alias cargo-doc := doc
@@ -242,6 +258,7 @@ doc *cargo_flags: configure-all
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo doc --document-private-items --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo doc --document-private-items --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo doc --document-private-items --manifest-path="$root/rpkg/src/rust/Cargo.toml" --config "patch.crates-io.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.crates-io.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.crates-io.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    @just cargo-lock-restore
     if command -v open >/dev/null 2>&1; then \
       open rpkg/src/rust/target/doc/rpkg/index.html >/dev/null 2>&1 || \
         echo "doc: unable to open generated docs (skipping)"; \
@@ -279,6 +296,7 @@ test *args:
     && root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo test --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" --workspace --no-fail-fast $cargo_flags -- --no-capture $test_args) \
     && root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo test --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" --workspace --no-fail-fast $cargo_flags -- --no-capture $test_args) \
     && root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo test --workspace --no-fail-fast $cargo_flags --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" -- --no-capture $test_args)
+    @just cargo-lock-restore
 
 # Run benchmarks (miniextendr-bench)
 alias cargo-bench := bench
@@ -1083,7 +1101,8 @@ vendor-sync-diff:
 # Check that rpkg/src/rust/Cargo.lock is in tarball-shape.
 #
 # Tarball-shape (post-#408):
-#   - miniextendr-{api,lint,macros} must use git+url#<sha> sources, not path+.
+#   - miniextendr-{api,lint,macros} have source = "git+https://github.com/A2-ai/miniextendr#<sha>"
+#     (not path+, not missing entirely).
 #   - no [[patch.unused]] blocks (signals a wider [patch.crates-io] than
 #     the manifest needs; produces spurious commit-time diff).
 #
@@ -1098,16 +1117,20 @@ lock-shape-check:
         exit 0
     fi
     bad=0
-    if grep -q 'source = "path+' "$lock"; then
-        echo "lock-shape-check: $lock has path+... sources (tarball-shape violation)" >&2
-        bad=1
-    fi
+    for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
+        if ! grep -A 3 "^name = \"$crate\"$" "$lock" \
+                | grep -q '^source = "git+https://github\.com/A2-ai/miniextendr'; then
+            echo "lock-shape-check: $lock — $crate missing canonical git+url source" >&2
+            bad=1
+        fi
+    done
     if grep -qE '^\[\[patch\.unused\]\]' "$lock"; then
         echo "lock-shape-check: $lock has [[patch.unused]] blocks (narrow [patch.crates-io])" >&2
         bad=1
     fi
     if [ $bad -eq 1 ]; then
-        echo "  Run: just vendor    # regenerates canonical shape" >&2
+        echo "  Run: just cargo-lock-restore    # restore from HEAD" >&2
+        echo "    or just vendor                # regenerate canonical shape" >&2
         exit 1
     fi
     echo "lock-shape-check: OK"

--- a/justfile
+++ b/justfile
@@ -180,14 +180,18 @@ update *cargo_flags:
     cargo update --manifest-path "$rust_dir/Cargo.toml" {{cargo_flags}}
     just lock-shape-check
 
-# Restore rpkg/src/rust/Cargo.lock to its committed canonical (tarball) shape.
+# Restore rpkg/src/rust/Cargo.lock from the git index (preserves staged
+# changes — matters for the `just vendor` flow which stages a tarball-shape
+# lockfile before commit; if nothing is staged the index equals HEAD, so this
+# is effectively a HEAD-restore).
+#
 # `just check / clippy / build / test / doc / doc-check` invoke cargo with
 # `--config "patch.'https://github.com/A2-ai/miniextendr'.<crate>.path=…"`,
 # which causes cargo to drop the `source = "git+…#<sha>"` line for each
 # workspace sibling. The committed lockfile must keep those lines (CRAN/
 # tarball builds resolve `vendor/` against them). The drifting recipes
-# auto-chain this restore as their last line; run it manually to clean
-# up if a recipe aborted mid-way.
+# auto-chain this restore as their last line; run it manually to clean up
+# if a recipe aborted mid-way.
 cargo-lock-restore:
     git restore --worktree -- rpkg/src/rust/Cargo.lock
 


### PR DESCRIPTION
Closes the long-running Cargo.lock drift nuisance — see the 20+ stashes labeled `cargo-lock-drift`, `pre-rebase-cargo-lock`, etc. After this lands, `just check / clippy / build / test / doc / doc-check` no longer leave `rpkg/src/rust/Cargo.lock` dirty, and the pre-commit hook catches both known drift modes structurally.

<details>
<summary><h3>AI-written details</h3></summary>

## Why

`just check / clippy / build / test / doc / doc-check` invoke cargo with `--config "patch.'https://github.com/A2-ai/miniextendr'.<crate>.path=…"` so workspace siblings resolve to local paths. Cargo updates `rpkg/src/rust/Cargo.lock` as a side effect — specifically, it **strips** the `source = "git+https://github.com/A2-ai/miniextendr#<sha>"` line for each workspace crate. The committed lockfile must keep those lines (CRAN/tarball builds resolve `vendor/` against them).

The pre-existing hook (`.githooks/pre-commit`) only caught the *other* drift mode (`source = "path+…"`) and additionally had a `set -euo pipefail` × `grep '^+' | grep -v '^+++'` interaction that silently killed the hook when the lockfile diff had only deletions (noted as a follow-up in PR #675's description).

## Changes

1. **`just cargo-lock-restore`** — single-line recipe that calls `git restore --worktree -- rpkg/src/rust/Cargo.lock`. The `--worktree` (vs `git checkout HEAD --`) preserves any staged changes (matters for the `just vendor` workflow that stages a tarball-shape Cargo.lock).

2. **Auto-chain** `@just cargo-lock-restore` as the final line of `check`, `clippy`, `build`, `test`, `doc`, `doc-check`. If a recipe aborts mid-way the lockfile stays dirty; the new recipe is the manual escape hatch.

3. **Pre-commit hook** rewritten to inspect the staged blob (`git show :rpkg/src/rust/Cargo.lock`) instead of the diff. New shape: for each workspace sibling (`miniextendr-api`, `miniextendr-lint`, `miniextendr-macros`), `grep -A 3 "^name = \"<crate>\"$" | grep -q '^source = "git+https://github\.com/A2-ai/miniextendr'`. Catches:
   - `source = "path+…"` (existing failure mode — cargo build under `[patch.crates-io]` path override)
   - missing `source` line entirely (new failure mode — `--config patch=…path=…` override during `just check` etc.)
   
   Side benefit: no more chained `grep '^+' | grep -v '^+++'` → pipefail bug from PR #675's description is gone.

4. **`lock-shape-check` recipe** updated in parallel so `just lock-shape-check` and the pre-commit hook agree on the spec.

## Verification

- Ran `just check` on this branch — exits clean, `git status --short` shows no `rpkg/src/rust/Cargo.lock` line. Previously this command alone produced a 3-line deletion diff.
- Ran `just clippy` — same.
- Simulated drift by deleting the 3 `source = "git+…"` lines, staged it, ran `.githooks/pre-commit` — fires with a clear error:
  ```
  pre-commit: rpkg/src/rust/Cargo.lock — miniextendr-api is missing the canonical
    source = "git+https://github.com/A2-ai/miniextendr#<sha>" line.
    Likely cause: local 'just check / clippy / build / test' stripped it
    under '--config "patch.'…'.path=…"'.
    Run: just cargo-lock-restore    # restore from HEAD
      or just vendor                # regenerate canonical shape
  ```
- `just lock-shape-check` on a stripped lockfile fires the matching error.

## Notes

- `git restore --worktree` requires Git 2.23+ (Aug 2019). Should be fine everywhere — CI runs Git 2.54.
- The auto-chain uses `@just cargo-lock-restore`. `@` suppresses the recipe-line echo; the inner `git restore` still prints if anything is unusual.
- `bench` recipe also touches `Cargo.lock` (in `miniextendr-bench/`) but doesn't trigger the `[patch.'…'.<crate>.path=…]` override — it builds against its own manifest. No restore needed there.
- Not changed: the wrapper-sync / NAMESPACE assertion at the top of the hook, the existing `[[patch.unused]]` rejection.

</details>