### PR TITLE
ci: bump r-tests timeout 30 → 45 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,7 +784,7 @@ jobs:
   r-tests:
     name: R tests / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: needs.changes.outputs.r == 'true'
 


### PR DESCRIPTION
## Summary

`r-tests` job is hitting `timeout-minutes: 30` mid-valgrind on PRs #714 and #723. Tests themselves pass (`[ FAIL 0 | WARN 7 | SKIP 20 | PASS 5962 ]`); only the valgrind ALTREP step is being cut off. Recent test additions pushed the cold-runner wall time over 30 min.

## Test plan

- [ ] CI green on this PR
- [ ] Re-run CI on #714 and #723 after merge, confirm CI Success passes