### PR TITLE
docs(api): top-level API choice map + docs/API_CHOICE_MATRIX.md

### DIFF
--- a/docs/API_CHOICE_MATRIX.md
+++ b/docs/API_CHOICE_MATRIX.md
@@ -1,0 +1,98 @@
+# API choice matrix
+
+miniextendr has several places where two or more APIs achieve the same goal
+with different tradeoffs. This page is a single-screen reference: for each
+decision point, the **safer / stricter / more validated** option is on the
+left, the **easier / faster / less protective** option is on the right, and
+the row tells you when to pick which. Each link points at the rustdoc landing
+page and the existing in-depth doc.
+
+For the long-form decision trees see [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md),
+[ALTREP.md](ALTREP.md), [STRICT_MODE.md](STRICT_MODE.md), and
+[ERROR_HANDLING.md](ERROR_HANDLING.md). This page is the index, not the
+textbook.
+
+## At a glance
+
+| Decision | Stricter / safer | Looser / faster | Pick stricter when... |
+|---|---|---|---|
+| **Rust → R for lossy ints** (`i64`/`u64`/`isize`/`usize`) | `#[miniextendr(strict)]` → `strict::checked_*` helpers (panic on overflow) | default `IntoR` (silently widens to `REALSXP` outside `[-2^53, 2^53]`) | the caller's data is *supposed to fit* the type you declared and a silent precision loss would mask a bug |
+| **Strict mode (project-wide)** | `default-strict` feature | strict opted-in per-fn | you'd rather a misuse fail loudly across the whole package |
+| **R → Rust shape mismatch** | `TryFromSexp` (returns `Result` on wrong R type) | `Coerce<R>` (widens across SEXP types) | the input is *supposed to be* one R type and accepting others would mask a caller bug |
+| **Numeric narrowing across types** | `TryCoerce<R>` (fallible) | `Coerce<R>` (infallible widening) | the source range exceeds the target type |
+| **Conversion impl style** | hand-rolled `TryFromSexp + IntoR` | `#[derive(RSerializeNative)]` (serde feature) | you need full control over the SEXP layout, zero-overhead, or your shape doesn't match serde's data model |
+| **FFI primitive** | checked (`Rf_foo`) | `Rf_foo_unchecked` | you're not provably inside an ALTREP callback, `with_r_unwind_protect`, or `with_r_thread` block. MXL301 enforces this. |
+| **Error emission** | `error!("msg", class = "my_class")` (typed condition) | `panic!(msg)` (becomes `rust_panic`) | R-side callers may want to `tryCatch` your specific error class. Never `Rf_error` directly — MXL300 forbids. |
+| **Error propagation** | `Result<T, E: std::error::Error>` + `?` | embed-the-error-in-the-return-type | you want value-style propagation through Rust code; convert at the boundary via `RErrorAdapter` / `unwrap_in_r` opt-out |
+| **ALTREP path** | `#[altrep(manual)]` + handwritten `AltrepLen`/`Alt*Data` | `#[derive(AltrepInteger)]` field-based | the field-based derive can't express your storage (custom backing, computed-on-access, etc.) |
+| **ALTREP guard** | `r_unwind` (calls `with_r_unwind_protect`) | `rust_unwind` (default `catch_unwind`) | the ALTREP callback calls R API functions that may longjmp. Use `unsafe` only when callbacks are pure Rust and panic-free. |
+| **Variadic args** | `#[miniextendr(dots = typed_list!(...))]` | `_dots: &Dots` raw access | you want missing/extra/wrong-type field errors at the macro call site, not at runtime |
+| **Choice arg** | `#[miniextendr]` + `MatchArg<MyEnum>` | manual `match` on `String` | you want R-side `match.arg`-style partial matching and a default value |
+| **GC protection** | `ProtectScope` (RAII, LIFO) within `.Call` | manual `Rf_protect` / `Rf_unprotect` | always. The RAII variant is correct by construction; manual is correct only by audit. |
+| **Long-lived SEXP** | `preserve::insert` / `preserve::release` (cross-.Call) | `ProtectScope` (single .Call) | the SEXP needs to survive past your function's return |
+| **Rust data owned by R** | `ExternalPtr<MyStruct>` | sidecar fields (multi-SEXP attribute slots) | one owned struct is the natural shape. Sidecars are for cases where R-side code wants to read individual fields without crossing the Rust boundary. |
+| **Worker thread** | `worker-thread` feature on (default) | inline (off) | always, unless you've measured a hot path and confirmed inline-without-longjmp-safety is acceptable |
+| **Thread re-entry** | wrap R calls in `with_r_thread` | call from any thread | you're on the worker thread or any non-main thread (which is *always* the case for user `#[miniextendr]` code) |
+
+## Class systems (one-of-six)
+
+This is its own decision because the six are mutually exclusive per type.
+See [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) for the full flowchart; the
+one-line summary is:
+
+| System | Pick when... | Avoid when... |
+|---|---|---|
+| **Env** | you want raw R env semantics, fastest dispatch, no formal class | you need inheritance or method dispatch beyond `$`-lookup |
+| **R6** | you want mutable, reference-semantics OOP with lifecycle hooks | you need value semantics or formal type checking |
+| **S3** | the type is simple and dispatch can ride on `class()` ordering | you need formal slot validation or multi-dispatch |
+| **S4** | you need formal validation, slots, multi-dispatch, and you accept the cost | startup time and `methods::` package loading is a concern |
+| **S7** | you want formal validation + value semantics + inheritance (newer than S4, similar power) | you need to interop with older S4-heavy code |
+| **Vctrs** | the type is a *vector* that should integrate with tidyverse `vctrs` | the type isn't vector-shaped |
+
+Default class system is controlled by the mutually-exclusive
+`default-r6` and `default-s7` features. Per-type override via the
+`#[miniextendr]` attribute.
+
+## Defaults that change behavior
+
+A few cargo features shift the project-wide defaults; flipping them
+changes which row of the matrix above is in force without changing any
+call sites:
+
+| Feature | What it changes |
+|---|---|
+| `default-strict` | All `#[miniextendr]` lossy conversions reject NA / truncation by default |
+| `default-coerce` | Numeric scalars use `TryCoerce` path by default |
+| `default-r6` / `default-s7` | Picks the default class system for `#[miniextendr] impl` blocks without an explicit attr |
+| `default-worker` | All `#[miniextendr]` fns dispatch through the worker thread (implies `worker-thread`) |
+
+See [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md) for the full story.
+
+## When in doubt
+
+Pick the **left column** (stricter). The framework's default opinion is
+"fail loudly, leave a trail." The looser variants exist for cases where
+you've measured the cost or confirmed the looser semantics are correct
+for your data.
+
+For AI coding assistants: if you find yourself reaching for the right
+column because it's easier, pause and ask whether the left column would
+catch a real bug. The looser path is correct for *some* problems; it is
+not the default.
+
+## Related reading
+
+- [STRICT_MODE.md](STRICT_MODE.md) — the strict-vs-lax conversion story
+- [CONVERSION_MATRIX.md](CONVERSION_MATRIX.md) — full R × Rust type behavior
+- [COERCE.md](COERCE.md) / [AS_COERCE.md](AS_COERCE.md) — coercion paths
+- [PREFER_DERIVES.md](PREFER_DERIVES.md) — derive-selector attribute
+- [CLASS_SYSTEMS.md](CLASS_SYSTEMS.md) — class system decision tree + flowchart
+- [ALTREP.md](ALTREP.md) — ALTREP field-derive vs manual flowchart
+- [ALTREP_GUARDS.md](ALTREP_GUARDS.md) — guard mode tradeoffs
+- [EXTERNALPTR.md](EXTERNALPTR.md) — `Box<Box<dyn Any>>` storage + provenance
+- [ERROR_HANDLING.md](ERROR_HANDLING.md) — panic / error! / Result paths
+- [CONDITIONS.md](CONDITIONS.md) — condition class layering
+- [DOTS_TYPED_LIST.md](DOTS_TYPED_LIST.md) — variadic + validation
+- [FFI_GUARD.md](FFI_GUARD.md) — checked/unchecked FFI boundary
+- [THREADS.md](THREADS.md) — worker-thread architecture
+- [FEATURE_DEFAULTS.md](FEATURE_DEFAULTS.md) — project-wide knobs

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ framework.
 
 | I want to... | Read |
 |---|---|
+| Choose between two miniextendr APIs that look similar | [API Choice Matrix](API_CHOICE_MATRIX.md) |
 | Build my first package | [Getting Started](GETTING_STARTED.md) |
 | Use the CLI tool | [miniextendr CLI](../miniextendr-cli/README.md) |
 | Use the R scaffolding helper | [minirextendr](MINIREXTENDR.md) |
@@ -30,6 +31,9 @@ framework.
 
 ### Core concepts
 
+- **[API Choice Matrix](API_CHOICE_MATRIX.md)** -- One-page index of every
+  place miniextendr offers a strict vs lax / safe vs fast / validated vs raw
+  choice, with one-line guidance and links to deep-dives
 - **[Architecture](ARCHITECTURE.md)** -- Crate structure, call flow, how Rust
   talks to R
 - **[Type Conversions](TYPE_CONVERSIONS.md)** -- `TryFromSexp` / `IntoR`

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -34,6 +34,35 @@
 //! extracted) by the cdylib-based wrapper generator and committed into
 //! `R/miniextendr_wrappers.R` so CRAN builds do not require codegen.
 //!
+//! ## Choosing the right API
+//!
+//! miniextendr has several places where two or more APIs reach the same
+//! goal with different tradeoffs — a stricter / safer / more validated
+//! option, and a looser / easier / less protective one. The full matrix
+//! lives in [`docs/API_CHOICE_MATRIX.md`](https://github.com/A2-ai/miniextendr/blob/main/docs/API_CHOICE_MATRIX.md);
+//! the short version is:
+//!
+//! | I'm reaching for... | Consider also | Why |
+//! |---|---|---|
+//! | default `IntoR` for `i64` / `u64` / `isize` / `usize` (silently widens to `REALSXP` on overflow) | `#[miniextendr(strict)]` → [`crate::strict`] helpers (panic on overflow) | strict catches the truncation bugs caused by R having no native 64-bit integer type |
+//! | [`Coerce`] (infallible widening) | [`TryCoerce`] (fallible) | the source range can exceed the target type |
+//! | `Rf_*_unchecked` FFI | checked variants | unchecked is only safe inside ALTREP callbacks, `with_r_unwind_protect`, or `with_r_thread` — MXL301 lint enforces |
+//! | `panic!(msg)` | `miniextendr_api::error!("msg", class = "...")` | typed conditions let R-side `tryCatch` handlers route by class |
+//! | raw `_dots: &Dots` | `#[miniextendr(dots = typed_list!(...))]` | validation moves from runtime to macro call site |
+//! | `#[derive(AltrepInteger)]` field-based | `#[altrep(manual)]` + handwritten traits | when custom storage or computed-on-access can't fit the derive |
+//! | hand-rolled [`TryFromSexp`] + [`IntoR`] | `#[derive(RSerializeNative)]` (serde feature) | serde is ergonomic for nested structs; hand-rolled is zero-overhead and fully controlled |
+//!
+//! Project-wide defaults are controlled by mutually-exclusive cargo
+//! features — see the "Project-wide Defaults" feature table below and
+//! [`docs/FEATURE_DEFAULTS.md`](https://github.com/A2-ai/miniextendr/blob/main/docs/FEATURE_DEFAULTS.md).
+//!
+//! ### Default opinion
+//!
+//! When in doubt, pick the **stricter** path. The framework's default
+//! stance is "fail loudly, leave a trail." The looser variants exist for
+//! cases where the cost is measured or the looser semantics are correct
+//! for your data — they are not the default.
+//!
 //! ## GC protection and ownership
 //!
 //! R's garbage collector can reclaim any SEXP that isn't protected. miniextendr

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -38,9 +38,8 @@
 //!
 //! miniextendr has several places where two or more APIs reach the same
 //! goal with different tradeoffs — a stricter / safer / more validated
-//! option, and a looser / easier / less protective one. The full matrix
-//! lives in [`docs/API_CHOICE_MATRIX.md`](https://github.com/A2-ai/miniextendr/blob/main/docs/API_CHOICE_MATRIX.md);
-//! the short version is:
+//! option, and a looser / easier / less protective one. The most common
+//! pairs are:
 //!
 //! | I'm reaching for... | Consider also | Why |
 //! |---|---|---|
@@ -53,8 +52,7 @@
 //! | hand-rolled [`TryFromSexp`] + [`IntoR`] | `#[derive(RSerializeNative)]` (serde feature) | serde is ergonomic for nested structs; hand-rolled is zero-overhead and fully controlled |
 //!
 //! Project-wide defaults are controlled by mutually-exclusive cargo
-//! features — see the "Project-wide Defaults" feature table below and
-//! [`docs/FEATURE_DEFAULTS.md`](https://github.com/A2-ai/miniextendr/blob/main/docs/FEATURE_DEFAULTS.md).
+//! features — see the "Project-wide Defaults" feature table below.
 //!
 //! ### Default opinion
 //!


### PR DESCRIPTION
This is PR 1 of a 6-PR rustdoc tradeoff pass aimed at the pattern where AI coding assistants (Claude in particular) reach for the looser miniextendr APIs because the rustdoc doesn't surface the choice. This first PR lands the top-level map; sibling PRs cover the per-module signposts.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- New `docs/API_CHOICE_MATRIX.md`. One page aggregating every place miniextendr offers two or more APIs for the same goal (strict vs lax conversions, checked vs unchecked FFI, panic vs `error!` vs `Result`, field-derive vs manual ALTREP, raw `Dots` vs `typed_list!`, class-system selection, GC-protection mechanisms, worker-thread on/off, etc.). Each row has one-line guidance and a link to the existing deep-dive doc, so it functions as an index rather than a replacement.
- `miniextendr-api/src/lib.rs` `//!` gets a new "Choosing the right API" section between Quick Start and GC protection. Compact table of the most common "I'm reaching for X, consider also Y" pairs, with intradoc links to the relevant traits (`Coerce` / `TryCoerce` / `TryFromSexp` / `IntoR`) and absolute links to the docs. Closes with a "when in doubt, pick the stricter path" default-opinion paragraph aimed directly at AI assistants.
- `docs/README.md` Quick-Links table gains a "Choose between two miniextendr APIs that look similar" row pointing at the new doc, plus an entry under Core concepts for orientation.
- Sibling PRs (2-6) are queued. They'll add module-level `//!` tradeoff signposts on the conversion paths (from_r / into_r / coerce / strict), the FFI checked-vs-unchecked surface, the error / condition transport, ExternalPtr + ALTREP, and the six class-system codegen modules. Each opens its own draft PR.

## Test plan
- [ ] `cargo doc --no-deps -p miniextendr-api` renders cleanly (verified locally; 0 new warnings introduced; 6 pre-existing warnings tracked in #715)
- [ ] `cargo fmt --check` clean
- [ ] Spot-check the `docs/API_CHOICE_MATRIX.md` links resolve on GitHub once the PR is up

## Notes
- Surfaced 6 pre-existing intradoc-link warnings in the api crate (broken or private-item links). Out of scope for this PR; tracked in #715 and expected to be absorbed by the sibling PRs (3 / 4 / 5) since the affected files (`unwind_protect.rs`, `condition.rs`, `error.rs`, `gc_protect.rs`, `registry.rs`) overlap their scope.
- The strict-mode framing in the matrix is asymmetric on purpose. The inbound side (`TryFromSexp`) is already strict-by-default because it returns `Result`. The outbound side (`IntoR` for `i64`/`u64`/`isize`/`usize`) is where the strict-vs-lax pairing actually lives, opted into via `#[miniextendr(strict)]`. The matrix and the lib.rs table both reflect this rather than implying a symmetric `TryFromSexpStrict` trait that doesn't exist.
- No code changes. Only `//!` and `docs/*.md` edits.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>