### PR TITLE
docs(api): fix 3 intradoc warnings + drop docs/*.md pointers (#715, #728)

### DIFF
--- a/miniextendr-api/src/altrep_sexp.rs
+++ b/miniextendr-api/src/altrep_sexp.rs
@@ -43,9 +43,6 @@
 //! // Or use the convenience helper on any SEXP:
 //! let safe_sexp = unsafe { ensure_materialized(sexp) };
 //! ```
-//!
-//! See also: `docs/ALTREP_SEXP.md` for the full guide on receiving ALTREP
-//! vectors from R.
 
 use crate::ffi::{self, Rcomplex, SEXP, SEXPTYPE, SexpExt};
 use crate::from_r::r_slice;

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -479,8 +479,6 @@ impl_try_from_sexp_scalar_native!(crate::ffi::Rcomplex, CPLXSXP);
 /// To receive the raw SEXP without any conversion (including no materialization),
 /// use `extern "C-unwind"`.
 ///
-/// See `docs/ALTREP_SEXP.md` for the full guide.
-///
 /// # Safety
 ///
 /// SEXP handles are only valid on R's main thread. Use with

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -951,7 +951,8 @@ impl std::ops::Deref for OwnedProtect {
 /// When constructed via [`Protected::new`], the inner [`OwnedProtect`] carries
 /// `!Send + !Sync` (via `NoSendSync`). When constructed via
 /// [`Protected::from_trusted`], the `_protect` field is `None` and the type
-/// becomes auto-`Send`/`Sync` — the same behaviour as [`ProtectedStrVec`] today.
+/// becomes auto-`Send`/`Sync` — the same behaviour as
+/// [`ProtectedStrVec`](crate::strvec::ProtectedStrVec) today.
 pub struct Protected<'a, T> {
     inner: T,
     _protect: Option<OwnedProtect>,

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -9,10 +9,10 @@
 //! ## Log drain
 //!
 //! Every call to `with_r_unwind_protect` (and its variants) drains the
-//! cross-thread log queue via [`drain_log_queue_if_available`] before
-//! returning or re-raising an R error. This ensures that records buffered by
-//! worker threads are flushed to R's console on every FFI exit — including
-//! error paths.
+//! cross-thread log queue via the crate-private `drain_log_queue_if_available`
+//! helper before returning or re-raising an R error. This ensures that records
+//! buffered by worker threads are flushed to R's console on every FFI exit —
+//! including error paths.
 use std::{
     any::Any,
     borrow::Cow,

--- a/miniextendr-api/src/wasm_registry_writer.rs
+++ b/miniextendr-api/src/wasm_registry_writer.rs
@@ -1,7 +1,7 @@
 //! Host-time generator of `wasm_registry.rs` — the WASM-side replacement for
 //! `linkme`'s runtime distributed-slice gather.
 //!
-//! On native builds, the cdylib runs [`write_wasm_registry_to_file`] to emit
+//! On native builds, the cdylib runs [`crate::wasm_registry_writer::write_wasm_registry_to_file`] to emit
 //! Rust source listing every `MX_CALL_DEFS` / `MX_ALTREP_REGISTRATIONS` /
 //! `MX_TRAIT_DISPATCH` entry as `extern "C" {}` declarations + ordinary
 //! `&[T]` static slices. On `wasm32-*` targets, the user crate compiles that


### PR DESCRIPTION
Closes #728 outright; closes the remaining 3 of 6 from #715 (the other 3 are fixed incidentally by #718 and #719).

<details>
<summary>AI-written details (Claude Opus 4.7)</summary>

## What changed
`cargo doc --no-deps -p miniextendr-api` drops from **6 warnings → 3 warnings** (the 3 remaining are owned by #718 / #719).

- `wasm_registry_writer.rs:4` — the outer `///` doc on the `pub mod wasm_registry_writer;` declaration in `lib.rs` merges with this inner `//!`, and rustdoc resolves the merged links against the **crate root** rather than the module scope. Unqualified names like `` [`write_wasm_registry_to_file`] `` miss; fully qualified the path.
- `unwind_protect.rs:12` — `drain_log_queue_if_available` is a crate-private helper. Drop the intradoc link and keep the name as inline code; the surrounding text already says "crate-private".
- `gc_protect.rs:954` — `ProtectedStrVec` lives in `crate::strvec`, not `crate::gc_protect`. Qualify with `[\`ProtectedStrVec\`](crate::strvec::ProtectedStrVec)`.
- `altrep_sexp.rs:47` and `from_r.rs:482` — rustdoc is standalone (ships to docs.rs); `docs/` ships to the GitHub Pages site. Drop the see-alsos. The surrounding text already names the relevant items (`AltrepSexp`, `ensure_materialized`).

## Verification
```
cargo doc --no-deps -p miniextendr-api 2>&1 | grep 'warning:'
```
Before:
```
warning: unresolved link to `write_wasm_registry_to_file`
warning: public documentation for `unwind_protect` links to private item `drain_log_queue_if_available`
warning: public documentation for `with_r_unwind_protect_or_raise` links to private item `with_r_unwind_protect_sourced`
warning: unresolved link to `crate::condition::RCondition::from_sexp`
warning: public documentation for `error` links to private item `r_stop`
warning: unresolved link to `ProtectedStrVec`
warning: `miniextendr-api` (lib doc) generated 6 warnings
```
After:
```
warning: public documentation for `with_r_unwind_protect_or_raise` links to private item `with_r_unwind_protect_sourced`
warning: unresolved link to `crate::condition::RCondition::from_sexp`
warning: public documentation for `error` links to private item `r_stop`
warning: `miniextendr-api` (lib doc) generated 3 warnings
```
Remaining 3 are touched by #718 (`with_r_unwind_protect_sourced`) and #719 (`RCondition::from_sexp`, `r_stop`).

## Risk
Docs-only. No runtime change, no API change, no behavioural change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)