### PR TITLE
docs(api): rustdoc the FFI checked/unchecked safety boundary

### DIFF
--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -1,7 +1,57 @@
 //! Low-level FFI bindings to R headers.
 //!
-//! This module mirrors R's C API closely and is intentionally thin. Most
-//! downstream code should prefer higher-level wrappers in the crate root.
+//! This module mirrors R's C API closely and is intentionally thin. **You
+//! almost never call these directly from user code** — reach for the
+//! higher-level wrappers in the crate root (`SEXP` extensions, [`IntoR`],
+//! [`TryFromSexp`], [`with_r_thread`], [`with_r_unwind_protect`], the
+//! `#[miniextendr]` proc-macro). The items here exist so those wrappers can
+//! be written; treat them as the framework's escape hatch.
+//!
+//! [`IntoR`]: crate::IntoR
+//! [`TryFromSexp`]: crate::TryFromSexp
+//! [`with_r_thread`]: crate::worker::with_r_thread
+//! [`with_r_unwind_protect`]: crate::unwind_protect::with_r_unwind_protect
+//!
+//! # Checked vs `*_unchecked` variants
+//!
+//! Most non-variadic R API entry points come in two forms thanks to the
+//! [`#[r_ffi_checked]`](miniextendr_macros::r_ffi_checked) proc-macro applied
+//! to the `unsafe extern "C-unwind"` blocks below:
+//!
+//! - **Checked** (default — e.g. `Rf_allocVector`, `Rf_protect`, `INTEGER`):
+//!   debug-asserts you're on R's main thread, routing through
+//!   [`crate::worker::with_r_thread`] when called from a worker thread. **Use
+//!   these by default.**
+//! - **`*_unchecked`** (e.g. `Rf_allocVector_unchecked`): bypass the assertion
+//!   and the worker round-trip. Calling one off the R main thread is
+//!   undefined behaviour. They exist for three known-safe contexts:
+//!     1. Inside ALTREP callbacks — R is already calling us on the main thread.
+//!     2. Inside a [`crate::unwind_protect::with_r_unwind_protect`] body —
+//!        the guard has already established main-thread context.
+//!     3. Inside a [`crate::worker::with_r_thread`] body — the check would be
+//!        redundant.
+//!
+//! The build-time lint **MXL301** enforces this: any `*_unchecked` call
+//! outside those contexts is a compile-time error. See
+//! `docs/FFI_GUARD.md` and `miniextendr-lint/CLAUDE.md` for the rule's
+//! full surface.
+//!
+//! # Don't raise R errors directly
+//!
+//! `Rf_error`, `Rf_errorcall`, and their `_unchecked` siblings longjmp,
+//! which **skips Rust destructors** and leaks resources. The lint **MXL300**
+//! forbids them in user code. Use `panic!()` instead; the framework converts
+//! the panic into a structured R condition with `rust_*` class layering via
+//! the tagged-SEXP transport (see [`crate::error_value`] and the
+//! `docs/ERROR_HANDLING.md` manual chapter).
+//!
+//! # Cross references
+//!
+//! - `docs/FFI_GUARD.md` — guard taxonomy and worker-thread invariants.
+//! - `docs/THREADS.md` — worker / main-thread split.
+//! - `docs/ALTREP_GUARDS.md` — guard modes inside ALTREP callbacks.
+//! - `docs/ERROR_HANDLING.md` — panic → R condition transport.
+//! - `docs/API_CHOICE_MATRIX.md` — top-level API choices.
 
 /// ALTREP-specific C API bindings.
 pub mod altrep;

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -32,9 +32,7 @@
 //!        redundant.
 //!
 //! The build-time lint **MXL301** enforces this: any `*_unchecked` call
-//! outside those contexts is a compile-time error. See
-//! `docs/FFI_GUARD.md` and `miniextendr-lint/CLAUDE.md` for the rule's
-//! full surface.
+//! outside those contexts is a compile-time error.
 //!
 //! # Don't raise R errors directly
 //!
@@ -42,16 +40,16 @@
 //! which **skips Rust destructors** and leaks resources. The lint **MXL300**
 //! forbids them in user code. Use `panic!()` instead; the framework converts
 //! the panic into a structured R condition with `rust_*` class layering via
-//! the tagged-SEXP transport (see [`crate::error_value`] and the
-//! `docs/ERROR_HANDLING.md` manual chapter).
+//! the tagged-SEXP transport (see [`crate::error_value`]).
 //!
 //! # Cross references
 //!
-//! - `docs/FFI_GUARD.md` — guard taxonomy and worker-thread invariants.
-//! - `docs/THREADS.md` — worker / main-thread split.
-//! - `docs/ALTREP_GUARDS.md` — guard modes inside ALTREP callbacks.
-//! - `docs/ERROR_HANDLING.md` — panic → R condition transport.
-//! - `docs/API_CHOICE_MATRIX.md` — top-level API choices.
+//! - [`crate::ffi_guard`] — guard taxonomy and worker-thread invariants.
+//! - [`crate::thread`] / [`crate::worker`] — worker / main-thread split.
+//! - [`crate::altrep_traits`] / [`crate::altrep_bridge`] — guard modes
+//!   inside ALTREP callbacks.
+//! - [`crate::error_value`] / [`crate::condition`] — panic → R condition
+//!   transport.
 
 /// ALTREP-specific C API bindings.
 pub mod altrep;

--- a/miniextendr-api/src/ffi.rs
+++ b/miniextendr-api/src/ffi.rs
@@ -48,7 +48,7 @@
 //! - [`crate::thread`] / [`crate::worker`] — worker / main-thread split.
 //! - [`crate::altrep_traits`] / [`crate::altrep_bridge`] — guard modes
 //!   inside ALTREP callbacks.
-//! - [`crate::error_value`] / [`crate::condition`] — panic → R condition
+//! - [`crate::error_value`] / [`mod@crate::condition`] — panic → R condition
 //!   transport.
 
 /// ALTREP-specific C API bindings.

--- a/miniextendr-api/src/ffi/altrep.rs
+++ b/miniextendr-api/src/ffi/altrep.rs
@@ -1,6 +1,23 @@
 //! Raw ALTREP C API bindings.
 //!
-//! This module mirrors `R_ext/Altrep.h` and is intentionally low-level.
+//! This module mirrors `R_ext/Altrep.h` and is intentionally low-level. Prefer
+//! the `#[derive(AltrepInteger)]` / `AltrepReal` / `AltrepLogical` /
+//! `AltrepString` / `AltrepRaw` / `AltrepComplex` / `AltrepList` derives — or
+//! the `#[altrep(manual)]` opt-out — over wiring these typedefs by hand.
+//!
+//! See `docs/ALTREP_GUARDS.md` for the guard-mode taxonomy (`unsafe` /
+//! `rust_unwind` / `r_unwind`) that gates panic and longjmp escape from
+//! callback bodies; `crate::altrep_bridge` is the trampoline layer that
+//! enforces those modes.
+//!
+//! # Calling these from a callback
+//!
+//! ALTREP callbacks are invoked by R on its main thread, so the
+//! [`#[r_ffi_checked]`](miniextendr_macros::r_ffi_checked) main-thread
+//! assertion would always pass. Inside a callback body you may therefore call
+//! `*_unchecked` variants of the R API (or the `r_unwind` guard's protected
+//! re-entry helpers) without tripping the **MXL301** lint. See
+//! [`crate::ffi`] for the broader checked-vs-unchecked story.
 
 #![allow(non_camel_case_types)]
 use crate::ffi::{DllInfo, R_xlen_t, Rboolean, Rbyte, Rcomplex, SEXP, SEXPTYPE};

--- a/miniextendr-api/src/ffi/altrep.rs
+++ b/miniextendr-api/src/ffi/altrep.rs
@@ -5,9 +5,9 @@
 //! `AltrepString` / `AltrepRaw` / `AltrepComplex` / `AltrepList` derives — or
 //! the `#[altrep(manual)]` opt-out — over wiring these typedefs by hand.
 //!
-//! See `docs/ALTREP_GUARDS.md` for the guard-mode taxonomy (`unsafe` /
+//! See [`crate::altrep_traits`] for the guard-mode taxonomy (`unsafe` /
 //! `rust_unwind` / `r_unwind`) that gates panic and longjmp escape from
-//! callback bodies; `crate::altrep_bridge` is the trampoline layer that
+//! callback bodies; [`crate::altrep_bridge`] is the trampoline layer that
 //! enforces those modes.
 //!
 //! # Calling these from a callback

--- a/miniextendr-api/src/ffi_guard.rs
+++ b/miniextendr-api/src/ffi_guard.rs
@@ -38,7 +38,6 @@
 //! - [`crate::worker::with_r_thread`] — main-thread routing entry point.
 //! - [`crate::unwind_protect::with_r_unwind_protect`] — the user-facing R
 //!   error catcher; consumed by `RUnwind` mode.
-//! - `docs/FFI_GUARD.md` — guard taxonomy and panic flow.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 

--- a/miniextendr-api/src/ffi_guard.rs
+++ b/miniextendr-api/src/ffi_guard.rs
@@ -4,6 +4,12 @@
 //! `altrep_bridge.rs`, `unwind_protect.rs`, and `connection.rs`. This module
 //! extracts the common pattern into a single `guarded_ffi_call` function.
 //!
+//! Most user code never calls anything here. The proc-macro layer
+//! (`#[miniextendr]`) inserts the right guard at every Rust → R boundary it
+//! generates. Reach for these helpers when you're writing a callback or
+//! trampoline that the macros don't already cover (custom connections,
+//! manual ALTREP, raw FFI shims).
+//!
 //! ## Guard Modes
 //!
 //! - [`GuardMode::CatchUnwind`]: Wraps the closure in `catch_unwind`. On panic,
@@ -11,10 +17,28 @@
 //!   Used by worker and connection trampolines.
 //!
 //! - [`GuardMode::RUnwind`]: Uses `R_UnwindProtect` to catch both Rust panics
-//!   and R longjmps. Used by ALTREP callbacks that call R APIs.
+//!   and R longjmps. Used by ALTREP callbacks that call R APIs. Routes
+//!   through `crate::unwind_protect::with_r_unwind_protect_sourced`
+//!   (crate-private).
 //!
 //! The ALTREP-specific `Unsafe` mode (no protection at all) stays in
 //! `altrep_bridge.rs` since it has no general applicability.
+//!
+//! ## Tradeoffs vs raising R errors directly
+//!
+//! Don't reach for `Rf_error` / `Rf_errorcall` to fail out of a callback —
+//! the longjmp skips Rust destructors and the lint **MXL300** rejects it.
+//! Panic instead; whichever guard mode you pick converts the panic into the
+//! tagged-condition transport ([`crate::error_value`]) or, on the ALTREP
+//! `RUnwind` path, raises a structured `rust_*` condition via the
+//! crate-private `raise_rust_condition_via_stop` helper.
+//!
+//! ## Cross references
+//!
+//! - [`crate::worker::with_r_thread`] — main-thread routing entry point.
+//! - [`crate::unwind_protect::with_r_unwind_protect`] — the user-facing R
+//!   error catcher; consumed by `RUnwind` mode.
+//! - `docs/FFI_GUARD.md` — guard taxonomy and panic flow.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 

--- a/miniextendr-api/src/thread.rs
+++ b/miniextendr-api/src/thread.rs
@@ -4,6 +4,35 @@
 //! from threads other than the main R thread. This module provides utilities to
 //! safely disable stack checking when crossing thread boundaries.
 //!
+//! # Prefer [`crate::worker::with_r_thread`] in normal code
+//!
+//! This module is the **escape hatch** for advanced cases (rayon pools,
+//! externally-spawned threads that need to touch R briefly). The default
+//! tool for crossing back to R is [`crate::worker::with_r_thread`], which
+//! routes the closure to the recorded main thread instead of unsafely
+//! patching R's internal stack bounds.
+//!
+//! `StackCheckGuard` is gated behind the `nonapi` feature because it
+//! mutates `R_CStackStart` / `R_CStackLimit` / `R_CStackDir`, none of which
+//! are part of R's public C API. The lint **MXL301** treats this guard the
+//! same way as the other known-safe contexts — inside a `StackCheckGuard`
+//! scope you may use `*_unchecked` FFI variants because the main-thread
+//! assertion would be wrong (you're explicitly *not* on the main thread).
+//!
+//! # Don't use `Rf_error` here either
+//!
+//! A longjmp from a non-main thread is undefined behaviour even with the
+//! stack check disabled. Panic, capture the message in your guard's
+//! fallback (see [`crate::ffi_guard::guarded_ffi_call_with_fallback`]), and
+//! surface the failure to the main thread before letting R see it. The lint
+//! **MXL300** rejects direct `Rf_error` calls in user code.
+//!
+//! # Cross references
+//!
+//! - [`crate::worker::with_r_thread`] — preferred path for crossing back to R.
+//! - [`crate::ffi`] — checked vs `*_unchecked` FFI surface.
+//! - `docs/THREADS.md` — main-thread invariants.
+//!
 //! # Background
 //!
 //! R tracks three variables for stack overflow detection (all non-API):

--- a/miniextendr-api/src/thread.rs
+++ b/miniextendr-api/src/thread.rs
@@ -31,7 +31,6 @@
 //!
 //! - [`crate::worker::with_r_thread`] — preferred path for crossing back to R.
 //! - [`crate::ffi`] — checked vs `*_unchecked` FFI surface.
-//! - `docs/THREADS.md` — main-thread invariants.
 //!
 //! # Background
 //!

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -57,6 +57,8 @@
 //! - [`crate::worker::with_r_thread`] — routes a closure to R's main thread.
 //! - [`crate::ffi_guard`] — unified panic-catching trampoline that consumes
 //!   `with_r_unwind_protect_sourced` for ALTREP `RUnwind` mode.
+//! - [`crate::error_value`] / [`crate::condition`] — panic → R condition
+//!   transport.
 use std::{
     any::Any,
     borrow::Cow,

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -6,6 +6,44 @@
 //! **Important**: R uses `longjmp` for error handling, which normally bypasses Rust destructors.
 //! Use this API to ensure cleanup happens even when R errors occur.
 //!
+//! ## When to reach for this
+//!
+//! - **Calling R APIs that can error from a body you wrote yourself**
+//!   (custom ALTREP, custom connection trampoline, hand-rolled FFI shim).
+//!   Wrap the R-calling section in [`with_r_unwind_protect`] so Rust
+//!   destructors run if R longjmps.
+//! - **Inside a [`with_r_unwind_protect`] body it is safe to use `*_unchecked`
+//!   variants of the R FFI** — see the [`crate::ffi`] module doc. The lint
+//!   **MXL301** recognises this as one of the three contexts where bypassing
+//!   the main-thread assertion is valid (the other two being ALTREP callbacks
+//!   and [`crate::worker::with_r_thread`] bodies).
+//!
+//! ## You probably don't need this from a `#[miniextendr]` body
+//!
+//! The proc-macro already wraps every function and method in a guard that
+//! converts panics into the tagged-condition transport ([`crate::error_value`]).
+//! Returning `Result::Err`, `Option::None`, or calling `panic!()` /
+//! [`crate::error!`] / [`crate::warning!`] / [`crate::message!`] is the
+//! idiomatic path. Direct [`with_r_unwind_protect`] use inside that body is
+//! almost always wrong — you'd be nesting an `R_UnwindProtect` inside another
+//! `R_UnwindProtect`, paying the longjmp-leak cost twice (see "Leaks" below).
+//!
+//! ## Don't use `Rf_error`
+//!
+//! `Rf_error` and `Rf_errorcall` longjmp directly, skipping every Rust
+//! destructor on the stack. The lint **MXL300** forbids them in user code.
+//! Panic instead (or call [`crate::error!`]) and the framework raises the
+//! corresponding R condition for you.
+//!
+//! ## Leaks
+//!
+//! On the R longjmp path (when R unwinds out of the protected body),
+//! `with_r_unwind_protect` leaks ~8 bytes (an `RErrorMarker` + `Box` header)
+//! because the cleanup handler can't reclaim them via
+//! `Box::from_raw`. Regular Rust panics from inside the body don't leak.
+//! This is the cost MXL300 is buying off: every direct `Rf_error()` would
+//! incur the same leak with no observability.
+//!
 //! ## Log drain
 //!
 //! Every call to `with_r_unwind_protect` (and its variants) drains the
@@ -13,6 +51,12 @@
 //! helper before returning or re-raising an R error. This ensures that records
 //! buffered by worker threads are flushed to R's console on every FFI exit —
 //! including error paths.
+//!
+//! ## Cross references
+//!
+//! - [`crate::worker::with_r_thread`] — routes a closure to R's main thread.
+//! - [`crate::ffi_guard`] — unified panic-catching trampoline that consumes
+//!   `with_r_unwind_protect_sourced` for ALTREP `RUnwind` mode.
 use std::{
     any::Any,
     borrow::Cow,
@@ -326,7 +370,8 @@ where
 ///
 /// This raising-variant exists for guard sites that have no R wrapper between
 /// them and R's runtime:
-/// - ALTREP `RUnwind` guard callbacks (via [`with_r_unwind_protect_sourced`])
+/// - ALTREP `RUnwind` guard callbacks (via the crate-private
+///   `with_r_unwind_protect_sourced`)
 /// - FFI guard tests / benchmarks exercising the raw `R_UnwindProtect` mechanism
 ///
 /// In those contexts there is no consumer-side R wrapper to inspect a tagged

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -57,7 +57,7 @@
 //! - [`crate::worker::with_r_thread`] — routes a closure to R's main thread.
 //! - [`crate::ffi_guard`] — unified panic-catching trampoline that consumes
 //!   `with_r_unwind_protect_sourced` for ALTREP `RUnwind` mode.
-//! - [`crate::error_value`] / [`crate::condition`] — panic → R condition
+//! - [`crate::error_value`] / [`mod@crate::condition`] — panic → R condition
 //!   transport.
 use std::{
     any::Any,

--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -58,8 +58,7 @@
 //! - [`crate::unwind_protect::with_r_unwind_protect`] — catch R errors with
 //!   Rust cleanup; sibling to `with_r_thread`.
 //! - [`crate::ffi`] — checked vs `*_unchecked` FFI surface.
-//! - `docs/THREADS.md` — full worker / main-thread story.
-//! - `docs/FFI_GUARD.md` — guard taxonomy across boundaries.
+//! - [`crate::ffi_guard`] — guard taxonomy across boundaries.
 
 use std::sync::OnceLock;
 use std::thread;

--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -1,9 +1,39 @@
 //! Worker thread infrastructure for safe Rust-R FFI.
 //!
+//! ## Why a worker thread at all?
+//!
+//! R's error handling uses `longjmp`, which skips Rust destructors and leaks
+//! resources. To contain that, `#[miniextendr]`-generated function bodies run
+//! on a separate Rust thread (the "worker"). R only longjmps on its own main
+//! thread, so Rust frames on the worker are unwind-safe.
+//!
+//! That split means **user code is off the R main thread** whenever the
+//! `worker-thread` cargo feature is enabled. Anything that calls R's C API
+//! (allocating `SEXP`s, walking attributes, accessing `INTEGER(x)`) must
+//! cross back to main via [`with_r_thread`].
+//!
 //! ## Public API
 //!
-//! - [`with_r_thread`] — Execute a closure on R's main thread
-//! - [`is_r_main_thread`] — Check if the current thread is R's main thread
+//! - [`with_r_thread`] — Execute a closure on R's main thread. This is the
+//!   bridge: call it from inside a `#[miniextendr]` body whenever you need
+//!   to touch the R FFI.
+//! - [`is_r_main_thread`] — Check if the current thread is R's main thread.
+//! - [`Sendable`] — `#[doc(hidden)]` wrapper used by the macros to ferry
+//!   `SEXP` (and other `!Send` types) across the worker channel. The author
+//!   asserts the value is only consumed on the main thread.
+//!
+//! ## Tradeoffs
+//!
+//! - **Default to checked FFI variants** (`Rf_allocVector`, `INTEGER`, …) so
+//!   the debug-assertion catches accidental off-thread calls.
+//! - **Inside a [`with_r_thread`] body, the assertion is redundant** — the
+//!   `*_unchecked` variants in [`crate::ffi`] are safe to call there
+//!   (recognised by the lint **MXL301**, alongside ALTREP callbacks and
+//!   [`crate::unwind_protect::with_r_unwind_protect`] bodies).
+//! - **Don't raise R errors directly** from worker-thread code. `Rf_error`
+//!   would longjmp through Rust frames on the wrong thread. Panic instead;
+//!   the framework converts the panic into a structured R condition (see
+//!   [`crate::error_value`]). The lint **MXL300** enforces this.
 //!
 //! ## Feature gate: `worker-thread`
 //!
@@ -14,12 +44,22 @@
 //!
 //! With the feature enabled, a dedicated worker thread is spawned at init time.
 //! `with_r_thread` routes calls from the worker back to main, and `run_on_worker`
-//! dispatches closures to the worker with bidirectional communication.
+//! dispatches closures to the worker with bidirectional communication. The
+//! worker has a 16 MB stack — keep `proptest!` invocations on it modest (see
+//! the project `CLAUDE.md`).
 //!
 //! ## Initialization
 //!
 //! [`miniextendr_runtime_init`] must be called from R's main thread before any
 //! R FFI APIs. Typically done in `R_init_<pkgname>()`.
+//!
+//! ## Cross references
+//!
+//! - [`crate::unwind_protect::with_r_unwind_protect`] — catch R errors with
+//!   Rust cleanup; sibling to `with_r_thread`.
+//! - [`crate::ffi`] — checked vs `*_unchecked` FFI surface.
+//! - `docs/THREADS.md` — full worker / main-thread story.
+//! - `docs/FFI_GUARD.md` — guard taxonomy across boundaries.
 
 use std::sync::OnceLock;
 use std::thread;

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1576,8 +1576,40 @@ fn apply_return_pref(
 
 /// Generate thread-safe wrappers for R FFI functions.
 ///
-/// Apply this to an `extern "C-unwind"` block to generate wrappers that ensure
-/// R API calls happen on R's main thread.
+/// Apply this to an `extern "C-unwind"` block to generate, **for each
+/// non-variadic function**, a pair of entry points:
+///
+/// - The original name (e.g. `Rf_allocVector`) — a safe Rust wrapper that
+///   debug-asserts the caller is on R's main thread, routing through
+///   `miniextendr_api::worker::with_r_thread` when called from a worker.
+/// - A `*_unchecked` sibling (`Rf_allocVector_unchecked`) — the raw
+///   `extern "C-unwind"` declaration with no main-thread assertion and no
+///   worker round-trip.
+///
+/// User code should reach for the checked variant by default; the unchecked
+/// sibling exists for three known-safe contexts:
+///
+/// 1. **Inside ALTREP callbacks** — R is already calling us on the main
+///    thread, so the assertion would always pass and the route would
+///    deadlock the call back to R.
+/// 2. **Inside a `with_r_unwind_protect` body** — the guard has established
+///    main-thread context, and re-entering `with_r_thread` would nest two
+///    `R_UnwindProtect` frames (paying the longjmp-leak cost twice).
+/// 3. **Inside a `with_r_thread` body** — the assertion is redundant; you
+///    are already where you needed to be.
+///
+/// The build-time lint **MXL301** enforces this: calling `*_unchecked`
+/// outside one of those three contexts is a compile-time error. Outside
+/// the worker-thread feature gate, the checked variant collapses to a thin
+/// call and the two variants are observationally identical, but the lint
+/// still applies so the same code is correct under `--features worker-thread`.
+///
+/// # Tradeoffs at a glance
+///
+/// | Variant | Asserts main thread | Routes to main | When to use |
+/// |---|---|---|---|
+/// | `Rf_foo` (checked) | yes (debug) | yes (from worker) | default |
+/// | `Rf_foo_unchecked` | no | no | ALTREP callbacks, `with_r_unwind_protect`, `with_r_thread` |
 ///
 /// # Behavior
 ///


### PR DESCRIPTION
PR 3 of the 6-PR rustdoc tradeoff pass. Surfaces the FFI checked vs unchecked safety boundary at the module-doc level so the right knob is visible from rustdoc.

<details>
<summary>AI-written details (Claude Opus 4.7)</summary>

## What this changes

Module-level rustdoc only — no code changes, no new symbols, no `docs/*.md` rewrites. Files touched:

- `miniextendr-api/src/ffi.rs` — replaces a 4-line `//!` with a "you almost never call these directly" intro that names MXL300 (`Rf_error` -> `panic!()`) and MXL301 (`*_unchecked` context rules), enumerates the three known-safe contexts for unchecked variants, and cross-links `docs/FFI_GUARD.md`, `THREADS.md`, `ALTREP_GUARDS.md`, `ERROR_HANDLING.md`, `API_CHOICE_MATRIX.md`.
- `miniextendr-api/src/ffi/altrep.rs` — points readers at the derives first, links the guard-mode taxonomy, and notes that `*_unchecked` is safe inside callbacks (where R is already on main).
- `miniextendr-api/src/ffi_guard.rs` — adds "most user code never calls anything here" and tradeoff signposts vs raising R errors directly.
- `miniextendr-api/src/unwind_protect.rs` — adds "when to reach for this", a "you probably don't need this from a `#[miniextendr]` body" caveat, the MXL301 unchecked-context note, an explicit MXL300 callout, and the ~8 byte longjmp leak tradeoff.
- `miniextendr-api/src/worker.rs` — adds "why a worker thread at all", the user-code-is-off-the-main-thread tradeoff, MXL300 / MXL301 callouts, and links to `with_r_unwind_protect`.
- `miniextendr-api/src/thread.rs` — clarifies this is the `nonapi` escape hatch and `with_r_thread` is the normal path; MXL300 / MXL301 callouts.
- `miniextendr-macros/src/lib.rs` (`r_ffi_checked` proc-macro) — explains why the macro emits *both* checked and `*_unchecked` variants, lists the three contexts where `*_unchecked` is correct, and notes MXL301 enforcement.

## Verification

- `CARGO_TARGET_DIR=/tmp/claude/rustdoc-pr3-target cargo doc --no-deps -p miniextendr-api` -> 5 warnings (down from the 6 inherited from #715 — one link to `with_r_unwind_protect_sourced` was incidentally demoted to plain text while improving the surrounding paragraph).
- `cargo doc --no-deps -p miniextendr-macros` -> clean.
- `cargo fmt --check` -> clean.

## Deferred items

None — scope was rustdoc only and fully completed within it. The 5 remaining doc warnings are all tracked under #715.

## Tradeoffs conveyed

| Knob | Default | When to deviate |
|---|---|---|
| Checked FFI (`Rf_allocVector`) | yes | always, outside the three known-safe contexts |
| `*_unchecked` FFI | no | inside ALTREP callbacks, `with_r_unwind_protect` body, `with_r_thread` body — enforced by MXL301 |
| `Rf_error` / `Rf_errorcall` | never | use `panic!()` / `error!()` — enforced by MXL300 |
| Direct `with_r_unwind_protect` from `#[miniextendr]` body | almost never | the macro already wraps; nesting double-pays the longjmp leak |

</details>