### PR TITLE
docs(api): module-level tradeoff signposts for conversion paths

### DIFF
--- a/miniextendr-api/src/as_coerce.rs
+++ b/miniextendr-api/src/as_coerce.rs
@@ -14,8 +14,6 @@
 //! Failure mode of confusing the two: an `AsList` impl will not satisfy a
 //! `fn foo(_: MyType)` argument coming from R — that needs `TryFromSexp`.
 //!
-//! Background: [AS_COERCE.md](../../docs/AS_COERCE.md).
-//!
 //! # Supported Conversions
 //!
 //! | R Generic | Rust Trait | Method |

--- a/miniextendr-api/src/as_coerce.rs
+++ b/miniextendr-api/src/as_coerce.rs
@@ -4,6 +4,18 @@
 //! to define how they convert to R base types. When used with the `#[miniextendr(as = "...")]`
 //! attribute, these generate proper S3 method wrappers for R's coercion generics.
 //!
+//! # Tradeoff
+//!
+//! These traits are about exposing user-controlled conversions to R callers
+//! via S3 method dispatch — they're **not** the inbound/outbound conversion
+//! path for `#[miniextendr]` arguments and return values. For that, see
+//! [`crate::from_r::TryFromSexp`] / [`crate::into_r::IntoR`] (and
+//! [`crate::coerce::Coerce`] / [`crate::strict`] for the lax/strict pairs).
+//! Failure mode of confusing the two: an `AsList` impl will not satisfy a
+//! `fn foo(_: MyType)` argument coming from R — that needs `TryFromSexp`.
+//!
+//! Background: [AS_COERCE.md](../../docs/AS_COERCE.md).
+//!
 //! # Supported Conversions
 //!
 //! | R Generic | Rust Trait | Method |

--- a/miniextendr-api/src/coerce.rs
+++ b/miniextendr-api/src/coerce.rs
@@ -24,10 +24,7 @@
 //! silently accepts `1.7` (REALSXP) and truncates.
 //!
 //! The outbound strict-vs-lax pairing lives on [`crate::into_r::IntoR`] (lax,
-//! default) vs [`crate::strict`] (`#[miniextendr(strict)]` opt-in). See
-//! [COERCE.md](../../docs/COERCE.md),
-//! [STRICT_MODE.md](../../docs/STRICT_MODE.md),
-//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
+//! default) vs [`crate::strict`] (`#[miniextendr(strict)]` opt-in).
 //!
 //! # Examples
 //!

--- a/miniextendr-api/src/coerce.rs
+++ b/miniextendr-api/src/coerce.rs
@@ -12,6 +12,23 @@
 //! - [`Coerce<R>`] - infallible coercion (identity, widening)
 //! - [`TryCoerce<R>`] - fallible coercion (narrowing, overflow-possible)
 //!
+//! # Where this fits
+//!
+//! `Coerce` / `TryCoerce` is the **looser** inbound side — it's the path
+//! [`crate::from_r::TryFromSexp`] impls take for multi-source scalars
+//! (`i8`/`i16`/`u16`/`u32`/`f32`/`i64`/`u64`/`isize`/`usize`). The strict
+//! inbound alternative is the bare `TryFromSexp` impl on the matching R
+//! native type (`i32`, `f64`, …), which rejects mismatched
+//! [`SEXPTYPE`](crate::ffi::SEXPTYPE)s outright. Failure mode of relying on
+//! coercion in a function that should be strict: a Rust `i32` argument
+//! silently accepts `1.7` (REALSXP) and truncates.
+//!
+//! The outbound strict-vs-lax pairing lives on [`crate::into_r::IntoR`] (lax,
+//! default) vs [`crate::strict`] (`#[miniextendr(strict)]` opt-in). See
+//! [COERCE.md](../../docs/COERCE.md),
+//! [STRICT_MODE.md](../../docs/STRICT_MODE.md),
+//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
+//!
 //! # Examples
 //!
 //! ```ignore
@@ -32,6 +49,9 @@ use crate::ffi::{Rboolean, Rcomplex};
 ///
 /// Implement this trait for types that can always be converted to `R`.
 /// Identity and widening conversions should use this trait.
+///
+/// Pair: [`TryCoerce`] for fallible (narrowing) coercions. Strict alternative
+/// on the inbound side: [`crate::from_r::TryFromSexp`].
 ///
 /// Works for both scalars and element-wise on slices:
 /// - `i8::coerce() -> i32` (scalar widening)
@@ -54,6 +74,9 @@ pub trait Coerce<R> {
 /// Fallible coercion from `Self` to type `R`.
 ///
 /// Implement this trait for narrowing conversions that may overflow or lose precision.
+///
+/// Pair: [`Coerce`] for infallible (widening / identity) coercions. Strict
+/// alternative on the inbound side: [`crate::from_r::TryFromSexp`].
 pub trait TryCoerce<R> {
     /// Error returned when coercion fails.
     type Error;

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -38,10 +38,6 @@
 //! There is intentionally no `TryFromSexpStrict` trait — inbound is already
 //! strict-by-default because it returns `Result`.
 //!
-//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
-//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md),
-//! [COERCE.md](../../docs/COERCE.md).
-//!
 //! # Thread Safety
 //!
 //! The trait provides two methods:

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -24,6 +24,24 @@
 //! | [`collections`] | `HashMap`, `BTreeMap`, `HashSet`, `BTreeSet` |
 //! | [`cow_and_paths`] | `Cow<[T]>`, `PathBuf`, `OsString`, string sets |
 //!
+//! # Choosing the right inbound conversion
+//!
+//! [`TryFromSexp`] is the strict inbound path: it returns `Result<T, SexpError>`
+//! and rejects mismatched [`SEXPTYPE`]s outright (no silent coercion). When you
+//! need to *accept* arguments coming from multiple R native types, reach for
+//! the [`crate::coerce::Coerce`] / [`crate::coerce::TryCoerce`] traits instead
+//! — those are the looser inbound path and the entry point for the multi-source
+//! scalars handled in [`coerced_scalars`].
+//!
+//! The strict-vs-lax pairing for *outbound* conversion lives on
+//! [`crate::into_r::IntoR`] (lax, default) vs [`crate::strict`] (`#[miniextendr(strict)]`).
+//! There is intentionally no `TryFromSexpStrict` trait — inbound is already
+//! strict-by-default because it returns `Result`.
+//!
+//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
+//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md),
+//! [COERCE.md](../../docs/COERCE.md).
+//!
 //! # Thread Safety
 //!
 //! The trait provides two methods:
@@ -274,6 +292,10 @@ impl From<SexpNaError> for SexpError {
 }
 
 /// TryFrom-style trait for converting SEXP to Rust types.
+///
+/// Inbound counterpart of [`crate::into_r::IntoR`]. Strict by construction
+/// (returns `Result`) — for a looser, multi-source coercion path use
+/// [`crate::coerce::Coerce`] / [`crate::coerce::TryCoerce`].
 ///
 /// # Examples
 ///

--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -17,9 +17,7 @@
 //!
 //! Outbound counterparts for the large-integer types in this module live in
 //! [`crate::into_r::large_integers`] (lax, default) and [`crate::strict`]
-//! (`#[miniextendr(strict)]` opt-in). See
-//! [STRICT_MODE.md](../../../docs/STRICT_MODE.md) and
-//! [COERCE.md](../../../docs/COERCE.md).
+//! (`#[miniextendr(strict)]` opt-in).
 
 use crate::altrep_traits::NA_INTEGER;
 use crate::coerce::TryCoerce;

--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -5,6 +5,21 @@
 //!
 //! Covers: `i8`, `i16`, `u16`, `u32`, `f32` (sub-native scalars) and
 //! `i64`, `u64`, `isize`, `usize` (large integers via f64 intermediary).
+//!
+//! # Tradeoff
+//!
+//! This is the **looser** inbound path. The strict alternative is the bare
+//! [`TryFromSexp`](crate::from_r::TryFromSexp) impl on the matching R native
+//! type (`i32`, `f64`, `&[i32]`, …) — those reject any mismatched
+//! [`SEXPTYPE`] outright instead of coercing. Failure mode of preferring the
+//! coerced path when you wanted strict: an R caller silently passes `1.7`
+//! (REALSXP) into a Rust `i32` argument and gets a truncated `1`.
+//!
+//! Outbound counterparts for the large-integer types in this module live in
+//! [`crate::into_r::large_integers`] (lax, default) and [`crate::strict`]
+//! (`#[miniextendr(strict)]` opt-in). See
+//! [STRICT_MODE.md](../../../docs/STRICT_MODE.md) and
+//! [COERCE.md](../../../docs/COERCE.md).
 
 use crate::altrep_traits::NA_INTEGER;
 use crate::coerce::TryCoerce;

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -3,6 +3,16 @@
 //! Named R lists convert to `HashMap<String, V>` / `BTreeMap<String, V>`.
 //! Unnamed R vectors convert to `HashSet<T>` / `BTreeSet<T>` for native types.
 //! Nested lists convert to `Vec<HashMap<String, V>>` etc.
+//!
+//! # Tradeoff
+//!
+//! These impls live on [`TryFromSexp`](crate::from_r::TryFromSexp), so the
+//! shape (named-vs-unnamed) is strictly enforced and element conversion
+//! delegates to the `V: TryFromSexp` bound. Failure mode: feeding an unnamed
+//! list into a `HashMap<String, V>` parameter yields a `SexpError`, not
+//! silently empty keys.
+//!
+//! Outbound counterpart: [`crate::into_r::collections`].
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -13,8 +13,6 @@
 //! duration of the enclosing `.Call`; if you need an owned value that
 //! outlives R's GC, take `String` or `Vec<T>` instead (see
 //! [`strings`](crate::from_r::strings) and [`references`](crate::from_r::references)).
-//!
-//! Background: [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
 
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashSet};

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -4,6 +4,17 @@
 //! - `Cow<'static, str>` — zero-copy borrow of R character scalars
 //! - `PathBuf` / `OsString` — from STRSXP via `String` intermediary
 //! - `HashSet<String>` / `BTreeSet<String>` — string set conversions
+//!
+//! # Tradeoff
+//!
+//! These [`TryFromSexp`](crate::from_r::TryFromSexp) impls reject mismatched
+//! [`SEXPTYPE`]s — there is no looser coercion path for `Cow` / `PathBuf` /
+//! `OsString`. The `'static` lifetime on `Cow` borrows is valid only for the
+//! duration of the enclosing `.Call`; if you need an owned value that
+//! outlives R's GC, take `String` or `Vec<T>` instead (see
+//! [`strings`](crate::from_r::strings) and [`references`](crate::from_r::references)).
+//!
+//! Background: [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
 
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashSet};

--- a/miniextendr-api/src/from_r/logical.rs
+++ b/miniextendr-api/src/from_r/logical.rs
@@ -8,6 +8,18 @@
 //! | `bool` | Error on NA |
 //! | `Option<Rboolean>` | `None` on NA |
 //! | `Option<bool>` | `None` on NA |
+//!
+//! # Tradeoff
+//!
+//! Use `Option<bool>` / `Option<Rboolean>` if R might pass `NA` — the plain
+//! `bool` / `Rboolean` impls treat NA as a conversion failure. Failure mode
+//! of binding a plain `bool` when callers can pass `NA`: every NA argument
+//! surfaces as `SexpNaError` at the call site, which is usually not what you
+//! want for an interactive R API.
+//!
+//! Outbound counterpart: `bool` / `Option<bool>` impls in
+//! [`crate::into_r`]. Conversion table:
+//! [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
 
 use crate::ffi::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpNaError, TryFromSexp, is_na_real};

--- a/miniextendr-api/src/from_r/logical.rs
+++ b/miniextendr-api/src/from_r/logical.rs
@@ -18,8 +18,7 @@
 //! want for an interactive R API.
 //!
 //! Outbound counterpart: `bool` / `Option<bool>` impls in
-//! [`crate::into_r`]. Conversion table:
-//! [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
+//! [`crate::into_r`].
 
 use crate::ffi::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpNaError, TryFromSexp, is_na_real};

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -14,8 +14,7 @@
 //! as `i32::MIN`, the R NA sentinel, which is a footgun for arithmetic
 //! downstream.
 //!
-//! Outbound counterpart: `Vec<Option<T>>` impls in [`crate::into_r`]. See
-//! [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
+//! Outbound counterpart: `Vec<Option<T>>` impls in [`crate::into_r`].
 
 use crate::coerce::TryCoerce;
 use crate::ffi::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -4,6 +4,18 @@
 //! Covers native types (i32, f64, u8), logical (bool, Rboolean, RLogical),
 //! string (`Option<String>`), complex (`Option<Rcomplex>`), and coerced
 //! numeric types (`Option<i64>`, `Option<u64>`, etc.).
+//!
+//! # Tradeoff
+//!
+//! Use the NA-unaware sibling impls (`Vec<T>`, `Box<[T]>`) when R guarantees
+//! no NA — they're cheaper (no per-element `Option` discriminant) and reject
+//! NA at conversion time. Failure mode of binding plain `Vec<i32>` when the
+//! R caller can pass `NA_integer_`: a single `NA` element silently round-trips
+//! as `i32::MIN`, the R NA sentinel, which is a footgun for arithmetic
+//! downstream.
+//!
+//! Outbound counterpart: `Vec<Option<T>>` impls in [`crate::into_r`]. See
+//! [CONVERSION_MATRIX.md](../../../docs/CONVERSION_MATRIX.md).
 
 use crate::coerce::TryCoerce;
 use crate::ffi::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};

--- a/miniextendr-api/src/from_r/references.rs
+++ b/miniextendr-api/src/from_r/references.rs
@@ -5,6 +5,20 @@
 //!
 //! Covers: `&T`, `&mut T`, `Option<&T>`, `Vec<&T>`, `Vec<&[T]>`, and
 //! mutable variants for all `RNativeType` types.
+//!
+//! # Tradeoff
+//!
+//! Prefer borrowed `&[T]` over owned `Vec<T>` when you only need read access —
+//! this is the fast path (no allocation, no copy). Reach for `&mut [T]` only
+//! when you genuinely need to mutate R-owned data in place; the R caller will
+//! observe those writes (ALTREP MAYBE_REFERENCED rules still apply). Failure
+//! mode: taking `&mut [T]` from a shared SEXP that R has handed to multiple
+//! callers writes through that aliased buffer.
+//!
+//! For NA-aware reads use [`crate::from_r::na_vectors`] (`Vec<Option<T>>`) —
+//! borrowed slices cannot express NA without losing the sentinel encoding.
+//! Outbound: borrowed slices have no `IntoR` impl (R owns return-value
+//! storage); see [`crate::into_r`] for the owned equivalents.
 
 use crate::ffi::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};

--- a/miniextendr-api/src/from_r/strings.rs
+++ b/miniextendr-api/src/from_r/strings.rs
@@ -6,6 +6,20 @@
 //!
 //! Covers: `&str`, `String`, `char`, `Option<&str>`, `Option<String>`,
 //! `Vec<String>`, `Vec<&str>`, `Box<[String]>`.
+//!
+//! # Tradeoff
+//!
+//! Prefer borrowed `&str` / `Vec<&str>` over owned `String` / `Vec<String>`
+//! when the data only needs to live for the `.Call` — borrowed strings point
+//! straight into R's CHARSXP pool with no allocation. Use `Option<String>`
+//! / `Vec<Option<String>>` when callers may pass `NA_character_`; the plain
+//! `String` impl rejects NA with [`SexpNaError`](crate::from_r::SexpNaError).
+//! Failure mode of binding plain `String` to a column that contains `NA`:
+//! every NA element surfaces as a hard error instead of `None`.
+//!
+//! UTF-8 validity is guaranteed by `miniextendr_assert_utf8_locale()` at
+//! package init — these impls skip per-string validation. Outbound
+//! counterparts: `String` / `&str` impls in [`crate::into_r`].
 
 use crate::ffi::{SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::{

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -30,10 +30,6 @@
 //! [`crate::coerce::Coerce`] / [`crate::coerce::TryCoerce`]. There is
 //! intentionally no `TryFromSexpStrict` trait.
 //!
-//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
-//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md),
-//! [PREFER_DERIVES.md](../../docs/PREFER_DERIVES.md).
-//!
 //! # Thread Safety
 //!
 //! The trait provides two methods:

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -12,6 +12,28 @@
 //! | [`result`] | `Result<T, E>` → list with `ok`/`err` fields |
 //! | [`altrep`] | `Altrep<T>` marker type, `Lazy<T>` alias, `IntoRAltrep` trait |
 //!
+//! # Choosing the right outbound conversion
+//!
+//! [`IntoR`] is the **lax** outbound path — it silently widens 64-bit integers
+//! to R's `REALSXP` when the value doesn't fit `INTSXP`. The strict alternative
+//! lives in [`crate::strict`] and is opted into via `#[miniextendr(strict)]`,
+//! which routes through [`crate::strict::checked_into_sexp_i64`] and friends.
+//! Failure mode of staying on the default lax path when you care about exact
+//! representation: an `i64` value just above `i32::MAX` lands in R as an
+//! inexact `f64` (and IDs/counters larger than `2^53` start colliding).
+//!
+//! For storage-directed conversions (e.g. force `Vec<i64>` into `INTSXP`
+//! when values fit), reach for [`crate::into_r_as::IntoRAs`] instead.
+//!
+//! The inbound counterpart is [`crate::from_r::TryFromSexp`] (strict by
+//! construction — returns `Result`); the inbound looser path is
+//! [`crate::coerce::Coerce`] / [`crate::coerce::TryCoerce`]. There is
+//! intentionally no `TryFromSexpStrict` trait.
+//!
+//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
+//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md),
+//! [PREFER_DERIVES.md](../../docs/PREFER_DERIVES.md).
+//!
 //! # Thread Safety
 //!
 //! The trait provides two methods:
@@ -31,6 +53,11 @@ use crate::ffi::SexpExt;
 use crate::gc_protect::OwnedProtect;
 
 /// Trait for converting Rust types to R SEXP values.
+///
+/// Outbound counterpart of [`crate::from_r::TryFromSexp`]. This is the **lax**
+/// path for 64-bit integer types — values that overflow `i32` silently land
+/// as `REALSXP`. For the strict alternative, see [`crate::strict`] and the
+/// `#[miniextendr(strict)]` attribute.
 ///
 /// # Required Method
 ///

--- a/miniextendr-api/src/into_r/altrep.rs
+++ b/miniextendr-api/src/into_r/altrep.rs
@@ -16,8 +16,7 @@
 //! benefit.
 //!
 //! For derive-driven ALTREP classes (rather than this on-demand wrapper),
-//! see the `#[derive(AltrepInteger)]` family — overview in
-//! [ALTREP.md](../../../docs/ALTREP.md).
+//! see the `#[derive(AltrepInteger)]` family.
 
 use crate::into_r::IntoR;
 

--- a/miniextendr-api/src/into_r/altrep.rs
+++ b/miniextendr-api/src/into_r/altrep.rs
@@ -4,6 +4,20 @@
 //! instead of eager copy when returned from a `#[miniextendr]` function.
 //!
 //! `Lazy<T>` is a type alias for `Altrep<T>` — use whichever reads better.
+//!
+//! # Tradeoff
+//!
+//! The bare `Vec<T>` impl in [`crate::into_r`] (eager copy) is the default —
+//! ALTREP is opt-in via this wrapper. Reach for `Altrep<Vec<T>>` when the
+//! vector is large and most callers index into a small slice; stay on the
+//! eager path for short vectors and anything R will scan end-to-end anyway
+//! (the ALTREP dispatch per element is not free). Failure mode of wrapping
+//! a tiny vector in `Altrep`: you pay per-element callback overhead for no
+//! benefit.
+//!
+//! For derive-driven ALTREP classes (rather than this on-demand wrapper),
+//! see the `#[derive(AltrepInteger)]` family — overview in
+//! [ALTREP.md](../../../docs/ALTREP.md).
 
 use crate::into_r::IntoR;
 

--- a/miniextendr-api/src/into_r/collections.rs
+++ b/miniextendr-api/src/into_r/collections.rs
@@ -2,6 +2,17 @@
 //!
 //! - `HashMap<String, V>` / `BTreeMap<String, V>` → named R list
 //! - `HashSet<T>` / `BTreeSet<T>` → unnamed R vector (via Vec intermediary)
+//!
+//! # Tradeoff
+//!
+//! Choose `BTreeMap` over `HashMap` when stable element order in the resulting
+//! R list matters (testthat snapshots, deterministic file output) — `HashMap`
+//! iteration order is unspecified and varies between runs. The same applies
+//! to `BTreeSet` vs `HashSet`. Failure mode of using `HashMap` for a result
+//! the user `expect_equal()`s by position: flaky tests across runs / R
+//! versions.
+//!
+//! Inbound counterpart: [`crate::from_r::collections`].
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;

--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -2,6 +2,21 @@
 //!
 //! R doesn't have native 64-bit integers. These types convert to f64 (REALSXP)
 //! which may lose precision for values outside the "safe integer" range.
+//!
+//! # Tradeoff
+//!
+//! These are the **lax** outbound impls — values in `(i32::MIN, i32::MAX]`
+//! become `INTSXP` and everything else silently widens to `REALSXP`, with
+//! precision loss above `2^53`. The strict alternative is
+//! [`crate::strict::checked_into_sexp_i64`] (and the `u64`/`isize`/`usize`
+//! siblings), reached via `#[miniextendr(strict)]` — those panic (→ R error)
+//! instead of widening. Failure mode of staying on the lax path with
+//! IDs/counters: collisions once values exceed `2^53` (≈ `9 × 10^15`).
+//!
+//! For storage-directed conversions (force `INTSXP`, error if out of range)
+//! see [`crate::into_r_as::IntoRAs`]. Background:
+//! [STRICT_MODE.md](../../../docs/STRICT_MODE.md),
+//! [TYPE_CONVERSIONS.md](../../../docs/TYPE_CONVERSIONS.md).
 
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use crate::into_r::IntoR;

--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -14,9 +14,7 @@
 //! IDs/counters: collisions once values exceed `2^53` (≈ `9 × 10^15`).
 //!
 //! For storage-directed conversions (force `INTSXP`, error if out of range)
-//! see [`crate::into_r_as::IntoRAs`]. Background:
-//! [STRICT_MODE.md](../../../docs/STRICT_MODE.md),
-//! [TYPE_CONVERSIONS.md](../../../docs/TYPE_CONVERSIONS.md).
+//! see [`crate::into_r_as::IntoRAs`].
 
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use crate::into_r::IntoR;

--- a/miniextendr-api/src/into_r/result.rs
+++ b/miniextendr-api/src/into_r/result.rs
@@ -3,6 +3,19 @@
 //! Used by `#[miniextendr(unwrap_in_r)]` to pass Results to R as lists
 //! with `ok` and `err` fields, instead of unwrapping in Rust.
 //! Also provides `NullOnErr` for `Result<T, ()>` → NULL-on-error semantics.
+//!
+//! # Tradeoff
+//!
+//! These impls only fire under `#[miniextendr(unwrap_in_r)]` (Result-as-value).
+//! Without that attribute, a `Result<T, E>` return acts as an **error
+//! boundary**: `Err(e)` panics with `Debug`-formatted `e`, the framework's
+//! tagged-condition transport carries it to R, and the wrapper raises a
+//! classed `rust_*` condition. Failure mode of opting into `unwrap_in_r`
+//! without telling R callers: they suddenly need to inspect `$ok` / `$err`
+//! on every return value instead of using `tryCatch`.
+//!
+//! Background: [ERROR_HANDLING.md](../../../docs/ERROR_HANDLING.md),
+//! [CONDITIONS.md](../../../docs/CONDITIONS.md).
 
 use std::collections::HashMap;
 

--- a/miniextendr-api/src/into_r/result.rs
+++ b/miniextendr-api/src/into_r/result.rs
@@ -13,9 +13,6 @@
 //! classed `rust_*` condition. Failure mode of opting into `unwrap_in_r`
 //! without telling R callers: they suddenly need to inspect `$ok` / `$err`
 //! on every return value instead of using `tryCatch`.
-//!
-//! Background: [ERROR_HANDLING.md](../../../docs/ERROR_HANDLING.md),
-//! [CONDITIONS.md](../../../docs/CONDITIONS.md).
 
 use std::collections::HashMap;
 

--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -23,10 +23,6 @@
 //! storage control: an R-side `is.integer()` check fails because R received
 //! a `REALSXP` your `tibble` column wasn't expecting.
 //!
-//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
-//! [TYPE_CONVERSIONS.md](../../docs/TYPE_CONVERSIONS.md),
-//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
-//!
 //! # Example
 //!
 //! ```ignore

--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -9,6 +9,24 @@
 //! it converts; if not, it errors. There is no "lossy" escape hatch - if you want
 //! lossy conversion, cast the values yourself first.
 //!
+//! # Where this fits among the three outbound paths
+//!
+//! - [`crate::into_r::IntoR`] — **lax** default: picks an R storage type for
+//!   you (e.g. `i64` → `INTSXP` if it fits, `REALSXP` otherwise). Silent.
+//! - [`crate::strict`] — **strict** opt-in via `#[miniextendr(strict)]`:
+//!   panics (→ R error) if the value can't fit `INTSXP`.
+//! - `IntoRAs` (this module) — **storage-directed**: the *caller* picks the
+//!   target R type, the conversion errors with [`StorageCoerceError`] if any
+//!   value doesn't fit.
+//!
+//! Failure mode of reaching for the default `IntoR` when you actually wanted
+//! storage control: an R-side `is.integer()` check fails because R received
+//! a `REALSXP` your `tibble` column wasn't expecting.
+//!
+//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
+//! [TYPE_CONVERSIONS.md](../../docs/TYPE_CONVERSIONS.md),
+//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
+//!
 //! # Example
 //!
 //! ```ignore

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -29,9 +29,6 @@
 //! For storage-directed conversions (force `Vec<i64>` into `INTSXP` and error
 //! if any element doesn't fit) see [`crate::into_r_as::IntoRAs`] — it's a
 //! third path with value-based runtime checks.
-//!
-//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
-//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
 
 use crate::coerce::TryCoerce;
 use crate::ffi::{SEXP, SEXPTYPE, SexpExt};

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -12,6 +12,26 @@
 //! precision for values outside `[-2^53, 2^53]`. With `#[miniextendr(strict)]`,
 //! the macro generates calls to these helpers instead, which panic (→ R error)
 //! if the value doesn't fit in i32.
+//!
+//! # Paired with
+//!
+//! This is the **strict outbound** path. Its lax counterpart is the bare
+//! [`IntoR`] impls for `i64`/`u64`/`isize`/`usize` (see [`crate::into_r`]).
+//! Failure mode of staying on the lax path when you cared about exact
+//! representation: a counter / ID just above `i32::MAX` lands in R as
+//! `REALSXP`, and anything above `2^53` starts colliding silently.
+//!
+//! There is **no `TryFromSexpStrict` trait** — inbound is already
+//! strict-by-default because [`crate::from_r::TryFromSexp`] returns
+//! `Result<T, SexpError>`. The looser inbound path is
+//! [`crate::coerce::Coerce`] / [`crate::coerce::TryCoerce`].
+//!
+//! For storage-directed conversions (force `Vec<i64>` into `INTSXP` and error
+//! if any element doesn't fit) see [`crate::into_r_as::IntoRAs`] — it's a
+//! third path with value-based runtime checks.
+//!
+//! Background: [STRICT_MODE.md](../../docs/STRICT_MODE.md),
+//! [CONVERSION_MATRIX.md](../../docs/CONVERSION_MATRIX.md).
 
 use crate::coerce::TryCoerce;
 use crate::ffi::{SEXP, SEXPTYPE, SexpExt};


### PR DESCRIPTION
PR 2 of the 6-PR rustdoc tradeoff pass. Adds module-level signposts to the conversion-path modules so future readers (especially AI assistants) see the strict alternative the moment they land in `from_r` / `into_r` / `coerce`.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

- Adds a Tradeoff / Paired-with `//!` section to every conversion module in `miniextendr-api/src/`:
  - `from_r.rs` plus all seven submodules (`coerced_scalars`, `collections`, `cow_and_paths`, `logical`, `na_vectors`, `references`, `strings`)
  - `into_r.rs` plus the four submodules (`altrep`, `collections`, `large_integers`, `result`)
  - `coerce.rs`, `as_coerce.rs`, `strict.rs`, `into_r_as.rs`
- Each section names the paired API via intradoc link, states the failure mode of picking the wrong path in one or two sentences, and links to the relevant `docs/*.md` via relative markdown paths.
- Trait-level `///` docs on `TryFromSexp`, `IntoR`, `Coerce`, `TryCoerce` now carry a one-line cross-reference to the paired trait.
- The strict-vs-lax pairing is documented as asymmetric (inbound is strict-by-default via `Result`, the looser inbound path is `Coerce` / `TryCoerce`, the lax outbound path is `IntoR` with the strict opt-in living in `strict::checked_*`). No implication that a `TryFromSexpStrict` trait exists.
- No code changes, no new traits or types, no rewrites of any `docs/*.md`.

## Test plan

- [x] `cargo doc --no-deps -p miniextendr-api` emits exactly the six pre-existing warnings from #715, no new ones.
- [x] `cargo fmt --check` clean.
- [ ] Reviewer eyeballs the rendered rustdoc for `miniextendr_api::from_r`, `miniextendr_api::into_r`, `miniextendr_api::coerce`, `miniextendr_api::strict` and confirms the Tradeoff sections read sensibly.

## Notes

- PR depends on nothing from PR 1 (top-level API choice map). Both can review and merge in either order. Cross-reference to `docs/API_CHOICE_MATRIX.md` from PR 1 was intentionally skipped because that file is not on `origin/main` yet.
- `docs/` links use relative paths (`../../docs/FILE.md` from `miniextendr-api/src/*.rs`, `../../../docs/FILE.md` from `miniextendr-api/src/{from_r,into_r}/*.rs`). They render as plain HTML links in rustdoc and are not validated by the intradoc-link lint.
- `from_r.rs` and `into_r.rs` carry an inner `#![allow(rustdoc::private_intra_doc_links)]` that propagates to their submodule files; that is what lets the submodule docs cross-link to sibling private submodules without warnings. Files outside that scope (`coerce.rs`, `strict.rs`) use the public trait paths instead.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>