### PR TITLE
test(api): contention tests for worker → main routing channel

### DIFF
--- a/journal/2026-05-26-worker-channel-stress.md
+++ b/journal/2026-05-26-worker-channel-stress.md
@@ -1,0 +1,178 @@
+# 2026-05-26 — Worker-channel contention audit
+
+User flagged that the *channel back to R API on main thread* (the
+worker → main routing in `miniextendr-api/src/worker.rs`) was originally
+written to experiment with progress bars and similar features, and was
+never put under contention. This note is the audit I did before writing
+the stress test that lives alongside it.
+
+## What the mechanism actually is
+
+`worker.rs::worker_channel` (lines 280–680). Three channels, two thread-locals,
+one mutex.
+
+```
+                       MAIN THREAD                           WORKER THREAD
+                       ===========                           =============
+
+  R_init_<pkg>:
+    init_worker():
+      mpsc::sync_channel::<WorkerMsg>(0)    ──▶ rx held by worker thread
+      WorkerState { tx, JoinHandle } ──▶ in `static WORKER: Mutex<Option<_>>`
+
+  run_on_worker(f):                                          rx.recv() ──┐
+    sync_channel::<WorkerMessage<T>>(1)         worker_tx           ┌────┘
+    sync_channel::<MainThreadResponse>(1)       response_rx         │
+    AnyJob wrapping (f, worker_tx, response_rx)                     │
+    WORKER.lock() clone tx                                          │
+    tx.send(Job(job))    ─── rendezvous (cap 0) ────────────────▶   │
+                                                                    │
+                                                          job() runs:
+                                                            TLS:
+                                                              WORKER_TO_MAIN_TX
+                                                                = Some(worker_tx)
+                                                              MAIN_RESPONSE_RX
+                                                                = Some(response_rx)
+                                                            catch_unwind(f)
+                                                              f may call with_r_thread:
+                                                                worker_tx.send(WorkRequest)
+                                                                response_rx.recv() ──┐
+                                                                                     │
+    loop {                                                                           │
+      worker_rx.recv():                                                              │
+        WorkRequest(work) ──◀──────────────────────────────────────────────          │
+          R_UnwindProtect( trampoline=catch_unwind(work), cleanup=send Err ):        │
+            ── trampoline ok ──▶ response_tx.send(Ok(boxed))   ───────────▶          │
+            ── trampoline rust panic ──▶ response_tx.send(Err)  ──────────▶          │
+            ── R longjmp ──▶ cleanup sends Err, panic_any(RErrorMarker)              │
+                              outer catch_unwind catches → R_ContinueUnwind          │
+                                                                                     │
+                                                            f returns r              │
+                                                            TLS cleared              │
+                                                            worker_tx.send(Done)──▶  │
+        Done(result) ──▶ return                                                      │
+    }
+```
+
+Key properties of the design that I want to pin down with tests:
+
+1. **Single worker** — capacity-0 rendezvous on the main→worker channel
+   means at most one job is in flight; `dispatch_to_worker` blocks in `send`
+   until the worker has picked it up via `recv`.
+2. **Per-job channel pair** — `(worker_tx, response_rx)` is created fresh
+   inside `dispatch_to_worker`, never shared between jobs.
+3. **Thread-local routing context** — `WORKER_TO_MAIN_TX` /
+   `MAIN_RESPONSE_RX` are set only on the worker thread. Threads that the
+   user spawns *from inside* a worker job do **not** inherit it, so
+   `with_r_thread` from them must panic with the documented
+   "called outside of `run_on_worker` context" message.
+4. **Bounded protocol** — capacity-1 buffers in each direction; one
+   round-trip outstanding at a time per job. Pumping N round-trips per
+   job is supposed to work, regardless of N.
+5. **Re-entry detection** — already covered (`run_on_worker_reentry_panics_not_deadlocks`).
+6. **Cleanup on R longjmp** — already covered structurally in
+   worker.rs lines 548–574; running an end-to-end test of it is risky
+   (see below) so it stays out of scope.
+
+## What's covered today
+
+- `worker::tests::sendable_is_send` — Send impl.
+- `worker::tests::with_r_thread_panics_before_init` — guard rail.
+- `worker::tests::has_worker_context_false_outside_worker` — TLS sanity.
+- `worker::tests::worker_tests::run_on_worker_reentry_panics_not_deadlocks` —
+  re-entry detection (not a deadlock).
+- `worker::tests::stub_tests::*` — no-worker-thread feature stubs.
+- `tests/worker_shutdown.rs` — `miniextendr_runtime_shutdown` blocks
+  until the worker has actually joined.
+- `tests/altrep_thread.rs::altrep_via_with_r_thread_from_worker` — one
+  round-trip from inside a `run_on_worker` job.
+- Indirect: `tests/rayon.rs` exercises `with_r_thread` from the worker
+  on every allocation, but always at most one round-trip and never
+  under contention.
+
+## What's NOT covered (the user's intuition was right)
+
+| # | Pattern | Why it matters |
+|---|---|---|
+| P1 | One job with **N inner `with_r_thread` calls** (N = 1k+) | Verifies the capacity-1 round-trip protocol doesn't lose messages or wedge under high churn. Progress-bar style "tick on main every iteration" usage. |
+| P2 | **M concurrent threads** each call `run_on_worker` | Worker is a single bottleneck; we want all M jobs to complete, no deadlock, no message mix-up. |
+| P3 | M threads using `std::sync::Barrier` to **race into `run_on_worker` simultaneously** | Forces maximum contention on `WORKER.lock()` and the rendezvous send. |
+| P4 | **Mixed long + short jobs** — one job that sleeps inside `with_r_thread`, plus a flock of short jobs | Liveness check: short jobs must queue and finish; the long one doesn't starve anyone permanently. |
+| P5 | **`with_r_thread` re-called from main thread** (short-circuit branch) | Cheap to verify but documents the main-thread fast-path. |
+| P6 | **`with_r_thread` from a thread that is not the worker, with `worker-thread` feature on** | Documented to panic; should be exercised, not just claimed. |
+| P7 | **Rust panic in the `with_r_thread` closure on main** | Trampoline catch_unwind → `data.panic_payload` → Err to worker → re-raise → outer catch_unwind in worker job → `Done(Err)`. |
+| P8 | **`std::thread` spawned inside a `run_on_worker` job tries `with_r_thread`** | TLS is set on the worker thread only; the descendant has no routing context. Must panic, not deadlock. This is what stops rayon parallel iters from accidentally calling R from worker pool threads. |
+
+Out of scope:
+- **R longjmp from inside the closure on main** — `Rf_error` from a
+  `with_r_thread` body would exercise the `cleanup_handler` path
+  (worker.rs:548). The path is correct on inspection, but the test thread
+  (spawned by `r_test_utils::with_r_thread`) has no outer R top-level
+  handler, so `R_ContinueUnwind(token)` resumes an unwind that has
+  nowhere to land. Triggering this in `cargo test` is more likely to
+  crash the test process than exercise the code. Better to cover it from
+  rpkg's testthat suite where R's own top-level handler is in place.
+- **`miniextendr_runtime_shutdown` mid-job** — out of scope here
+  (`worker_shutdown.rs` covers the idle case; mid-job shutdown is the
+  package-unload-with-active-worker case and overlaps with #277).
+
+## Test design
+
+One integration binary `tests/worker_channel_stress.rs` so a wedged
+channel doesn't take other tests down. Single top-level `#[test]`
+function inside `r_test_utils::with_r_thread(|| { … })` running
+sub-cases sequentially, matching the existing rayon/allocator pattern
+(R can only initialise once per process).
+
+Each sub-case has its own deadline via `recv_timeout` — a regression
+that wedges the channel must surface as a test failure, never a hang.
+
+Counts kept modest (N ≈ 200 round-trips, M ≈ 8 threads) so CI cost
+stays low. They can be turned up locally for smoke runs.
+
+## Finding: `run_on_worker` has an undocumented "main-thread caller" precondition
+
+The first cut of this test tried to model contention by spawning M std
+threads, each calling `run_on_worker` independently from inside the
+test-util's R-main-thread closure. They all failed with
+
+```
+panic in `with_r_thread`: assertion failed: is_r_main_thread()
+```
+
+inside the closure passed to `with_r_thread`.
+
+Tracing the implementation: `dispatch_to_worker` (worker.rs:419) runs
+the main-thread event loop **on whatever thread called it**, and
+`route_to_main_thread` (worker.rs:385) sends `WorkRequest` to that
+caller's `worker_rx`. So `with_r_thread` from the worker job routes
+back to the *caller of `run_on_worker`*, not to whichever thread holds
+`R_MAIN_THREAD_ID`. If the caller isn't main, R API work lands on the
+wrong thread silently.
+
+This is reasonable for the design's intended use — `#[miniextendr]`
+entry points are called via `.Call` which is always on R's main thread,
+so in practice the caller IS the main thread. But it's an *implicit*
+contract that isn't asserted anywhere and isn't called out in the
+rustdoc.
+
+Three options to make the contract explicit:
+
+1. Add a `debug_assert!(is_r_main_thread())` at the top of
+   `dispatch_to_worker`. Cheap, catches misuse in test builds, doesn't
+   change release behaviour.
+2. Promote it to a real `assert!` (release-too). Slightly more
+   defensive but adds a per-dispatch atomic load.
+3. Document the precondition in the `run_on_worker` rustdoc and on
+   `with_r_thread`. Lowest effort, highest blast radius if someone
+   misses it.
+
+(1) or (1)+(3) is probably right. Out of scope for this PR; tracked
+in #730 with the failing-test snippet as the repro.
+
+## What I'm NOT changing
+
+- No changes to `worker.rs`. This is a coverage exercise.
+- No new public API.
+- The precondition finding above will be filed as a separate issue,
+  not addressed in this PR.

--- a/miniextendr-api/tests/worker_channel_stress.rs
+++ b/miniextendr-api/tests/worker_channel_stress.rs
@@ -1,0 +1,287 @@
+//! Contention tests for the worker → main routing channel.
+//!
+//! `with_r_thread` / `run_on_worker` (`miniextendr-api/src/worker.rs`) is
+//! how Rust code calls R API entry points from a non-main thread.
+//! Existing coverage exercises a *single* round-trip
+//! (`altrep_thread::altrep_via_with_r_thread_from_worker`), shutdown
+//! (`worker_shutdown.rs`), and re-entry detection
+//! (`worker::tests::run_on_worker_reentry_panics_not_deadlocks`). This
+//! binary covers the gaps: many round-trips, barrier-storms of
+//! descendant threads, error-propagation, and the routing-context
+//! boundary.
+//!
+//! Single integration binary by design — a wedged channel here must
+//! not take other test binaries down. Every cross-thread `recv` is
+//! `recv_timeout`-bounded so a regression that deadlocks fails loudly
+//! rather than hanging CI.
+//!
+//! Run with:
+//!
+//!   MINIEXTENDR_BACKTRACE=1 \
+//!     cargo test -p miniextendr-api --test worker_channel_stress \
+//!                --features worker-thread -- --nocapture
+//!
+//! `MINIEXTENDR_BACKTRACE=1` is needed only when *debugging* a failure
+//! — without it, `miniextendr_panic_hook` silently swallows panic
+//! tracebacks (the framework's normal behaviour, since panics turn into
+//! tagged R errors). The test failure itself still reports as
+//! `FAILED`; only the panic detail is suppressed.
+
+#![cfg(feature = "worker-thread")]
+
+mod r_test_utils;
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc;
+use std::sync::{Arc, Barrier};
+use std::time::{Duration, Instant};
+
+use miniextendr_api::unwind_protect::panic_payload_to_string;
+use miniextendr_api::with_r_thread;
+use miniextendr_api::worker::{is_r_main_thread, run_on_worker};
+
+/// Deadline for every cross-thread `recv` in this file. Long enough to
+/// absorb slow-CI jitter, short enough that a real deadlock surfaces
+/// well under a minute.
+const RECV_DEADLINE: Duration = Duration::from_secs(30);
+
+#[test]
+fn worker_channel_stress_suite() {
+    r_test_utils::with_r_thread(|| {
+        // The r-test-main thread is the one that ran
+        // `miniextendr_runtime_init()`, so it IS `is_r_main_thread()`.
+        // Every `run_on_worker` in this file is dispatched from here —
+        // that's the documented invariant: only the main thread runs
+        // the main-thread event loop inside `dispatch_to_worker`.
+        assert!(
+            is_r_main_thread(),
+            "test harness should run sub-cases on R main thread"
+        );
+
+        case_main_thread_short_circuit();
+        case_recursive_with_r_thread_on_main();
+        case_many_round_trips_one_job();
+        case_descendant_thread_storm();
+        case_main_thread_keeps_working_after_descendant_panics();
+        case_rust_panic_in_main_closure();
+        case_rust_panic_in_worker_body();
+        case_with_r_thread_outside_run_on_worker_context();
+    });
+}
+
+// region: Main-thread fast paths
+
+/// `with_r_thread` from the main thread runs inline; no channel
+/// touched.
+fn case_main_thread_short_circuit() {
+    let result = with_r_thread(|| {
+        assert!(
+            is_r_main_thread(),
+            "closure must observe main-thread fast path"
+        );
+        7i32
+    });
+    assert_eq!(result, 7);
+}
+
+/// Nested `with_r_thread` from main — both calls short-circuit.
+fn case_recursive_with_r_thread_on_main() {
+    let outer = with_r_thread(|| {
+        let inner = with_r_thread(|| {
+            assert!(is_r_main_thread());
+            5i32
+        });
+        inner * 2
+    });
+    assert_eq!(outer, 10);
+}
+
+// endregion
+
+// region: Sustained round-trip protocol
+
+/// One worker job that pumps N round-trips through the capacity-1
+/// protocol. Verifies neither direction wedges and every message is
+/// delivered in order (an ordered sum catches drops and reorderings
+/// cheaply).
+fn case_many_round_trips_one_job() {
+    const N: i64 = 512;
+
+    let result = run_on_worker(move || {
+        assert!(
+            !is_r_main_thread(),
+            "worker job should run off the main thread"
+        );
+
+        let mut acc = 0i64;
+        for i in 0..N {
+            let v = with_r_thread(move || {
+                assert!(
+                    is_r_main_thread(),
+                    "with_r_thread closure must land on R main thread"
+                );
+                i
+            });
+            acc += v;
+        }
+        acc
+    });
+
+    let expected: i64 = (0..N).sum();
+    assert_eq!(result, Ok(expected), "round-trip sum mismatch");
+}
+
+// endregion
+
+// region: Descendant thread storm
+
+/// Worker job spawns M descendant threads, holds them at a Barrier,
+/// then releases them all at once. Each descendant tries
+/// `with_r_thread` — none has the routing TLS, so each must panic with
+/// the documented "outside of `run_on_worker` context" message. The
+/// worker's own thread is unaffected and the job completes.
+///
+/// This is the highest-contention shape that real workloads can
+/// produce (rayon parallel iter inside a `#[miniextendr]` function
+/// being the canonical example). The job ends up serialising any
+/// R access either by (a) running it *outside* the parallel section
+/// or (b) routing through `with_r_thread` from the worker's own
+/// thread only.
+fn case_descendant_thread_storm() {
+    const M: usize = 16;
+
+    let r = run_on_worker(|| {
+        let barrier = Arc::new(Barrier::new(M));
+        let (tx, rx) = mpsc::sync_channel::<bool>(M);
+
+        for _ in 0..M {
+            let b = barrier.clone();
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                b.wait();
+                let outcome = catch_unwind(AssertUnwindSafe(|| with_r_thread(|| 0i32)));
+                let detected = match outcome {
+                    Ok(_) => false,
+                    Err(payload) => panic_payload_to_string(payload.as_ref())
+                        .contains("outside of `run_on_worker` context"),
+                };
+                let _ = tx.send(detected);
+            });
+        }
+        drop(tx);
+
+        let deadline = Instant::now() + RECV_DEADLINE;
+        let mut detected_all = true;
+        for _ in 0..M {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match rx.recv_timeout(remaining) {
+                Ok(b) => detected_all &= b,
+                Err(_) => return Err("descendant storm wedged"),
+            }
+        }
+        if !detected_all {
+            return Err("at least one descendant did NOT panic with the documented message");
+        }
+        Ok(M)
+    });
+
+    assert_eq!(
+        r,
+        Ok(Ok(M)),
+        "descendant thread storm did not behave as documented"
+    );
+}
+
+/// After a wave of descendant panics, the worker's own thread can
+/// still call `with_r_thread` successfully. Catches a regression where
+/// a descendant panic somehow poisons the routing context (it
+/// shouldn't — TLS lives on the worker thread, descendants never had
+/// access — but exercise it explicitly).
+fn case_main_thread_keeps_working_after_descendant_panics() {
+    const M: usize = 8;
+
+    let r = run_on_worker(|| {
+        // First, spawn M descendants that try with_r_thread and panic.
+        let (tx, rx) = mpsc::sync_channel::<()>(M);
+        for _ in 0..M {
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                let _ = catch_unwind(AssertUnwindSafe(|| with_r_thread(|| 0i32)));
+                let _ = tx.send(());
+            });
+        }
+        drop(tx);
+        let deadline = Instant::now() + RECV_DEADLINE;
+        for _ in 0..M {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            rx.recv_timeout(remaining).expect("descendant lost");
+        }
+
+        // Then verify the worker's own thread can still round-trip.
+        let mut acc = 0i64;
+        for i in 0..32 {
+            acc += with_r_thread(move || {
+                assert!(is_r_main_thread());
+                i
+            });
+        }
+        acc
+    });
+
+    let expected: i64 = (0..32).sum();
+    assert_eq!(
+        r,
+        Ok(expected),
+        "routing channel poisoned by descendant panics"
+    );
+}
+
+// endregion
+
+// region: Error propagation
+
+/// Rust panic in the main-side closure: trampoline catches → response
+/// sends Err → worker re-raises → outer catch_unwind in worker job →
+/// `Done(Err)` → `run_on_worker` returns Err with the panic message.
+fn case_rust_panic_in_main_closure() {
+    let r = run_on_worker(|| with_r_thread(|| panic!("worker-channel-stress: boom-on-main")));
+    let msg = r.expect_err("panic in `with_r_thread` must become Err");
+    assert!(
+        msg.contains("boom-on-main"),
+        "panic message did not survive: {msg}"
+    );
+}
+
+/// Panic directly in the worker job body, outside any `with_r_thread`.
+/// The worker's `catch_unwind` catches it and `Done(Err)` returns.
+fn case_rust_panic_in_worker_body() {
+    let r = run_on_worker::<_, ()>(|| {
+        panic!("worker-channel-stress: panic in worker body");
+    });
+    let msg = r.expect_err("panic in worker body must become Err");
+    assert!(
+        msg.contains("panic in worker body"),
+        "worker-body panic message did not survive: {msg}"
+    );
+}
+
+// endregion
+
+// region: Routing-context boundary
+
+/// A thread that is neither main nor a worker-job context calling
+/// `with_r_thread` must panic with the documented message — never
+/// silently wait, never run inline.
+fn case_with_r_thread_outside_run_on_worker_context() {
+    let handle = std::thread::spawn(|| catch_unwind(AssertUnwindSafe(|| with_r_thread(|| 0i32))));
+    let r = handle.join().expect("spawned thread crashed unrecoverably");
+    let payload =
+        r.expect_err("with_r_thread from a non-main, non-worker thread must panic, not run inline");
+    let msg = panic_payload_to_string(payload.as_ref());
+    assert!(
+        msg.contains("outside of `run_on_worker` context"),
+        "wrong panic message: {msg}"
+    );
+}
+
+// endregion


### PR DESCRIPTION
I wasn't sure the "channel back to R API on main thread" stuff in `worker.rs` was thoroughly tested — it was originally written to experiment with progress bars and similar features. Wanted tests that exercise threads, barriers, and contention so we can see what actually happens.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- New integration binary `miniextendr-api/tests/worker_channel_stress.rs` (feature-gated on `worker-thread`) with eight sub-cases inside a single `#[test]`, matching the `rayon.rs` / `allocator.rs` pattern (R initialises once per process). Every cross-thread `recv` is `recv_timeout`-bounded so a regression that deadlocks fails loudly rather than hanging CI.
- Sub-cases cover: main-thread short-circuit, recursive `with_r_thread` from main, a 512-deep round-trip pump in one job, a 16-descendant barrier storm (each descendant correctly panics with "outside of `run_on_worker` context"), routing channel remains healthy after descendants panic, Rust panic in main-side closure, Rust panic in worker body, `with_r_thread` from an outside-context thread.
- `journal/2026-05-26-worker-channel-stress.md` documents what the routing channel actually is (channels, thread-locals, mutex, capacity semantics), what was already covered, the gap inventory, and the finding below.
- Filed #730 along the way: `dispatch_to_worker` runs the main-thread event loop on whatever thread called it, so a `run_on_worker` issued from a non-main thread routes `with_r_thread` work back to that caller rather than to R's main thread. Fine in practice (`.Call` is always on main) but undocumented and un-asserted. This PR does **not** touch `worker.rs`; the fix (a `debug_assert!(is_r_main_thread())` plus rustdoc) is tracked in #730.

## Test plan
- [x] `cargo test -p miniextendr-api --test worker_channel_stress --features worker-thread` passes locally (5 consecutive runs, ~0.1s each, no flakes).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p miniextendr-api --tests --features worker-thread -- -D warnings` clean.
- [x] CI's `clippy_all` curated feature list reproduced locally, clean.

## Notes
- The test file lives in its own integration binary by design. A wedged channel here must not take other test binaries down.
- `MINIEXTENDR_BACKTRACE=1` is documented at the top of the file as the env var to set when debugging a failure — without it, `miniextendr_panic_hook` silently swallows panic tracebacks (intentional framework behaviour for production, but it hides test panic detail).

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>