### PR TITLE
docs(macros): rustdoc tradeoff signposts for class-system generators

### DIFF
--- a/miniextendr-macros/src/match_arg_derive.rs
+++ b/miniextendr-macros/src/match_arg_derive.rs
@@ -4,6 +4,20 @@
 //! the `MatchArg` trait implementation for C-style enums, enabling automatic
 //! conversion between Rust enums and R character strings with partial matching.
 //!
+//! ## Tradeoff
+//!
+//! Without `#[derive(MatchArg)]`, an enum-shaped argument lands in the Rust
+//! function as a raw `String` that you match on by hand — invalid values
+//! surface as Rust `Err` deep in the body, with no R-side defaulting and no
+//! partial matching. `#[derive(MatchArg)]` shifts that work to the wrapper
+//! boundary: the generated R wrapper picks up `match.arg`-style **partial
+//! string matching** against the enum's variant list, fills in the first
+//! variant as the **R-visible default**, and rejects unknown values before
+//! the Rust function is even called. The variant list reaches the R side
+//! via a write-time placeholder (`MX_MATCH_ARG_CHOICES`) rather than a
+//! string baked into the proc macro, so adding a variant only requires
+//! re-running the build.
+//!
 //! ## Usage
 //!
 //! ```ignore

--- a/miniextendr-macros/src/match_arg_keys.rs
+++ b/miniextendr-macros/src/match_arg_keys.rs
@@ -1,5 +1,16 @@
 //! Write-time placeholder & symbol-name formatting for the match_arg pipeline.
 //!
+//! Tradeoff signpost: this module is the **wiring** between the
+//! `#[derive(MatchArg)]` proc macro (see [`match_arg_derive`]) and the
+//! cdylib's write-time substitution pass. The `match.arg` codegen path
+//! deliberately splits responsibilities — the proc macro emits placeholders
+//! into the R wrapper, and the cdylib resolves them to a concrete `c("a",
+//! "b", ...)` literal at write time using `MX_MATCH_ARG_CHOICES`. That
+//! split lets the variant list change without re-running `cargo expand` on
+//! every consumer. Compared to hand-rolling `match.arg` in a wrapper body,
+//! the user gets partial matching, R-visible defaults, and `@param` doc
+//! lines for free, without ever stringifying the variant list in source.
+//!
 //! All four shapes (`choices_placeholder`, `param_doc_placeholder`,
 //! `choices_helper_c_name`, `choices_helper_def_ident`) share the same
 //! `{c_ident_without_prefix}_{r_param}` stem so the cdylib's write-time pass

--- a/miniextendr-macros/src/miniextendr_impl/env_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/env_class.rs
@@ -1,4 +1,15 @@
 //! Env-class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! for the full decision tree.
+//!
+//! Generates an R environment (`new.env(parent = emptyenv())`) that serves as
+//! the class namespace, with `obj$method()` dispatched through an `$.ClassName`
+//! S3 method. This is the **fastest** of the six class systems and has **no R
+//! package dependencies**, but provides no formal class machinery: no
+//! inheritance, no multi-dispatch, no slot validation. Pick env for simple
+//! ExternalPtr-backed APIs; reach for R6/S3/S4/S7 when you need dispatch or
+//! formal class semantics.
 
 use super::ParsedImpl;
 

--- a/miniextendr-macros/src/miniextendr_impl/env_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/env_class.rs
@@ -1,8 +1,5 @@
 //! Env-class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! for the full decision tree.
-//!
 //! Generates an R environment (`new.env(parent = emptyenv())`) that serves as
 //! the class namespace, with `obj$method()` dispatched through an `$.ClassName`
 //! S3 method. This is the **fastest** of the six class systems and has **no R

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -1,8 +1,5 @@
 //! R6-class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! for the full decision tree.
-//!
 //! Generates an `R6::R6Class(...)` definition with **mutable, reference
 //! semantics**: `obj$method()` dispatches via R6, and `&mut self` methods
 //! modify state in place without re-binding `obj`. Supports private methods,

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -1,4 +1,15 @@
 //! R6-class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! for the full decision tree.
+//!
+//! Generates an `R6::R6Class(...)` definition with **mutable, reference
+//! semantics**: `obj$method()` dispatches via R6, and `&mut self` methods
+//! modify state in place without re-binding `obj`. Supports private methods,
+//! active bindings (computed/settable properties), lifecycle hooks
+//! (`finalize`, `deep_clone`), and inheritance via `r6(inherit = ...)`.
+//! Slower than env (R6 dispatch chain) and requires the R6 package; no value
+//! semantics — for value-semantics formal OOP, use S7.
 
 use super::ParsedImpl;
 use crate::r_class_formatter::class_ref_or_verbatim;

--- a/miniextendr-macros/src/miniextendr_impl/s3_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s3_class.rs
@@ -1,8 +1,5 @@
 //! S3-class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! for the full decision tree.
-//!
 //! Generates **lightweight, single-dispatch** S3 generics with
 //! `<generic>.<class>` methods. Method dispatch is driven by the `class()`
 //! attribute vector — first match wins — so inheritance is "string-prefix"

--- a/miniextendr-macros/src/miniextendr_impl/s3_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s3_class.rs
@@ -1,4 +1,16 @@
 //! S3-class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! for the full decision tree.
+//!
+//! Generates **lightweight, single-dispatch** S3 generics with
+//! `<generic>.<class>` methods. Method dispatch is driven by the `class()`
+//! attribute vector — first match wins — so inheritance is "string-prefix"
+//! based and cheap. No formal slot validation, no multi-dispatch (vctrs-style
+//! double-dispatch is supported via `#[miniextendr(generic, class)]` for
+//! `vec_ptype2.a.b` patterns). Pick S3 for tidyverse interop and for
+//! extending existing base generics (`print`, `format`, `summary`); use S4/S7
+//! when you need validation or formal hierarchies.
 
 use super::ParsedImpl;
 

--- a/miniextendr-macros/src/miniextendr_impl/s4_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s4_class.rs
@@ -1,4 +1,16 @@
 //! S4-class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! for the full decision tree.
+//!
+//! Generates `methods::setClass(...)` with an `externalptr` slot, plus
+//! `methods::setGeneric` / `methods::setMethod` for each instance method.
+//! Supports **formal slot validation, multi-dispatch on method signatures,
+//! and contains-based inheritance** — the only system here with native
+//! multi-dispatch. Cost: slowest dispatch path, all helpers live in the
+//! `methods::` namespace (`methods` must be imported, not `base`), and the
+//! ecosystem is increasingly legacy. Pick S4 for Bioconductor interop;
+//! use S7 for new packages wanting similar formal semantics.
 
 use super::ParsedImpl;
 

--- a/miniextendr-macros/src/miniextendr_impl/s4_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s4_class.rs
@@ -1,8 +1,5 @@
 //! S4-class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! for the full decision tree.
-//!
 //! Generates `methods::setClass(...)` with an `externalptr` slot, plus
 //! `methods::setGeneric` / `methods::setMethod` for each instance method.
 //! Supports **formal slot validation, multi-dispatch on method signatures,

--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -1,8 +1,5 @@
 //! S7-class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! for the full decision tree.
-//!
 //! Generates `S7::new_class(...)` with **value semantics, formal property
 //! validation, and parent-based inheritance**. Property attributes
 //! (`s7(getter)` / `s7(setter, prop = "...")`) compile to `S7::new_property`

--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -1,4 +1,16 @@
 //! S7-class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! for the full decision tree.
+//!
+//! Generates `S7::new_class(...)` with **value semantics, formal property
+//! validation, and parent-based inheritance**. Property attributes
+//! (`s7(getter)` / `s7(setter, prop = "...")`) compile to `S7::new_property`
+//! with `@`-access semantics, including read-only computed properties and
+//! read-write dynamic ones. Similar formal power to S4 with cleaner syntax,
+//! but the S7 ecosystem is younger and the R-package dependency surface is
+//! evolving. Pick S7 for **new** packages wanting modern formal OOP; use S4
+//! when you need Bioconductor compatibility or multi-dispatch.
 
 use super::{ParsedImpl, ParsedMethod};
 use crate::r_class_formatter::{class_ref_or_verbatim, is_bare_identifier};

--- a/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
@@ -1,9 +1,5 @@
 //! Vctrs class R wrapper generator.
 //!
-//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
-//! and [`VCTRS.md`](../../../docs/VCTRS.md) for the full design and the
-//! protocol method catalogue.
-//!
 //! Generates an S3 class that **integrates with the tidyverse `vctrs`
 //! package**: emits a `new_<class>` wrapper around `vctrs::new_vctr` /
 //! `new_rcrd` / `new_list_of` (selected via `VctrsKind`), plus the standard

--- a/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
@@ -1,4 +1,16 @@
 //! Vctrs class R wrapper generator.
+//!
+//! Tradeoff signpost — see [`CLASS_SYSTEMS.md`](../../../docs/CLASS_SYSTEMS.md)
+//! and [`VCTRS.md`](../../../docs/VCTRS.md) for the full design and the
+//! protocol method catalogue.
+//!
+//! Generates an S3 class that **integrates with the tidyverse `vctrs`
+//! package**: emits a `new_<class>` wrapper around `vctrs::new_vctr` /
+//! `new_rcrd` / `new_list_of` (selected via `VctrsKind`), plus the standard
+//! `vec_ptype2` / `vec_cast` self-coercion methods so the type composes
+//! cleanly inside `tibble`, `dplyr`, and `tidyr`. Pick vctrs when your Rust
+//! type is "a vector of X" and you want first-class tibble columns; use
+//! plain S3/S7 for scalar-like objects.
 
 use super::{ParsedImpl, VctrsKind};
 

--- a/miniextendr-macros/src/typed_list.rs
+++ b/miniextendr-macros/src/typed_list.rs
@@ -1,8 +1,5 @@
 //! Parser for the `typed_list!` macro.
 //!
-//! Tradeoff signpost — see [`DOTS_TYPED_LIST.md`](../../docs/DOTS_TYPED_LIST.md)
-//! for the full design.
-//!
 //! Without `typed_list!`, an `#[miniextendr]` function that takes `...` reads
 //! the dots as raw `&Dots` and validates field names, types, and required-vs-
 //! optional shape **at runtime** inside the function body. `typed_list!`

--- a/miniextendr-macros/src/typed_list.rs
+++ b/miniextendr-macros/src/typed_list.rs
@@ -1,5 +1,17 @@
 //! Parser for the `typed_list!` macro.
 //!
+//! Tradeoff signpost — see [`DOTS_TYPED_LIST.md`](../../docs/DOTS_TYPED_LIST.md)
+//! for the full design.
+//!
+//! Without `typed_list!`, an `#[miniextendr]` function that takes `...` reads
+//! the dots as raw `&Dots` and validates field names, types, and required-vs-
+//! optional shape **at runtime** inside the function body. `typed_list!`
+//! lifts that shape into the macro signature: writing
+//! `#[miniextendr(dots = typed_list!(alpha => numeric(4), beta? => "list"))]`
+//! generates a `dots_typed` binding with strongly-typed accessors, validates
+//! field names/types at the call boundary, and surfaces a single batched
+//! diagnostic on shape mismatch instead of one-error-per-field.
+//!
 //! Parses syntax like:
 //! ```ignore
 //! typed_list!(


### PR DESCRIPTION
PR 6 of the 6-PR rustdoc tradeoff pass. Each class-system codegen module gets a tradeoff signpost so authors picking between Env/R6/S3/S4/S7/Vctrs see the choice without leaving rustdoc.

<details>
<summary>AI-written details</summary>

## Scope

Module-level `//!` rustdoc blurbs only — no code changes, no new symbols, no `docs/*.md` rewrites.

Files modified:

- `miniextendr-macros/src/miniextendr_impl/env_class.rs`
- `miniextendr-macros/src/miniextendr_impl/r6_class.rs`
- `miniextendr-macros/src/miniextendr_impl/s3_class.rs`
- `miniextendr-macros/src/miniextendr_impl/s4_class.rs`
- `miniextendr-macros/src/miniextendr_impl/s7_class.rs`
- `miniextendr-macros/src/miniextendr_impl/vctrs_class.rs`
- `miniextendr-macros/src/typed_list.rs`
- `miniextendr-macros/src/match_arg_derive.rs`
- `miniextendr-macros/src/match_arg_keys.rs`

## What each blurb says

For the six class-system generators: what R class system it emits, the tradeoff axis vs the alternatives (dispatch speed, mutability, formal validation, inheritance, tidyverse interop), and a relative link to `docs/CLASS_SYSTEMS.md` (vctrs also links `docs/VCTRS.md`). Tradeoff language was cross-checked against `docs/CLASS_SYSTEMS.md`'s decision tree.

For `typed_list.rs`: explains that without `typed_list!`, dots validation is runtime-only; the macro lifts the shape into the signature so field names, types, and required-vs-optional are checked at the call boundary with a batched diagnostic. Links to `docs/DOTS_TYPED_LIST.md`.

For `match_arg_derive.rs` and `match_arg_keys.rs`: explains that `#[derive(MatchArg)]` shifts hand-rolled string matching to the wrapper boundary — R-visible defaults, partial matching, validated values before the Rust body runs — and that the variant list reaches R via write-time placeholders (`MX_MATCH_ARG_CHOICES`) rather than baked strings.

## Verification

- `cargo doc --no-deps -p miniextendr-macros` clean (no broken intra-doc links).
- `cargo fmt --check` clean.
- `cargo check -p miniextendr-macros` clean.

## Test plan

- [ ] `cargo doc --no-deps -p miniextendr-macros` succeeds on a fresh checkout.
- [ ] Rendered HTML shows the tradeoff blurbs at the top of each class-system module page with a working link to `docs/CLASS_SYSTEMS.md`.

</details>