### PR TITLE
docs(api): rustdoc the error/condition transport story

### DIFF
--- a/miniextendr-api/src/condition.rs
+++ b/miniextendr-api/src/condition.rs
@@ -4,12 +4,56 @@
 //!
 //! 1. **[`RCondition`] enum** — the internal panic payload used by `error!()`,
 //!    `warning!()`, `message!()`, and `condition!()` macros. Caught by
-//!    `with_r_unwind_protect` before the generic panic→error path, then
-//!    forwarded to R as a structured condition with `rust_*` class layering.
+//!    [`crate::unwind_protect::with_r_unwind_protect`] before the generic
+//!    panic→error path, then forwarded to R as a structured condition with
+//!    `rust_*` class layering via
+//!    [`crate::error_value::make_rust_condition_value`].
 //!
 //! 2. **[`AsRError`] struct** — wraps any `E: std::error::Error` and
 //!    preserves the full error chain (cause/source) when converting to an R
 //!    error message. Use as the `Err` type in `Result` returns.
+//!
+//! # When to reach for what
+//!
+//! There are three Rust→R error-emission paths and they are not
+//! interchangeable. The crate-level rationale (why tagged-SEXP at all, what
+//! `error_in_r` defaults imply, and the `with_r_unwind_protect` leak) lives
+//! on [`crate::error_value`]; the practical picking-one summary:
+//!
+//! - **`panic!`** — escape hatch. Becomes class `c("rust_error",
+//!   "simpleError", "error", "condition")` with `kind = "panic"`. Use for
+//!   genuine bugs or impossible states. Cheapest in source; coarsest in R
+//!   (callers can only match `rust_error` / `error`, not a specific class).
+//! - **`error!` / `warning!` / `message!` / `condition!`** (this module) —
+//!   typed conditions. Same transport, but allow an optional `class =
+//!   "name"` so R-side `tryCatch` can route by class. `warning!` /
+//!   `message!` / `condition!` are the only way to emit non-error
+//!   conditions; `panic!` is always an error.
+//! - **`Result<T, E>` with [`AsRError<E>`]** — value-style propagation
+//!   through Rust code. Converts at the boundary; `kind = "result_err"`.
+//!   Best when the failure path is real-and-recoverable in Rust and the
+//!   error chain (`std::error::Error::source`) is worth preserving.
+//!
+//! `Rf_error` is *not* on this list. Direct `Rf_error` skips Rust
+//! destructors unconditionally and is forbidden by lint MXL300; see
+//! [`crate::error_value`] for the full reasoning.
+//!
+//! # Macro-vs-module name collision
+//!
+//! `#[macro_export]` puts each macro at the *crate root*, where `error!` and
+//! `condition!` collide with the same-named modules `pub mod error` and `pub
+//! mod condition`. The practical implication: `use miniextendr_api::{error,
+//! condition}` imports the *modules*, not the macros, and a subsequent
+//! `error!(...)` call fails to resolve.
+//!
+//! Workarounds, in rough order of ergonomics:
+//!
+//! 1. Invoke via fully-qualified path: `miniextendr_api::error!("...")`.
+//! 2. `use miniextendr_api as mx;` then `mx::error!("...")`.
+//! 3. `warning!` and `message!` have no module conflict — `use
+//!    miniextendr_api::{warning, message};` works directly.
+//!
+//! See the individual macro docs for the per-macro reminder.
 //!
 //! # Condition macros
 //!
@@ -112,20 +156,38 @@ pub enum RCondition {
 /// An optional `class = "name"` form prepends a custom class for programmatic catching:
 /// `c("name", "rust_error", "simpleError", "error", "condition")`.
 ///
+/// # See also
+///
+/// - [`crate::warning!`] / [`crate::message!`] / [`crate::condition!`] — the
+///   non-error sibling kinds (warning continues execution; message is muffled
+///   by `suppressMessages`; condition is silent without a handler).
+/// - [`std::panic!`] — escape hatch with the same `rust_error` class layering
+///   but no custom-class slot. Use for true bugs / impossible states; reach for
+///   `error!` when callers might want to route by class.
+/// - [`AsRError`] — wraps `Result<_, E: std::error::Error>` for value-style
+///   propagation through Rust code; converts at the boundary.
+/// - [`crate::error_value`] — module-level rationale for the tagged-SEXP
+///   transport and the `error_in_r` default.
+///
+/// **Name-collision note.** Because `pub mod error` exists at the crate root,
+/// `use miniextendr_api::error` imports the module rather than this macro.
+/// Invoke via `miniextendr_api::error!(...)` (fully qualified) or via
+/// `mx::error!(...)` after `use miniextendr_api as mx;`.
+///
 /// # Examples
 ///
 /// ```ignore
-/// use miniextendr_api::error;
+/// use miniextendr_api as mx;
 ///
 /// #[miniextendr]
 /// fn fail() {
-///     error!("something went wrong: {}", 42);
+///     mx::error!("something went wrong: {}", 42);
 /// }
 ///
 /// // With a custom class for tryCatch:
 /// #[miniextendr]
 /// fn typed_fail(name: &str) {
-///     error!(class = "my_error", "missing field: {name}");
+///     mx::error!(class = "my_error", "missing field: {name}");
 /// }
 /// ```
 ///
@@ -159,6 +221,18 @@ macro_rules! error {
 /// The raised condition has class `c("rust_warning", "simpleWarning", "warning", "condition")`.
 ///
 /// An optional `class = "name"` form prepends a custom class.
+///
+/// # See also
+///
+/// - [`crate::error!`] — fatal sibling; aborts the call instead of continuing.
+/// - [`crate::message!`] / [`crate::condition!`] — softer signal kinds (muffled
+///   by `suppressMessages` / silent without handler, respectively).
+/// - [`std::panic!`] — escape hatch when "continue after this" is not a sensible
+///   semantic.
+/// - [`crate::error_value`] — tagged-SEXP transport rationale.
+///
+/// No name-collision caveat: there is no `pub mod warning`, so
+/// `use miniextendr_api::warning;` then `warning!(...)` works directly.
 ///
 /// # Example
 ///
@@ -204,6 +278,16 @@ macro_rules! warning {
 /// The raised condition has class `c("rust_message", "simpleMessage", "message", "condition")`.
 /// Muffled by `suppressMessages()` automatically (standard R restart mechanism).
 ///
+/// # See also
+///
+/// - [`crate::warning!`] / [`crate::condition!`] — louder/quieter sibling kinds.
+/// - [`crate::error!`] — for fatal failures.
+/// - [`std::panic!`] — escape hatch.
+/// - [`crate::error_value`] — tagged-SEXP transport rationale.
+///
+/// No name-collision caveat: there is no `pub mod message`, so
+/// `use miniextendr_api::message;` then `message!(...)` works directly.
+///
 /// # Example
 ///
 /// ```ignore
@@ -237,6 +321,19 @@ macro_rules! message {
 /// The raised condition has class `c("rust_condition", "simpleCondition", "condition")`.
 ///
 /// An optional `class = "name"` form prepends a custom class.
+///
+/// # See also
+///
+/// - [`crate::error!`] / [`crate::warning!`] / [`crate::message!`] — louder
+///   condition kinds. Pick `condition!` when "no handler = silent" is the
+///   right default (progress events, structured logging hooks).
+/// - [`std::panic!`] — escape hatch when the failure cannot be ignored.
+/// - [`crate::error_value`] — tagged-SEXP transport rationale.
+///
+/// **Name-collision note.** Because `pub mod condition` exists at the crate
+/// root, `use miniextendr_api::condition` imports the module rather than this
+/// macro. Invoke via `miniextendr_api::condition!(...)` (fully qualified) or
+/// via `mx::condition!(...)` after `use miniextendr_api as mx;`.
 ///
 /// # Example
 ///

--- a/miniextendr-api/src/error.rs
+++ b/miniextendr-api/src/error.rs
@@ -13,7 +13,11 @@
 //! User code should use:
 //! - `panic!()` — for unrecoverable Rust errors (becomes `rust_error` in R)
 //! - `error!()` / `warning!()` / `message!()` / `condition!()` — for structured
-//!   R conditions (see `crate::condition`)
+//!   R conditions (see [`mod@crate::condition`])
+//!
+//! See [`crate::error_value`] for the tagged-SEXP layout, the
+//! `error_in_r` default + `no_error_in_r` / `unwrap_in_r` opt-outs, and the
+//! PROTECT-discipline gotcha that R-devel surfaces.
 //!
 //! ## When `Rf_error` still fires (framework-internal)
 //!
@@ -29,7 +33,7 @@
 //! `with_r_unwind_protect_sourced` → `raise_rust_condition_via_stop`, which
 //! preserves `rust_*` class layering without going through `r_stop`.
 //!
-//! [`r_stop`] is `pub(crate)` — no user code should depend on it.
+//! `r_stop` is `pub(crate)` — no user code should depend on it.
 //!
 //! # Example
 //!

--- a/miniextendr-api/src/error_value.rs
+++ b/miniextendr-api/src/error_value.rs
@@ -6,7 +6,67 @@
 //! The generated R wrapper inspects this tagged value and escalates it to a
 //! proper R condition past the Rust boundary, with `rust_*` class layering.
 //!
-//! This ensures Rust destructors run cleanly before R sees the error.
+//! # Why tagged SEXP instead of `Rf_error`
+//!
+//! The naive way to surface a Rust error in R is to call `Rf_error`, which
+//! `longjmp`s out of the call frame. That works for C — C has no destructors —
+//! but in Rust it skips every drop on the stack: open files, `Mutex` guards,
+//! `Box::into_raw` round-trips, the worker-thread continuation token. Anything
+//! holding a resource leaks or corrupts.
+//!
+//! The framework instead catches every Rust panic (and every `RCondition`
+//! `panic_any` payload) at the boundary inside
+//! [`crate::unwind_protect::with_r_unwind_protect`], encodes it as the
+//! 4-element list described below, and *returns* that SEXP normally. The
+//! generated R wrapper then re-raises with `stop(structure(..., class =
+//! c("rust_*", ...)))`. Destructors run; `tryCatch` sees the right class.
+//!
+//! There is one accepted leak: on the R-longjmp branch inside
+//! `with_r_unwind_protect` (when an R-origin error is propagated through via
+//! `R_ContinueUnwind`), the `RErrorMarker` panic payload — about 8 bytes plus
+//! `Box` header — escapes Rust drop ordering. This is the price we pay for
+//! routing Rust failures through real R conditions instead of
+//! `Rf_error`-via-longjmp, and is exactly why lint MXL300 forbids direct
+//! `Rf_error` / `Rf_errorcall` in user code: every `Rf_error` skips Rust
+//! destructors unconditionally, not just on the (rare) R-longjmp path.
+//!
+//! # The three error-emission entry points
+//!
+//! Authors of `#[miniextendr]` functions reach for one of:
+//!
+//! 1. **`panic!(msg)`** — escape hatch. Produces `kind = "panic"` and R class
+//!    `c("rust_error", "simpleError", "error", "condition")`. Use for true
+//!    bugs / impossible states; the caller has nothing to catch by class.
+//! 2. **`miniextendr_api::error!("msg")`** — typed condition. Produces `kind
+//!    = "error"` and the same `rust_error` class layering. The `class =
+//!    "my_class"` form prepends a user class, giving R-side
+//!    `c("rust_my_class", "rust_error", "simpleError", "error", "condition")`
+//!    — exactly what a caller's `tryCatch(my_class = …)` matches on. The
+//!    sibling [`crate::warning!`], [`crate::message!`], [`crate::condition!`]
+//!    macros cover the non-error condition kinds.
+//! 3. **`Result<_, E>` where `E: std::error::Error`**, often via
+//!    [`crate::condition::AsRError`] — value-style propagation through Rust
+//!    code. Converts at the boundary using `kind = "result_err"`.
+//!    `Option::None` follows the same path with `kind = "none_err"`.
+//!
+//! # `error_in_r` is the default
+//!
+//! For every `#[miniextendr]` fn / method, the proc macro emits a wrapper that
+//! routes through this tagged-SEXP transport — i.e. `error_in_r = true` is the
+//! default. The opt-outs are documented on the macro:
+//!
+//! - `#[miniextendr(no_error_in_r)]` — bypass the tagged-SEXP path entirely.
+//!   Useful for trait-ABI vtable shims and benchmarks; Rust panics become
+//!   classic `Rf_error` longjmps. Drops the leak above at the cost of skipping
+//!   Rust destructors universally.
+//! - `#[miniextendr(unwrap_in_r)]` — `Result<T, E>` returns are unwrapped on
+//!   the R side rather than encoded as `kind = "result_err"`. Orthogonal to
+//!   the transport: still rides this SEXP path, just changes how `Err` is
+//!   stringified.
+//!
+//! Older comments suggesting `Rf_error` is the user-facing path predate PR
+//! #344 and are wrong. The wrapper preambles now consistently use this
+//! transport.
 //!
 //! # Condition value structure (`make_rust_condition_value`)
 //!
@@ -17,6 +77,23 @@
 //! - `call`: the R call SEXP (or `NULL` if not available)
 //! - class attribute: `"rust_condition_value"`
 //! - `__rust_condition__` attribute: `TRUE`
+//!
+//! # PROTECT discipline (read before editing)
+//!
+//! [`make_rust_condition_value`] allocates four SEXPs that must remain live
+//! across subsequent allocations (`SET_VECTOR_ELT` / `SETATTRIB` both
+//! trigger old-to-new GC barriers): the list itself, the message scalar
+//! STRSXP, the kind scalar STRSXP, the optional class scalar STRSXP, and
+//! the `TRUE` marker LGLSXP. Each is `Rf_protect`ed before the next
+//! allocation; `prot` counts them; `Rf_unprotect(prot)` balances at exit.
+//!
+//! R-devel runs a more aggressive GC than R-release/oldrel and *will* fire
+//! inside the window between two allocations. PR #344 commit `af6b4875`
+//! tracked down a `recursive gc invocation` segfault that lit up only on
+//! R-devel because the pre-existing 3-element version was lucky-not-safe;
+//! adding the class slot crossed the threshold. **If you add a fifth fresh
+//! allocation, protect it.** A green R-release CI run is *not* proof of
+//! safety here; run `gctorture(TRUE)` on R-devel before merging.
 
 use crate::cached_class::{
     condition_names_sexp, rust_condition_attr_symbol, rust_condition_class_sexp,
@@ -58,7 +135,7 @@ pub mod kind {
     /// Fallback kind written by [`super::make_rust_condition_value`] when the
     /// caller's `kind` argument contained an interior NUL and could not be
     /// converted to a `CString`. Should not appear in normal flow; the match
-    /// arm in [`crate::condition::RCondition::from_sexp`] handles it
+    /// arm in [`crate::condition::RCondition::from_tagged_sexp`] handles it
     /// defensively by degrading to `RCondition::Error`.
     pub const OTHER_RUST_ERROR: &str = "other_rust_error";
 }

--- a/miniextendr-api/src/panic_telemetry.rs
+++ b/miniextendr-api/src/panic_telemetry.rs
@@ -4,6 +4,28 @@
 //! trampolines, and unwind_protect). This module provides a unified hook point
 //! that fires before each panic is converted to an R error.
 //!
+//! # Relationship to the three emission paths
+//!
+//! This module is **observability, not emission**. It does not raise R
+//! conditions and does not change how panics become errors; it only lets a
+//! caller observe them. The three actual emission paths are documented on
+//! [`crate::error_value`]:
+//!
+//! - `panic!(msg)` — escape hatch; tagged-SEXP with `kind = "panic"`.
+//! - [`crate::error!`] / [`crate::warning!`] / [`crate::message!`] /
+//!   [`crate::condition!`] — typed conditions via `RCondition` panic payloads.
+//! - `Result<_, E: std::error::Error>` with [`crate::condition::AsRError`] —
+//!   value-style propagation; tagged-SEXP with `kind = "result_err"`.
+//!
+//! `fire` is invoked from each catch site *before* the panic message is encoded
+//! into a tagged condition value, so a registered hook sees every Rust-origin
+//! failure regardless of which of the three paths produced it. Typical uses:
+//! routing to `tracing` / `log`, capturing stack snapshots for crash reports,
+//! or surfacing the panic message in test harnesses where R's stderr is
+//! buffered. The hook must not raise R conditions itself (it runs inside the
+//! panic-handling path) and must not panic — secondary panics from the hook
+//! are caught and silently suppressed by `fire` (this crate, `pub(crate)`).
+//!
 //! # Usage
 //!
 //! ```ignore


### PR DESCRIPTION
PR 4 of the 6-PR rustdoc tradeoff pass. Surfaces the panic / error! / RErrorAdapter choice in module docs so the right error-emission path is visible at the point of authoring.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Expand `//!` blocks on `error_value.rs`, `condition.rs`, `panic_telemetry.rs`, and `error.rs` so the four-module surface that carries Rust→R errors documents the choice between the three emission paths.
- `error_value.rs` now covers (a) why tagged-SEXP transport instead of `Rf_error`, including the accepted ~8-byte leak on the `R_ContinueUnwind` branch and why MXL300 forbids direct `Rf_error`; (b) the three entry points (`panic!`, `error!`/sibling macros, `Result<_, E>` with `AsRError`); (c) the `error_in_r` default plus the `no_error_in_r` / `unwrap_in_r` opt-outs; (d) a PROTECT-discipline warning citing PR #344 commit `af6b4875`.
- `condition.rs` gets a "when to reach for what" overview plus a macro-vs-module name-collision note. Each macro (`error!`, `warning!`, `message!`, `condition!`) now has a `# See also` block cross-referencing the others, `panic!` as the escape hatch, and `error_value` for the deeper rationale.
- `panic_telemetry.rs` is reframed as observability rather than emission, pointing readers at the three real emission paths.
- `error.rs` keeps its existing structure and adds a single cross-link to `error_value` for the deeper transport story.
- No code changes; no new symbols; no `docs/*.md` rewrites. Cross-links stay inside the crate.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/claude/rustdoc-pr4-target cargo doc --no-deps -p miniextendr-api` clean for the four touched modules (no new warnings introduced).
- [x] `cargo fmt --check -p miniextendr-api` clean.
- [ ] Reviewer spot-checks that the rendered rustdoc reads naturally and the macro-vs-module collision note is visible on the macro pages.

## Notes
- Incidentally fixes two pre-existing rustdoc warnings that fell inside the touched files: `crate::condition::RCondition::from_sexp` (corrected to `from_tagged_sexp`) and the `[r_stop]` private-item link in `error.rs`. The remaining four pre-existing warnings (`write_wasm_registry_to_file`, `drain_log_queue_if_available`, `with_r_unwind_protect_sourced`, `ProtectedStrVec`) are untouched and stay with #715.
- Cross-references use bare `[Name]` form per the brief; `[crate::warning!]` / `[crate::message!]` / `[crate::condition!]` use the `!` suffix to disambiguate from the same-named modules at the crate root.
- No deferred items; nothing punted to a follow-up issue.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>