### PR TITLE
refactor(api): finish #675 — drop sys:: bridge re-exports, migrate all callers

### DIFF
--- a/miniextendr-api/src/abi.rs
+++ b/miniextendr-api/src/abi.rs
@@ -56,7 +56,7 @@
 //! All ABI operations are main-thread only. R invokes `.Call` on the main thread,
 //! and method shims do not route through `with_r_thread`.
 
-use crate::sys::SEXP;
+use crate::SEXP;
 use std::os::raw::c_void;
 
 /// Type tag for runtime type identification.

--- a/miniextendr-api/src/allocator.rs
+++ b/miniextendr-api/src/allocator.rs
@@ -37,8 +37,9 @@
 //! For long-lived allocations or critical cleanup requirements, consider using
 //! Rust's standard allocator instead.
 
-use crate::sys::{R_PreserveObject_unchecked, R_ReleaseObject_unchecked, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{R_PreserveObject_unchecked, R_ReleaseObject_unchecked};
 use crate::worker::{has_worker_context, is_r_main_thread, with_r_thread};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use core::{
     alloc::{GlobalAlloc, Layout},
     mem, ptr,

--- a/miniextendr-api/src/altrep_bridge.rs
+++ b/miniextendr-api/src/altrep_bridge.rs
@@ -36,7 +36,7 @@ use crate::altrep_traits::{
     AltrepGuard,
 };
 use crate::sys::altrep::R_altrep_class_t;
-use crate::sys::*;
+use crate::{R_xlen_t, Rboolean, Rbyte, Rcomplex, SEXP, SEXPTYPE};
 use core::ffi::c_void;
 
 /// Dispatch an ALTREP callback through the guard mode selected by `T::GUARD`.

--- a/miniextendr-api/src/altrep_data/builtins.rs
+++ b/miniextendr-api/src/altrep_data/builtins.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use std::ops::Range;
 
 use crate::altrep_traits::NA_REAL;
-use crate::sys::{Rcomplex, SEXP};
+use crate::{Rcomplex, SEXP};
 
 use super::{
     AltComplexData, AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltStringData,

--- a/miniextendr-api/src/altrep_data/core.rs
+++ b/miniextendr-api/src/altrep_data/core.rs
@@ -9,11 +9,12 @@
 //! - [`Logical`] — three-valued logical (TRUE/FALSE/NA)
 //! - [`fill_region`] — helper for `get_region` implementations
 
+use crate::SEXP;
 use crate::altrep_traits::{
     KNOWN_UNSORTED, SORTED_DECR, SORTED_DECR_NA_1ST, SORTED_INCR, SORTED_INCR_NA_1ST,
     UNKNOWN_SORTEDNESS,
 };
-use crate::sys::SEXP;
+use crate::sys::{self};
 
 /// Helper for ALTREP `get_region` implementations.
 ///
@@ -110,16 +111,16 @@ impl From<bool> for Logical {
 }
 
 /// Convert from RLogical (FFI type) to Logical (semantic type).
-impl From<crate::sys::RLogical> for Logical {
-    fn from(r: crate::sys::RLogical) -> Self {
+impl From<crate::RLogical> for Logical {
+    fn from(r: crate::RLogical) -> Self {
         Logical::from_r_int(r.to_i32())
     }
 }
 
 /// Convert from Logical (semantic type) to RLogical (FFI type).
-impl From<Logical> for crate::sys::RLogical {
+impl From<Logical> for crate::RLogical {
     fn from(l: Logical) -> Self {
-        crate::sys::RLogical::from_i32(l.to_r_int())
+        crate::RLogical::from_i32(l.to_r_int())
     }
 }
 // endregion
@@ -249,11 +250,9 @@ pub trait AltrepDataptr<T> {
 /// # Safety
 /// - `x` must be a valid ALTREP SEXP of element type `T`
 /// - Must be called on R's main thread
-pub unsafe fn materialize_altrep_data2<T: crate::sys::RNativeType>(
-    x: SEXP,
-) -> *mut core::ffi::c_void {
+pub unsafe fn materialize_altrep_data2<T: crate::RNativeType>(x: SEXP) -> *mut core::ffi::c_void {
+    use crate::SexpExt;
     use crate::altrep_ext::AltrepSexpExt;
-    use crate::sys::{self, SexpExt};
 
     let n = x.len();
     let (vec, dst) = unsafe { crate::into_r::alloc_r_vector_unchecked::<T>(n) };
@@ -318,7 +317,7 @@ pub trait AltrepExtract: Sized {
     ///
     /// - `x` must be a valid ALTREP SEXP whose data1 holds data of type `Self`
     /// - Must be called from R's main thread
-    unsafe fn altrep_extract_ref(x: crate::sys::SEXP) -> &'static Self;
+    unsafe fn altrep_extract_ref(x: crate::SEXP) -> &'static Self;
 
     /// Extract a mutable reference from the ALTREP data1 slot.
     ///
@@ -327,7 +326,7 @@ pub trait AltrepExtract: Sized {
     /// - `x` must be a valid ALTREP SEXP whose data1 holds data of type `Self`
     /// - Must be called from R's main thread
     /// - The caller must ensure no other references to the data exist
-    unsafe fn altrep_extract_mut(x: crate::sys::SEXP) -> &'static mut Self;
+    unsafe fn altrep_extract_mut(x: crate::SEXP) -> &'static mut Self;
 }
 
 /// Blanket implementation for types stored in ExternalPtr (the common case).
@@ -335,7 +334,7 @@ pub trait AltrepExtract: Sized {
 /// This is the default storage strategy: data1 is an EXTPTRSXP wrapping a
 /// `Box<Box<dyn Any>>` that downcasts to `&T`.
 impl<T: crate::externalptr::TypedExternal> AltrepExtract for T {
-    unsafe fn altrep_extract_ref(x: crate::sys::SEXP) -> &'static Self {
+    unsafe fn altrep_extract_ref(x: crate::SEXP) -> &'static Self {
         // SAFETY: ALTREP callbacks are always on R's main thread, so unchecked is safe.
         // `ExternalPtr` is a non-owning wrapper around an R SEXP — dropping it does NOT
         // deallocate the underlying data. The data lives in the ALTREP's data1 slot,
@@ -348,7 +347,7 @@ impl<T: crate::externalptr::TypedExternal> AltrepExtract for T {
         }
     }
 
-    unsafe fn altrep_extract_mut(x: crate::sys::SEXP) -> &'static mut Self {
+    unsafe fn altrep_extract_mut(x: crate::SEXP) -> &'static mut Self {
         // SAFETY: caller guarantees x is a valid ALTREP with ExternalPtr<T> in data1
         // and that no other references exist. ALTREP callbacks are on R's main thread.
         // `altrep_data1_mut_unchecked` goes through `ErasedExternalPtr::downcast_mut`

--- a/miniextendr-api/src/altrep_data/iter/coerce.rs
+++ b/miniextendr-api/src/altrep_data/iter/coerce.rs
@@ -4,11 +4,11 @@
 //! for iterators that produce values coercible to the target R type.
 
 use super::IterState;
+use crate::SEXP;
 use crate::altrep_data::{
     AltComplexData, AltIntegerData, AltListData, AltRealData, AltStringData, AltrepLen, InferBase,
     fill_region,
 };
-use crate::sys::SEXP;
 
 /// Iterator-backed integer vector with coercion from any integer-like type.
 ///
@@ -129,9 +129,9 @@ where
     I: Iterator<Item = T> + 'static,
     T: crate::coerce::Coerce<i32> + Copy + 'static,
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -149,7 +149,7 @@ where
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -157,13 +157,13 @@ where
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -285,9 +285,9 @@ where
     I: Iterator<Item = T> + 'static,
     T: crate::coerce::Coerce<f64> + Copy + 'static,
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -305,7 +305,7 @@ where
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRealData::elt(data, i as usize)
     }
@@ -313,13 +313,13 @@ where
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -416,9 +416,9 @@ impl<I: Iterator<Item = bool> + 'static> InferBase for IterIntFromBoolData<I> {
 }
 
 impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for IterIntFromBoolData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -429,7 +429,7 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltInteger
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -437,13 +437,13 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltInteger
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -557,16 +557,16 @@ impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::Altrep for Iter
     // String ALTREP elt calls Rf_mkCharLenCE (R API) — must use RUnwind to catch longjmps.
     const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
 
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
 impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::AltVec for IterStringData<I> {}
 
 impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::AltString for IterStringData<I> {
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::SEXP {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltStringData::elt(data, i as usize)
             .map(|s| unsafe { crate::altrep_impl::checked_mkchar(s) })
@@ -645,7 +645,7 @@ where
     I: Iterator<Item = SEXP>,
 {
     fn elt(&self, i: usize) -> SEXP {
-        use crate::sys::SEXP;
+        use crate::SEXP;
         self.state.get_element(i).unwrap_or(SEXP::nil())
     }
 }
@@ -676,16 +676,16 @@ impl<I: Iterator<Item = SEXP> + 'static> InferBase for IterListData<I> {
 }
 
 impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::Altrep for IterListData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
 impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::AltVec for IterListData<I> {}
 
 impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::AltList for IterListData<I> {
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::SEXP {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltListData::elt(data, i as usize)
     }
@@ -706,14 +706,14 @@ impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::AltList for IterL
 /// ```
 pub struct IterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
-    state: IterState<I, crate::sys::Rcomplex>,
+    state: IterState<I, crate::Rcomplex>,
 }
 
 impl<I> IterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
     /// Create from an iterator with explicit length.
     pub fn from_iter(iter: I, len: usize) -> Self {
@@ -725,7 +725,7 @@ where
 
 impl<I> IterComplexData<I>
 where
-    I: ExactSizeIterator<Item = crate::sys::Rcomplex>,
+    I: ExactSizeIterator<Item = crate::Rcomplex>,
 {
     /// Create from an ExactSizeIterator (length auto-detected).
     pub fn from_exact_iter(iter: I) -> Self {
@@ -737,7 +737,7 @@ where
 
 impl<I> AltrepLen for IterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
     fn len(&self) -> usize {
         self.state.len()
@@ -746,25 +746,25 @@ where
 
 impl<I> AltComplexData for IterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
-    fn elt(&self, i: usize) -> crate::sys::Rcomplex {
-        self.state.get_element(i).unwrap_or(crate::sys::Rcomplex {
+    fn elt(&self, i: usize) -> crate::Rcomplex {
+        self.state.get_element(i).unwrap_or(crate::Rcomplex {
             r: f64::NAN,
             i: f64::NAN,
         })
     }
 
-    fn as_slice(&self) -> Option<&[crate::sys::Rcomplex]> {
+    fn as_slice(&self) -> Option<&[crate::Rcomplex]> {
         self.state.as_materialized()
     }
 
-    fn get_region(&self, start: usize, len: usize, buf: &mut [crate::sys::Rcomplex]) -> usize {
+    fn get_region(&self, start: usize, len: usize, buf: &mut [crate::Rcomplex]) -> usize {
         fill_region(start, len, self.len(), buf, |idx| self.elt(idx))
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::externalptr::TypedExternal
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExternal
     for IterComplexData<I>
 {
     const TYPE_NAME: &'static str = "IterComplexData";
@@ -772,7 +772,7 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::externalptr::Typ
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterComplexData\0";
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> InferBase for IterComplexData<I> {
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> InferBase for IterComplexData<I> {
     const BASE: crate::altrep::RBase = crate::altrep::RBase::Complex;
 
     unsafe fn make_class(
@@ -791,26 +791,26 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> InferBase for IterCompl
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::Altrep
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::Altrep
     for IterComplexData<I>
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::AltVec
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltVec
     for IterComplexData<I>
 {
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::AltComplex
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltComplex
     for IterComplexData<I>
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::Rcomplex {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::Rcomplex {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltComplexData::elt(data, i as usize)
     }
@@ -818,13 +818,13 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::A
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
-        buf: &mut [crate::sys::Rcomplex],
-    ) -> crate::sys::R_xlen_t {
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
+        buf: &mut [crate::Rcomplex],
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/sparse.rs
+++ b/miniextendr-api/src/altrep_data/iter/sparse.rs
@@ -253,9 +253,9 @@ impl<I: Iterator<Item = i32> + 'static> InferBase for SparseIterIntData<I> {
 }
 
 impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for SparseIterIntData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -264,7 +264,7 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltVec for SparseI
 impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for SparseIterIntData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -272,13 +272,13 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for Spa
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -356,9 +356,9 @@ impl<I: Iterator<Item = f64> + 'static> InferBase for SparseIterRealData<I> {
 }
 
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for SparseIterRealData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -367,7 +367,7 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for SparseI
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for SparseIterRealData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRealData::elt(data, i as usize)
     }
@@ -375,13 +375,13 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for Sparse
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -455,9 +455,9 @@ impl<I: Iterator<Item = bool> + 'static> InferBase for SparseIterLogicalData<I> 
 }
 
 impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for SparseIterLogicalData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -468,7 +468,7 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltLogicalData::elt(data, i as usize).to_r_int()
     }
@@ -476,13 +476,13 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -555,9 +555,9 @@ impl<I: Iterator<Item = u8> + 'static> InferBase for SparseIterRawData<I> {
 }
 
 impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::Altrep for SparseIterRawData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -566,7 +566,7 @@ impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltVec for SparseIt
 impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for SparseIterRawData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> u8 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> u8 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRawData::elt(data, i as usize)
     }
@@ -574,27 +574,27 @@ impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for SparseIt
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [u8],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
 /// Sparse iterator-backed complex number vector.
 pub struct SparseIterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
-    state: SparseIterState<I, crate::sys::Rcomplex>,
+    state: SparseIterState<I, crate::Rcomplex>,
 }
 
 impl<I> SparseIterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
     /// Create from an iterator with explicit length.
     pub fn from_iter(iter: I, len: usize) -> Self {
@@ -606,7 +606,7 @@ where
 
 impl<I> SparseIterComplexData<I>
 where
-    I: ExactSizeIterator<Item = crate::sys::Rcomplex>,
+    I: ExactSizeIterator<Item = crate::Rcomplex>,
 {
     /// Create from an ExactSizeIterator (length auto-detected).
     pub fn from_exact_iter(iter: I) -> Self {
@@ -618,7 +618,7 @@ where
 
 impl<I> AltrepLen for SparseIterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
     fn len(&self) -> usize {
         self.state.len()
@@ -627,25 +627,25 @@ where
 
 impl<I> AltComplexData for SparseIterComplexData<I>
 where
-    I: Iterator<Item = crate::sys::Rcomplex>,
+    I: Iterator<Item = crate::Rcomplex>,
 {
-    fn elt(&self, i: usize) -> crate::sys::Rcomplex {
-        self.state.get_element(i).unwrap_or(crate::sys::Rcomplex {
+    fn elt(&self, i: usize) -> crate::Rcomplex {
+        self.state.get_element(i).unwrap_or(crate::Rcomplex {
             r: f64::NAN,
             i: f64::NAN,
         })
     }
 
-    fn as_slice(&self) -> Option<&[crate::sys::Rcomplex]> {
+    fn as_slice(&self) -> Option<&[crate::Rcomplex]> {
         None
     }
 
-    fn get_region(&self, start: usize, len: usize, buf: &mut [crate::sys::Rcomplex]) -> usize {
+    fn get_region(&self, start: usize, len: usize, buf: &mut [crate::Rcomplex]) -> usize {
         fill_region(start, len, self.len(), buf, |idx| self.elt(idx))
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::externalptr::TypedExternal
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExternal
     for SparseIterComplexData<I>
 {
     const TYPE_NAME: &'static str = "SparseIterComplexData";
@@ -653,7 +653,7 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::externalptr::Typ
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterComplexData\0";
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> InferBase for SparseIterComplexData<I> {
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> InferBase for SparseIterComplexData<I> {
     const BASE: crate::altrep::RBase = crate::altrep::RBase::Complex;
 
     unsafe fn make_class(
@@ -672,26 +672,26 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> InferBase for SparseIte
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::Altrep
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::Altrep
     for SparseIterComplexData<I>
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::AltVec
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltVec
     for SparseIterComplexData<I>
 {
 }
 
-impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::AltComplex
+impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltComplex
     for SparseIterComplexData<I>
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::Rcomplex {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::Rcomplex {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltComplexData::elt(data, i as usize)
     }
@@ -699,13 +699,13 @@ impl<I: Iterator<Item = crate::sys::Rcomplex> + 'static> crate::altrep_traits::A
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
-        buf: &mut [crate::sys::Rcomplex],
-    ) -> crate::sys::R_xlen_t {
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
+        buf: &mut [crate::Rcomplex],
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/state.rs
+++ b/miniextendr-api/src/altrep_data/iter/state.rs
@@ -299,9 +299,9 @@ impl<I: Iterator<Item = i32> + 'static> InferBase for IterIntData<I> {
 }
 
 impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for IterIntData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -310,7 +310,7 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltVec for IterInt
 impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for IterIntData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -318,13 +318,13 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for Ite
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -399,9 +399,9 @@ impl<I: Iterator<Item = f64> + 'static> InferBase for IterRealData<I> {
 }
 
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for IterRealData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -410,7 +410,7 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for IterRea
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for IterRealData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRealData::elt(data, i as usize)
     }
@@ -418,13 +418,13 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for IterRe
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -498,9 +498,9 @@ impl<I: Iterator<Item = bool> + 'static> InferBase for IterLogicalData<I> {
 }
 
 impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for IterLogicalData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -509,7 +509,7 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltVec for IterLo
 impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical for IterLogicalData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltLogicalData::elt(data, i as usize).to_r_int()
     }
@@ -517,13 +517,13 @@ impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical for It
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -598,9 +598,9 @@ impl<I: Iterator<Item = u8> + 'static> InferBase for IterRawData<I> {
 }
 
 impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::Altrep for IterRawData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -609,7 +609,7 @@ impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltVec for IterRawD
 impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for IterRawData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> u8 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> u8 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRawData::elt(data, i as usize)
     }
@@ -617,13 +617,13 @@ impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for IterRawD
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [u8],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/windowed.rs
+++ b/miniextendr-api/src/altrep_data/iter/windowed.rs
@@ -299,9 +299,9 @@ impl<I: Iterator<Item = i32> + 'static> InferBase for WindowedIterIntData<I> {
 }
 
 impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for WindowedIterIntData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -312,7 +312,7 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -320,13 +320,13 @@ impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 
@@ -405,9 +405,9 @@ impl<I: Iterator<Item = f64> + 'static> InferBase for WindowedIterRealData<I> {
 }
 
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for WindowedIterRealData<I> {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -416,7 +416,7 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for Windowe
 impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for WindowedIterRealData<I> {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRealData::elt(data, i as usize)
     }
@@ -424,13 +424,13 @@ impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for Window
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/macros/tests.rs
+++ b/miniextendr-api/src/altrep_data/macros/tests.rs
@@ -1,10 +1,10 @@
+use crate::Rcomplex;
 use crate::altrep_data::{
     AltComplexData, AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltStringData,
     AltrepLen, IterComplexData, IterIntCoerceData, IterIntData, IterIntFromBoolData,
     IterLogicalData, IterRawData, IterRealCoerceData, IterRealData, IterStringData, Logical,
     Sortedness,
 };
-use crate::sys::Rcomplex;
 
 #[test]
 pub(crate) fn test_logical_to_r_int() {

--- a/miniextendr-api/src/altrep_data/stream.rs
+++ b/miniextendr-api/src/altrep_data/stream.rs
@@ -134,9 +134,9 @@ impl<F: Fn(usize, &mut [f64]) -> usize + 'static> InferBase for StreamingRealDat
 impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::Altrep
     for StreamingRealData<F>
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -150,7 +150,7 @@ impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::AltReal
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltRealData::elt(data, i as usize)
     }
@@ -158,13 +158,13 @@ impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::AltReal
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion
@@ -294,9 +294,9 @@ impl<F: Fn(usize, &mut [i32]) -> usize + 'static> InferBase for StreamingIntData
 impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::Altrep
     for StreamingIntData<F>
 {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::sys::R_xlen_t
+        data.len() as crate::R_xlen_t
     }
 }
 
@@ -310,7 +310,7 @@ impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::AltInteg
 {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         AltIntegerData::elt(data, i as usize)
     }
@@ -318,13 +318,13 @@ impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::AltInteg
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::sys::R_xlen_t
+        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
     }
 }
 // endregion

--- a/miniextendr-api/src/altrep_data/traits.rs
+++ b/miniextendr-api/src/altrep_data/traits.rs
@@ -13,7 +13,7 @@
 //! | [`AltListData`] | VECSXP | `elt(i) -> SEXP` |
 
 use super::{AltrepLen, Logical, Sortedness, fill_region};
-use crate::sys::{Rcomplex, SEXP};
+use crate::{Rcomplex, SEXP};
 
 // region: Integer ALTREP
 

--- a/miniextendr-api/src/altrep_ext.rs
+++ b/miniextendr-api/src/altrep_ext.rs
@@ -2,9 +2,9 @@
 //!
 //! Using methods on SEXP (via `&self`) instead of free functions avoids
 //! `clippy::not_unsafe_ptr_arg_deref` in ALTREP trait implementations,
-//! mirroring the pattern established by [`SexpExt`](crate::sys::SexpExt).
+//! mirroring the pattern established by [`SexpExt`](crate::SexpExt).
 
-use crate::sys::SEXP;
+use crate::SEXP;
 
 /// ALTREP-specific extension methods for SEXP.
 ///

--- a/miniextendr-api/src/altrep_impl.rs
+++ b/miniextendr-api/src/altrep_impl.rs
@@ -30,14 +30,14 @@
 ///
 /// Panics if `s.len() > i32::MAX`.
 #[inline]
-pub unsafe fn checked_mkchar(s: &str) -> crate::sys::SEXP {
+pub unsafe fn checked_mkchar(s: &str) -> crate::SEXP {
     let _len = i32::try_from(s.len()).unwrap_or_else(|_| {
         panic!(
             "string length {} exceeds i32::MAX for Rf_mkCharLenCE",
             s.len()
         )
     });
-    crate::sys::SEXP::charsxp(s)
+    crate::SEXP::charsxp(s)
 }
 // endregion
 

--- a/miniextendr-api/src/altrep_impl/arrays.rs
+++ b/miniextendr-api/src/altrep_impl/arrays.rs
@@ -27,18 +27,18 @@ macro_rules! impl_altrep_array_numeric {
         $(,)?
     ) => {
         impl<const N: usize> crate::altrep_traits::Altrep for [$elem; N] {
-            fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+            fn length(x: crate::SEXP) -> crate::R_xlen_t {
                 let data = unsafe {
                     <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
                 };
-                crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+                crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
             }
         }
 
         impl<const N: usize> crate::altrep_traits::AltVec for [$elem; N] {
             const HAS_DATAPTR: bool = true;
 
-            fn dataptr(x: crate::sys::SEXP, _writable: bool) -> *mut core::ffi::c_void {
+            fn dataptr(x: crate::SEXP, _writable: bool) -> *mut core::ffi::c_void {
                 let data = unsafe {
                     <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_mut(x)
                 };
@@ -49,7 +49,7 @@ macro_rules! impl_altrep_array_numeric {
         impl<const N: usize> $alt_trait for [$elem; N] {
             const HAS_ELT: bool = true;
 
-            fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> $elem {
+            fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> $elem {
                 let data = unsafe {
                     <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
                 };
@@ -59,11 +59,11 @@ macro_rules! impl_altrep_array_numeric {
             const HAS_GET_REGION: bool = true;
 
             fn get_region(
-                x: crate::sys::SEXP,
-                start: crate::sys::R_xlen_t,
-                len: crate::sys::R_xlen_t,
+                x: crate::SEXP,
+                start: crate::R_xlen_t,
+                len: crate::R_xlen_t,
                 buf: &mut [$elem],
-            ) -> crate::sys::R_xlen_t {
+            ) -> crate::R_xlen_t {
                 if start < 0 || len <= 0 {
                     return 0;
                 }
@@ -71,7 +71,7 @@ macro_rules! impl_altrep_array_numeric {
                     <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
                 };
                 <[$elem; N] as $data_trait>::get_region(data, start as usize, len as usize, buf)
-                    as crate::sys::R_xlen_t
+                    as crate::R_xlen_t
             }
 
             $($($extra)*)?
@@ -103,7 +103,7 @@ macro_rules! altrep_array_no_na {
     ($elem:ty, $data_trait:path) => {
         const HAS_NO_NA: bool = true;
 
-        fn no_na(x: crate::sys::SEXP) -> i32 {
+        fn no_na(x: crate::SEXP) -> i32 {
             let data =
                 unsafe { <[$elem; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
             <[$elem; N] as $data_trait>::no_na(data)
@@ -140,7 +140,7 @@ impl_altrep_array_numeric!(
     install_family_fn = install_raw,
 );
 impl_altrep_array_numeric!(
-    elem = crate::sys::Rcomplex,
+    elem = crate::Rcomplex,
     data_trait = crate::altrep_data::AltComplexData,
     alt_trait = crate::altrep_traits::AltComplex,
     rbase = crate::altrep::RBase::Complex,
@@ -150,10 +150,10 @@ impl_altrep_array_numeric!(
 
 // Logical arrays — bool != i32, no direct dataptr, elt returns i32 via to_r_int()
 impl<const N: usize> crate::altrep_traits::Altrep for [bool; N] {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data =
             unsafe { <[bool; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
@@ -162,7 +162,7 @@ impl<const N: usize> crate::altrep_traits::AltVec for [bool; N] {}
 impl<const N: usize> crate::altrep_traits::AltLogical for [bool; N] {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data =
             unsafe { <[bool; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         <[bool; N] as crate::altrep_data::AltLogicalData>::elt(data, i.max(0) as usize).to_r_int()
@@ -170,7 +170,7 @@ impl<const N: usize> crate::altrep_traits::AltLogical for [bool; N] {
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data =
             unsafe { <[bool; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         <[bool; N] as crate::altrep_data::AltLogicalData>::no_na(data)
@@ -208,22 +208,22 @@ impl<const N: usize> crate::altrep_data::InferBase for [bool; N] {
 impl<const N: usize> crate::altrep_traits::Altrep for [String; N] {
     const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
 
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data =
             unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl<const N: usize> crate::altrep_traits::AltVec for [String; N] {}
 
 impl<const N: usize> crate::altrep_traits::AltString for [String; N] {
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::SEXP {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
         let data =
             unsafe { <[String; N] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         match <[String; N] as crate::altrep_data::AltStringData>::elt(data, i.max(0) as usize) {
             Some(s) => unsafe { super::checked_mkchar(s) },
-            None => crate::sys::SEXP::na_string(),
+            None => crate::SEXP::na_string(),
         }
     }
 }

--- a/miniextendr-api/src/altrep_impl/builtins.rs
+++ b/miniextendr-api/src/altrep_impl/builtins.rs
@@ -396,7 +396,7 @@ impl_builtin_altrep_family!(
     __MX_ALTREP_REG_ENTRY_builtin_Vec_Option_Cow_str
 );
 impl_builtin_altrep_family!(
-    Vec<crate::sys::Rcomplex>,
+    Vec<crate::Rcomplex>,
     complex,
     dataptr,
     __mx_altrep_reg_builtin_Vec_Rcomplex,
@@ -469,7 +469,7 @@ impl_builtin_altrep_family!(
     __MX_ALTREP_REG_ENTRY_builtin_Box_String
 );
 impl_builtin_altrep_family!(
-    Box<[crate::sys::Rcomplex]>,
+    Box<[crate::Rcomplex]>,
     complex,
     dataptr,
     __mx_altrep_reg_builtin_Box_Rcomplex,
@@ -500,7 +500,7 @@ impl_builtin_altrep_family!(
     __MX_ALTREP_REG_ENTRY_builtin_Cow_u8
 );
 impl_builtin_altrep_family!(
-    std::borrow::Cow<'static, [crate::sys::Rcomplex]>,
+    std::borrow::Cow<'static, [crate::Rcomplex]>,
     complex,
     dataptr,
     __mx_altrep_reg_builtin_Cow_Rcomplex,
@@ -557,7 +557,7 @@ impl_register_altrep_builtin!(Vec<bool>, "Vec_bool");
 impl_register_altrep_builtin!(Vec<u8>, "Vec_u8");
 impl_register_altrep_builtin!(Vec<String>, "Vec_String");
 impl_register_altrep_builtin!(Vec<Option<String>>, "Vec_Option_String");
-impl_register_altrep_builtin!(Vec<crate::sys::Rcomplex>, "Vec_Rcomplex");
+impl_register_altrep_builtin!(Vec<crate::Rcomplex>, "Vec_Rcomplex");
 
 // Range types - RegisterAltrep only
 impl_register_altrep_builtin!(std::ops::Range<i32>, "Range_i32");
@@ -570,16 +570,13 @@ impl_register_altrep_builtin!(Box<[f64]>, "Box_f64");
 impl_register_altrep_builtin!(Box<[bool]>, "Box_bool");
 impl_register_altrep_builtin!(Box<[u8]>, "Box_u8");
 impl_register_altrep_builtin!(Box<[String]>, "Box_String");
-impl_register_altrep_builtin!(Box<[crate::sys::Rcomplex]>, "Box_Rcomplex");
+impl_register_altrep_builtin!(Box<[crate::Rcomplex]>, "Box_Rcomplex");
 
 // Cow types - RegisterAltrep for zero-copy borrow from R
 impl_register_altrep_builtin!(std::borrow::Cow<'static, [i32]>, "Cow_i32");
 impl_register_altrep_builtin!(std::borrow::Cow<'static, [f64]>, "Cow_f64");
 impl_register_altrep_builtin!(std::borrow::Cow<'static, [u8]>, "Cow_u8");
-impl_register_altrep_builtin!(
-    std::borrow::Cow<'static, [crate::sys::Rcomplex]>,
-    "Cow_Rcomplex"
-);
+impl_register_altrep_builtin!(std::borrow::Cow<'static, [crate::Rcomplex]>, "Cow_Rcomplex");
 
 // Cow string vector types
 impl_register_altrep_builtin!(Vec<std::borrow::Cow<'static, str>>, "Vec_Cow_str");

--- a/miniextendr-api/src/altrep_impl/macros.rs
+++ b/miniextendr-api/src/altrep_impl/macros.rs
@@ -128,10 +128,10 @@ macro_rules! __impl_altrep_base {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
-            fn length(x: $crate::sys::SEXP) -> $crate::sys::R_xlen_t {
+            fn length(x: $crate::SEXP) -> $crate::R_xlen_t {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::sys::R_xlen_t
+                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::R_xlen_t
             }
         }
     };
@@ -140,15 +140,15 @@ macro_rules! __impl_altrep_base {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
-            fn length(x: $crate::sys::SEXP) -> $crate::sys::R_xlen_t {
+            fn length(x: $crate::SEXP) -> $crate::R_xlen_t {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::sys::R_xlen_t
+                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::R_xlen_t
             }
 
             const HAS_SERIALIZED_STATE: bool = true;
 
-            fn serialized_state(x: $crate::sys::SEXP) -> $crate::sys::SEXP {
+            fn serialized_state(x: $crate::SEXP) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltrepSerialize>::serialized_state(data)
@@ -156,10 +156,7 @@ macro_rules! __impl_altrep_base {
 
             const HAS_UNSERIALIZE: bool = true;
 
-            fn unserialize(
-                class: $crate::sys::SEXP,
-                state: $crate::sys::SEXP,
-            ) -> $crate::sys::SEXP {
+            fn unserialize(class: $crate::SEXP, state: $crate::SEXP) -> $crate::SEXP {
                 let Some(data) = <$ty as $crate::altrep_data::AltrepSerialize>::unserialize(state)
                 else {
                     panic!(
@@ -170,9 +167,10 @@ macro_rules! __impl_altrep_base {
 
                 // SAFETY: Unserialize is called by R on the main thread.
                 unsafe {
+                    use $crate::SEXP;
                     use $crate::externalptr::ExternalPtr;
                     use $crate::sys::altrep::R_altrep_class_t;
-                    use $crate::sys::{Rf_protect_unchecked, Rf_unprotect_unchecked, SEXP};
+                    use $crate::sys::{Rf_protect_unchecked, Rf_unprotect_unchecked};
 
                     let ext_ptr = ExternalPtr::new_unchecked(data);
                     let data1 = ext_ptr.as_sexp();
@@ -202,13 +200,13 @@ macro_rules! __impl_altvec_dataptr {
         impl $crate::altrep_traits::AltVec for $ty {
             const HAS_DATAPTR: bool = true;
 
-            fn dataptr(x: $crate::sys::SEXP, writable: bool) -> *mut core::ffi::c_void {
+            fn dataptr(x: $crate::SEXP, writable: bool) -> *mut core::ffi::c_void {
                 // Check data2 cache first (materialized by a prior call).
                 unsafe {
                     let data2 = $crate::altrep_ext::AltrepSexpExt::altrep_data2_raw(&x);
                     if !data2.is_null()
-                        && $crate::sys::SexpExt::type_of(&data2)
-                            == <$elem as $crate::sys::RNativeType>::SEXP_TYPE
+                        && $crate::SexpExt::type_of(&data2)
+                            == <$elem as $crate::RNativeType>::SEXP_TYPE
                     {
                         return $crate::sys::DATAPTR_RO(data2).cast_mut();
                     }
@@ -255,13 +253,13 @@ macro_rules! __impl_altvec_dataptr {
 
             const HAS_DATAPTR_OR_NULL: bool = true;
 
-            fn dataptr_or_null(x: $crate::sys::SEXP) -> *const core::ffi::c_void {
+            fn dataptr_or_null(x: $crate::SEXP) -> *const core::ffi::c_void {
                 // Check data2 cache first (may have been materialized by a prior dataptr call)
                 unsafe {
                     let data2 = $crate::altrep_ext::AltrepSexpExt::altrep_data2_raw(&x);
                     if !data2.is_null()
-                        && $crate::sys::SexpExt::type_of(&data2)
-                            == <$elem as $crate::sys::RNativeType>::SEXP_TYPE
+                        && $crate::SexpExt::type_of(&data2)
+                            == <$elem as $crate::RNativeType>::SEXP_TYPE
                     {
                         return $crate::sys::DATAPTR_RO(data2);
                     }
@@ -289,14 +287,14 @@ macro_rules! __impl_altvec_string_dataptr {
         impl $crate::altrep_traits::AltVec for $ty {
             const HAS_DATAPTR: bool = true;
 
-            fn dataptr(x: $crate::sys::SEXP, _writable: bool) -> *mut core::ffi::c_void {
+            fn dataptr(x: $crate::SEXP, _writable: bool) -> *mut core::ffi::c_void {
                 unsafe {
                     let n = <$ty as $crate::altrep_traits::Altrep>::length(x);
 
                     // Get or allocate the data2 cache STRSXP
                     let mut data2 = $crate::altrep_ext::AltrepSexpExt::altrep_data2_raw(&x);
                     let fresh_alloc = data2.is_null()
-                        || $crate::sys::SexpExt::type_of(&data2) != $crate::sys::SEXPTYPE::STRSXP;
+                        || $crate::SexpExt::type_of(&data2) != $crate::SEXPTYPE::STRSXP;
                     if fresh_alloc {
                         // Rf_allocVector(STRSXP, n) leaves elements UNINITIALIZED
                         // (garbage SEXP pointers). Must fill with R_NaString sentinel
@@ -305,14 +303,10 @@ macro_rules! __impl_altvec_string_dataptr {
                         // Inside ALTREP dispatch — _unchecked variants skip the
                         // with_r_thread debug-assert (MXL301 permits).
                         data2 = $crate::sys::Rf_protect_unchecked(
-                            $crate::sys::Rf_allocVector_unchecked($crate::sys::SEXPTYPE::STRSXP, n),
+                            $crate::sys::Rf_allocVector_unchecked($crate::SEXPTYPE::STRSXP, n),
                         );
                         for j in 0..n {
-                            $crate::sys::SexpExt::set_string_elt(
-                                &data2,
-                                j,
-                                $crate::sys::SEXP::na_string(),
-                            );
+                            $crate::SexpExt::set_string_elt(&data2, j, $crate::SEXP::na_string());
                         }
                         $crate::altrep_ext::AltrepSexpExt::set_altrep_data2(&x, data2);
                         $crate::sys::Rf_unprotect_unchecked(1);
@@ -322,13 +316,13 @@ macro_rules! __impl_altvec_string_dataptr {
                     // are non-NA CHARSXPs and are skipped. NA elements are re-probed
                     // from Rust (O(1)) to handle mixed cached/uncached NA slots.
                     for i in 0..n {
-                        let cached = $crate::sys::SexpExt::string_elt(&data2, i);
-                        if cached != $crate::sys::SEXP::na_string() {
+                        let cached = $crate::SexpExt::string_elt(&data2, i);
+                        if cached != $crate::SEXP::na_string() {
                             continue; // already cached by a prior Elt call
                         }
                         // Compute from Rust and store
                         let elt = <$ty as $crate::altrep_traits::AltString>::elt(x, i);
-                        $crate::sys::SexpExt::set_string_elt(&data2, i, elt);
+                        $crate::SexpExt::set_string_elt(&data2, i, elt);
                     }
 
                     $crate::sys::DATAPTR_RO(data2).cast_mut()
@@ -337,7 +331,7 @@ macro_rules! __impl_altvec_string_dataptr {
 
             const HAS_DATAPTR_OR_NULL: bool = true;
 
-            fn dataptr_or_null(x: $crate::sys::SEXP) -> *const core::ffi::c_void {
+            fn dataptr_or_null(x: $crate::SEXP) -> *const core::ffi::c_void {
                 // Always return null. The data2 STRSXP may be partially cached
                 // (Elt filled some slots, others are R_NaString sentinels).
                 // Returning a pointer to a partial cache would expose sentinel
@@ -360,12 +354,12 @@ macro_rules! __impl_altvec_string_dataptr {
 #[doc(hidden)]
 macro_rules! __impl_altvec_logical_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<$crate::sys::RLogical> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::sys::RLogical> {
+        impl $crate::altrep_data::AltrepDataptr<$crate::RLogical> for $ty {
+            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::RLogical> {
                 None
             }
         }
-        $crate::__impl_altvec_dataptr!($ty, $crate::sys::RLogical);
+        $crate::__impl_altvec_dataptr!($ty, $crate::RLogical);
     };
 }
 
@@ -421,12 +415,12 @@ macro_rules! __impl_altvec_raw_dataptr {
 #[doc(hidden)]
 macro_rules! __impl_altvec_complex_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<$crate::sys::Rcomplex> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::sys::Rcomplex> {
+        impl $crate::altrep_data::AltrepDataptr<$crate::Rcomplex> for $ty {
+            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::Rcomplex> {
                 None
             }
         }
-        $crate::__impl_altvec_dataptr!($ty, $crate::sys::Rcomplex);
+        $crate::__impl_altvec_dataptr!($ty, $crate::Rcomplex);
     };
 }
 
@@ -439,23 +433,23 @@ macro_rules! __impl_altvec_extract_subset {
             const HAS_EXTRACT_SUBSET: bool = true;
 
             fn extract_subset(
-                x: $crate::sys::SEXP,
-                indx: $crate::sys::SEXP,
-                _call: $crate::sys::SEXP,
-            ) -> $crate::sys::SEXP {
+                x: $crate::SEXP,
+                indx: $crate::SEXP,
+                _call: $crate::SEXP,
+            ) -> $crate::SEXP {
                 // Validate that indx is an integer vector before calling INTEGER().
                 // Return NULL to signal R to use default subsetting if not.
-                if $crate::sys::SexpExt::type_of(&indx) != $crate::sys::SEXPTYPE::INTSXP {
+                if $crate::SexpExt::type_of(&indx) != $crate::SEXPTYPE::INTSXP {
                     return core::ptr::null_mut();
                 }
 
                 // Convert indx SEXP to slice using SexpExt (avoids raw-ptr-deref lint)
-                let indices = unsafe { $crate::sys::SexpExt::as_slice::<i32>(&indx) };
+                let indices = unsafe { $crate::SexpExt::as_slice::<i32>(&indx) };
 
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltrepExtractSubset>::extract_subset(data, indices)
-                    .unwrap_or($crate::sys::SEXP::nil())
+                    .unwrap_or($crate::SEXP::nil())
             }
         }
     };
@@ -478,7 +472,7 @@ macro_rules! __impl_alt_elt {
     ($ty:ty, $trait:path, $elem:ty, $na:expr) => {
         const HAS_ELT: bool = true;
 
-        fn elt(x: $crate::sys::SEXP, i: $crate::sys::R_xlen_t) -> $elem {
+        fn elt(x: $crate::SEXP, i: $crate::R_xlen_t) -> $elem {
             let data =
                 unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
             <$ty as $trait>::elt(data, i.max(0) as usize)
@@ -497,18 +491,18 @@ macro_rules! __impl_alt_get_region {
         const HAS_GET_REGION: bool = true;
 
         fn get_region(
-            x: $crate::sys::SEXP,
-            start: $crate::sys::R_xlen_t,
-            len: $crate::sys::R_xlen_t,
+            x: $crate::SEXP,
+            start: $crate::R_xlen_t,
+            len: $crate::R_xlen_t,
             buf: &mut [$buf_ty],
-        ) -> $crate::sys::R_xlen_t {
+        ) -> $crate::R_xlen_t {
             if start < 0 || len <= 0 {
                 return 0;
             }
             let data =
                 unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
             let len = len as usize;
-            <$ty as $trait>::get_region(data, start as usize, len, buf) as $crate::sys::R_xlen_t
+            <$ty as $trait>::get_region(data, start as usize, len, buf) as $crate::R_xlen_t
         }
     };
 }
@@ -523,7 +517,7 @@ macro_rules! __impl_alt_is_sorted {
     ($ty:ty, $trait:path) => {
         const HAS_IS_SORTED: bool = true;
 
-        fn is_sorted(x: $crate::sys::SEXP) -> i32 {
+        fn is_sorted(x: $crate::SEXP) -> i32 {
             let data =
                 unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
             <$ty as $trait>::is_sorted(data)
@@ -543,7 +537,7 @@ macro_rules! __impl_alt_no_na {
     ($ty:ty, $trait:path) => {
         const HAS_NO_NA: bool = true;
 
-        fn no_na(x: $crate::sys::SEXP) -> i32 {
+        fn no_na(x: $crate::SEXP) -> i32 {
             let data =
                 unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
             <$ty as $trait>::no_na(data)
@@ -667,39 +661,39 @@ macro_rules! __impl_altinteger_methods {
             const HAS_SUM: bool = true;
 
             // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-            fn sum(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn sum(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 match <$ty as $crate::altrep_data::AltIntegerData>::sum(data, narm) {
                     Some(s) => {
                         if s >= i32::MIN as i64 && s <= i32::MAX as i64 {
-                            $crate::sys::SEXP::scalar_integer(s as i32)
+                            $crate::SEXP::scalar_integer(s as i32)
                         } else {
-                            $crate::sys::SEXP::scalar_real(s as f64)
+                            $crate::SEXP::scalar_real(s as f64)
                         }
                     }
-                    None => $crate::sys::SEXP::null(),
+                    None => $crate::SEXP::null(),
                 }
             }
 
             const HAS_MIN: bool = true;
 
-            fn min(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn min(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltIntegerData>::min(data, narm)
-                    .map(|m| $crate::sys::SEXP::scalar_integer(m))
-                    .unwrap_or($crate::sys::SEXP::null())
+                    .map(|m| $crate::SEXP::scalar_integer(m))
+                    .unwrap_or($crate::SEXP::null())
             }
 
             const HAS_MAX: bool = true;
 
-            fn max(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn max(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltIntegerData>::max(data, narm)
-                    .map(|m| $crate::sys::SEXP::scalar_integer(m))
-                    .unwrap_or($crate::sys::SEXP::null())
+                    .map(|m| $crate::SEXP::scalar_integer(m))
+                    .unwrap_or($crate::SEXP::null())
             }
         }
     };
@@ -785,32 +779,32 @@ macro_rules! __impl_altreal_methods {
             const HAS_SUM: bool = true;
 
             // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-            fn sum(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn sum(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltRealData>::sum(data, narm)
-                    .map(|s| $crate::sys::SEXP::scalar_real(s))
-                    .unwrap_or($crate::sys::SEXP::null())
+                    .map(|s| $crate::SEXP::scalar_real(s))
+                    .unwrap_or($crate::SEXP::null())
             }
 
             const HAS_MIN: bool = true;
 
-            fn min(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn min(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltRealData>::min(data, narm)
-                    .map(|m| $crate::sys::SEXP::scalar_real(m))
-                    .unwrap_or($crate::sys::SEXP::null())
+                    .map(|m| $crate::SEXP::scalar_real(m))
+                    .unwrap_or($crate::SEXP::null())
             }
 
             const HAS_MAX: bool = true;
 
-            fn max(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn max(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltRealData>::max(data, narm)
-                    .map(|m| $crate::sys::SEXP::scalar_real(m))
-                    .unwrap_or($crate::sys::SEXP::null())
+                    .map(|m| $crate::SEXP::scalar_real(m))
+                    .unwrap_or($crate::SEXP::null())
             }
         }
     };
@@ -896,7 +890,7 @@ macro_rules! __impl_altlogical_methods {
             // Logical elt is special: returns Logical → .to_r_int()
             const HAS_ELT: bool = true;
 
-            fn elt(x: $crate::sys::SEXP, i: $crate::sys::R_xlen_t) -> i32 {
+            fn elt(x: $crate::SEXP, i: $crate::R_xlen_t) -> i32 {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltLogicalData>::elt(data, i.max(0) as usize)
@@ -910,18 +904,18 @@ macro_rules! __impl_altlogical_methods {
             const HAS_SUM: bool = true;
 
             // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-            fn sum(x: $crate::sys::SEXP, narm: bool) -> $crate::sys::SEXP {
+            fn sum(x: $crate::SEXP, narm: bool) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 match <$ty as $crate::altrep_data::AltLogicalData>::sum(data, narm) {
                     Some(s) => {
                         if s >= i32::MIN as i64 && s <= i32::MAX as i64 {
-                            $crate::sys::SEXP::scalar_integer(s as i32)
+                            $crate::SEXP::scalar_integer(s as i32)
                         } else {
-                            $crate::sys::SEXP::scalar_real(s as f64)
+                            $crate::SEXP::scalar_real(s as f64)
                         }
                     }
-                    None => $crate::sys::SEXP::null(),
+                    None => $crate::SEXP::null(),
                 }
             }
         }
@@ -1082,14 +1076,14 @@ macro_rules! __impl_altstring_methods {
             // For NA elements (Rust elt returns None), data2[i] stays R_NaString — we
             // re-probe Rust each time (O(1) index, returns None immediately). This is
             // simpler than a separate materialization bitmap and the cost is negligible.
-            fn elt(x: $crate::sys::SEXP, i: $crate::sys::R_xlen_t) -> $crate::sys::SEXP {
+            fn elt(x: $crate::SEXP, i: $crate::R_xlen_t) -> $crate::SEXP {
                 unsafe {
                     let idx = i.max(0) as usize;
 
                     // Get or allocate the data2 cache STRSXP
                     let mut data2 = $crate::altrep_ext::AltrepSexpExt::altrep_data2_raw(&x);
                     if data2.is_null()
-                        || $crate::sys::SexpExt::type_of(&data2) != $crate::sys::SEXPTYPE::STRSXP
+                        || $crate::SexpExt::type_of(&data2) != $crate::SEXPTYPE::STRSXP
                     {
                         let n = <$ty as $crate::altrep_traits::Altrep>::length(x);
                         // Rf_allocVector(STRSXP, n) leaves elements UNINITIALIZED
@@ -1098,22 +1092,18 @@ macro_rules! __impl_altstring_methods {
                         // Inside ALTREP dispatch — _unchecked variants skip the
                         // with_r_thread debug-assert (MXL301 permits).
                         data2 = $crate::sys::Rf_protect_unchecked(
-                            $crate::sys::Rf_allocVector_unchecked($crate::sys::SEXPTYPE::STRSXP, n),
+                            $crate::sys::Rf_allocVector_unchecked($crate::SEXPTYPE::STRSXP, n),
                         );
                         for j in 0..n {
-                            $crate::sys::SexpExt::set_string_elt(
-                                &data2,
-                                j,
-                                $crate::sys::SEXP::na_string(),
-                            );
+                            $crate::SexpExt::set_string_elt(&data2, j, $crate::SEXP::na_string());
                         }
                         $crate::altrep_ext::AltrepSexpExt::set_altrep_data2(&x, data2);
                         $crate::sys::Rf_unprotect_unchecked(1);
                     }
 
                     // Check cache: non-NA means already materialized
-                    let cached = $crate::sys::SexpExt::string_elt(&data2, i);
-                    if cached != $crate::sys::SEXP::na_string() {
+                    let cached = $crate::SexpExt::string_elt(&data2, i);
+                    if cached != $crate::SEXP::na_string() {
                         return cached;
                     }
 
@@ -1122,10 +1112,10 @@ macro_rules! __impl_altstring_methods {
                     match <$ty as $crate::altrep_data::AltStringData>::elt(data, idx) {
                         Some(s) => {
                             let charsxp = $crate::altrep_impl::checked_mkchar(s);
-                            $crate::sys::SexpExt::set_string_elt(&data2, i, charsxp);
+                            $crate::SexpExt::set_string_elt(&data2, i, charsxp);
                             charsxp
                         }
-                        None => $crate::sys::SEXP::na_string(),
+                        None => $crate::SEXP::na_string(),
                     }
                 }
             }
@@ -1147,17 +1137,17 @@ macro_rules! impl_altlist_from_data {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
-            fn length(x: $crate::sys::SEXP) -> $crate::sys::R_xlen_t {
+            fn length(x: $crate::SEXP) -> $crate::R_xlen_t {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::sys::R_xlen_t
+                <$ty as $crate::altrep_data::AltrepLen>::len(data) as $crate::R_xlen_t
             }
         }
 
         impl $crate::altrep_traits::AltVec for $ty {}
 
         impl $crate::altrep_traits::AltList for $ty {
-            fn elt(x: $crate::sys::SEXP, i: $crate::sys::R_xlen_t) -> $crate::sys::SEXP {
+            fn elt(x: $crate::SEXP, i: $crate::R_xlen_t) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
                 <$ty as $crate::altrep_data::AltListData>::elt(data, i.max(0) as usize)
@@ -1177,8 +1167,8 @@ macro_rules! __impl_altcomplex_methods {
             $crate::__impl_alt_elt!(
                 $ty,
                 $crate::altrep_data::AltComplexData,
-                $crate::sys::Rcomplex,
-                $crate::sys::Rcomplex {
+                $crate::Rcomplex,
+                $crate::Rcomplex {
                     r: f64::NAN,
                     i: f64::NAN
                 }
@@ -1186,7 +1176,7 @@ macro_rules! __impl_altcomplex_methods {
             $crate::__impl_alt_get_region!(
                 $ty,
                 $crate::altrep_data::AltComplexData,
-                $crate::sys::Rcomplex
+                $crate::Rcomplex
             );
         }
     };
@@ -1211,7 +1201,7 @@ macro_rules! impl_altcomplex_from_data {
             $ty,
             __impl_altcomplex_methods,
             impl_inferbase_complex,
-            dataptr($crate::sys::Rcomplex)
+            dataptr($crate::Rcomplex)
         );
     };
     ($ty:ty, serialize) => {
@@ -1233,7 +1223,7 @@ macro_rules! impl_altcomplex_from_data {
             $ty,
             __impl_altcomplex_methods,
             impl_inferbase_complex,
-            dataptr($crate::sys::Rcomplex),
+            dataptr($crate::Rcomplex),
             serialize
         );
     };

--- a/miniextendr-api/src/altrep_impl/static_slices.rs
+++ b/miniextendr-api/src/altrep_impl/static_slices.rs
@@ -21,17 +21,17 @@
 
 // Integer static slices
 impl crate::altrep_traits::Altrep for &'static [i32] {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl crate::altrep_traits::AltVec for &'static [i32] {
     const HAS_DATAPTR: bool = true;
 
-    fn dataptr(x: crate::sys::SEXP, writable: bool) -> *mut std::ffi::c_void {
+    fn dataptr(x: crate::SEXP, writable: bool) -> *mut std::ffi::c_void {
         // Static data cannot be modified. Panic is caught by RUnwind guard.
         assert!(
             !writable,
@@ -44,7 +44,7 @@ impl crate::altrep_traits::AltVec for &'static [i32] {
 
     const HAS_DATAPTR_OR_NULL: bool = true;
 
-    fn dataptr_or_null(x: crate::sys::SEXP) -> *const std::ffi::c_void {
+    fn dataptr_or_null(x: crate::SEXP) -> *const std::ffi::c_void {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         data.as_ptr().cast::<std::ffi::c_void>()
@@ -54,7 +54,7 @@ impl crate::altrep_traits::AltVec for &'static [i32] {
 impl crate::altrep_traits::AltInteger for &'static [i32] {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltIntegerData::elt(data, i.max(0) as usize)
@@ -63,11 +63,11 @@ impl crate::altrep_traits::AltInteger for &'static [i32] {
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [i32],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         if start < 0 || len <= 0 {
             return 0;
         }
@@ -75,12 +75,12 @@ impl crate::altrep_traits::AltInteger for &'static [i32] {
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         let len = len as usize;
         crate::altrep_data::AltIntegerData::get_region(data, start as usize, len, buf)
-            as crate::sys::R_xlen_t
+            as crate::R_xlen_t
     }
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltIntegerData::no_na(data)
@@ -91,38 +91,38 @@ impl crate::altrep_traits::AltInteger for &'static [i32] {
     const HAS_SUM: bool = true;
 
     // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-    fn sum(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn sum(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltIntegerData::sum(data, narm)
             .map(|s| {
                 if s >= i32::MIN as i64 && s <= i32::MAX as i64 {
-                    crate::sys::SEXP::scalar_integer(s as i32)
+                    crate::SEXP::scalar_integer(s as i32)
                 } else {
-                    crate::sys::SEXP::scalar_real(s as f64)
+                    crate::SEXP::scalar_real(s as f64)
                 }
             })
-            .unwrap_or(crate::sys::SEXP::null())
+            .unwrap_or(crate::SEXP::null())
     }
 
     const HAS_MIN: bool = true;
 
-    fn min(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn min(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltIntegerData::min(data, narm)
-            .map(crate::sys::SEXP::scalar_integer)
-            .unwrap_or(crate::sys::SEXP::null())
+            .map(crate::SEXP::scalar_integer)
+            .unwrap_or(crate::SEXP::null())
     }
 
     const HAS_MAX: bool = true;
 
-    fn max(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn max(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [i32] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltIntegerData::max(data, narm)
-            .map(crate::sys::SEXP::scalar_integer)
-            .unwrap_or(crate::sys::SEXP::null())
+            .map(crate::SEXP::scalar_integer)
+            .unwrap_or(crate::SEXP::null())
     }
 }
 
@@ -130,17 +130,17 @@ crate::impl_inferbase_integer!(&'static [i32]);
 
 // Real static slices
 impl crate::altrep_traits::Altrep for &'static [f64] {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl crate::altrep_traits::AltVec for &'static [f64] {
     const HAS_DATAPTR: bool = true;
 
-    fn dataptr(x: crate::sys::SEXP, writable: bool) -> *mut std::ffi::c_void {
+    fn dataptr(x: crate::SEXP, writable: bool) -> *mut std::ffi::c_void {
         assert!(
             !writable,
             "cannot get writable DATAPTR for static ALTREP data"
@@ -152,7 +152,7 @@ impl crate::altrep_traits::AltVec for &'static [f64] {
 
     const HAS_DATAPTR_OR_NULL: bool = true;
 
-    fn dataptr_or_null(x: crate::sys::SEXP) -> *const std::ffi::c_void {
+    fn dataptr_or_null(x: crate::SEXP) -> *const std::ffi::c_void {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         data.as_ptr().cast::<std::ffi::c_void>()
@@ -162,7 +162,7 @@ impl crate::altrep_traits::AltVec for &'static [f64] {
 impl crate::altrep_traits::AltReal for &'static [f64] {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> f64 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRealData::elt(data, i.max(0) as usize)
@@ -171,11 +171,11 @@ impl crate::altrep_traits::AltReal for &'static [f64] {
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [f64],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         if start < 0 || len <= 0 {
             return 0;
         }
@@ -183,12 +183,12 @@ impl crate::altrep_traits::AltReal for &'static [f64] {
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         let len = len as usize;
         crate::altrep_data::AltRealData::get_region(data, start as usize, len, buf)
-            as crate::sys::R_xlen_t
+            as crate::R_xlen_t
     }
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRealData::no_na(data)
@@ -199,32 +199,32 @@ impl crate::altrep_traits::AltReal for &'static [f64] {
     const HAS_SUM: bool = true;
 
     // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-    fn sum(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn sum(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRealData::sum(data, narm)
-            .map(crate::sys::SEXP::scalar_real)
-            .unwrap_or(crate::sys::SEXP::null())
+            .map(crate::SEXP::scalar_real)
+            .unwrap_or(crate::SEXP::null())
     }
 
     const HAS_MIN: bool = true;
 
-    fn min(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn min(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRealData::min(data, narm)
-            .map(crate::sys::SEXP::scalar_real)
-            .unwrap_or(crate::sys::SEXP::null())
+            .map(crate::SEXP::scalar_real)
+            .unwrap_or(crate::SEXP::null())
     }
 
     const HAS_MAX: bool = true;
 
-    fn max(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn max(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data =
             unsafe { <&'static [f64] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRealData::max(data, narm)
-            .map(crate::sys::SEXP::scalar_real)
-            .unwrap_or(crate::sys::SEXP::null())
+            .map(crate::SEXP::scalar_real)
+            .unwrap_or(crate::SEXP::null())
     }
 }
 
@@ -232,11 +232,11 @@ crate::impl_inferbase_real!(&'static [f64]);
 
 // Logical static slices
 impl crate::altrep_traits::Altrep for &'static [bool] {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe {
             <&'static [bool] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
@@ -245,7 +245,7 @@ impl crate::altrep_traits::AltVec for &'static [bool] {}
 impl crate::altrep_traits::AltLogical for &'static [bool] {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> i32 {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
         let data = unsafe {
             <&'static [bool] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
@@ -254,7 +254,7 @@ impl crate::altrep_traits::AltLogical for &'static [bool] {
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data = unsafe {
             <&'static [bool] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
@@ -266,19 +266,19 @@ impl crate::altrep_traits::AltLogical for &'static [bool] {
     const HAS_SUM: bool = true;
 
     // ALTREP protocol: return C NULL (not R_NilValue) to signal "can't compute"
-    fn sum(x: crate::sys::SEXP, narm: bool) -> crate::sys::SEXP {
+    fn sum(x: crate::SEXP, narm: bool) -> crate::SEXP {
         let data = unsafe {
             <&'static [bool] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
         crate::altrep_data::AltLogicalData::sum(data, narm)
             .map(|s| {
                 if s >= i32::MIN as i64 && s <= i32::MAX as i64 {
-                    crate::sys::SEXP::scalar_integer(s as i32)
+                    crate::SEXP::scalar_integer(s as i32)
                 } else {
-                    crate::sys::SEXP::scalar_real(s as f64)
+                    crate::SEXP::scalar_real(s as f64)
                 }
             })
-            .unwrap_or(crate::sys::SEXP::null())
+            .unwrap_or(crate::SEXP::null())
     }
 }
 
@@ -286,17 +286,17 @@ crate::impl_inferbase_logical!(&'static [bool]);
 
 // Raw static slices
 impl crate::altrep_traits::Altrep for &'static [u8] {
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data =
             unsafe { <&'static [u8] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl crate::altrep_traits::AltVec for &'static [u8] {
     const HAS_DATAPTR: bool = true;
 
-    fn dataptr(x: crate::sys::SEXP, writable: bool) -> *mut std::ffi::c_void {
+    fn dataptr(x: crate::SEXP, writable: bool) -> *mut std::ffi::c_void {
         assert!(
             !writable,
             "cannot get writable DATAPTR for static ALTREP data"
@@ -308,7 +308,7 @@ impl crate::altrep_traits::AltVec for &'static [u8] {
 
     const HAS_DATAPTR_OR_NULL: bool = true;
 
-    fn dataptr_or_null(x: crate::sys::SEXP) -> *const std::ffi::c_void {
+    fn dataptr_or_null(x: crate::SEXP) -> *const std::ffi::c_void {
         let data =
             unsafe { <&'static [u8] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         data.as_ptr().cast::<std::ffi::c_void>()
@@ -318,7 +318,7 @@ impl crate::altrep_traits::AltVec for &'static [u8] {
 impl crate::altrep_traits::AltRaw for &'static [u8] {
     const HAS_ELT: bool = true;
 
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::Rbyte {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::Rbyte {
         let data =
             unsafe { <&'static [u8] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         crate::altrep_data::AltRawData::elt(data, i.max(0) as usize)
@@ -327,11 +327,11 @@ impl crate::altrep_traits::AltRaw for &'static [u8] {
     const HAS_GET_REGION: bool = true;
 
     fn get_region(
-        x: crate::sys::SEXP,
-        start: crate::sys::R_xlen_t,
-        len: crate::sys::R_xlen_t,
+        x: crate::SEXP,
+        start: crate::R_xlen_t,
+        len: crate::R_xlen_t,
         buf: &mut [u8],
-    ) -> crate::sys::R_xlen_t {
+    ) -> crate::R_xlen_t {
         if start < 0 || len <= 0 {
             return 0;
         }
@@ -339,7 +339,7 @@ impl crate::altrep_traits::AltRaw for &'static [u8] {
             unsafe { <&'static [u8] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
         let len = len as usize;
         crate::altrep_data::AltRawData::get_region(data, start as usize, len, buf)
-            as crate::sys::R_xlen_t
+            as crate::R_xlen_t
     }
 }
 
@@ -350,30 +350,30 @@ impl crate::altrep_traits::Altrep for &'static [String] {
     // String ALTREP elt calls Rf_mkCharLenCE (R API) — must use RUnwind.
     const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
 
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe {
             <&'static [String] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl crate::altrep_traits::AltVec for &'static [String] {}
 
 impl crate::altrep_traits::AltString for &'static [String] {
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::SEXP {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
         let data = unsafe {
             <&'static [String] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
         match crate::altrep_data::AltStringData::elt(data, i.max(0) as usize) {
             Some(s) => unsafe { super::checked_mkchar(s) },
-            None => crate::sys::SEXP::na_string(),
+            None => crate::SEXP::na_string(),
         }
     }
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data = unsafe {
             <&'static [String] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
@@ -390,30 +390,30 @@ impl crate::altrep_traits::Altrep for &'static [&'static str] {
     // String ALTREP elt calls Rf_mkCharLenCE (R API) — must use RUnwind.
     const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
 
-    fn length(x: crate::sys::SEXP) -> crate::sys::R_xlen_t {
+    fn length(x: crate::SEXP) -> crate::R_xlen_t {
         let data = unsafe {
             <&'static [&'static str] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
-        crate::altrep_data::AltrepLen::len(data) as crate::sys::R_xlen_t
+        crate::altrep_data::AltrepLen::len(data) as crate::R_xlen_t
     }
 }
 
 impl crate::altrep_traits::AltVec for &'static [&'static str] {}
 
 impl crate::altrep_traits::AltString for &'static [&'static str] {
-    fn elt(x: crate::sys::SEXP, i: crate::sys::R_xlen_t) -> crate::sys::SEXP {
+    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
         let data = unsafe {
             <&'static [&'static str] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };
         match crate::altrep_data::AltStringData::elt(data, i.max(0) as usize) {
             Some(s) => unsafe { super::checked_mkchar(s) },
-            None => crate::sys::SEXP::na_string(),
+            None => crate::SEXP::na_string(),
         }
     }
 
     const HAS_NO_NA: bool = true;
 
-    fn no_na(x: crate::sys::SEXP) -> i32 {
+    fn no_na(x: crate::SEXP) -> i32 {
         let data = unsafe {
             <&'static [&'static str] as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x)
         };

--- a/miniextendr-api/src/altrep_sexp.rs
+++ b/miniextendr-api/src/altrep_sexp.rs
@@ -45,7 +45,8 @@
 //! ```
 
 use crate::from_r::r_slice;
-use crate::sys::{self, Rcomplex, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{self};
+use crate::{R_xlen_t, Rcomplex, SEXP, SEXPTYPE, SexpExt};
 use std::marker::PhantomData;
 use std::rc::Rc;
 
@@ -231,7 +232,7 @@ impl AltrepSexp {
         let n = self.sexp.len();
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
-            let elt = self.sexp.string_elt(i as sys::R_xlen_t);
+            let elt = self.sexp.string_elt(i as R_xlen_t);
             if elt == SEXP::na_string() {
                 out.push(None);
             } else {

--- a/miniextendr-api/src/altrep_traits.rs
+++ b/miniextendr-api/src/altrep_traits.rs
@@ -33,7 +33,7 @@
 //! `#[altrep(rust_unwind)]` / `#[altrep(r_unwind)]`; bridging through these
 //! modes is handled by [`crate::altrep_bridge`].
 
-use crate::sys::{R_xlen_t, Rcomplex, SEXP, SEXPTYPE};
+use crate::{R_xlen_t, Rcomplex, SEXP, SEXPTYPE};
 use core::ffi::c_void;
 
 // region: ALTREP GUARD MODE

--- a/miniextendr-api/src/as_coerce.rs
+++ b/miniextendr-api/src/as_coerce.rs
@@ -225,7 +225,7 @@ pub trait AsList {
 /// return a vector with one element per item.
 pub trait AsCharacter {
     /// Convert to an R character vector.
-    fn as_character(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_character(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `numeric`/`double` via `as.numeric()`.
@@ -233,7 +233,7 @@ pub trait AsCharacter {
 /// The result should be an R numeric vector (REALSXP).
 pub trait AsNumeric {
     /// Convert to an R numeric vector.
-    fn as_numeric(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_numeric(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `integer` via `as.integer()`.
@@ -241,7 +241,7 @@ pub trait AsNumeric {
 /// The result should be an R integer vector (INTSXP).
 pub trait AsInteger {
     /// Convert to an R integer vector.
-    fn as_integer(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_integer(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `logical` via `as.logical()`.
@@ -249,7 +249,7 @@ pub trait AsInteger {
 /// The result should be an R logical vector (LGLSXP).
 pub trait AsLogical {
     /// Convert to an R logical vector.
-    fn as_logical(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_logical(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `matrix` via `as.matrix()`.
@@ -257,7 +257,7 @@ pub trait AsLogical {
 /// The result should be an R matrix with appropriate dimensions.
 pub trait AsMatrix {
     /// Convert to an R matrix.
-    fn as_matrix(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_matrix(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to a generic `vector` via `as.vector()`.
@@ -265,7 +265,7 @@ pub trait AsMatrix {
 /// This is the most general vector coercion, typically stripping attributes.
 pub trait AsVector {
     /// Convert to an R vector.
-    fn as_vector(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_vector(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `factor` via `as.factor()`.
@@ -273,7 +273,7 @@ pub trait AsVector {
 /// The result should be an R factor (integer vector with levels attribute).
 pub trait AsFactor {
     /// Convert to an R factor.
-    fn as_factor(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_factor(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `Date` via `as.Date()`.
@@ -281,7 +281,7 @@ pub trait AsFactor {
 /// The result should be an R Date object (numeric with "Date" class).
 pub trait AsDate {
     /// Convert to an R Date.
-    fn as_date(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_date(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `POSIXct` via `as.POSIXct()`.
@@ -289,7 +289,7 @@ pub trait AsDate {
 /// The result should be an R POSIXct object (numeric with "POSIXct", "POSIXt" class).
 pub trait AsPOSIXct {
     /// Convert to an R POSIXct.
-    fn as_posixct(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_posixct(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `complex` via `as.complex()`.
@@ -297,7 +297,7 @@ pub trait AsPOSIXct {
 /// The result should be an R complex vector (CPLXSXP).
 pub trait AsComplex {
     /// Convert to an R complex vector.
-    fn as_complex(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_complex(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `raw` via `as.raw()`.
@@ -305,7 +305,7 @@ pub trait AsComplex {
 /// The result should be an R raw vector (RAWSXP).
 pub trait AsRaw {
     /// Convert to an R raw vector.
-    fn as_raw(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_raw(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `environment` via `as.environment()`.
@@ -313,7 +313,7 @@ pub trait AsRaw {
 /// The result should be an R environment.
 pub trait AsEnvironment {
     /// Convert to an R environment.
-    fn as_environment(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_environment(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 
 /// Trait for types that can be coerced to `function` via `as.function()`.
@@ -321,7 +321,7 @@ pub trait AsEnvironment {
 /// The result should be an R function (closure).
 pub trait AsFunction {
     /// Convert to an R function.
-    fn as_function(&self) -> Result<crate::sys::SEXP, AsCoerceError>;
+    fn as_function(&self) -> Result<crate::SEXP, AsCoerceError>;
 }
 // endregion
 

--- a/miniextendr-api/src/cached_class.rs
+++ b/miniextendr-api/src/cached_class.rs
@@ -38,8 +38,8 @@
 macro_rules! cached_symbol {
     ($(#[$meta:meta])* $vis:vis fn $name:ident() = $cstr:expr) => {
         $(#[$meta])*
-        $vis fn $name() -> $crate::sys::SEXP {
-            static CACHE: ::std::sync::OnceLock<$crate::sys::SEXP> = ::std::sync::OnceLock::new();
+        $vis fn $name() -> $crate::SEXP {
+            static CACHE: ::std::sync::OnceLock<$crate::SEXP> = ::std::sync::OnceLock::new();
             *CACHE.get_or_init(|| unsafe { $crate::sys::Rf_install($cstr.as_ptr()) })
         }
     };
@@ -69,13 +69,13 @@ pub(crate) use cached_symbol;
 macro_rules! cached_strsxp {
     ($(#[$meta:meta])* $vis:vis fn $name:ident() = [$($cstr:expr),+ $(,)?]) => {
         $(#[$meta])*
-        $vis fn $name() -> $crate::sys::SEXP {
-            static CACHE: ::std::sync::OnceLock<$crate::sys::SEXP> = ::std::sync::OnceLock::new();
+        $vis fn $name() -> $crate::SEXP {
+            static CACHE: ::std::sync::OnceLock<$crate::SEXP> = ::std::sync::OnceLock::new();
             *CACHE.get_or_init(|| unsafe {
-                use $crate::sys::SexpExt as _;
+                use $crate::SexpExt as _;
                 let strings: &[&::std::ffi::CStr] = &[$($cstr),+];
                 let sexp = $crate::sys::Rf_allocVector(
-                    $crate::sys::SEXPTYPE::STRSXP,
+                    $crate::SEXPTYPE::STRSXP,
                     strings.len() as ::std::primitive::isize,
                 );
                 $crate::sys::R_PreserveObject(sexp);
@@ -106,8 +106,8 @@ pub(crate) use cached_strsxp;
 /// from any module.
 #[doc(hidden)]
 #[inline]
-pub(crate) fn permanent_charsxp(name: &std::ffi::CStr) -> crate::sys::SEXP {
-    use crate::sys::SexpExt;
+pub(crate) fn permanent_charsxp(name: &std::ffi::CStr) -> crate::SEXP {
+    use crate::SexpExt;
     unsafe { crate::sys::Rf_install(name.as_ptr()) }.printname()
 }
 
@@ -204,8 +204,8 @@ cached_symbol!(
 ///
 /// `sexp` must be a valid REALSXP. Must be called on R's main thread.
 #[cfg(any(feature = "time", feature = "jiff"))]
-pub fn set_posixct_utc(sexp: crate::sys::SEXP) {
-    use crate::sys::SexpExt as _;
+pub fn set_posixct_utc(sexp: crate::SEXP) {
+    use crate::SexpExt as _;
     sexp.set_class(posixct_class_sexp());
     sexp.set_attr(tzone_symbol(), utc_tzone_sexp());
 }
@@ -219,13 +219,13 @@ pub fn set_posixct_utc(sexp: crate::sys::SEXP) {
 ///
 /// `sexp` must be a valid REALSXP. Must be called on R's main thread.
 #[cfg(feature = "jiff")]
-pub fn set_posixct_tz(sexp: crate::sys::SEXP, iana: &str) {
-    use crate::sys::SexpExt as _;
+pub fn set_posixct_tz(sexp: crate::SEXP, iana: &str) {
+    use crate::SexpExt as _;
     sexp.set_class(posixct_class_sexp());
     // Build a one-element STRSXP for the tzone attribute.
     unsafe {
-        let tzone_charsxp = crate::sys::SEXP::charsxp(iana);
-        let tzone_sexp = crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, 1);
+        let tzone_charsxp = crate::SEXP::charsxp(iana);
+        let tzone_sexp = crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, 1);
         crate::sys::Rf_protect(tzone_sexp);
         tzone_sexp.set_string_elt(0, tzone_charsxp);
         sexp.set_attr(tzone_symbol(), tzone_sexp);

--- a/miniextendr-api/src/coerce.rs
+++ b/miniextendr-api/src/coerce.rs
@@ -19,7 +19,7 @@
 //! (`i8`/`i16`/`u16`/`u32`/`f32`/`i64`/`u64`/`isize`/`usize`). The strict
 //! inbound alternative is the bare `TryFromSexp` impl on the matching R
 //! native type (`i32`, `f64`, …), which rejects mismatched
-//! [`SEXPTYPE`](crate::sys::SEXPTYPE)s outright. Failure mode of relying on
+//! [`SEXPTYPE`](crate::SEXPTYPE)s outright. Failure mode of relying on
 //! coercion in a function that should be strict: a Rust `i32` argument
 //! silently accepts `1.7` (REALSXP) and truncates.
 //!
@@ -40,7 +40,7 @@
 //! ```
 
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
-use crate::sys::{Rboolean, Rcomplex};
+use crate::{Rboolean, Rcomplex};
 
 /// Infallible coercion from `Self` to type `R`.
 ///
@@ -518,7 +518,7 @@ impl TryCoerce<bool> for Rboolean {
     }
 }
 
-impl TryCoerce<bool> for crate::sys::RLogical {
+impl TryCoerce<bool> for crate::RLogical {
     type Error = LogicalCoerceError;
 
     #[inline]

--- a/miniextendr-api/src/condition.rs
+++ b/miniextendr-api/src/condition.rs
@@ -390,8 +390,8 @@ impl RCondition {
     /// # Safety
     ///
     /// Must be called from R's main thread.
-    pub unsafe fn from_tagged_sexp(sexp: crate::sys::SEXP) -> Option<Self> {
-        use crate::sys::SexpExt;
+    pub unsafe fn from_tagged_sexp(sexp: crate::SEXP) -> Option<Self> {
+        use crate::SexpExt;
 
         // Use SexpExt::inherits_class — wraps Rf_inherits, already main-thread.
         if !sexp.inherits_class(c"rust_condition_value") {
@@ -506,7 +506,7 @@ impl RCondition {
 ///
 /// Must be called from R's main thread. `sexp` must be a valid (possibly
 /// tagged) SEXP.
-pub unsafe fn repanic_if_rust_error(sexp: crate::sys::SEXP) {
+pub unsafe fn repanic_if_rust_error(sexp: crate::SEXP) {
     if let Some(cond) = unsafe { RCondition::from_tagged_sexp(sexp) } {
         std::panic::panic_any(cond);
     }

--- a/miniextendr-api/src/connection.rs
+++ b/miniextendr-api/src/connection.rs
@@ -61,7 +61,8 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 
-use crate::sys::{R_CONNECTIONS_VERSION, Rboolean, Rconnection, SEXP};
+use crate::sys::{R_CONNECTIONS_VERSION, Rconnection};
+use crate::{Rboolean, SEXP};
 
 /// The expected R connections API version this module is compatible with.
 ///
@@ -128,9 +129,10 @@ pub fn check_connections_version() {
 /// }
 /// ```
 pub unsafe fn check_connections_runtime() -> Result<(), String> {
+    use crate::SexpExt;
     use crate::expression::{RCall, dollar_extract};
     use crate::gc_protect::OwnedProtect;
-    use crate::sys::{R_BaseEnv, SexpExt};
+    use crate::sys::R_BaseEnv;
 
     unsafe {
         // Evaluate R.Version() in base env.

--- a/miniextendr-api/src/connection/io_adapters.rs
+++ b/miniextendr-api/src/connection/io_adapters.rs
@@ -3,7 +3,7 @@
 //! Provides adapter types that wrap `std::io::{Read, Write, Seek}` implementations
 //! and expose them as R connections via [`RConnectionImpl`](super::RConnectionImpl).
 
-use crate::sys::SEXP;
+use crate::SEXP;
 
 use super::{RConnectionImpl, RCustomConnection};
 

--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -63,7 +63,7 @@ use crate::externalptr::{ExternalPtr, IntoExternalPtr};
 use crate::into_r::IntoR;
 use crate::list::{IntoList, List};
 use crate::named_vector::AtomicElement;
-use crate::sys::{RNativeType, SexpExt};
+use crate::{RNativeType, SexpExt};
 
 /// Wrap a value and convert it to an R list via [`IntoList`] when returned from Rust.
 ///
@@ -95,17 +95,17 @@ impl<T: IntoList> IntoR for AsList<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.0.into_list().into_sexp()
     }
 }
@@ -156,17 +156,17 @@ impl<T: IntoDataFrame> IntoR for ToDataFrame<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.0.into_data_frame().into_sexp()
     }
 }
@@ -178,17 +178,17 @@ impl<T: IntoList> IntoR for DataFrame<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.into_data_frame().into_sexp()
     }
 }
@@ -271,11 +271,11 @@ pub trait IntoDataFrame {
     ///
     /// This method calls R API functions and must run on the R main thread.
     #[doc(hidden)]
-    fn into_named_columns(self) -> Vec<(String, crate::sys::SEXP)>
+    fn into_named_columns(self) -> Vec<(String, crate::SEXP)>
     where
         Self: Sized,
     {
-        use crate::sys::SexpExt as _;
+        use crate::SexpExt as _;
         let list = self.into_data_frame();
         let sexp = list.as_sexp();
         let n = sexp.len();
@@ -318,14 +318,14 @@ pub trait IntoDataFrame {
 /// parent data frame.
 #[doc(hidden)]
 pub unsafe fn scatter_column(
-    src: crate::sys::SEXP,
+    src: crate::SEXP,
     present_idx: &[usize],
     n_rows: usize,
-) -> crate::sys::SEXP {
+) -> crate::SEXP {
     // SAFETY: caller guarantees R main thread; src is valid; n_rows is correct.
     #[allow(unused_unsafe)]
     unsafe {
-        use crate::sys::{SEXPTYPE, SexpExt as _};
+        use crate::{SEXPTYPE, SexpExt as _};
 
         let stype = src.type_of();
         let n_present = present_idx.len();
@@ -373,7 +373,7 @@ pub unsafe fn scatter_column(
                 let out = crate::sys::Rf_allocVector(SEXPTYPE::STRSXP, n_rows as isize);
                 // Fill with NA_character_
                 for i in 0..(n_rows as isize) {
-                    out.set_string_elt(i, crate::sys::SEXP::na_string());
+                    out.set_string_elt(i, crate::SEXP::na_string());
                 }
                 for (pi, &row_i) in present_idx.iter().enumerate() {
                     if pi < n_present {
@@ -458,7 +458,7 @@ impl<T: serde::Serialize> From<T> for AsSerializeRow<T> {
 impl<T: serde::Serialize> IntoList for AsSerializeRow<T> {
     fn into_list(self) -> List {
         use crate::serde::RSerializer;
-        use crate::sys::{SEXPTYPE, SexpExt};
+        use crate::{SEXPTYPE, SexpExt};
         match RSerializer::to_sexp(&self.0) {
             Ok(sexp) => {
                 if sexp.type_of() == SEXPTYPE::VECSXP {
@@ -627,7 +627,7 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
     fn into_data_frame(self) -> List {
         if self.rows.is_empty() {
             // Empty data frame
-            return List::from_raw_pairs(Vec::<(&str, crate::sys::SEXP)>::new())
+            return List::from_raw_pairs(Vec::<(&str, crate::SEXP)>::new())
                 .set_data_frame_class()
                 .set_row_names_int(0);
         }
@@ -673,7 +673,7 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
         // Element SEXPs from get_named are children of protected row lists,
         // so they don't need individual protection.
         use std::collections::HashMap;
-        let mut columns: HashMap<String, Vec<crate::sys::SEXP>> =
+        let mut columns: HashMap<String, Vec<crate::SEXP>> =
             HashMap::with_capacity(col_names.len());
         for name in &col_names {
             columns.insert(name.clone(), Vec::with_capacity(n_rows as usize));
@@ -682,8 +682,8 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
         for list in &lists {
             for name in &col_names {
                 let value = list
-                    .get_named::<crate::sys::SEXP>(name)
-                    .unwrap_or(crate::sys::SEXP::nil());
+                    .get_named::<crate::SEXP>(name)
+                    .unwrap_or(crate::SEXP::nil());
                 columns
                     .get_mut(name)
                     .expect("column inserted above")
@@ -694,7 +694,7 @@ impl<T: IntoList> IntoDataFrame for DataFrame<T> {
         // Build column vectors, protecting each from GC.
         // Coalesce homogeneous length-1 scalars into atomic vectors so that
         // columns are INTSXP/REALSXP/LGLSXP/STRSXP instead of VECSXP (list).
-        let mut df_pairs: Vec<(String, crate::sys::SEXP)> = Vec::with_capacity(col_names.len());
+        let mut df_pairs: Vec<(String, crate::SEXP)> = Vec::with_capacity(col_names.len());
         for name in col_names {
             let col_values = columns.remove(&name).expect("column inserted above");
             let col_sexp = List::from_scalars_or_list(&col_values).as_sexp();
@@ -742,17 +742,17 @@ impl<T: IntoExternalPtr> IntoR for AsExternalPtr<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         ExternalPtr::new(self.0).into_sexp()
     }
 }
@@ -794,17 +794,17 @@ impl<T: RNativeType> IntoR for AsRNative<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // Directly allocate a length-1 R vector and write the scalar value.
         // This avoids the intermediate Rust Vec allocation.
         unsafe {
@@ -816,7 +816,7 @@ impl<T: RNativeType> IntoR for AsRNative<T> {
     }
 
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, 1);
             let ptr = T::dataptr_mut(sexp);
@@ -865,16 +865,16 @@ impl<T> From<T> for AsNamedList<T> {
 impl<K: AsRef<str>, V: IntoR> IntoR for AsNamedList<Vec<(K, V)>> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
-        let pairs: Vec<(K, crate::sys::SEXP)> = self
+    fn into_sexp(self) -> crate::SEXP {
+        let pairs: Vec<(K, crate::SEXP)> = self
             .0
             .into_iter()
             .map(|(k, v)| (k, v.into_sexp()))
@@ -886,16 +886,16 @@ impl<K: AsRef<str>, V: IntoR> IntoR for AsNamedList<Vec<(K, V)>> {
 impl<K: AsRef<str>, V: IntoR, const N: usize> IntoR for AsNamedList<[(K, V); N]> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
-        let pairs: Vec<(K, crate::sys::SEXP)> = self
+    fn into_sexp(self) -> crate::SEXP {
+        let pairs: Vec<(K, crate::SEXP)> = self
             .0
             .into_iter()
             .map(|(k, v)| (k, v.into_sexp()))
@@ -907,16 +907,16 @@ impl<K: AsRef<str>, V: IntoR, const N: usize> IntoR for AsNamedList<[(K, V); N]>
 impl<K: AsRef<str>, V: Clone + IntoR> IntoR for AsNamedList<&[(K, V)]> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
-        let pairs: Vec<(&K, crate::sys::SEXP)> = self
+    fn into_sexp(self) -> crate::SEXP {
+        let pairs: Vec<(&K, crate::SEXP)> = self
             .0
             .iter()
             .map(|(k, v)| (k, v.clone().into_sexp()))
@@ -960,15 +960,15 @@ impl<T> From<T> for AsNamedVector<T> {
 impl<K: AsRef<str>, V: AtomicElement> IntoR for AsNamedVector<Vec<(K, V)>> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         named_vector_from_pairs(self.0)
     }
 }
@@ -976,15 +976,15 @@ impl<K: AsRef<str>, V: AtomicElement> IntoR for AsNamedVector<Vec<(K, V)>> {
 impl<K: AsRef<str>, V: AtomicElement, const N: usize> IntoR for AsNamedVector<[(K, V); N]> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         named_vector_from_pairs(self.0)
     }
 }
@@ -992,15 +992,15 @@ impl<K: AsRef<str>, V: AtomicElement, const N: usize> IntoR for AsNamedVector<[(
 impl<K: AsRef<str>, V: Clone + AtomicElement> IntoR for AsNamedVector<&[(K, V)]> {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let (keys, values): (Vec<&K>, Vec<V>) = self.0.iter().map(|(k, v)| (k, v.clone())).unzip();
         let sexp = V::vec_to_sexp(values);
         unsafe {
@@ -1013,7 +1013,7 @@ impl<K: AsRef<str>, V: Clone + AtomicElement> IntoR for AsNamedVector<&[(K, V)]>
 }
 
 /// Shared helper: build a named atomic vector from an owning iterator of (key, value) pairs.
-fn named_vector_from_pairs<K, V>(pairs: impl IntoIterator<Item = (K, V)>) -> crate::sys::SEXP
+fn named_vector_from_pairs<K, V>(pairs: impl IntoIterator<Item = (K, V)>) -> crate::SEXP
 where
     K: AsRef<str>,
     V: AtomicElement,
@@ -1212,12 +1212,12 @@ impl<T: std::fmt::Display> IntoR for AsDisplay<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.0.to_string().into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.0.to_string().into_sexp_unchecked() })
     }
 }
@@ -1239,13 +1239,13 @@ impl<T: std::fmt::Display> IntoR for AsDisplayVec<T> {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         let strings: Vec<String> = self.0.into_iter().map(|x| x.to_string()).collect();
         Ok(strings.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         let strings: Vec<String> = self.0.into_iter().map(|x| x.to_string()).collect();
         Ok(unsafe { strings.into_sexp_unchecked() })
     }
@@ -1275,7 +1275,7 @@ where
 {
     type Error = crate::from_r::SexpError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let s: &str = crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
         let value = s
             .parse::<T>()
@@ -1283,7 +1283,7 @@ where
         Ok(AsFromStr(value))
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let s: &str = unsafe { crate::from_r::TryFromSexp::try_from_sexp_unchecked(sexp)? };
         let value = s
             .parse::<T>()
@@ -1317,7 +1317,7 @@ where
 {
     type Error = crate::from_r::SexpError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let strings: Vec<String> = crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
         let mut result = Vec::with_capacity(strings.len());
         let mut errors = Vec::new();
@@ -1337,7 +1337,7 @@ where
         }
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let strings: Vec<String> =
             unsafe { crate::from_r::TryFromSexp::try_from_sexp_unchecked(sexp)? };
         let mut result = Vec::with_capacity(strings.len());
@@ -1383,22 +1383,22 @@ pub struct Collect<I>(pub I);
 impl<I, T> IntoR for Collect<I>
 where
     I: ExactSizeIterator<Item = T>,
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector::<T>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {
@@ -1409,7 +1409,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector_unchecked::<T>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {
@@ -1442,7 +1442,7 @@ where
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         // Collect String refs for str_iter_to_strsxp.
         let strings: Vec<String> = self.0.collect();
         Ok(crate::into_r::str_iter_to_strsxp(
@@ -1451,7 +1451,7 @@ where
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         let strings: Vec<String> = self.0.collect();
         Ok(unsafe {
             crate::into_r::str_iter_to_strsxp_unchecked(strings.iter().map(|s| s.as_str()))
@@ -1480,17 +1480,17 @@ where
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector::<f64>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {
@@ -1501,7 +1501,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector_unchecked::<f64>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {
@@ -1522,17 +1522,17 @@ where
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
 
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
 
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector::<i32>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {
@@ -1543,7 +1543,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let (sexp, dst) = crate::into_r::alloc_r_vector_unchecked::<i32>(self.0.len());
             for (slot, val) in dst.iter_mut().zip(self.0) {

--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -21,8 +21,8 @@
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
 use crate::list::{List, NamedList};
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
 use crate::typed_list::{TypedList, TypedListError, TypedListSpec, validate_list};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use std::ffi::CStr;
 
 // region: Error type

--- a/miniextendr-api/src/dots.rs
+++ b/miniextendr-api/src/dots.rs
@@ -28,8 +28,8 @@
 
 use crate::from_r::TryFromSexp;
 use crate::list::{List, ListFromSexpError};
-use crate::sys::{SEXP, SexpExt};
 use crate::typed_list::{TypedList, TypedListError, TypedListSpec, validate_list};
+use crate::{SEXP, SexpExt};
 
 /// Rust type representing R's `...` (variadic arguments).
 ///

--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -57,7 +57,8 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         crate::worker::is_r_main_thread(),
         "must be called from R main thread"
     );
-    use crate::sys::{R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect, SexpExt};
+    use crate::SexpExt;
+    use crate::sys::{R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect};
 
     unsafe {
         // Call l10n_info()
@@ -100,7 +101,8 @@ pub extern "C-unwind" fn miniextendr_encoding_init() {
     let _ = ENCODING_INFO.get_or_init(|| {
         #[cfg(feature = "nonapi")]
         unsafe {
-            use crate::sys::{Rboolean, nonapi_encoding};
+            use crate::Rboolean;
+            use crate::sys::nonapi_encoding;
 
             let native_encoding = {
                 let ptr = nonapi_encoding::R_nativeEncoding();

--- a/miniextendr-api/src/error_value.rs
+++ b/miniextendr-api/src/error_value.rs
@@ -98,7 +98,9 @@
 use crate::cached_class::{
     condition_names_sexp, rust_condition_attr_symbol, rust_condition_class_sexp,
 };
-use crate::sys::{self, SEXP, SexpExt};
+use crate::sexp_types::CE_UTF8;
+use crate::sys::{self};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Canonical kind strings for tagged condition values.
 ///
@@ -186,13 +188,13 @@ pub fn make_rust_condition_value(
         // trigger old-to-new GC barriers; R-devel's GC fires more aggressively
         // here than R-release/oldrel, so unprotected intermediates corrupt the
         // heap on R-devel even when R 4.5/4.4 happen to survive (PR #344 fix).
-        let list = sys::Rf_allocVector(sys::SEXPTYPE::VECSXP, 4);
+        let list = sys::Rf_allocVector(SEXPTYPE::VECSXP, 4);
         sys::Rf_protect(list);
         let mut prot = 1;
 
         // Element 0: error message
         let msg_cstr = to_cstring_lossy(message, "<invalid error message>");
-        let msg_charsxp = sys::Rf_mkCharCE(msg_cstr.as_ptr(), sys::CE_UTF8);
+        let msg_charsxp = sys::Rf_mkCharCE(msg_cstr.as_ptr(), CE_UTF8);
         let msg_sexp = SEXP::scalar_string(msg_charsxp);
         sys::Rf_protect(msg_sexp);
         prot += 1;
@@ -200,7 +202,7 @@ pub fn make_rust_condition_value(
 
         // Element 1: kind string
         let kind_cstr = to_cstring_lossy(kind, kind::OTHER_RUST_ERROR);
-        let kind_charsxp = sys::Rf_mkCharCE(kind_cstr.as_ptr(), sys::CE_UTF8);
+        let kind_charsxp = sys::Rf_mkCharCE(kind_cstr.as_ptr(), CE_UTF8);
         let kind_sexp = SEXP::scalar_string(kind_charsxp);
         sys::Rf_protect(kind_sexp);
         prot += 1;
@@ -210,7 +212,7 @@ pub fn make_rust_condition_value(
         // Only the Some-branch allocates; nil is constant.
         let class_sexp = if let Some(class_name) = class {
             let class_cstr = to_cstring_lossy(class_name, "rust_condition");
-            let class_charsxp = sys::Rf_mkCharCE(class_cstr.as_ptr(), sys::CE_UTF8);
+            let class_charsxp = sys::Rf_mkCharCE(class_cstr.as_ptr(), CE_UTF8);
             let s = SEXP::scalar_string(class_charsxp);
             sys::Rf_protect(s);
             prot += 1;

--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -26,10 +26,9 @@
 //! ```
 
 use crate::gc_protect::{OwnedProtect, ProtectScope};
-use crate::sys::{
-    self, PairListExt, R_BaseEnv, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent, Rf_install, SEXP,
-    SexpExt,
-};
+use crate::sexp_ext::PairListExt;
+use crate::sys::{self, R_BaseEnv, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent, Rf_install};
+use crate::{SEXP, SexpExt};
 use std::ffi::{CStr, CString};
 
 // region: RSymbol
@@ -232,7 +231,7 @@ impl REnv {
 /// unsafe {
 ///     // seq_len(10)
 ///     let result = RCall::new("seq_len")
-///         .arg(sys::SEXP::scalar_integer(10))
+///         .arg(SEXP::scalar_integer(10))
 ///         .eval_base()?;
 ///
 ///     // paste(x, collapse = ", ")

--- a/miniextendr-api/src/externalptr.rs
+++ b/miniextendr-api/src/externalptr.rs
@@ -148,10 +148,10 @@ use std::ptr::{self, NonNull};
 use crate::sys::{
     R_ClearExternalPtr, R_ExternalPtrAddr, R_ExternalPtrProtected, R_ExternalPtrTag,
     R_MakeExternalPtr, R_MakeExternalPtr_unchecked, R_RegisterCFinalizerEx,
-    R_RegisterCFinalizerEx_unchecked, Rboolean, Rf_allocVector, Rf_allocVector_unchecked,
-    Rf_install, Rf_install_unchecked, Rf_protect, Rf_protect_unchecked, Rf_unprotect,
-    Rf_unprotect_unchecked, SEXP, SEXPTYPE, SexpExt,
+    R_RegisterCFinalizerEx_unchecked, Rf_allocVector, Rf_allocVector_unchecked, Rf_install,
+    Rf_install_unchecked, Rf_protect, Rf_protect_unchecked, Rf_unprotect, Rf_unprotect_unchecked,
 };
+use crate::{Rboolean, SEXP, SEXPTYPE, SexpExt};
 
 /// A wrapper around a raw pointer that implements [`Send`].
 ///
@@ -242,7 +242,7 @@ unsafe fn type_id_symbol_unchecked<T: TypedExternal>() -> SEXP {
 /// `sym` must be a valid SYMSXP.
 #[inline]
 fn symbol_name(sym: SEXP) -> &'static str {
-    use crate::sys::SexpExt;
+    use crate::SexpExt;
     let printname = sym.printname();
     let cstr = printname.r_char();
     let len = printname.len();
@@ -910,7 +910,7 @@ impl<T: TypedExternal> ExternalPtr<T> {
     pub unsafe fn wrap_sexp(sexp: SEXP) -> Option<Self> {
         debug_assert_eq!(
             sexp.type_of(),
-            crate::sys::SEXPTYPE::EXTPTRSXP,
+            crate::SEXPTYPE::EXTPTRSXP,
             "wrap_sexp: expected EXTPTRSXP, got {:?}",
             sexp.type_of()
         );
@@ -956,7 +956,7 @@ impl<T: TypedExternal> ExternalPtr<T> {
 
         debug_assert_eq!(
             sexp.type_of(),
-            crate::sys::SEXPTYPE::EXTPTRSXP,
+            crate::SEXPTYPE::EXTPTRSXP,
             "wrap_sexp_unchecked: expected EXTPTRSXP, got {:?}",
             sexp.type_of()
         );
@@ -995,7 +995,7 @@ impl<T: TypedExternal> ExternalPtr<T> {
     pub unsafe fn wrap_sexp_with_error(sexp: SEXP) -> Result<Self, TypeMismatchError> {
         debug_assert_eq!(
             sexp.type_of(),
-            crate::sys::SEXPTYPE::EXTPTRSXP,
+            crate::SEXPTYPE::EXTPTRSXP,
             "wrap_sexp_with_error: expected EXTPTRSXP, got {:?}",
             sexp.type_of()
         );
@@ -1056,7 +1056,7 @@ impl<T: TypedExternal> ExternalPtr<T> {
     pub unsafe fn from_sexp_unchecked(sexp: SEXP) -> Self {
         debug_assert_eq!(
             sexp.type_of(),
-            crate::sys::SEXPTYPE::EXTPTRSXP,
+            crate::SEXPTYPE::EXTPTRSXP,
             "from_sexp_unchecked: expected EXTPTRSXP, got {:?}",
             sexp.type_of()
         );

--- a/miniextendr-api/src/externalptr/altrep_helpers.rs
+++ b/miniextendr-api/src/externalptr/altrep_helpers.rs
@@ -5,7 +5,7 @@
 //! `#[r_data]` fields.
 
 use super::{ErasedExternalPtr, ExternalPtr, TypedExternal};
-use crate::sys::SEXP;
+use crate::SEXP;
 
 /// Extract the ALTREP data1 slot as a typed `ExternalPtr<T>`.
 ///

--- a/miniextendr-api/src/factor.rs
+++ b/miniextendr-api/src/factor.rs
@@ -32,7 +32,8 @@ use crate::altrep_traits::NA_INTEGER;
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, Rf_install, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{Rf_allocVector, Rf_install};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Cached "factor" class STRSXP
 
@@ -470,10 +471,10 @@ impl<T> std::ops::DerefMut for FactorVec<T> {
 
 impl<T: RFactor> IntoR for FactorVec<T> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -569,10 +570,10 @@ pub trait UnitEnumFactor {
 
 impl<T: UnitEnumFactor> IntoR for FactorOptionVec<T> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -53,7 +53,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::altrep_traits::NA_REAL;
 use crate::coerce::TryCoerce;
-use crate::sys::{RLogical, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, SEXP, SEXPTYPE, SexpExt};
 
 /// Check if an f64 value is R's NA_real_ (a specific NaN bit pattern).
 ///
@@ -475,7 +475,7 @@ impl TryFromSexp for i32 {
 impl_try_from_sexp_scalar_native!(f64, REALSXP);
 impl_try_from_sexp_scalar_native!(u8, RAWSXP);
 impl_try_from_sexp_scalar_native!(RLogical, LGLSXP);
-impl_try_from_sexp_scalar_native!(crate::sys::Rcomplex, CPLXSXP);
+impl_try_from_sexp_scalar_native!(crate::Rcomplex, CPLXSXP);
 
 /// Pass-through conversion for raw SEXP values with ALTREP auto-materialization.
 ///
@@ -558,7 +558,7 @@ mod references;
 /// to use blanket impls without needing helper functions.
 impl<T> TryFromSexp for &[T]
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpTypeError;
 
@@ -596,7 +596,7 @@ where
 /// no two `&mut` borrows alias the same SEXP.
 impl<T> TryFromSexp for &mut [T]
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpTypeError;
 
@@ -632,7 +632,7 @@ where
 /// Blanket impl for `Option<&[T]>` where T: RNativeType
 impl<T> TryFromSexp for Option<&[T]>
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpError;
 
@@ -659,7 +659,7 @@ where
 /// Blanket impl for `Option<&mut [T]>` where T: RNativeType
 impl<T> TryFromSexp for Option<&mut [T]>
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpError;
 
@@ -727,7 +727,7 @@ mod collections;
 /// Useful for SHA hashes ([u8; 32]), fixed-size patterns, etc.
 impl<T, const N: usize> TryFromSexp for [T; N]
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpError;
 
@@ -765,7 +765,7 @@ use std::collections::VecDeque;
 /// Blanket impl: Convert R vector to `VecDeque<T>` where T: RNativeType.
 impl<T> TryFromSexp for VecDeque<T>
 where
-    T: crate::sys::RNativeType + Copy,
+    T: crate::RNativeType + Copy,
 {
     type Error = SexpTypeError;
 
@@ -790,7 +790,7 @@ use std::collections::BinaryHeap;
 /// Creates a binary heap from the R vector elements.
 impl<T> TryFromSexp for BinaryHeap<T>
 where
-    T: crate::sys::RNativeType + Copy + Ord,
+    T: crate::RNativeType + Copy + Ord,
 {
     type Error = SexpTypeError;
 
@@ -934,7 +934,7 @@ where
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+            let elem = sexp.vector_elt(i as crate::R_xlen_t);
             let inner: Vec<T> = Vec::<T>::try_from_sexp(elem).map_err(Into::into)?;
             result.push(inner);
         }
@@ -956,7 +956,7 @@ where
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+            let elem = sexp.vector_elt(i as crate::R_xlen_t);
             let inner: Vec<T> =
                 unsafe { Vec::<T>::try_from_sexp_unchecked(elem).map_err(Into::into)? };
             result.push(inner);
@@ -1299,7 +1299,7 @@ mod connections_from_r {
 
     use crate::connection::{RNullConnection, RStderr, RStdin, RStdout, Rconn};
     use crate::from_r::{SexpError, TryFromSexp};
-    use crate::sys::{Rboolean, SEXP};
+    use crate::{Rboolean, SEXP};
 
     // Read the connection description and class fields from an Rconn handle.
     //
@@ -1446,8 +1446,9 @@ mod connections_from_r {
 #[cfg(feature = "connections")]
 mod txt_progress_bar_from_r {
     use crate::from_r::{SexpError, TryFromSexp};
-    use crate::sys::{R_PreserveObject, SEXP, SexpExt};
+    use crate::sys::R_PreserveObject;
     use crate::txt_progress_bar::RTxtProgressBar;
+    use crate::{SEXP, SexpExt};
 
     impl TryFromSexp for RTxtProgressBar {
         type Error = SexpError;
@@ -1483,18 +1484,16 @@ macro_rules! impl_option_try_from_sexp {
         impl $crate::from_r::TryFromSexp for Option<$t> {
             type Error = $crate::from_r::SexpError;
 
-            fn try_from_sexp(sexp: $crate::sys::SEXP) -> Result<Self, Self::Error> {
-                use $crate::sys::{SEXPTYPE, SexpExt};
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                use $crate::{SEXPTYPE, SexpExt};
                 if sexp.type_of() == SEXPTYPE::NILSXP {
                     return Ok(None);
                 }
                 <$t as $crate::from_r::TryFromSexp>::try_from_sexp(sexp).map(Some)
             }
 
-            unsafe fn try_from_sexp_unchecked(
-                sexp: $crate::sys::SEXP,
-            ) -> Result<Self, Self::Error> {
-                use $crate::sys::{SEXPTYPE, SexpExt};
+            unsafe fn try_from_sexp_unchecked(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                use $crate::{SEXPTYPE, SexpExt};
                 if sexp.type_of() == SEXPTYPE::NILSXP {
                     return Ok(None);
                 }
@@ -1515,9 +1514,9 @@ macro_rules! impl_vec_try_from_sexp_list {
         impl $crate::from_r::TryFromSexp for Vec<$t> {
             type Error = $crate::from_r::SexpError;
 
-            fn try_from_sexp(sexp: $crate::sys::SEXP) -> Result<Self, Self::Error> {
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 use $crate::from_r::SexpTypeError;
-                use $crate::sys::{SEXPTYPE, SexpExt};
+                use $crate::{SEXPTYPE, SexpExt};
 
                 let actual = sexp.type_of();
                 if actual != SEXPTYPE::VECSXP {
@@ -1531,17 +1530,15 @@ macro_rules! impl_vec_try_from_sexp_list {
                 let len = sexp.len();
                 let mut result = Vec::with_capacity(len);
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as $crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as $crate::R_xlen_t);
                     result.push(<$t as $crate::from_r::TryFromSexp>::try_from_sexp(elem)?);
                 }
                 Ok(result)
             }
 
-            unsafe fn try_from_sexp_unchecked(
-                sexp: $crate::sys::SEXP,
-            ) -> Result<Self, Self::Error> {
+            unsafe fn try_from_sexp_unchecked(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 use $crate::from_r::SexpTypeError;
-                use $crate::sys::{SEXPTYPE, SexpExt};
+                use $crate::{SEXPTYPE, SexpExt};
 
                 let actual = sexp.type_of();
                 if actual != SEXPTYPE::VECSXP {
@@ -1555,7 +1552,7 @@ macro_rules! impl_vec_try_from_sexp_list {
                 let len = unsafe { sexp.len_unchecked() };
                 let mut result = Vec::with_capacity(len);
                 for i in 0..len {
-                    let elem = unsafe { sexp.vector_elt_unchecked(i as $crate::sys::R_xlen_t) };
+                    let elem = unsafe { sexp.vector_elt_unchecked(i as $crate::R_xlen_t) };
                     result.push(unsafe {
                         <$t as $crate::from_r::TryFromSexp>::try_from_sexp_unchecked(elem)?
                     });
@@ -1575,9 +1572,9 @@ macro_rules! impl_vec_option_try_from_sexp_list {
         impl $crate::from_r::TryFromSexp for Vec<Option<$t>> {
             type Error = $crate::from_r::SexpError;
 
-            fn try_from_sexp(sexp: $crate::sys::SEXP) -> Result<Self, Self::Error> {
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 use $crate::from_r::SexpTypeError;
-                use $crate::sys::{SEXPTYPE, SexpExt};
+                use $crate::{SEXPTYPE, SexpExt};
 
                 let actual = sexp.type_of();
                 if actual != SEXPTYPE::VECSXP {
@@ -1591,8 +1588,8 @@ macro_rules! impl_vec_option_try_from_sexp_list {
                 let len = sexp.len();
                 let mut result = Vec::with_capacity(len);
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as $crate::sys::R_xlen_t);
-                    if elem == $crate::sys::SEXP::nil() {
+                    let elem = sexp.vector_elt(i as $crate::R_xlen_t);
+                    if elem == $crate::SEXP::nil() {
                         result.push(None);
                     } else {
                         result.push(Some(<$t as $crate::from_r::TryFromSexp>::try_from_sexp(
@@ -1603,11 +1600,9 @@ macro_rules! impl_vec_option_try_from_sexp_list {
                 Ok(result)
             }
 
-            unsafe fn try_from_sexp_unchecked(
-                sexp: $crate::sys::SEXP,
-            ) -> Result<Self, Self::Error> {
+            unsafe fn try_from_sexp_unchecked(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 use $crate::from_r::SexpTypeError;
-                use $crate::sys::{SEXPTYPE, SexpExt};
+                use $crate::{SEXPTYPE, SexpExt};
 
                 let actual = sexp.type_of();
                 if actual != SEXPTYPE::VECSXP {
@@ -1621,8 +1616,8 @@ macro_rules! impl_vec_option_try_from_sexp_list {
                 let len = unsafe { sexp.len_unchecked() };
                 let mut result = Vec::with_capacity(len);
                 for i in 0..len {
-                    let elem = unsafe { sexp.vector_elt_unchecked(i as $crate::sys::R_xlen_t) };
-                    if elem == $crate::sys::SEXP::nil() {
+                    let elem = unsafe { sexp.vector_elt_unchecked(i as $crate::R_xlen_t) };
+                    if elem == $crate::SEXP::nil() {
                         result.push(None);
                     } else {
                         result.push(Some(unsafe {

--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -22,7 +22,7 @@
 use crate::altrep_traits::NA_INTEGER;
 use crate::coerce::TryCoerce;
 use crate::from_r::{SexpError, TryFromSexp, is_na_real};
-use crate::sys::{RLogical, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, SEXP, SEXPTYPE, SexpExt};
 
 #[inline]
 pub(crate) fn coerce_value<R, T>(value: R) -> Result<T, SexpError>

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str};
-use crate::sys::{RLogical, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, SEXP, SEXPTYPE, SexpExt};
 
 macro_rules! impl_map_try_from_sexp {
     ($(#[$meta:meta])* $map_ty:ident, $create:expr) => {
@@ -101,7 +101,7 @@ where
 
     for i in 0..len {
         let key = if has_names {
-            let charsxp = names.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = names.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 String::new()
             } else {
@@ -117,7 +117,7 @@ where
             return Err(SexpError::DuplicateName(key));
         }
 
-        let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+        let elem = sexp.vector_elt(i as crate::R_xlen_t);
         let value = V::try_from_sexp(elem).map_err(|e| e.into())?;
         map.extend(std::iter::once((key, value)));
     }
@@ -170,7 +170,7 @@ where
     let mut result = Vec::with_capacity(len);
 
     for i in 0..len {
-        let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+        let elem = sexp.vector_elt(i as crate::R_xlen_t);
         let map = M::try_from_sexp(elem).map_err(Into::into)?;
         result.push(map);
     }
@@ -214,7 +214,7 @@ impl_vec_try_from_sexp_native!(i32);
 impl_vec_try_from_sexp_native!(f64);
 impl_vec_try_from_sexp_native!(u8);
 impl_vec_try_from_sexp_native!(RLogical);
-impl_vec_try_from_sexp_native!(crate::sys::Rcomplex);
+impl_vec_try_from_sexp_native!(crate::Rcomplex);
 
 macro_rules! impl_boxed_slice_try_from_sexp_native {
     ($t:ty) => {
@@ -233,5 +233,5 @@ impl_boxed_slice_try_from_sexp_native!(i32);
 impl_boxed_slice_try_from_sexp_native!(f64);
 impl_boxed_slice_try_from_sexp_native!(u8);
 impl_boxed_slice_try_from_sexp_native!(RLogical);
-impl_boxed_slice_try_from_sexp_native!(crate::sys::Rcomplex);
+impl_boxed_slice_try_from_sexp_native!(crate::Rcomplex);
 // endregion

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Blanket impl: Convert R vector to `Cow<'static, [T]>` where T: RNativeType.
 ///
@@ -33,7 +33,7 @@ use crate::sys::{SEXP, SEXPTYPE, SexpExt};
 /// R's protection stack guards this SEXP.
 impl<T> TryFromSexp for Cow<'static, [T]>
 where
-    T: crate::sys::RNativeType + Copy + Clone,
+    T: crate::RNativeType + Copy + Clone,
 {
     type Error = SexpTypeError;
 
@@ -98,7 +98,7 @@ impl TryFromSexp for Vec<Cow<'static, str>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() || charsxp == SEXP::blank_string() {
                 result.push(Cow::Borrowed(""));
             } else {
@@ -130,7 +130,7 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
@@ -190,7 +190,7 @@ impl TryFromSexp for Vec<String> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             let s = if charsxp == SEXP::na_string() {
                 String::new()
             } else {
@@ -235,7 +235,7 @@ impl TryFromSexp for Vec<&'static str> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 result.push("");
                 continue;
@@ -269,7 +269,7 @@ impl TryFromSexp for Vec<Option<&'static str>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 result.push(None);
                 continue;

--- a/miniextendr-api/src/from_r/logical.rs
+++ b/miniextendr-api/src/from_r/logical.rs
@@ -21,7 +21,7 @@
 //! [`crate::into_r`].
 
 use crate::from_r::{SexpError, SexpNaError, TryFromSexp, is_na_real};
-use crate::sys::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 
 impl TryFromSexp for Rboolean {
     type Error = SexpError;
@@ -241,7 +241,7 @@ impl TryFromSexp for Option<u8> {
     }
 }
 
-impl TryFromSexp for Option<crate::sys::Rcomplex> {
+impl TryFromSexp for Option<crate::Rcomplex> {
     type Error = SexpError;
 
     #[inline]
@@ -251,7 +251,7 @@ impl TryFromSexp for Option<crate::sys::Rcomplex> {
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
-        let value: crate::sys::Rcomplex = TryFromSexp::try_from_sexp(sexp)?;
+        let value: crate::Rcomplex = TryFromSexp::try_from_sexp(sexp)?;
         let na_bits = NA_REAL.to_bits();
         if value.r.to_bits() == na_bits || value.i.to_bits() == na_bits {
             Ok(None)
@@ -267,7 +267,7 @@ impl TryFromSexp for Option<crate::sys::Rcomplex> {
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
-        let value: crate::sys::Rcomplex = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
+        let value: crate::Rcomplex = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
         let na_bits = NA_REAL.to_bits();
         if value.r.to_bits() == na_bits || value.i.to_bits() == na_bits {
             Ok(None)

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -21,7 +21,7 @@ use crate::from_r::{
     SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str, coerce_value, is_na_real,
     r_slice,
 };
-use crate::sys::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 
 /// Macro for NA-aware `R vector → Vec<Option<T>>` conversions.
 macro_rules! impl_vec_option_try_from_sexp {
@@ -259,7 +259,7 @@ impl TryFromSexp for Vec<Option<String>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
 
             if charsxp == SEXP::na_string() {
                 result.push(None);

--- a/miniextendr-api/src/from_r/references.rs
+++ b/miniextendr-api/src/from_r/references.rs
@@ -21,7 +21,7 @@
 //! storage); see [`crate::into_r`] for the owned equivalents.
 
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
-use crate::sys::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 macro_rules! impl_ref_conversions_for {
     ($t:ty) => {
@@ -192,7 +192,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut out = Vec::with_capacity(len);
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     let value: &'static $t = TryFromSexp::try_from_sexp(elem)?;
                     out.push(value);
                 }
@@ -218,7 +218,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut out = Vec::with_capacity(len);
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     if elem.type_of() == SEXPTYPE::NILSXP {
                         out.push(None);
                     } else {
@@ -249,7 +249,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut ptrs: Vec<*mut $t> = Vec::new();
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     let value: &'static mut $t = TryFromSexp::try_from_sexp(elem)?;
                     let ptr = std::ptr::from_mut(value);
                     if ptrs.iter().any(|&p| p == ptr) {
@@ -284,7 +284,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut ptrs: Vec<*mut $t> = Vec::new();
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     if elem.type_of() == SEXPTYPE::NILSXP {
                         out.push(None);
                         continue;
@@ -322,7 +322,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut out = Vec::with_capacity(len);
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     let slice: &'static [$t] =
                         TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
                     out.push(slice);
@@ -349,7 +349,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut out = Vec::with_capacity(len);
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     if elem.type_of() == SEXPTYPE::NILSXP {
                         out.push(None);
                     } else {
@@ -381,7 +381,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut ptrs: Vec<*mut $t> = Vec::new();
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     let slice: &'static mut [$t] =
                         TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
                     if !slice.is_empty() {
@@ -419,7 +419,7 @@ macro_rules! impl_ref_conversions_for {
                 let mut ptrs: Vec<*mut $t> = Vec::new();
 
                 for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::sys::R_xlen_t);
+                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
                     if elem.type_of() == SEXPTYPE::NILSXP {
                         out.push(None);
                         continue;
@@ -449,5 +449,5 @@ impl_ref_conversions_for!(i32);
 impl_ref_conversions_for!(f64);
 impl_ref_conversions_for!(u8);
 impl_ref_conversions_for!(RLogical);
-impl_ref_conversions_for!(crate::sys::Rcomplex);
+impl_ref_conversions_for!(crate::Rcomplex);
 // endregion

--- a/miniextendr-api/src/from_r/strings.rs
+++ b/miniextendr-api/src/from_r/strings.rs
@@ -25,7 +25,7 @@ use crate::from_r::{
     SexpError, SexpLengthError, SexpTypeError, TryFromSexp, charsxp_to_str,
     charsxp_to_str_unchecked,
 };
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Convert R character vector (STRSXP) to Rust &str.
 ///

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -165,9 +165,10 @@
 //! This avoids the LIFO drop-order pitfall of reassigning `OwnedProtect` guards.
 
 use crate::sys::{
-    R_NewEnv, R_ProtectWithIndex, R_Reprotect, R_xlen_t, RNativeType, Rf_allocList, Rf_allocMatrix,
-    Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt,
+    R_NewEnv, R_ProtectWithIndex, R_Reprotect, Rf_allocList, Rf_allocMatrix, Rf_allocVector,
+    Rf_protect, Rf_unprotect,
 };
+use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use core::cell::Cell;
 use core::marker::PhantomData;
 use std::rc::Rc;
@@ -601,7 +602,7 @@ impl ProtectScope {
     ///
     /// Must be called from the R main thread.
     #[inline]
-    pub unsafe fn scalar_complex<'a>(&'a self, x: crate::sys::Rcomplex) -> Root<'a> {
+    pub unsafe fn scalar_complex<'a>(&'a self, x: crate::Rcomplex) -> Root<'a> {
         unsafe { self.protect(SEXP::scalar_complex(x)) }
     }
 
@@ -680,9 +681,9 @@ impl ProtectScope {
             self.protect(R_NewEnv(
                 parent,
                 if hash {
-                    crate::sys::Rboolean::TRUE
+                    crate::Rboolean::TRUE
                 } else {
-                    crate::sys::Rboolean::FALSE
+                    crate::Rboolean::FALSE
                 },
                 size,
             ))
@@ -726,8 +727,8 @@ impl ProtectScope {
     /// | `i32` | `INTSXP` |
     /// | `f64` | `REALSXP` |
     /// | `u8` | `RAWSXP` |
-    /// | [`RLogical`](crate::sys::RLogical) | `LGLSXP` |
-    /// | [`Rcomplex`](crate::sys::Rcomplex) | `CPLXSXP` |
+    /// | [`RLogical`](crate::RLogical) | `LGLSXP` |
+    /// | [`Rcomplex`](crate::Rcomplex) | `CPLXSXP` |
     ///
     /// # Safety
     ///
@@ -1502,7 +1503,7 @@ mod tests {
         // This should panic because there's no active scope
         // Note: Can't actually call protect without R, but we test the panic message
         unsafe {
-            let _ = tls::protect(crate::sys::SEXP(std::ptr::null_mut()));
+            let _ = tls::protect(crate::SEXP(std::ptr::null_mut()));
         }
     }
     // endregion
@@ -1562,7 +1563,7 @@ mod tests {
         // never dereference the SEXP itself, only the already-constructed inner)
         let v = vec![1i32, 2, 3];
         let p = unsafe {
-            Protected::<'static, Vec<i32>>::from_trusted(crate::sys::SEXP(core::ptr::null_mut()), v)
+            Protected::<'static, Vec<i32>>::from_trusted(crate::SEXP(core::ptr::null_mut()), v)
         };
         assert_eq!(p.get(), &[1, 2, 3]);
     }
@@ -1572,7 +1573,7 @@ mod tests {
     fn protected_deref_reaches_inner() {
         let v = vec![10i32, 20];
         let p = unsafe {
-            Protected::<'static, Vec<i32>>::from_trusted(crate::sys::SEXP(core::ptr::null_mut()), v)
+            Protected::<'static, Vec<i32>>::from_trusted(crate::SEXP(core::ptr::null_mut()), v)
         };
         // Deref should let us call Vec methods directly.
         assert_eq!(p.len(), 2);
@@ -1583,7 +1584,7 @@ mod tests {
     fn protected_into_inner_moves_value() {
         let v = vec![42i32];
         let p = unsafe {
-            Protected::<'static, Vec<i32>>::from_trusted(crate::sys::SEXP(core::ptr::null_mut()), v)
+            Protected::<'static, Vec<i32>>::from_trusted(crate::SEXP(core::ptr::null_mut()), v)
         };
         let got = p.into_inner();
         assert_eq!(got, [42]);
@@ -1594,7 +1595,7 @@ mod tests {
     fn protected_from_trusted_does_not_hold_protect() {
         let v: Vec<u8> = vec![];
         let p = unsafe {
-            Protected::<'static, Vec<u8>>::from_trusted(crate::sys::SEXP(core::ptr::null_mut()), v)
+            Protected::<'static, Vec<u8>>::from_trusted(crate::SEXP(core::ptr::null_mut()), v)
         };
         // This test uses `from_trusted` to avoid touching the protect stack;
         // `Protected::new` would require an initialized R runtime (see
@@ -1607,7 +1608,7 @@ mod tests {
     #[test]
     fn protected_from_trusted_compile_check() {
         let p = unsafe {
-            Protected::<'static, i32>::from_trusted(crate::sys::SEXP(core::ptr::null_mut()), 99)
+            Protected::<'static, i32>::from_trusted(crate::SEXP(core::ptr::null_mut()), 99)
         };
         assert_eq!(*p, 99);
     }

--- a/miniextendr-api/src/gc_protect/tls.rs
+++ b/miniextendr-api/src/gc_protect/tls.rs
@@ -27,7 +27,7 @@
 //! }
 //! ```
 use super::ProtectScope;
-use crate::sys::SEXP;
+use crate::SEXP;
 use std::cell::RefCell;
 use std::ptr::NonNull;
 

--- a/miniextendr-api/src/init.rs
+++ b/miniextendr-api/src/init.rs
@@ -15,7 +15,8 @@
 //! This expands to an `extern "C-unwind" fn R_init_mypkg(dll)` that calls
 //! [`package_init`](crate::init::package_init) with the appropriate package name.
 
-use crate::sys::{DllInfo, R_forceSymbols, R_useDynamicSymbols, Rboolean};
+use crate::Rboolean;
+use crate::sys::{DllInfo, R_forceSymbols, R_useDynamicSymbols};
 use std::ffi::CStr;
 
 /// Initialize a miniextendr R package.

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -44,9 +44,9 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
+use crate::SexpExt;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use crate::gc_protect::OwnedProtect;
-use crate::sys::SexpExt;
 
 /// Trait for converting Rust types to R SEXP values.
 ///
@@ -84,14 +84,14 @@ pub trait IntoR {
     /// Try to convert this value to an R SEXP.
     ///
     /// This is the **required** method. All other methods delegate to it.
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error>;
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error>;
 
     /// Try to convert to SEXP without thread safety checks.
     ///
     /// # Safety
     ///
     /// Must be called from R's main thread.
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error>
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error>
     where
         Self: Sized,
     {
@@ -101,7 +101,7 @@ pub trait IntoR {
     /// Convert this value to an R SEXP, panicking on error.
     ///
     /// In debug builds, asserts that we're on R's main thread.
-    fn into_sexp(self) -> crate::sys::SEXP
+    fn into_sexp(self) -> crate::SEXP
     where
         Self: Sized,
     {
@@ -118,7 +118,7 @@ pub trait IntoR {
     /// Must be called from R's main thread. In debug builds, this still
     /// calls the checked version by default, but implementations may
     /// skip thread assertions for performance.
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP
     where
         Self: Sized,
     {
@@ -127,41 +127,41 @@ pub trait IntoR {
     }
 }
 
-impl IntoR for crate::sys::SEXP {
+impl IntoR for crate::SEXP {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self)
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self)
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self
     }
 }
 
-impl IntoR for crate::worker::Sendable<crate::sys::SEXP> {
+impl IntoR for crate::worker::Sendable<crate::SEXP> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.0)
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.0)
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.0
     }
 }
 
-impl From<crate::worker::Sendable<crate::sys::SEXP>> for crate::sys::SEXP {
+impl From<crate::worker::Sendable<crate::SEXP>> for crate::SEXP {
     #[inline]
-    fn from(s: crate::worker::Sendable<crate::sys::SEXP>) -> Self {
+    fn from(s: crate::worker::Sendable<crate::SEXP>) -> Self {
         s.0
     }
 }
@@ -169,32 +169,32 @@ impl From<crate::worker::Sendable<crate::sys::SEXP>> for crate::sys::SEXP {
 impl IntoR for () {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
-        Ok(crate::sys::SEXP::nil())
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(crate::SEXP::nil())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
-        crate::sys::SEXP::nil()
+    fn into_sexp(self) -> crate::SEXP {
+        crate::SEXP::nil()
     }
 }
 
 impl IntoR for std::convert::Infallible {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
-        Ok(crate::sys::SEXP::nil())
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(crate::SEXP::nil())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
-        crate::sys::SEXP::nil()
+    fn into_sexp(self) -> crate::SEXP {
+        crate::SEXP::nil()
     }
 }
 
@@ -204,20 +204,20 @@ macro_rules! impl_scalar_into_r {
         impl IntoR for $ty {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
-                Ok(crate::sys::SEXP::$checked(self))
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+                Ok(crate::SEXP::$checked(self))
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
-                crate::sys::SEXP::$checked(self)
+            fn into_sexp(self) -> crate::SEXP {
+                crate::SEXP::$checked(self)
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
-                unsafe { crate::sys::SEXP::$unchecked(self) }
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
+                unsafe { crate::SEXP::$unchecked(self) }
             }
         }
     };
@@ -226,38 +226,34 @@ macro_rules! impl_scalar_into_r {
 impl_scalar_into_r!(i32, scalar_integer, scalar_integer_unchecked);
 impl_scalar_into_r!(f64, scalar_real, scalar_real_unchecked);
 impl_scalar_into_r!(u8, scalar_raw, scalar_raw_unchecked);
-impl_scalar_into_r!(
-    crate::sys::Rcomplex,
-    scalar_complex,
-    scalar_complex_unchecked
-);
+impl_scalar_into_r!(crate::Rcomplex, scalar_complex, scalar_complex_unchecked);
 
-impl IntoR for Option<crate::sys::Rcomplex> {
+impl IntoR for Option<crate::Rcomplex> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::scalar_complex(crate::sys::Rcomplex {
+            None => crate::SEXP::scalar_complex(crate::Rcomplex {
                 r: NA_REAL,
                 i: NA_REAL,
             }),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
             None => unsafe {
-                crate::sys::SEXP::scalar_complex_unchecked(crate::sys::Rcomplex {
+                crate::SEXP::scalar_complex_unchecked(crate::Rcomplex {
                     r: NA_REAL,
                     i: NA_REAL,
                 })
@@ -272,19 +268,19 @@ macro_rules! impl_into_r_via_coerce {
         impl IntoR for $from {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(crate::coerce::Coerce::<$to>::coerce(self).into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 crate::coerce::Coerce::<$to>::coerce(self).into_sexp()
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe { crate::coerce::Coerce::<$to>::coerce(self).into_sexp_unchecked() }
             }
         }
@@ -318,19 +314,19 @@ macro_rules! impl_into_r_vec_native {
         impl IntoR for Vec<$t> {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { vec_to_sexp(&self) })
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe { vec_to_sexp(&self) }
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe { vec_to_sexp_unchecked(&self) }
             }
         }
@@ -340,51 +336,51 @@ macro_rules! impl_into_r_vec_native {
 impl_into_r_vec_native!(i32);
 impl_into_r_vec_native!(f64);
 impl_into_r_vec_native!(u8);
-impl_into_r_vec_native!(crate::sys::RLogical);
-impl_into_r_vec_native!(crate::sys::Rcomplex);
+impl_into_r_vec_native!(crate::RLogical);
+impl_into_r_vec_native!(crate::Rcomplex);
 
 impl<T> IntoR for &[T]
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { vec_to_sexp(self) })
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe { vec_to_sexp(self) }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { vec_to_sexp_unchecked(self) }
     }
 }
 
 impl<T> IntoR for Box<[T]>
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { vec_to_sexp(&self) })
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { vec_to_sexp_unchecked(&self) })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe { vec_to_sexp(&self) }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { vec_to_sexp_unchecked(&self) }
     }
 }
@@ -404,11 +400,11 @@ where
 ///
 /// Must be called from R's main thread.
 #[inline]
-pub(crate) unsafe fn alloc_r_vector<T: crate::sys::RNativeType>(
+pub(crate) unsafe fn alloc_r_vector<T: crate::RNativeType>(
     n: usize,
-) -> (crate::sys::SEXP, &'static mut [T]) {
+) -> (crate::SEXP, &'static mut [T]) {
     unsafe {
-        let sexp = crate::sys::Rf_allocVector(T::SEXP_TYPE, n as crate::sys::R_xlen_t);
+        let sexp = crate::sys::Rf_allocVector(T::SEXP_TYPE, n as crate::R_xlen_t);
         let slice = crate::from_r::r_slice_mut(T::dataptr_mut(sexp), n);
         (sexp, slice)
     }
@@ -420,11 +416,11 @@ pub(crate) unsafe fn alloc_r_vector<T: crate::sys::RNativeType>(
 ///
 /// Must be called from R's main thread.
 #[inline]
-pub(crate) unsafe fn alloc_r_vector_unchecked<T: crate::sys::RNativeType>(
+pub(crate) unsafe fn alloc_r_vector_unchecked<T: crate::RNativeType>(
     n: usize,
-) -> (crate::sys::SEXP, &'static mut [T]) {
+) -> (crate::SEXP, &'static mut [T]) {
     unsafe {
-        let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, n as crate::sys::R_xlen_t);
+        let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, n as crate::R_xlen_t);
         let slice = crate::from_r::r_slice_mut(T::dataptr_mut(sexp), n);
         (sexp, slice)
     }
@@ -434,7 +430,7 @@ pub(crate) unsafe fn alloc_r_vector_unchecked<T: crate::sys::RNativeType>(
 
 /// Convert a slice to an R vector (checked) using `copy_from_slice`.
 #[inline]
-unsafe fn vec_to_sexp<T: crate::sys::RNativeType>(slice: &[T]) -> crate::sys::SEXP {
+unsafe fn vec_to_sexp<T: crate::RNativeType>(slice: &[T]) -> crate::SEXP {
     unsafe {
         let (sexp, dst) = alloc_r_vector::<T>(slice.len());
         dst.copy_from_slice(slice);
@@ -444,7 +440,7 @@ unsafe fn vec_to_sexp<T: crate::sys::RNativeType>(slice: &[T]) -> crate::sys::SE
 
 /// Convert a slice to an R vector (unchecked) using `copy_from_slice`.
 #[inline]
-unsafe fn vec_to_sexp_unchecked<T: crate::sys::RNativeType>(slice: &[T]) -> crate::sys::SEXP {
+unsafe fn vec_to_sexp_unchecked<T: crate::RNativeType>(slice: &[T]) -> crate::SEXP {
     unsafe {
         let (sexp, dst) = alloc_r_vector_unchecked::<T>(slice.len());
         dst.copy_from_slice(slice);
@@ -463,15 +459,15 @@ macro_rules! impl_vec_coerce_into_r {
         impl IntoR for Vec<$from> {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector::<$to>(self.len());
                     for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
@@ -481,7 +477,7 @@ macro_rules! impl_vec_coerce_into_r {
                 }
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector_unchecked::<$to>(self.len());
                     for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
@@ -495,15 +491,15 @@ macro_rules! impl_vec_coerce_into_r {
         impl IntoR for &[$from] {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector::<$to>(self.len());
                     for (slot, &val) in dst.iter_mut().zip(self.iter()) {
@@ -513,7 +509,7 @@ macro_rules! impl_vec_coerce_into_r {
                 }
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector_unchecked::<$to>(self.len());
                     for (slot, &val) in dst.iter_mut().zip(self.iter()) {
@@ -541,13 +537,13 @@ macro_rules! impl_vec_smart_i64_into_r {
     ($t:ty, $fits_i32:expr) => {
         impl IntoR for Vec<$t> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     if self.iter().all(|&x| $fits_i32(x)) {
                         let (sexp, dst) = alloc_r_vector::<i32>(self.len());
@@ -566,7 +562,7 @@ macro_rules! impl_vec_smart_i64_into_r {
                     }
                 }
             }
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     if self.iter().all(|&x| $fits_i32(x)) {
                         let (sexp, dst) = alloc_r_vector_unchecked::<i32>(self.len());
@@ -610,22 +606,22 @@ pub use result::*;
 ///
 /// Enables direct conversion of fixed-size arrays to R vectors.
 /// Useful for SHA hashes, fixed-size byte patterns, etc.
-impl<T: crate::sys::RNativeType, const N: usize> IntoR for [T; N] {
+impl<T: crate::RNativeType, const N: usize> IntoR for [T; N] {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.as_slice().into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_slice().into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.as_slice().into_sexp_unchecked() }
     }
 }
@@ -638,20 +634,20 @@ use std::collections::VecDeque;
 /// Convert `VecDeque<T>` to R vector where T: RNativeType.
 impl<T> IntoR for VecDeque<T>
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         vec.into_sexp()
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         unsafe { vec.into_sexp_unchecked() }
     }
@@ -668,19 +664,19 @@ use std::collections::BinaryHeap;
 /// Elements are returned in arbitrary order, not sorted.
 impl<T> IntoR for BinaryHeap<T>
 where
-    T: crate::sys::RNativeType + Ord,
+    T: crate::RNativeType + Ord,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_vec().into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.into_vec().into_sexp()
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.into_vec().into_sexp_unchecked() }
     }
 }
@@ -693,9 +689,7 @@ use std::borrow::Cow;
 /// Try SEXP pointer recovery for a borrowed Cow slice.
 #[inline]
 #[allow(clippy::ptr_arg)] // Need &Cow to inspect Borrowed vs Owned variant
-fn try_recover_cow_slice<T: crate::sys::RNativeType>(
-    cow: &Cow<'_, [T]>,
-) -> Option<crate::sys::SEXP> {
+fn try_recover_cow_slice<T: crate::RNativeType>(cow: &Cow<'_, [T]>) -> Option<crate::SEXP> {
     if let Cow::Borrowed(slice) = cow {
         unsafe {
             crate::r_memory::try_recover_r_sexp(
@@ -717,22 +711,22 @@ fn try_recover_cow_slice<T: crate::sys::RNativeType>(
 /// falls through to the standard copy path.
 impl<T> IntoR for Cow<'_, [T]>
 where
-    T: crate::sys::RNativeType + Clone,
+    T: crate::RNativeType + Clone,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         if let Some(sexp) = try_recover_cow_slice(&self) {
             return sexp;
         }
         self.as_ref().into_sexp()
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         if let Some(sexp) = try_recover_cow_slice(&self) {
             return sexp;
         }
@@ -744,19 +738,19 @@ where
 impl IntoR for Cow<'_, str> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         self.as_ref().try_into_sexp()
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_ref().into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.as_ref().into_sexp_unchecked() }
     }
 }
@@ -794,19 +788,19 @@ macro_rules! impl_lossy_string_into_r {
         impl IntoR for $owned_ty {
             type Error = crate::into_r_error::IntoRError;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 self.to_string_lossy().into_owned().try_into_sexp()
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 self.to_string_lossy().into_owned().into_sexp()
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe { self.to_string_lossy().into_owned().into_sexp_unchecked() }
             }
         }
@@ -815,19 +809,19 @@ macro_rules! impl_lossy_string_into_r {
         impl IntoR for $ref_ty {
             type Error = crate::into_r_error::IntoRError;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 self.to_string_lossy().into_owned().try_into_sexp()
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 self.to_string_lossy().into_owned().into_sexp()
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe { self.to_string_lossy().into_owned().into_sexp_unchecked() }
             }
         }
@@ -836,19 +830,19 @@ macro_rules! impl_lossy_string_into_r {
         impl IntoR for Option<$owned_ty> {
             type Error = crate::into_r_error::IntoRError;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 self.map(|v| v.to_string_lossy().into_owned()).try_into_sexp()
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 self.map(|v| v.to_string_lossy().into_owned()).into_sexp()
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     self.map(|v| v.to_string_lossy().into_owned())
                         .into_sexp_unchecked()
@@ -859,20 +853,20 @@ macro_rules! impl_lossy_string_into_r {
         $(#[$vec_meta])*
         impl IntoR for Vec<$owned_ty> {
             type Error = crate::into_r_error::IntoRError;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let strings: Vec<String> = self
                     .into_iter()
                     .map(|v| v.to_string_lossy().into_owned())
                     .collect();
                 strings.into_sexp()
             }
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 let strings: Vec<String> = self
                     .into_iter()
                     .map(|v| v.to_string_lossy().into_owned())
@@ -884,20 +878,20 @@ macro_rules! impl_lossy_string_into_r {
         $(#[$vec_option_meta])*
         impl IntoR for Vec<Option<$owned_ty>> {
             type Error = crate::into_r_error::IntoRError;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let strings: Vec<Option<String>> = self
                     .into_iter()
                     .map(|opt| opt.map(|v| v.to_string_lossy().into_owned()))
                     .collect();
                 strings.into_sexp()
             }
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 let strings: Vec<Option<String>> = self
                     .into_iter()
                     .map(|opt| opt.map(|v| v.to_string_lossy().into_owned()))
@@ -948,13 +942,13 @@ macro_rules! impl_set_coerce_into_r {
     ($from:ty) => {
         impl IntoR for HashSet<$from> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let vec: Vec<i32> = self.into_iter().map(|x| i32::from(x)).collect();
                 vec.into_sexp()
             }
@@ -962,13 +956,13 @@ macro_rules! impl_set_coerce_into_r {
 
         impl IntoR for BTreeSet<$from> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let vec: Vec<i32> = self.into_iter().map(|x| i32::from(x)).collect();
                 vec.into_sexp()
             }
@@ -988,28 +982,28 @@ impl_set_coerce_into_r!(u16);
 // This differs from Option<scalar> which returns NA for None.
 
 /// Convert `Option<Vec<T>>` to R: Some(vec) → vector, None → NULL.
-impl<T: crate::sys::RNativeType> IntoR for Option<Vec<T>> {
+impl<T: crate::RNativeType> IntoR for Option<Vec<T>> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -1018,25 +1012,25 @@ impl<T: crate::sys::RNativeType> IntoR for Option<Vec<T>> {
 impl IntoR for Option<Vec<String>> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -1045,25 +1039,25 @@ impl IntoR for Option<Vec<String>> {
 impl<V: IntoR> IntoR for Option<HashMap<String, V>> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -1072,79 +1066,79 @@ impl<V: IntoR> IntoR for Option<HashMap<String, V>> {
 impl<V: IntoR> IntoR for Option<BTreeMap<String, V>> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
 
 /// Convert `Option<HashSet<T>>` to R: Some(set) -> vector, None -> NULL.
-impl<T: crate::sys::RNativeType + Eq + Hash> IntoR for Option<HashSet<T>> {
+impl<T: crate::RNativeType + Eq + Hash> IntoR for Option<HashSet<T>> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
 
 /// Convert `Option<BTreeSet<T>>` to R: Some(set) -> vector, None -> NULL.
-impl<T: crate::sys::RNativeType + Ord> IntoR for Option<BTreeSet<T>> {
+impl<T: crate::RNativeType + Ord> IntoR for Option<BTreeSet<T>> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -1155,25 +1149,25 @@ macro_rules! impl_option_collection_into_r {
         impl IntoR for Option<$ty> {
             type Error = crate::into_r_error::IntoRError;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 match self {
                     Some(v) => v.into_sexp(),
-                    None => crate::sys::SEXP::nil(),
+                    None => crate::SEXP::nil(),
                 }
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 match self {
                     Some(v) => unsafe { v.into_sexp_unchecked() },
-                    None => crate::sys::SEXP::nil(),
+                    None => crate::SEXP::nil(),
                 }
             }
         }
@@ -1190,17 +1184,15 @@ impl_option_collection_into_r!(
 );
 
 /// Helper: allocate STRSXP and fill from a string iterator (checked).
-pub(crate) fn str_iter_to_strsxp<'a>(
-    iter: impl ExactSizeIterator<Item = &'a str>,
-) -> crate::sys::SEXP {
+pub(crate) fn str_iter_to_strsxp<'a>(iter: impl ExactSizeIterator<Item = &'a str>) -> crate::SEXP {
     unsafe {
-        let n: crate::sys::R_xlen_t = iter
+        let n: crate::R_xlen_t = iter
             .len()
             .try_into()
             .expect("string vec length exceeds isize::MAX");
-        let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, n));
+        let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
         for (i, s) in iter.enumerate() {
-            let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
             let charsxp = str_to_charsxp(s);
             sexp.set_string_elt(idx, charsxp);
         }
@@ -1211,18 +1203,18 @@ pub(crate) fn str_iter_to_strsxp<'a>(
 /// Helper: allocate STRSXP and fill from a string iterator (unchecked).
 pub(crate) unsafe fn str_iter_to_strsxp_unchecked<'a>(
     iter: impl ExactSizeIterator<Item = &'a str>,
-) -> crate::sys::SEXP {
+) -> crate::SEXP {
     unsafe {
-        let n: crate::sys::R_xlen_t = iter
+        let n: crate::R_xlen_t = iter
             .len()
             .try_into()
             .expect("string vec length exceeds isize::MAX");
         let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-            crate::sys::SEXPTYPE::STRSXP,
+            crate::SEXPTYPE::STRSXP,
             n,
         ));
         for (i, s) in iter.enumerate() {
-            let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
             let charsxp = str_to_charsxp_unchecked(s);
             sexp.set_string_elt_unchecked(idx, charsxp);
         }
@@ -1233,17 +1225,17 @@ pub(crate) unsafe fn str_iter_to_strsxp_unchecked<'a>(
 /// Convert `Vec<String>` to R character vector (STRSXP).
 impl IntoR for Vec<String> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().map(|s| s.as_str()))
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_str())) }
     }
 }
@@ -1251,17 +1243,17 @@ impl IntoR for Vec<String> {
 /// Convert `&[String]` to R character vector (STRSXP).
 impl IntoR for &[String] {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().map(|s| s.as_str()))
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_str())) }
     }
 }
@@ -1269,16 +1261,16 @@ impl IntoR for &[String] {
 /// Convert `Box<[String]>` to R character vector (STRSXP).
 impl IntoR for Box<[String]> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().map(|s| s.as_str()))
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_str())) }
     }
 }
@@ -1286,17 +1278,17 @@ impl IntoR for Box<[String]> {
 /// Convert &[&str] to R character vector (STRSXP).
 impl IntoR for &[&str] {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().copied())
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().copied()) }
     }
 }
@@ -1304,16 +1296,16 @@ impl IntoR for &[&str] {
 /// Convert `Vec<Cow<'_, str>>` to R character vector (STRSXP).
 impl IntoR for Vec<std::borrow::Cow<'_, str>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().map(|s| s.as_ref()))
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_ref())) }
     }
 }
@@ -1321,16 +1313,16 @@ impl IntoR for Vec<std::borrow::Cow<'_, str>> {
 /// Convert `Box<[Cow<'_, str>]>` to R character vector (STRSXP).
 impl IntoR for Box<[std::borrow::Cow<'_, str>]> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         str_iter_to_strsxp(self.iter().map(|s| s.as_ref()))
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_ref())) }
     }
 }
@@ -1340,46 +1332,45 @@ impl IntoR for Box<[std::borrow::Cow<'_, str>]> {
 /// `None` values become `NA_character_` in R.
 impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
-            let sexp =
-                OwnedProtect::new(crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, n));
+            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp(s.as_ref()),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt(idx, charsxp);
             }
             *sexp
         }
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
             let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::STRSXP,
+                crate::SEXPTYPE::STRSXP,
                 n,
             ));
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp_unchecked(s.as_ref()),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt_unchecked(idx, charsxp);
             }
@@ -1394,46 +1385,45 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
 /// `None` values become `NA_character_` in R. Borrowed analogue of `Vec<Option<String>>`.
 impl IntoR for Vec<Option<&str>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
-            let sexp =
-                OwnedProtect::new(crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, n));
+            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp(s),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt(idx, charsxp);
             }
             *sexp
         }
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
             let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::STRSXP,
+                crate::SEXPTYPE::STRSXP,
                 n,
             ));
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp_unchecked(s),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt_unchecked(idx, charsxp);
             }
@@ -1446,17 +1436,17 @@ impl IntoR for Vec<Option<&str>> {
 /// Convert `Vec<&str>` to R character vector (STRSXP).
 impl IntoR for Vec<&str> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_slice().into_sexp()
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.as_slice().into_sexp_unchecked() }
     }
 }
@@ -1467,25 +1457,24 @@ impl IntoR for Vec<&str> {
 /// Convert `Vec<Vec<T>>` to R list of vectors (VECSXP of typed vectors).
 impl<T> IntoR for Vec<Vec<T>>
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -1493,18 +1482,16 @@ where
         }
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list = crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::VECSXP,
-                n as crate::sys::R_xlen_t,
-            );
+            let list =
+                crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp_unchecked();
-                list.set_vector_elt_unchecked(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt_unchecked(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -1516,39 +1503,36 @@ where
 /// Convert `Vec<&[T]>` to R list of typed vectors (VECSXP).
 ///
 /// Borrowed analogue of `Vec<Vec<T>>` — each slice is copied into a fresh R vector.
-impl<T: crate::sys::RNativeType> IntoR for Vec<&[T]> {
+impl<T: crate::RNativeType> IntoR for Vec<&[T]> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
             crate::sys::Rf_unprotect(1);
             list
         }
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list = crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::VECSXP,
-                n as crate::sys::R_xlen_t,
-            );
+            let list =
+                crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp_unchecked();
-                list.set_vector_elt_unchecked(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt_unchecked(i as crate::R_xlen_t, inner_sexp);
             }
             crate::sys::Rf_unprotect(1);
             list
@@ -1561,37 +1545,34 @@ impl<T: crate::sys::RNativeType> IntoR for Vec<&[T]> {
 /// Borrowed analogue of `Vec<Vec<String>>`.
 impl IntoR for Vec<&[String]> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
             crate::sys::Rf_unprotect(1);
             list
         }
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list = crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::VECSXP,
-                n as crate::sys::R_xlen_t,
-            );
+            let list =
+                crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp_unchecked();
-                list.set_vector_elt_unchecked(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt_unchecked(i as crate::R_xlen_t, inner_sexp);
             }
             crate::sys::Rf_unprotect(1);
             list
@@ -1602,22 +1583,21 @@ impl IntoR for Vec<&[String]> {
 /// Convert `Vec<Vec<String>>` to R list of character vectors.
 impl IntoR for Vec<Vec<String>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -1625,18 +1605,16 @@ impl IntoR for Vec<Vec<String>> {
         }
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list = crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::VECSXP,
-                n as crate::sys::R_xlen_t,
-            );
+            let list =
+                crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, inner) in self.into_iter().enumerate() {
                 let inner_sexp = inner.into_sexp_unchecked();
-                list.set_vector_elt_unchecked(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt_unchecked(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -1655,13 +1633,13 @@ macro_rules! impl_vec_option_into_r {
     ($t:ty, $na_value:expr) => {
         impl IntoR for Vec<Option<$t>> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector::<$t>(self.len());
                     for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
@@ -1671,7 +1649,7 @@ macro_rules! impl_vec_option_into_r {
                 }
             }
 
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     let (sexp, dst) = alloc_r_vector_unchecked::<$t>(self.len());
                     for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
@@ -1695,13 +1673,13 @@ macro_rules! impl_vec_option_smart_i64_into_r {
     ($t:ty, $fits_i32:expr) => {
         impl IntoR for Vec<Option<$t>> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     if self.iter().all(|opt| match opt {
                         Some(x) => $fits_i32(*x),
@@ -1745,13 +1723,13 @@ macro_rules! impl_vec_option_coerce_into_r {
     ($from:ty => $to:ty) => {
         impl IntoR for Vec<Option<$from>> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 // Delegate to the target Option type's impl (coerce inline)
                 let coerced: Vec<Option<$to>> = self
                     .into_iter()
@@ -1772,9 +1750,9 @@ impl_vec_option_coerce_into_r!(f32 => f64);
 /// Helper: allocate LGLSXP and fill from an i32 iterator (checked).
 ///
 /// Uses `alloc_r_vector` — logical vectors are `RLogical` (repr(transparent) i32).
-fn logical_iter_to_lglsxp(n: usize, iter: impl Iterator<Item = i32>) -> crate::sys::SEXP {
+fn logical_iter_to_lglsxp(n: usize, iter: impl Iterator<Item = i32>) -> crate::SEXP {
     unsafe {
-        let (sexp, dst) = alloc_r_vector::<crate::sys::RLogical>(n);
+        let (sexp, dst) = alloc_r_vector::<crate::RLogical>(n);
         // RLogical is repr(transparent) over i32, safe to write i32 values.
         let dst_i32: &mut [i32] = std::slice::from_raw_parts_mut(dst.as_mut_ptr().cast::<i32>(), n);
         for (slot, val) in dst_i32.iter_mut().zip(iter) {
@@ -1788,9 +1766,9 @@ fn logical_iter_to_lglsxp(n: usize, iter: impl Iterator<Item = i32>) -> crate::s
 unsafe fn logical_iter_to_lglsxp_unchecked(
     n: usize,
     iter: impl Iterator<Item = i32>,
-) -> crate::sys::SEXP {
+) -> crate::SEXP {
     unsafe {
-        let (sexp, dst) = alloc_r_vector_unchecked::<crate::sys::RLogical>(n);
+        let (sexp, dst) = alloc_r_vector_unchecked::<crate::RLogical>(n);
         let dst_i32: &mut [i32] = std::slice::from_raw_parts_mut(dst.as_mut_ptr().cast::<i32>(), n);
         for (slot, val) in dst_i32.iter_mut().zip(iter) {
             *slot = val;
@@ -1802,18 +1780,18 @@ unsafe fn logical_iter_to_lglsxp_unchecked(
 /// Convert `Vec<bool>` to R logical vector.
 impl IntoR for Vec<bool> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let n = self.len();
         logical_iter_to_lglsxp(n, self.into_iter().map(i32::from))
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.into_iter().map(i32::from)) }
     }
@@ -1822,17 +1800,17 @@ impl IntoR for Vec<bool> {
 /// Convert `Box<[bool]>` to R logical vector.
 impl IntoR for Box<[bool]> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let n = self.len();
         logical_iter_to_lglsxp(n, self.iter().map(|&v| i32::from(v)))
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&v| i32::from(v))) }
     }
@@ -1841,18 +1819,18 @@ impl IntoR for Box<[bool]> {
 /// Convert `&[bool]` to R logical vector.
 impl IntoR for &[bool] {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let n = self.len();
         logical_iter_to_lglsxp(n, self.iter().map(|&v| i32::from(v)))
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&v| i32::from(v))) }
     }
@@ -1863,18 +1841,18 @@ macro_rules! impl_vec_option_logical_into_r {
         $(#[$meta])*
         impl IntoR for Vec<Option<$t>> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let n = self.len();
                 logical_iter_to_lglsxp(n, self.into_iter().map($convert))
             }
 
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 let n = self.len();
                 unsafe { logical_iter_to_lglsxp_unchecked(n, self.into_iter().map($convert)) }
             }
@@ -1893,16 +1871,16 @@ impl_vec_option_logical_into_r!(
 );
 impl_vec_option_logical_into_r!(
     /// Convert `Vec<Option<Rboolean>>` to R logical vector with NA support.
-    crate::sys::Rboolean,
-    |v: Option<crate::sys::Rboolean>| match v {
+    crate::Rboolean,
+    |v: Option<crate::Rboolean>| match v {
         Some(b) => b as i32,
         None => NA_LOGICAL,
     }
 );
 impl_vec_option_logical_into_r!(
     /// Convert `Vec<Option<RLogical>>` to R logical vector with NA support.
-    crate::sys::RLogical,
-    |v: Option<crate::sys::RLogical>| match v {
+    crate::RLogical,
+    |v: Option<crate::RLogical>| match v {
         Some(b) => b.to_i32(),
         None => NA_LOGICAL,
     }
@@ -1913,26 +1891,25 @@ impl_vec_option_logical_into_r!(
 /// `None` values become `NA_character_` in R.
 impl IntoR for Vec<Option<String>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
-            let sexp =
-                OwnedProtect::new(crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, n));
+            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
 
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp(s),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt(idx, charsxp);
             }
@@ -1941,22 +1918,22 @@ impl IntoR for Vec<Option<String>> {
         }
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
-            let n: crate::sys::R_xlen_t = self
+            let n: crate::R_xlen_t = self
                 .len()
                 .try_into()
                 .expect("vec length exceeds isize::MAX");
             let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::sys::SEXPTYPE::STRSXP,
+                crate::SEXPTYPE::STRSXP,
                 n,
             ));
 
             for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
                 let charsxp = match opt_s {
                     Some(s) => str_to_charsxp_unchecked(s),
-                    None => crate::sys::SEXP::na_string(),
+                    None => crate::SEXP::na_string(),
                 };
                 sexp.set_string_elt_unchecked(idx, charsxp);
             }
@@ -1976,23 +1953,23 @@ macro_rules! impl_tuple_into_r {
     (($($T:ident),+), ($($idx:tt),+), $n:expr) => {
         impl<$($T: IntoR),+> IntoR for ($($T,)+) {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 unsafe {
                     let list = crate::sys::Rf_allocVector(
-                        crate::sys::SEXPTYPE::VECSXP,
-                        $n as crate::sys::R_xlen_t
+                        crate::SEXPTYPE::VECSXP,
+                        $n as crate::R_xlen_t
                     );
                     crate::sys::Rf_protect(list);
 
                     $(
 
-                            list.set_vector_elt($idx as crate::sys::R_xlen_t, self.$idx.into_sexp()
+                            list.set_vector_elt($idx as crate::R_xlen_t, self.$idx.into_sexp()
                         );
                     )+
 
@@ -2001,17 +1978,17 @@ macro_rules! impl_tuple_into_r {
                 }
             }
 
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
                     let list = crate::sys::Rf_allocVector_unchecked(
-                        crate::sys::SEXPTYPE::VECSXP,
-                        $n as crate::sys::R_xlen_t
+                        crate::SEXPTYPE::VECSXP,
+                        $n as crate::R_xlen_t
                     );
                     crate::sys::Rf_protect(list);
 
                     $(
 
-                            list.set_vector_elt_unchecked($idx as crate::sys::R_xlen_t, self.$idx.into_sexp_unchecked()
+                            list.set_vector_elt_unchecked($idx as crate::R_xlen_t, self.$idx.into_sexp_unchecked()
                         );
                     )+
 
@@ -2066,7 +2043,7 @@ impl_tuple_into_r!((A, B, C, D, E, F, G, H), (0, 1, 2, 3, 4, 5, 6, 7), 8);
 /// # Example
 ///
 /// ```rust,ignore
-/// use miniextendr_api::{miniextendr, IntoRAltrep, IntoR, sys::SEXP};
+/// use miniextendr_api::{miniextendr, IntoRAltrep, IntoR, SEXP};
 ///
 /// #[miniextendr]
 /// fn large_dataset() -> SEXP {
@@ -2089,14 +2066,14 @@ pub trait IntoRAltrep {
     ///
     /// This is equivalent to `Altrep(self).into_sexp()` but more discoverable
     /// and explicit about the zero-copy intent.
-    fn into_sexp_altrep(self) -> crate::sys::SEXP;
+    fn into_sexp_altrep(self) -> crate::SEXP;
 
     /// Convert to R SEXP using ALTREP, skipping debug thread assertions.
     ///
     /// # Safety
     ///
     /// Caller must ensure they are on R's main thread.
-    unsafe fn into_sexp_altrep_unchecked(self) -> crate::sys::SEXP
+    unsafe fn into_sexp_altrep_unchecked(self) -> crate::SEXP
     where
         Self: Sized,
     {
@@ -2119,11 +2096,11 @@ impl<T> IntoRAltrep for T
 where
     T: crate::altrep::RegisterAltrep + crate::externalptr::TypedExternal,
 {
-    fn into_sexp_altrep(self) -> crate::sys::SEXP {
+    fn into_sexp_altrep(self) -> crate::SEXP {
         Altrep(self).into_sexp()
     }
 
-    unsafe fn into_sexp_altrep_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_altrep_unchecked(self) -> crate::SEXP {
         unsafe { Altrep(self).into_sexp_unchecked() }
     }
 }
@@ -2135,26 +2112,25 @@ where
 /// Each boxed slice becomes an R vector.
 impl<T> IntoR for Vec<Box<[T]>>
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, boxed_slice) in self.into_iter().enumerate() {
                 let vec: Vec<T> = boxed_slice.into_vec();
                 let inner_sexp = vec.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -2166,23 +2142,22 @@ where
 /// Convert `Vec<Box<[String]>>` to R list of character vectors.
 impl IntoR for Vec<Box<[String]>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let n = self.len();
-            let list =
-                crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, boxed_slice) in self.into_iter().enumerate() {
                 let vec: Vec<String> = boxed_slice.into_vec();
                 let inner_sexp = vec.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -2195,28 +2170,25 @@ impl IntoR for Vec<Box<[String]>> {
 /// Each array becomes an R vector.
 impl<T, const N: usize> IntoR for Vec<[T; N]>
 where
-    T: crate::sys::RNativeType,
+    T: crate::RNativeType,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         unsafe {
             let len = self.len();
-            let list = crate::sys::Rf_allocVector(
-                crate::sys::SEXPTYPE::VECSXP,
-                len as crate::sys::R_xlen_t,
-            );
+            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, len as crate::R_xlen_t);
             crate::sys::Rf_protect(list);
 
             for (i, array) in self.into_iter().enumerate() {
                 let vec: Vec<T> = array.into();
                 let inner_sexp = vec.into_sexp();
-                list.set_vector_elt(i as crate::sys::R_xlen_t, inner_sexp);
+                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
             }
 
             crate::sys::Rf_unprotect(1);
@@ -2226,16 +2198,16 @@ where
 }
 
 /// Helper: convert a Vec of IntoR items to an R list (VECSXP).
-fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::sys::SEXP {
+fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::SEXP {
     unsafe {
         let n = items.len();
         let list = OwnedProtect::new(crate::sys::Rf_allocVector(
-            crate::sys::SEXPTYPE::VECSXP,
-            n as crate::sys::R_xlen_t,
+            crate::SEXPTYPE::VECSXP,
+            n as crate::R_xlen_t,
         ));
         for (i, item) in items.into_iter().enumerate() {
             list.get()
-                .set_vector_elt(i as crate::sys::R_xlen_t, item.into_sexp());
+                .set_vector_elt(i as crate::R_xlen_t, item.into_sexp());
         }
         *list
     }
@@ -2245,37 +2217,37 @@ fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::sys::SEXP {
 
 /// Helper: convert `Vec<Option<C: IntoR>>` to a VECSXP, with `None` mapping to
 /// `R_NilValue` (NULL) and `Some(v)` mapping to whatever `v.into_sexp()` produces.
-fn vec_option_of_into_r_to_list<T: IntoR>(items: Vec<Option<T>>) -> crate::sys::SEXP {
+fn vec_option_of_into_r_to_list<T: IntoR>(items: Vec<Option<T>>) -> crate::SEXP {
     unsafe {
         let n = items.len();
         let list = OwnedProtect::new(crate::sys::Rf_allocVector(
-            crate::sys::SEXPTYPE::VECSXP,
-            n as crate::sys::R_xlen_t,
+            crate::SEXPTYPE::VECSXP,
+            n as crate::R_xlen_t,
         ));
         for (i, item) in items.into_iter().enumerate() {
             let elt = match item {
                 Some(v) => v.into_sexp(),
-                None => crate::sys::SEXP::nil(),
+                None => crate::SEXP::nil(),
             };
-            list.get().set_vector_elt(i as crate::sys::R_xlen_t, elt);
+            list.get().set_vector_elt(i as crate::R_xlen_t, elt);
         }
         *list
     }
 }
 
 /// Convert `Vec<Option<Vec<T>>>` to R list where `None` → NULL, `Some(v)` → typed vector.
-impl<T: crate::sys::RNativeType> IntoR for Vec<Option<Vec<T>>>
+impl<T: crate::RNativeType> IntoR for Vec<Option<Vec<T>>>
 where
     Vec<T>: IntoR,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2283,30 +2255,30 @@ where
 /// Convert `Vec<Option<Vec<String>>>` to R list where `None` → NULL, `Some(v)` → character vector.
 impl IntoR for Vec<Option<Vec<String>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
 
 /// Convert `Vec<Option<HashSet<T>>>` to R list where `None` → NULL, `Some(s)` → unordered vector.
-impl<T: crate::sys::RNativeType + Eq + Hash> IntoR for Vec<Option<HashSet<T>>>
+impl<T: crate::RNativeType + Eq + Hash> IntoR for Vec<Option<HashSet<T>>>
 where
     HashSet<T>: IntoR,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2314,30 +2286,30 @@ where
 /// Convert `Vec<Option<HashSet<String>>>` to R list where `None` → NULL, `Some(s)` → character vector.
 impl IntoR for Vec<Option<HashSet<String>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
 
 /// Convert `Vec<Option<BTreeSet<T>>>` to R list where `None` → NULL, `Some(s)` → sorted vector.
-impl<T: crate::sys::RNativeType + Ord> IntoR for Vec<Option<BTreeSet<T>>>
+impl<T: crate::RNativeType + Ord> IntoR for Vec<Option<BTreeSet<T>>>
 where
     BTreeSet<T>: IntoR,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2345,13 +2317,13 @@ where
 /// Convert `Vec<Option<BTreeSet<String>>>` to R list where `None` → NULL, `Some(s)` → sorted character vector.
 impl IntoR for Vec<Option<BTreeSet<String>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2359,13 +2331,13 @@ impl IntoR for Vec<Option<BTreeSet<String>>> {
 /// Convert `Vec<Option<HashMap<String, V>>>` to R list where `None` → NULL, `Some(m)` → named list.
 impl<V: IntoR> IntoR for Vec<Option<HashMap<String, V>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2373,13 +2345,13 @@ impl<V: IntoR> IntoR for Vec<Option<HashMap<String, V>>> {
 /// Convert `Vec<Option<BTreeMap<String, V>>>` to R list where `None` → NULL, `Some(m)` → named list.
 impl<V: IntoR> IntoR for Vec<Option<BTreeMap<String, V>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2387,15 +2359,15 @@ impl<V: IntoR> IntoR for Vec<Option<BTreeMap<String, V>>> {
 /// Convert `Vec<Option<&[T]>>` to R list where `None` → NULL, `Some(s)` → typed vector.
 ///
 /// Borrowed analogue of `Vec<Option<Vec<T>>>` — each slice is copied into a fresh R vector.
-impl<T: crate::sys::RNativeType> IntoR for Vec<Option<&[T]>> {
+impl<T: crate::RNativeType> IntoR for Vec<Option<&[T]>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2405,13 +2377,13 @@ impl<T: crate::sys::RNativeType> IntoR for Vec<Option<&[T]>> {
 /// Borrowed analogue of `Vec<Option<Vec<String>>>`.
 impl IntoR for Vec<Option<&[String]>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         vec_option_of_into_r_to_list(self)
     }
 }
@@ -2420,18 +2392,18 @@ impl IntoR for Vec<Option<&[String]>> {
 
 /// Convert `Vec<HashSet<T>>` to R list of vectors (for RNativeType elements).
 /// Each HashSet becomes an R vector (unordered).
-impl<T: crate::sys::RNativeType> IntoR for Vec<std::collections::HashSet<T>>
+impl<T: crate::RNativeType> IntoR for Vec<std::collections::HashSet<T>>
 where
     Vec<T>: IntoR,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let converted: Vec<Vec<T>> = self.into_iter().map(|s| s.into_iter().collect()).collect();
         vec_of_into_r_to_list(converted)
     }
@@ -2439,18 +2411,18 @@ where
 
 /// Convert `Vec<BTreeSet<T>>` to R list of vectors (for RNativeType elements).
 /// Each BTreeSet becomes an R vector (sorted).
-impl<T: crate::sys::RNativeType> IntoR for Vec<std::collections::BTreeSet<T>>
+impl<T: crate::RNativeType> IntoR for Vec<std::collections::BTreeSet<T>>
 where
     Vec<T>: IntoR,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let converted: Vec<Vec<T>> = self.into_iter().map(|s| s.into_iter().collect()).collect();
         vec_of_into_r_to_list(converted)
     }
@@ -2459,13 +2431,13 @@ where
 /// Convert `Vec<HashSet<String>>` to R list of character vectors.
 impl IntoR for Vec<std::collections::HashSet<String>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let converted: Vec<Vec<String>> =
             self.into_iter().map(|s| s.into_iter().collect()).collect();
         vec_of_into_r_to_list(converted)
@@ -2475,13 +2447,13 @@ impl IntoR for Vec<std::collections::HashSet<String>> {
 /// Convert `Vec<BTreeSet<String>>` to R list of character vectors.
 impl IntoR for Vec<std::collections::BTreeSet<String>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let converted: Vec<Vec<String>> =
             self.into_iter().map(|s| s.into_iter().collect()).collect();
         vec_of_into_r_to_list(converted)
@@ -2493,13 +2465,13 @@ macro_rules! impl_vec_map_into_r {
         $(#[$meta])*
         impl<V: IntoR> IntoR for Vec<$map_ty<String, V>> {
             type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 vec_of_maps_to_list(self)
             }
         }
@@ -2516,15 +2488,14 @@ impl_vec_map_into_r!(
 );
 
 /// Helper to convert a Vec of map-like types to an R list of named lists.
-fn vec_of_maps_to_list<T: IntoR>(vec: Vec<T>) -> crate::sys::SEXP {
+fn vec_of_maps_to_list<T: IntoR>(vec: Vec<T>) -> crate::SEXP {
     unsafe {
         let n = vec.len();
-        let list =
-            crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n as crate::sys::R_xlen_t);
+        let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
         crate::sys::Rf_protect(list);
 
         for (i, map) in vec.into_iter().enumerate() {
-            list.set_vector_elt(i as crate::sys::R_xlen_t, map.into_sexp());
+            list.set_vector_elt(i as crate::R_xlen_t, map.into_sexp());
         }
 
         crate::sys::Rf_unprotect(1);
@@ -2537,9 +2508,9 @@ fn vec_of_maps_to_list<T: IntoR>(vec: Vec<T>) -> crate::sys::SEXP {
 
 #[cfg(feature = "connections")]
 mod connections_into_r {
+    use crate::SEXP;
     use crate::connection::{RNullConnection, RStderr, RStdin, RStdout};
     use crate::into_r::IntoR;
-    use crate::sys::SEXP;
 
     // Evaluate a no-arg base function and return the resulting SEXP (unprotected).
     //
@@ -2621,8 +2592,8 @@ mod connections_into_r {
 
 #[cfg(feature = "connections")]
 mod txt_progress_bar_into_r {
+    use crate::SEXP;
     use crate::into_r::IntoR;
-    use crate::sys::SEXP;
     use crate::txt_progress_bar::RTxtProgressBar;
 
     /// Transfer ownership of the `RTxtProgressBar` back to R.

--- a/miniextendr-api/src/into_r/altrep.rs
+++ b/miniextendr-api/src/into_r/altrep.rs
@@ -154,31 +154,31 @@ where
     T: crate::altrep::RegisterAltrep + crate::externalptr::TypedExternal,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let cls = <T as crate::altrep::RegisterAltrep>::get_or_init_class();
         let ext_ptr = crate::externalptr::ExternalPtr::new(self.0);
         let data1 = ext_ptr.as_sexp();
         // Protect data1 across new_altrep — it may allocate and trigger GC.
         unsafe {
             crate::sys::Rf_protect_unchecked(data1);
-            let out = cls.new_altrep(data1, crate::sys::SEXP::nil());
+            let out = cls.new_altrep(data1, crate::SEXP::nil());
             crate::sys::Rf_unprotect_unchecked(1);
             out
         }
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let cls = <T as crate::altrep::RegisterAltrep>::get_or_init_class();
         let ext_ptr = crate::externalptr::ExternalPtr::new(self.0);
         let data1 = ext_ptr.as_sexp();
         unsafe {
             crate::sys::Rf_protect_unchecked(data1);
-            let out = cls.new_altrep_unchecked(data1, crate::sys::SEXP::nil());
+            let out = cls.new_altrep_unchecked(data1, crate::SEXP::nil());
             crate::sys::Rf_unprotect_unchecked(1);
             out
         }
@@ -191,13 +191,13 @@ where
 /// functions, transparently passing the ALTREP SEXP back to R.
 impl IntoR for crate::altrep_sexp::AltrepSexp {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // Safety: returning to R which is always the main thread context
         unsafe { self.as_raw() }
     }

--- a/miniextendr-api/src/into_r/collections.rs
+++ b/miniextendr-api/src/into_r/collections.rs
@@ -17,24 +17,24 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
+use crate::SexpExt;
 use crate::into_r::{IntoR, str_to_charsxp, str_to_charsxp_unchecked};
-use crate::sys::SexpExt;
 
 macro_rules! impl_map_into_r {
     ($(#[$meta:meta])* $map_ty:ident) => {
         $(#[$meta])*
         impl<V: IntoR> IntoR for $map_ty<String, V> {
             type Error = crate::into_r_error::IntoRError;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 map_to_named_list(self.into_iter())
             }
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe { map_to_named_list_unchecked(self.into_iter()) }
             }
         }
@@ -51,23 +51,21 @@ impl_map_into_r!(
 );
 
 /// Helper to convert an iterator of (String, V) pairs to a named R list.
-fn map_to_named_list<V: IntoR>(
-    iter: impl ExactSizeIterator<Item = (String, V)>,
-) -> crate::sys::SEXP {
+fn map_to_named_list<V: IntoR>(iter: impl ExactSizeIterator<Item = (String, V)>) -> crate::SEXP {
     unsafe {
-        let n: crate::sys::R_xlen_t = iter
+        let n: crate::R_xlen_t = iter
             .len()
             .try_into()
             .expect("map length exceeds isize::MAX");
-        let list = crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::VECSXP, n);
+        let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n);
         crate::sys::Rf_protect(list);
 
         // Allocate names vector
-        let names = crate::sys::Rf_allocVector(crate::sys::SEXPTYPE::STRSXP, n);
+        let names = crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n);
         crate::sys::Rf_protect(names);
 
         for (i, (key, value)) in iter.enumerate() {
-            let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
             // Set list element
             list.set_vector_elt(idx, value.into_sexp());
 
@@ -87,27 +85,27 @@ fn map_to_named_list<V: IntoR>(
 /// Unchecked version of [`map_to_named_list`].
 unsafe fn map_to_named_list_unchecked<V: IntoR>(
     iter: impl ExactSizeIterator<Item = (String, V)>,
-) -> crate::sys::SEXP {
+) -> crate::SEXP {
     unsafe {
-        let n: crate::sys::R_xlen_t = iter
+        let n: crate::R_xlen_t = iter
             .len()
             .try_into()
             .expect("map length exceeds isize::MAX");
-        let list = crate::sys::Rf_allocVector_unchecked(crate::sys::SEXPTYPE::VECSXP, n);
+        let list = crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n);
         crate::sys::Rf_protect(list);
 
-        let names = crate::sys::Rf_allocVector_unchecked(crate::sys::SEXPTYPE::STRSXP, n);
+        let names = crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::STRSXP, n);
         crate::sys::Rf_protect(names);
 
         for (i, (key, value)) in iter.enumerate() {
-            let idx: crate::sys::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
+            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
             list.set_vector_elt_unchecked(idx, value.into_sexp_unchecked());
 
             let charsxp = str_to_charsxp_unchecked(&key);
             names.set_string_elt_unchecked(idx, charsxp);
         }
 
-        list.set_attr_unchecked(crate::sys::SEXP::names_symbol(), names);
+        list.set_attr_unchecked(crate::SEXP::names_symbol(), names);
 
         crate::sys::Rf_unprotect(2);
         list
@@ -117,20 +115,20 @@ unsafe fn map_to_named_list_unchecked<V: IntoR>(
 /// Convert `HashSet<T>` to R vector.
 impl<T> IntoR for HashSet<T>
 where
-    T: crate::sys::RNativeType + Eq + Hash,
+    T: crate::RNativeType + Eq + Hash,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         vec.into_sexp()
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         unsafe { vec.into_sexp_unchecked() }
     }
@@ -139,20 +137,20 @@ where
 /// Convert `BTreeSet<T>` to R vector.
 impl<T> IntoR for BTreeSet<T>
 where
-    T: crate::sys::RNativeType + Ord,
+    T: crate::RNativeType + Ord,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         vec.into_sexp()
     }
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let vec: Vec<T> = self.into_iter().collect();
         unsafe { vec.into_sexp_unchecked() }
     }
@@ -163,17 +161,17 @@ macro_rules! impl_set_string_into_r {
         $(#[$meta])*
         impl IntoR for $set_ty<String> {
             type Error = crate::into_r_error::IntoRError;
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 let vec: Vec<String> = self.into_iter().collect();
                 vec.into_sexp()
             }
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 let vec: Vec<String> = self.into_iter().collect();
                 unsafe { vec.into_sexp_unchecked() }
             }

--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -50,15 +50,15 @@ use crate::into_r::IntoR;
 impl IntoR for i64 {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // i32::MIN is NA_integer_ in R, so exclude it from the integer range
         if self > i32::MIN as i64 && self <= i32::MAX as i64 {
             // Range guard verified — cast is safe
@@ -69,7 +69,7 @@ impl IntoR for i64 {
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         if self > i32::MIN as i64 && self <= i32::MAX as i64 {
             unsafe { (self as i32).into_sexp_unchecked() }
         } else {
@@ -85,15 +85,15 @@ impl IntoR for i64 {
 impl IntoR for u64 {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         if self <= i32::MAX as u64 {
             (self as i32).into_sexp()
         } else {
@@ -101,7 +101,7 @@ impl IntoR for u64 {
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         if self <= i32::MAX as u64 {
             unsafe { (self as i32).into_sexp_unchecked() }
         } else {
@@ -117,19 +117,19 @@ impl IntoR for u64 {
 impl IntoR for isize {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok((self as i64).into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         (self as i64).into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { (self as i64).into_sexp_unchecked() }
     }
 }
@@ -141,19 +141,19 @@ impl IntoR for isize {
 impl IntoR for usize {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok((self as u64).into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         (self as u64).into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { (self as u64).into_sexp_unchecked() }
     }
 }
@@ -164,51 +164,51 @@ macro_rules! impl_logical_into_r {
         impl IntoR for $ty {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
-                Ok(crate::sys::SEXP::scalar_logical_raw($to_i32(self)))
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+                Ok(crate::SEXP::scalar_logical_raw($to_i32(self)))
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
-                crate::sys::SEXP::scalar_logical_raw($to_i32(self))
+            fn into_sexp(self) -> crate::SEXP {
+                crate::SEXP::scalar_logical_raw($to_i32(self))
             }
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
-                unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked($to_i32(self)) }
+            unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
+                unsafe { crate::SEXP::scalar_logical_raw_unchecked($to_i32(self)) }
             }
         }
     };
 }
 
 impl_logical_into_r!(bool, |v: bool| i32::from(v));
-impl_logical_into_r!(crate::sys::Rboolean, |v: crate::sys::Rboolean| v as i32);
-impl_logical_into_r!(crate::sys::RLogical, crate::sys::RLogical::to_i32);
+impl_logical_into_r!(crate::Rboolean, |v: crate::Rboolean| v as i32);
+impl_logical_into_r!(crate::RLogical, crate::RLogical::to_i32);
 
 impl IntoR for Option<i32> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::scalar_integer(NA_INTEGER),
+            None => crate::SEXP::scalar_integer(NA_INTEGER),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => unsafe { crate::sys::SEXP::scalar_integer_unchecked(NA_INTEGER) },
+            None => unsafe { crate::SEXP::scalar_integer_unchecked(NA_INTEGER) },
         }
     }
 }
@@ -216,78 +216,78 @@ impl IntoR for Option<i32> {
 impl IntoR for Option<f64> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::scalar_real(NA_REAL),
+            None => crate::SEXP::scalar_real(NA_REAL),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => unsafe { crate::sys::SEXP::scalar_real_unchecked(NA_REAL) },
+            None => unsafe { crate::SEXP::scalar_real_unchecked(NA_REAL) },
         }
     }
 }
 
-impl IntoR for Option<crate::sys::Rboolean> {
+impl IntoR for Option<crate::Rboolean> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             // Rboolean is repr(i32), `as i32` is a no-op transmute
-            Some(v) => crate::sys::SEXP::scalar_logical_raw(v as i32),
-            None => crate::sys::SEXP::scalar_logical_raw(NA_LOGICAL),
+            Some(v) => crate::SEXP::scalar_logical_raw(v as i32),
+            None => crate::SEXP::scalar_logical_raw(NA_LOGICAL),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
-            Some(v) => unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked(v as i32) },
-            None => unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
+            Some(v) => unsafe { crate::SEXP::scalar_logical_raw_unchecked(v as i32) },
+            None => unsafe { crate::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
         }
     }
 }
 
-impl IntoR for Option<crate::sys::RLogical> {
+impl IntoR for Option<crate::RLogical> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
-            Some(v) => crate::sys::SEXP::scalar_logical_raw(v.to_i32()),
-            None => crate::sys::SEXP::scalar_logical_raw(NA_LOGICAL),
+            Some(v) => crate::SEXP::scalar_logical_raw(v.to_i32()),
+            None => crate::SEXP::scalar_logical_raw(NA_LOGICAL),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
-            Some(v) => unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked(v.to_i32()) },
-            None => unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
+            Some(v) => unsafe { crate::SEXP::scalar_logical_raw_unchecked(v.to_i32()) },
+            None => unsafe { crate::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
         }
     }
 }
@@ -295,25 +295,25 @@ impl IntoR for Option<crate::sys::RLogical> {
 impl IntoR for Option<bool> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(v) => v.into_sexp(),
-            None => crate::sys::SEXP::scalar_logical_raw(NA_LOGICAL),
+            None => crate::SEXP::scalar_logical_raw(NA_LOGICAL),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(v) => unsafe { v.into_sexp_unchecked() },
-            None => unsafe { crate::sys::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
+            None => unsafe { crate::SEXP::scalar_logical_raw_unchecked(NA_LOGICAL) },
         }
     }
 }
@@ -326,19 +326,19 @@ macro_rules! impl_option_smart_i64_into_r {
         impl IntoR for Option<$t> {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 match self {
                     Some(x) if $fits_i32(x) => (x as i32).into_sexp(),
                     Some(x) => (x as f64).into_sexp(),
-                    None => crate::sys::SEXP::scalar_integer(NA_INTEGER),
+                    None => crate::SEXP::scalar_integer(NA_INTEGER),
                 }
             }
         }
@@ -357,15 +357,15 @@ macro_rules! impl_option_coerce_into_r {
         impl IntoR for Option<$from> {
             type Error = std::convert::Infallible;
             #[inline]
-            fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
                 Ok(self.map(|x| x as $to).into_sexp())
             }
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
             #[inline]
-            fn into_sexp(self) -> crate::sys::SEXP {
+            fn into_sexp(self) -> crate::SEXP {
                 self.map(|x| x as $to).into_sexp()
             }
         }
@@ -381,15 +381,15 @@ impl_option_coerce_into_r!(f32 => f64);
 impl<T: crate::externalptr::TypedExternal> IntoR for crate::externalptr::ExternalPtr<T> {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.as_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.as_sexp())
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_sexp()
     }
 }
@@ -401,19 +401,19 @@ impl<T: crate::externalptr::TypedExternal> IntoR for crate::externalptr::Externa
 impl<T: crate::externalptr::IntoExternalPtr> IntoR for T {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         crate::externalptr::ExternalPtr::new(self).into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { crate::externalptr::ExternalPtr::new_unchecked(self).into_sexp() }
     }
 }
@@ -421,24 +421,24 @@ impl<T: crate::externalptr::IntoExternalPtr> IntoR for T {
 /// Helper to convert a string slice to R CHARSXP.
 /// Uses UTF-8 encoding. Empty strings return R_BlankString (static, no allocation).
 #[inline]
-pub(crate) fn str_to_charsxp(s: &str) -> crate::sys::SEXP {
+pub(crate) fn str_to_charsxp(s: &str) -> crate::SEXP {
     if s.is_empty() {
-        crate::sys::SEXP::blank_string()
+        crate::SEXP::blank_string()
     } else {
         let _len: i32 = s.len().try_into().expect("string exceeds i32::MAX bytes");
-        crate::sys::SEXP::charsxp(s)
+        crate::SEXP::charsxp(s)
     }
 }
 
 /// Unchecked version of [`str_to_charsxp`].
 #[inline]
-pub(crate) unsafe fn str_to_charsxp_unchecked(s: &str) -> crate::sys::SEXP {
+pub(crate) unsafe fn str_to_charsxp_unchecked(s: &str) -> crate::SEXP {
     unsafe {
         if s.is_empty() {
-            crate::sys::SEXP::blank_string()
+            crate::SEXP::blank_string()
         } else {
             let len: i32 = s.len().try_into().expect("string exceeds i32::MAX bytes");
-            crate::sys::Rf_mkCharLenCE_unchecked(s.as_ptr().cast(), len, crate::sys::CE_UTF8)
+            crate::sys::Rf_mkCharLenCE_unchecked(s.as_ptr().cast(), len, crate::sexp_types::CE_UTF8)
         }
     }
 }
@@ -446,19 +446,19 @@ pub(crate) unsafe fn str_to_charsxp_unchecked(s: &str) -> crate::sys::SEXP {
 impl IntoR for String {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         self.as_str().try_into_sexp()
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_str().into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.as_str().into_sexp_unchecked() }
     }
 }
@@ -466,22 +466,22 @@ impl IntoR for String {
 impl IntoR for char {
     type Error = std::convert::Infallible;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // Convert char to a single-character string — always ≤ 4 bytes, cannot overflow i32
         let mut buf = [0u8; 4];
         let s = self.encode_utf8(&mut buf);
-        crate::sys::SEXP::scalar_string(str_to_charsxp(s))
+        crate::SEXP::scalar_string(str_to_charsxp(s))
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let mut buf = [0u8; 4];
         let s = self.encode_utf8(&mut buf);
         unsafe { s.into_sexp_unchecked() }
@@ -491,24 +491,24 @@ impl IntoR for char {
 impl IntoR for &str {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         let _len = i32::try_from(self.len())
             .map_err(|_| crate::into_r_error::IntoRError::StringTooLong { len: self.len() })?;
-        Ok(crate::sys::SEXP::scalar_string(str_to_charsxp(self)))
+        Ok(crate::SEXP::scalar_string(str_to_charsxp(self)))
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
-        crate::sys::SEXP::scalar_string(str_to_charsxp(self))
+    fn into_sexp(self) -> crate::SEXP {
+        crate::SEXP::scalar_string(str_to_charsxp(self))
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let charsxp = str_to_charsxp_unchecked(self);
-            crate::sys::SEXP::scalar_string_unchecked(charsxp)
+            crate::SEXP::scalar_string_unchecked(charsxp)
         }
     }
 }
@@ -516,38 +516,36 @@ impl IntoR for &str {
 impl IntoR for Option<&str> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         match self {
             Some(s) => {
                 let _len = i32::try_from(s.len())
                     .map_err(|_| crate::into_r_error::IntoRError::StringTooLong { len: s.len() })?;
-                Ok(crate::sys::SEXP::scalar_string(str_to_charsxp(s)))
+                Ok(crate::SEXP::scalar_string(str_to_charsxp(s)))
             }
-            None => Ok(crate::sys::SEXP::scalar_string(
-                crate::sys::SEXP::na_string(),
-            )),
+            None => Ok(crate::SEXP::scalar_string(crate::SEXP::na_string())),
         }
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         let charsxp = match self {
             Some(s) => str_to_charsxp(s),
-            None => crate::sys::SEXP::na_string(),
+            None => crate::SEXP::na_string(),
         };
-        crate::sys::SEXP::scalar_string(charsxp)
+        crate::SEXP::scalar_string(charsxp)
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
             let charsxp = match self {
                 Some(s) => str_to_charsxp_unchecked(s),
-                None => crate::sys::SEXP::na_string(),
+                None => crate::SEXP::na_string(),
             };
-            crate::sys::SEXP::scalar_string_unchecked(charsxp)
+            crate::SEXP::scalar_string_unchecked(charsxp)
         }
     }
 }
@@ -555,19 +553,19 @@ impl IntoR for Option<&str> {
 impl IntoR for Option<String> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         self.as_deref().try_into_sexp()
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         self.as_deref().into_sexp()
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.as_deref().into_sexp_unchecked() }
     }
 }
@@ -585,30 +583,30 @@ where
 {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         match self {
             Some(&v) => v
                 .try_into_sexp()
                 .map_err(|e| crate::into_r_error::IntoRError::Inner(e.to_string())),
-            None => Ok(crate::sys::SEXP::nil()),
+            None => Ok(crate::SEXP::nil()),
         }
     }
     #[inline]
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     #[inline]
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(&v) => v.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
     #[inline]
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(&v) => unsafe { v.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }

--- a/miniextendr-api/src/into_r/result.rs
+++ b/miniextendr-api/src/into_r/result.rs
@@ -72,13 +72,13 @@ where
     E: std::fmt::Display,
 {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Ok(value) => value.into_sexp(),
             Err(msg) => {
@@ -125,16 +125,16 @@ pub struct NullOnErr;
 /// carries no information. Instead of raising an R error, we return NULL.
 impl<T: IntoR> IntoR for Result<T, NullOnErr> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Ok(value) => value.into_sexp(),
-            Err(NullOnErr) => crate::sys::SEXP::nil(),
+            Err(NullOnErr) => crate::SEXP::nil(),
         }
     }
 }

--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -49,7 +49,7 @@
 
 use crate::coerce::{CoerceError, TryCoerce};
 use crate::into_r::IntoR;
-use crate::sys::{RLogical, SEXP};
+use crate::{RLogical, SEXP};
 use std::fmt;
 
 // region: Error type

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -270,10 +270,19 @@ pub mod sexp;
 /// `SexpExt` — the ergonomic extension trait on `SEXP`.
 pub mod sexp_ext;
 
-/// Raw R FFI bindings.
+/// Raw R FFI bindings — `extern "C-unwind"` blocks for `Rf_*` / `R_*` /
+/// `INTEGER` / etc., plus the ALTREP method type aliases under
+/// [`sys::altrep`]. The escape hatch for code that genuinely needs the raw
+/// R C API.
 ///
-/// Most users should prefer safe wrappers from higher-level modules — see
-/// [`sexp`], [`sexp_ext`], and [`sexp_types`].
+/// **Almost no user code should reach into this module.** The framework
+/// expects you to use the crate-root re-exports for the type vocabulary
+/// ([`SEXP`], [`SexpExt`], [`SEXPTYPE`], [`R_xlen_t`], …) and the
+/// higher-level safe wrappers ([`IntoR`], [`TryFromSexp`],
+/// [`worker::with_r_thread`], [`unwind_protect::with_r_unwind_protect`],
+/// the `#[miniextendr]` proc-macro). `sys::` is only here so those
+/// wrappers — and the rare hand-rolled FFI in tests or benchmarks — have
+/// something to call.
 pub mod sys;
 
 // Crate-root re-exports for the ergonomic API surface.

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -17,11 +17,12 @@
 //! - [`ListBuilder`] — fixed-size batch construction
 //! - [`IntoList`] / [`TryFromList`] — conversion traits
 
+use crate::SEXPTYPE::{LISTSXP, STRSXP, VECSXP};
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::SEXPTYPE::{LISTSXP, STRSXP, VECSXP};
-use crate::sys::{self, SEXP, SexpExt};
+use crate::sys::{self};
+use crate::{SEXP, SexpExt};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
@@ -266,7 +267,7 @@ impl List {
     /// ```
     #[inline]
     pub fn set_class_str(self, classes: &[&str]) -> Self {
-        use crate::sys::SEXPTYPE::STRSXP;
+        use crate::SEXPTYPE::STRSXP;
 
         let n: isize = classes
             .len()
@@ -310,7 +311,7 @@ impl List {
     /// ```
     #[inline]
     pub fn set_names_str(self, names: &[&str]) -> Self {
-        use crate::sys::SEXPTYPE::STRSXP;
+        use crate::SEXPTYPE::STRSXP;
 
         let n: isize = names
             .len()
@@ -379,7 +380,7 @@ impl List {
     /// ```
     #[inline]
     pub fn set_row_names_str(self, row_names: &[&str]) -> Self {
-        use crate::sys::SEXPTYPE::STRSXP;
+        use crate::SEXPTYPE::STRSXP;
 
         let n: isize = row_names
             .len()
@@ -940,8 +941,8 @@ impl List {
     /// The input SEXPs should already be protected or be children of protected
     /// containers.
     pub fn from_scalars_or_list(elements: &[SEXP]) -> Self {
+        use crate::SEXPTYPE;
         use crate::into_r::alloc_r_vector;
-        use crate::sys::SEXPTYPE;
 
         if elements.is_empty() {
             return Self::from_raw_values(Vec::new());
@@ -975,10 +976,10 @@ impl List {
                 v
             },
             SEXPTYPE::LGLSXP => unsafe {
-                let (v, dst) = alloc_r_vector::<crate::sys::RLogical>(n);
+                let (v, dst) = alloc_r_vector::<crate::RLogical>(n);
                 for (slot, &elem) in dst.iter_mut().zip(elements.iter()) {
                     *slot = *elem
-                        .as_slice::<crate::sys::RLogical>()
+                        .as_slice::<crate::RLogical>()
                         .first()
                         .expect("scalar has length 1");
                 }
@@ -1090,12 +1091,13 @@ impl IntoR for Vec<List> {
     }
     fn into_sexp(self) -> SEXP {
         unsafe {
-            use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt as _};
-            let n = self.len() as crate::sys::R_xlen_t;
+            use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+            use crate::{SEXPTYPE, SexpExt as _};
+            let n = self.len() as crate::R_xlen_t;
             let out = Rf_allocVector(SEXPTYPE::VECSXP, n);
             Rf_protect(out);
             for (i, list) in self.into_iter().enumerate() {
-                out.set_vector_elt(i as crate::sys::R_xlen_t, list.0);
+                out.set_vector_elt(i as crate::R_xlen_t, list.0);
             }
             Rf_unprotect(1);
             out
@@ -1118,15 +1120,16 @@ impl IntoR for Vec<Option<List>> {
     }
     fn into_sexp(self) -> SEXP {
         unsafe {
-            use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt as _};
-            let n = self.len() as crate::sys::R_xlen_t;
+            use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+            use crate::{SEXPTYPE, SexpExt as _};
+            let n = self.len() as crate::R_xlen_t;
             // VECSXP slots are zero-initialised to R_NilValue by Rf_allocVector,
             // so None elements require no explicit fill.
             let out = Rf_allocVector(SEXPTYPE::VECSXP, n);
             Rf_protect(out);
             for (i, opt) in self.into_iter().enumerate() {
                 if let Some(list) = opt {
-                    out.set_vector_elt(i as crate::sys::R_xlen_t, list.0);
+                    out.set_vector_elt(i as crate::R_xlen_t, list.0);
                 }
             }
             Rf_unprotect(1);

--- a/miniextendr-api/src/list/accumulator.rs
+++ b/miniextendr-api/src/list/accumulator.rs
@@ -4,11 +4,12 @@
 //! `ListAccumulator` supports dynamic growth via `push`. It uses
 //! `ReprotectSlot` internally to maintain O(1) protect stack usage.
 
+use crate::SEXPTYPE::{STRSXP, VECSXP};
 use crate::from_r::SexpError;
 use crate::gc_protect::{OwnedProtect, ProtectScope, ReprotectSlot, Root};
 use crate::into_r::IntoR;
-use crate::sys::SEXPTYPE::{STRSXP, VECSXP};
-use crate::sys::{self, SEXP, SexpExt};
+use crate::sys::{self};
+use crate::{SEXP, SexpExt};
 
 use super::ListMut;
 
@@ -275,7 +276,7 @@ impl<'a> ListAccumulator<'a> {
                     let idx: isize = i.try_into().expect("index exceeds isize::MAX");
                     if let Some(n) = name {
                         let _n_len: i32 = n.len().try_into().expect("name exceeds i32::MAX bytes");
-                        let charsxp = sys::SEXP::charsxp(n);
+                        let charsxp = SEXP::charsxp(n);
                         names_sexp.get().set_string_elt(idx, charsxp);
                     } else {
                         names_sexp.get().set_string_elt(idx, SEXP::blank_string());

--- a/miniextendr-api/src/list/named.rs
+++ b/miniextendr-api/src/list/named.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SexpExt};
+use crate::{SEXP, SexpExt};
 
 use super::List;
 

--- a/miniextendr-api/src/macro_coverage/fn_matrix.rs
+++ b/miniextendr-api/src/macro_coverage/fn_matrix.rs
@@ -11,8 +11,8 @@
 //! Every `MiniextendrFnAttrs` option has at least one atomic fixture,
 //! and common combinations are also covered.
 
+use crate::SEXP;
 use crate::miniextendr;
-use crate::sys::{self, SEXP};
 
 #[derive(Debug)]
 struct DropTracer(&'static str);
@@ -336,14 +336,14 @@ pub fn cov_explicit_inline() -> i32 {
 
 #[miniextendr]
 #[unsafe(no_mangle)]
-pub(crate) extern "C-unwind" fn C_cov_direct() -> sys::SEXP {
+pub(crate) extern "C-unwind" fn C_cov_direct() -> SEXP {
     SEXP::nil()
 }
 
 #[miniextendr]
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
-pub(crate) extern "C-unwind" fn C_cov_indirect() -> sys::SEXP {
+pub(crate) extern "C-unwind" fn C_cov_indirect() -> SEXP {
     SEXP::nil()
 }
 // endregion

--- a/miniextendr-api/src/macro_coverage/helper_macro_matrix.rs
+++ b/miniextendr-api/src/macro_coverage/helper_macro_matrix.rs
@@ -4,7 +4,7 @@
 //!
 //! Exercises `r_ffi_checked`, `list!`, and `typed_list!` proc-macro entrypoints.
 
-use crate::sys::{R_xlen_t, SEXP, SEXPTYPE};
+use crate::{R_xlen_t, SEXP, SEXPTYPE};
 use crate::{miniextendr, r_ffi_checked};
 
 // region: r_ffi_checked: value-returning and pointer-returning wrappers
@@ -19,7 +19,7 @@ unsafe extern "C-unwind" {
 // region: list! macro usage
 
 #[miniextendr]
-pub(crate) fn cov_list_macro() -> crate::sys::SEXP {
+pub(crate) fn cov_list_macro() -> crate::SEXP {
     use crate::IntoR;
     crate::list!(a = 1i32, b = "x").into_sexp()
 }

--- a/miniextendr-api/src/markers.rs
+++ b/miniextendr-api/src/markers.rs
@@ -212,7 +212,7 @@ pub trait PrefersExternalPtr: crate::externalptr::IntoExternalPtr {}
 /// Marker trait for types that prefer native SEXP conversion.
 ///
 /// Implemented by the `PreferRNativeType` derive; currently informational.
-pub trait PrefersRNativeType: crate::sys::RNativeType {}
+pub trait PrefersRNativeType: crate::RNativeType {}
 
 // region: Coercion marker traits
 

--- a/miniextendr-api/src/match_arg.rs
+++ b/miniextendr-api/src/match_arg.rs
@@ -30,7 +30,7 @@
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::ProtectScope;
 use crate::into_r::IntoR;
-use crate::sys::{self, SEXP, SEXPTYPE, SexpExt};
+use crate::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 
 /// Trait for enum types that support `match.arg`-style string conversion.
 ///
@@ -144,7 +144,7 @@ pub fn choices_sexp<T: MatchArg>() -> SEXP {
             } else {
                 SEXP::charsxp(s)
             };
-            vec.set_string_elt(i as sys::R_xlen_t, charsxp);
+            vec.set_string_elt(i as R_xlen_t, charsxp);
         }
         vec
     }
@@ -176,8 +176,8 @@ fn factor_elt_to_choice<T: MatchArg>(sexp: SEXP) -> Result<T, MatchArgError> {
     }
     let levels = sexp.get_levels();
     // R factor indices are 1-based.
-    let level_idx = (idx - 1) as sys::R_xlen_t;
-    if level_idx < 0 || level_idx >= levels.len() as sys::R_xlen_t {
+    let level_idx = (idx - 1) as R_xlen_t;
+    if level_idx < 0 || level_idx >= levels.len() as R_xlen_t {
         return Err(MatchArgError::NoMatch {
             input: format!("<factor index {}>", idx),
             choices: <T as MatchArg>::CHOICES,
@@ -260,7 +260,7 @@ pub fn match_arg_vec_into_sexp<T: MatchArg>(values: Vec<T>) -> SEXP {
             } else {
                 SEXP::charsxp(s)
             };
-            vec.set_string_elt(i as sys::R_xlen_t, charsxp);
+            vec.set_string_elt(i as R_xlen_t, charsxp);
         }
         vec
     }

--- a/miniextendr-api/src/missing.rs
+++ b/miniextendr-api/src/missing.rs
@@ -67,8 +67,8 @@
 //! 2. `SEXP::missing_arg()` to be passed through `.Call()` to Rust
 //! 3. `Missing<T>` to detect it as `Missing::Absent`
 
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
-use crate::sys::SEXP;
 
 /// Wrapper type that detects if an R argument was not passed (missing).
 ///

--- a/miniextendr-api/src/mx_abi.rs
+++ b/miniextendr-api/src/mx_abi.rs
@@ -9,8 +9,9 @@ use crate::abi::{mx_erased, mx_tag};
 use crate::gc_protect::OwnedProtect;
 use crate::sys::{
     R_ClearExternalPtr, R_ExternalPtrAddr, R_ExternalPtrTag, R_MakeExternalPtr, R_PreserveObject,
-    R_RegisterCCallable, R_RegisterCFinalizerEx, Rboolean, Rf_install, SEXP, SEXPTYPE, SexpExt,
+    R_RegisterCCallable, R_RegisterCFinalizerEx, Rf_install,
 };
+use crate::{Rboolean, SEXP, SEXPTYPE, SexpExt};
 use std::ffi::CStr;
 use std::sync::OnceLock;
 
@@ -37,7 +38,7 @@ unsafe fn get_tag() -> SEXP {
 /// Invokes the object's drop function to clean up the Rust allocation.
 unsafe extern "C-unwind" fn mx_externalptr_finalizer(ptr: SEXP) {
     unsafe {
-        debug_assert_eq!(ptr.type_of(), crate::sys::SEXPTYPE::EXTPTRSXP,);
+        debug_assert_eq!(ptr.type_of(), crate::SEXPTYPE::EXTPTRSXP,);
         let erased = R_ExternalPtrAddr(ptr) as *mut mx_erased;
         if !erased.is_null() {
             let base = (*erased).base;

--- a/miniextendr-api/src/named_vector.rs
+++ b/miniextendr-api/src/named_vector.rs
@@ -26,7 +26,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::gc_protect::{OwnedProtect, ProtectScope};
 use crate::into_r::IntoR;
-use crate::sys::{self, SEXP, SEXPTYPE, SexpExt};
+use crate::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 
 // region: AtomicElement trait
 
@@ -226,7 +226,7 @@ pub(crate) unsafe fn set_names_on_sexp<S: AsRef<str>>(sexp: SEXP, keys: &[S]) {
             } else {
                 SEXP::charsxp(s)
             };
-            names.set_string_elt(i as sys::R_xlen_t, charsxp);
+            names.set_string_elt(i as R_xlen_t, charsxp);
         }
 
         sexp.set_names(names);
@@ -252,7 +252,7 @@ fn extract_names_strict(sexp: SEXP) -> Result<Vec<String>, SexpError> {
     let mut seen = HashSet::with_capacity(len);
 
     for i in 0..len {
-        let charsxp = names.string_elt(i as sys::R_xlen_t);
+        let charsxp = names.string_elt(i as R_xlen_t);
 
         // Reject NA names
         if charsxp == SEXP::na_string() {
@@ -286,10 +286,10 @@ fn extract_names_strict(sexp: SEXP) -> Result<Vec<String>, SexpError> {
 
 impl<V: AtomicElement> IntoR for NamedVector<HashMap<String, V>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -305,10 +305,10 @@ impl<V: AtomicElement> IntoR for NamedVector<HashMap<String, V>> {
 
 impl<V: AtomicElement> IntoR for NamedVector<BTreeMap<String, V>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/aho_corasick_impl.rs
+++ b/miniextendr-api/src/optionals/aho_corasick_impl.rs
@@ -42,7 +42,7 @@ pub use aho_corasick::{AhoCorasick, MatchKind};
 
 use crate::from_r::charsxp_to_str;
 use crate::from_r::{SexpError, TryFromSexp};
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use crate::{
     impl_option_try_from_sexp, impl_vec_option_try_from_sexp_list, impl_vec_try_from_sexp_list,
 };
@@ -78,7 +78,7 @@ impl TryFromSexp for AhoCorasick {
 
         let mut patterns = Vec::with_capacity(len);
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed in patterns",

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -50,7 +50,7 @@ use arrow_array::types::ArrowPrimitiveType;
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{self, R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 // region: RSourced trait — R buffer provenance for Arrow types
 
@@ -473,7 +473,7 @@ impl TryFromSexp for Float64Array {
         // Read element-by-element via elt() which works for all SEXP types.
         let values: Vec<Option<f64>> = (0..len)
             .map(|i| {
-                let v = f64::elt(sexp, i as sys::R_xlen_t);
+                let v = f64::elt(sexp, i as R_xlen_t);
                 if is_na_real(v) { None } else { Some(v) }
             })
             .collect();
@@ -516,7 +516,7 @@ impl TryFromSexp for Int32Array {
         // Read element-by-element via elt() which works for all SEXP types.
         let values: Vec<Option<i32>> = (0..len)
             .map(|i| {
-                let v = i32::elt(sexp, i as sys::R_xlen_t);
+                let v = i32::elt(sexp, i as R_xlen_t);
                 if v == NA_INTEGER { None } else { Some(v) }
             })
             .collect();
@@ -552,9 +552,7 @@ impl TryFromSexp for UInt8Array {
         }
 
         // Fallback: DATAPTR_RO returned null. Read element-by-element via elt().
-        let values: Vec<u8> = (0..len)
-            .map(|i| u8::elt(sexp, i as sys::R_xlen_t))
-            .collect();
+        let values: Vec<u8> = (0..len).map(|i| u8::elt(sexp, i as R_xlen_t)).collect();
         Ok(UInt8Array::from(values))
     }
 
@@ -1209,14 +1207,14 @@ impl IntoR for BooleanArray {
 
     fn into_sexp(self) -> SEXP {
         unsafe {
-            let (sexp, dst) = crate::into_r::alloc_r_vector::<crate::sys::RLogical>(self.len());
+            let (sexp, dst) = crate::into_r::alloc_r_vector::<crate::RLogical>(self.len());
             for (i, slot) in dst.iter_mut().enumerate() {
                 *slot = if self.is_null(i) {
-                    crate::sys::RLogical::NA
+                    crate::RLogical::NA
                 } else if self.value(i) {
-                    crate::sys::RLogical::TRUE
+                    crate::RLogical::TRUE
                 } else {
-                    crate::sys::RLogical::FALSE
+                    crate::RLogical::FALSE
                 };
             }
             sexp

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -50,6 +50,7 @@ use arrow_array::types::ArrowPrimitiveType;
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
+use crate::sys;
 use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 // region: RSourced trait — R buffer provenance for Arrow types

--- a/miniextendr-api/src/optionals/bitflags_impl.rs
+++ b/miniextendr-api/src/optionals/bitflags_impl.rs
@@ -61,7 +61,7 @@ pub use bitflags::Flags;
 use crate::altrep_traits::NA_INTEGER;
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use std::fmt;
 use std::ops::{BitAnd, BitOr, BitXor, Deref, Not};
 

--- a/miniextendr-api/src/optionals/bitvec_impl.rs
+++ b/miniextendr-api/src/optionals/bitvec_impl.rs
@@ -50,7 +50,7 @@ use crate::altrep_traits::NA_LOGICAL;
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::impl_option_try_from_sexp;
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Standard bit vector type for R interop.
 ///
@@ -76,7 +76,7 @@ impl TryFromSexp for RBitVec {
         let mut bits = RBitVec::with_capacity(len);
 
         for i in 0..len {
-            let val = sexp.logical_elt(i as crate::sys::R_xlen_t);
+            let val = sexp.logical_elt(i as crate::R_xlen_t);
             if val == NA_LOGICAL {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for RBitVec",
@@ -97,21 +97,21 @@ impl_option_try_from_sexp!(RBitVec);
 
 impl IntoR for RBitVec {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         use crate::sys::Rf_allocVector;
 
         let len = self.len();
-        let sexp = unsafe { Rf_allocVector(SEXPTYPE::LGLSXP, len as crate::sys::R_xlen_t) };
+        let sexp = unsafe { Rf_allocVector(SEXPTYPE::LGLSXP, len as crate::R_xlen_t) };
 
         for (i, bit) in self.iter().enumerate() {
             let val = if *bit { 1 } else { 0 };
-            sexp.set_logical_elt(i as crate::sys::R_xlen_t, val);
+            sexp.set_logical_elt(i as crate::R_xlen_t, val);
         }
 
         sexp
@@ -120,16 +120,16 @@ impl IntoR for RBitVec {
 
 impl IntoR for Option<RBitVec> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         match self {
             Some(bits) => bits.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -154,7 +154,7 @@ impl TryFromSexp for BitVec<u8, Msb0> {
         let mut bits = BitVec::<u8, Msb0>::with_capacity(len);
 
         for i in 0..len {
-            let val = sexp.logical_elt(i as crate::sys::R_xlen_t);
+            let val = sexp.logical_elt(i as crate::R_xlen_t);
             if val == NA_LOGICAL {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for BitVec",
@@ -172,21 +172,21 @@ impl_option_try_from_sexp!(BitVec<u8, Msb0>);
 
 impl IntoR for BitVec<u8, Msb0> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         use crate::sys::Rf_allocVector;
 
         let len = self.len();
-        let sexp = unsafe { Rf_allocVector(SEXPTYPE::LGLSXP, len as crate::sys::R_xlen_t) };
+        let sexp = unsafe { Rf_allocVector(SEXPTYPE::LGLSXP, len as crate::R_xlen_t) };
 
         for (i, bit) in self.iter().enumerate() {
             let val = if *bit { 1 } else { 0 };
-            sexp.set_logical_elt(i as crate::sys::R_xlen_t, val);
+            sexp.set_logical_elt(i as crate::R_xlen_t, val);
         }
 
         sexp
@@ -195,16 +195,16 @@ impl IntoR for BitVec<u8, Msb0> {
 
 impl IntoR for Option<BitVec<u8, Msb0>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         match self {
             Some(bits) => bits.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }

--- a/miniextendr-api/src/optionals/borsh_impl.rs
+++ b/miniextendr-api/src/optionals/borsh_impl.rs
@@ -19,9 +19,9 @@
 //! | `borsh_to_raw` | `&T` | R raw vector (SEXP) |
 //! | `borsh_from_raw` | R raw vector (SEXP) | `Result<T, SexpError>` |
 
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::SEXP;
 
 // region: Borsh<T> wrapper type
 

--- a/miniextendr-api/src/optionals/bytes_impl.rs
+++ b/miniextendr-api/src/optionals/bytes_impl.rs
@@ -358,18 +358,18 @@ use crate::into_r::IntoR;
 /// Convert `Bytes` to R raw vector (RAWSXP).
 impl IntoR for Bytes {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // Convert to Vec<u8> for efficient bulk copy
         Vec::from(self.as_ref()).into_sexp()
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { Vec::from(self.as_ref()).into_sexp_unchecked() }
     }
 }
@@ -378,12 +378,12 @@ impl IntoR for Bytes {
 impl TryFromSexp for Bytes {
     type Error = crate::from_r::SexpTypeError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let vec: Vec<u8> = TryFromSexp::try_from_sexp(sexp)?;
         Ok(Bytes::from(vec))
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let vec: Vec<u8> = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
         Ok(Bytes::from(vec))
     }
@@ -392,18 +392,18 @@ impl TryFromSexp for Bytes {
 /// Convert `BytesMut` to R raw vector (RAWSXP).
 impl IntoR for BytesMut {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         // Convert to Vec<u8> for efficient bulk copy
         self.to_vec().into_sexp()
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe { self.to_vec().into_sexp_unchecked() }
     }
 }
@@ -412,12 +412,12 @@ impl IntoR for BytesMut {
 impl TryFromSexp for BytesMut {
     type Error = crate::from_r::SexpTypeError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let vec: Vec<u8> = TryFromSexp::try_from_sexp(sexp)?;
         Ok(BytesMut::from(vec.as_slice()))
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
         let vec: Vec<u8> = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
         Ok(BytesMut::from(vec.as_slice()))
     }
@@ -427,16 +427,16 @@ impl TryFromSexp for BytesMut {
 impl TryFromSexp for Option<Bytes> {
     type Error = crate::from_r::SexpTypeError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::{SEXPTYPE, SexpExt};
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
+        use crate::{SEXPTYPE, SexpExt};
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
         Bytes::try_from_sexp(sexp).map(Some)
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::{SEXPTYPE, SexpExt};
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
+        use crate::{SEXPTYPE, SexpExt};
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
@@ -448,16 +448,16 @@ impl TryFromSexp for Option<Bytes> {
 impl TryFromSexp for Option<BytesMut> {
     type Error = crate::from_r::SexpTypeError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::{SEXPTYPE, SexpExt};
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
+        use crate::{SEXPTYPE, SexpExt};
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
         BytesMut::try_from_sexp(sexp).map(Some)
     }
 
-    unsafe fn try_from_sexp_unchecked(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::{SEXPTYPE, SexpExt};
+    unsafe fn try_from_sexp_unchecked(sexp: crate::SEXP) -> Result<Self, Self::Error> {
+        use crate::{SEXPTYPE, SexpExt};
         if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
@@ -468,23 +468,23 @@ impl TryFromSexp for Option<BytesMut> {
 /// Convert `Option<Bytes>` to R: Some → raw vector, None → NULL.
 impl IntoR for Option<Bytes> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(b) => b.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(b) => unsafe { b.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
@@ -492,23 +492,23 @@ impl IntoR for Option<Bytes> {
 /// Convert `Option<BytesMut>` to R: Some → raw vector, None → NULL.
 impl IntoR for Option<BytesMut> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         match self {
             Some(b) => b.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 
-    unsafe fn into_sexp_unchecked(self) -> crate::sys::SEXP {
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         match self {
             Some(b) => unsafe { b.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }

--- a/miniextendr-api/src/optionals/datafusion_impl.rs
+++ b/miniextendr-api/src/optionals/datafusion_impl.rs
@@ -59,8 +59,8 @@ use datafusion::prelude::*;
 use std::sync::Arc;
 
 use super::arrow_impl::RecordBatch;
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
-use crate::sys::SEXP;
 
 /// Get or create a thread-local Tokio runtime for blocking on async DataFusion operations.
 ///
@@ -199,7 +199,7 @@ impl TryFromSexp for RSessionContext {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::{SEXPTYPE, SexpExt};
+        use crate::{SEXPTYPE, SexpExt};
         if sexp.type_of() == SEXPTYPE::NILSXP {
             Ok(Self::new())
         } else {

--- a/miniextendr-api/src/optionals/either_impl.rs
+++ b/miniextendr-api/src/optionals/either_impl.rs
@@ -85,9 +85,9 @@
 
 pub use either::{Either, Left, Right};
 
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::SEXP;
 
 /// Implements `TryFromSexp` for `Either<L, R>`.
 ///

--- a/miniextendr-api/src/optionals/indexmap_impl.rs
+++ b/miniextendr-api/src/optionals/indexmap_impl.rs
@@ -54,7 +54,8 @@ pub use indexmap::IndexMap;
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{R_xlen_t, Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::Rf_allocVector;
+use crate::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 
 // region: TryFromSexp for IndexMap<String, T>
 

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -41,7 +41,8 @@ pub use jiff::{SignedDuration, Span, Timestamp, Zoned};
 use crate::cached_class::{date_class_sexp, set_posixct_tz, set_posixct_utc};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Unix epoch as a civil::Date constant.
 fn unix_epoch_date() -> Date {
@@ -884,7 +885,7 @@ impl IntoR for Vec<Option<Zoned>> {
 
 fn set_difftime_secs_class(sexp: SEXP) {
     unsafe {
-        use crate::sys::SexpExt as _;
+        use crate::SexpExt as _;
         // Build class = "difftime"
         let class_sexp = Rf_allocVector(SEXPTYPE::STRSXP, 1);
         Rf_protect(class_sexp);
@@ -1588,7 +1589,7 @@ impl JiffZonedVec {
     /// This is the primary conversion path. The derive-generated [`IntoR`] impl
     /// produces a raw ALTREP without class/tzone; use this method instead when
     /// you want a fully-formed R POSIXct.
-    pub fn into_posixct_sexp(self) -> crate::sys::SEXP {
+    pub fn into_posixct_sexp(self) -> crate::SEXP {
         use crate::into_r::IntoRAltrep;
         let tzone = self.tzone.clone();
         let altrep = self.into_sexp_altrep();
@@ -1604,12 +1605,12 @@ impl JiffZonedVec {
 impl crate::from_r::TryFromSexp for JiffZonedVec {
     type Error = crate::from_r::SexpError;
 
-    fn try_from_sexp(sexp: crate::sys::SEXP) -> Result<Self, Self::Error> {
-        use crate::sys::SexpExt as _;
+    fn try_from_sexp(sexp: crate::SEXP) -> Result<Self, Self::Error> {
+        use crate::SexpExt as _;
         let actual = sexp.type_of();
-        if actual != crate::sys::SEXPTYPE::REALSXP {
+        if actual != crate::SEXPTYPE::REALSXP {
             return Err(crate::from_r::SexpTypeError {
-                expected: crate::sys::SEXPTYPE::REALSXP,
+                expected: crate::SEXPTYPE::REALSXP,
                 actual,
             }
             .into());
@@ -1619,7 +1620,7 @@ impl crate::from_r::TryFromSexp for JiffZonedVec {
         let tz_name: String = unsafe {
             let tzone_sym = crate::cached_class::tzone_symbol();
             let tzone_attr = sexp.get_attr(tzone_sym);
-            if tzone_attr.type_of() == crate::sys::SEXPTYPE::STRSXP && tzone_attr.len() >= 1 {
+            if tzone_attr.type_of() == crate::SEXPTYPE::STRSXP && tzone_attr.len() >= 1 {
                 let charsxp = tzone_attr.string_elt(0);
                 let cstr = std::ffi::CStr::from_ptr(charsxp.r_char());
                 cstr.to_string_lossy().into_owned()
@@ -1756,7 +1757,7 @@ pub mod vctrs_support {
 
         // STRSXP column — allocate and protect via OwnedProtect so it outlives
         // the List::from_raw_values call (which allocates a VECSXP and can GC).
-        let tz_col = unsafe { Rf_allocVector(SEXPTYPE::STRSXP, n as crate::sys::R_xlen_t) };
+        let tz_col = unsafe { Rf_allocVector(SEXPTYPE::STRSXP, n as crate::R_xlen_t) };
         // GC-SAFETY: _tz_guard keeps tz_col rooted until after from_raw_values.
         let _tz_guard = unsafe { crate::gc_protect::OwnedProtect::new(tz_col) };
 
@@ -1764,7 +1765,7 @@ pub mod vctrs_support {
             let ts = z.timestamp();
             ts_dst[i] = ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0);
             let iana = z.time_zone().iana_name().unwrap_or("UTC");
-            tz_col.set_string_elt(i as crate::sys::R_xlen_t, SEXP::charsxp(iana));
+            tz_col.set_string_elt(i as crate::R_xlen_t, SEXP::charsxp(iana));
         }
         // Guards (_ts_guard, _tz_guard) drop after from_raw_values returns —
         // at that point the VECSXP owns both columns via SET_VECTOR_ELT, keeping

--- a/miniextendr-api/src/optionals/log_impl.rs
+++ b/miniextendr-api/src/optionals/log_impl.rs
@@ -320,7 +320,7 @@ impl crate::TryFromSexp for log::LevelFilter {
     type Error = crate::SexpError;
 
     fn try_from_sexp(
-        sexp: crate::sys::SEXP,
+        sexp: crate::SEXP,
     ) -> Result<Self, <log::LevelFilter as crate::TryFromSexp>::Error> {
         crate::match_arg_from_sexp(sexp).map_err(Into::into)
     }
@@ -332,17 +332,17 @@ impl crate::TryFromSexp for log::LevelFilter {
 impl crate::IntoR for log::LevelFilter {
     type Error = std::convert::Infallible;
 
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, <log::LevelFilter as crate::IntoR>::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, <log::LevelFilter as crate::IntoR>::Error> {
         Ok(self.into_sexp())
     }
 
     unsafe fn try_into_sexp_unchecked(
         self,
-    ) -> Result<crate::sys::SEXP, <log::LevelFilter as crate::IntoR>::Error> {
+    ) -> Result<crate::SEXP, <log::LevelFilter as crate::IntoR>::Error> {
         self.try_into_sexp()
     }
 
-    fn into_sexp(self) -> crate::sys::SEXP {
+    fn into_sexp(self) -> crate::SEXP {
         use crate::MatchArg;
         self.to_choice().into_sexp()
     }

--- a/miniextendr-api/src/optionals/nalgebra_impl.rs
+++ b/miniextendr-api/src/optionals/nalgebra_impl.rs
@@ -66,7 +66,7 @@ pub use nalgebra::{DMatrix, DVector, SMatrix, SVector};
 use crate::from_r::{SexpError, SexpLengthError, TryFromSexp};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use nalgebra::Scalar;
 
 // region: Blanket implementations for DVector and DMatrix
@@ -339,7 +339,7 @@ impl<T: RNativeType + Scalar, const R: usize, const C: usize> IntoR for Option<S
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(m) => m.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 
@@ -347,7 +347,7 @@ impl<T: RNativeType + Scalar, const R: usize, const C: usize> IntoR for Option<S
     unsafe fn try_into_sexp_unchecked(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(m) => unsafe { m.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 }
@@ -1076,7 +1076,7 @@ impl<T: RNativeType> RVecStorage<T, Dyn, U1> {
     ///
     /// Must be called on R's main thread.
     pub unsafe fn new_vector(len: usize, init: impl FnOnce(&mut [T])) -> Self {
-        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, len as sys::R_xlen_t) };
+        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, len as R_xlen_t) };
         unsafe { crate::sys::R_PreserveObject(sexp) };
         let ptr = unsafe { T::dataptr_mut(sexp) };
         let slice = unsafe { crate::from_r::r_slice_mut(ptr, len) };
@@ -1133,7 +1133,7 @@ impl<T: RNativeType> RVecStorage<T, Dyn, Dyn> {
     /// Must be called on R's main thread.
     pub unsafe fn new_matrix(nrows: usize, ncols: usize, init: impl FnOnce(&mut [T])) -> Self {
         let total = nrows * ncols;
-        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, total as sys::R_xlen_t) };
+        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, total as R_xlen_t) };
         unsafe { crate::sys::R_PreserveObject(sexp) };
         let ptr = unsafe { T::dataptr_mut(sexp) };
         let slice = unsafe { crate::from_r::r_slice_mut(ptr, total) };

--- a/miniextendr-api/src/optionals/ndarray_impl.rs
+++ b/miniextendr-api/src/optionals/ndarray_impl.rs
@@ -111,7 +111,7 @@ use crate::coerce::TryCoerce;
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
 use crate::gc_protect::{OwnedProtect, ProtectScope};
 use crate::into_r::IntoR;
-use crate::sys::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 // region: Blanket implementations for ndarray types where T: RNativeType
 
@@ -677,7 +677,7 @@ impl_all_arrays_try_from_sexp_coerce!(f64 => f32);
 // endregion
 
 // region: Logical coercions: R logical (RLogical) -> bool
-impl_all_arrays_try_from_sexp_coerce!(crate::sys::RLogical => bool);
+impl_all_arrays_try_from_sexp_coerce!(crate::RLogical => bool);
 // endregion
 
 // region: Array2 conversions
@@ -752,7 +752,7 @@ impl<T: RNativeType + Clone> IntoR for Array3<T> {
             let scope = ProtectScope::new();
 
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, data.len() as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, data.len() as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -797,7 +797,7 @@ impl<T: RNativeType + Clone> IntoR for Array4<T> {
         Ok(unsafe {
             let scope = ProtectScope::new();
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, total_len as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -842,7 +842,7 @@ impl<T: RNativeType + Clone> IntoR for Array5<T> {
         Ok(unsafe {
             let scope = ProtectScope::new();
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, total_len as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -883,7 +883,7 @@ impl<T: RNativeType + Clone> IntoR for Array6<T> {
         Ok(unsafe {
             let scope = ProtectScope::new();
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, total_len as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -931,7 +931,7 @@ impl<T: RNativeType + Clone> IntoR for ArrayD<T> {
             let scope = ProtectScope::new();
 
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, total_len as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -1099,7 +1099,7 @@ impl<'a, T: RNativeType + Clone> IntoR for ArrayView3<'a, T> {
             let scope = ProtectScope::new();
 
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, data.len() as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, data.len() as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -1140,7 +1140,7 @@ impl<'a, T: RNativeType + Clone> IntoR for ArrayViewD<'a, T> {
             let scope = ProtectScope::new();
 
             let arr = scope
-                .alloc_vector(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t)
+                .alloc_vector(T::SEXP_TYPE, total_len as crate::R_xlen_t)
                 .into_raw();
 
             let dst = crate::from_r::r_slice_mut(T::dataptr_mut(arr), data.len());
@@ -1587,8 +1587,8 @@ impl<T: RNativeType + Clone, const NDIM: usize> From<&RArray<T, NDIM>> for Array
 // Default behavior: `Array1<f64>` → copies to R vector (via IntoR)
 // Explicit ExternalPtr: `ExternalPtr::new(arr)` → wraps without copying
 
+use crate::Rcomplex;
 use crate::externalptr::TypedExternal;
-use crate::sys::Rcomplex;
 
 // Helper macro for implementing TypedExternal for ndarray types.
 // For these well-known library types, we use the descriptive name as both
@@ -2772,7 +2772,7 @@ impl<T: RNativeType> RndVec<T> {
     ///
     /// Must be called on R's main thread.
     pub unsafe fn new(len: usize, init: impl FnOnce(&mut [T])) -> Self {
-        let sexp = unsafe { crate::sys::Rf_allocVector(T::SEXP_TYPE, len as crate::sys::R_xlen_t) };
+        let sexp = unsafe { crate::sys::Rf_allocVector(T::SEXP_TYPE, len as crate::R_xlen_t) };
         unsafe { crate::sys::R_PreserveObject(sexp) };
         let ptr = unsafe { T::dataptr_mut(sexp) };
         let slice = unsafe { crate::from_r::r_slice_mut(ptr, len) };

--- a/miniextendr-api/src/optionals/num_bigint_impl.rs
+++ b/miniextendr-api/src/optionals/num_bigint_impl.rs
@@ -16,7 +16,7 @@ pub use num_bigint::{BigInt, BigUint};
 use crate::coerce::{Coerce, CoerceError, TryCoerce};
 use crate::from_r::{SexpError, SexpNaError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE};
+use crate::{SEXP, SEXPTYPE};
 use std::str::FromStr;
 
 // region: Coerce/TryCoerce impls for BigInt and BigUint
@@ -305,10 +305,10 @@ impl TryFromSexp for Vec<Option<BigUint>> {
 
 impl IntoR for BigInt {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -318,10 +318,10 @@ impl IntoR for BigInt {
 
 impl IntoR for BigUint {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -331,10 +331,10 @@ impl IntoR for BigUint {
 
 impl IntoR for Option<BigInt> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -344,10 +344,10 @@ impl IntoR for Option<BigInt> {
 
 impl IntoR for Option<BigUint> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -357,10 +357,10 @@ impl IntoR for Option<BigUint> {
 
 impl IntoR for Vec<BigInt> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -373,10 +373,10 @@ impl IntoR for Vec<BigInt> {
 
 impl IntoR for Vec<BigUint> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -389,10 +389,10 @@ impl IntoR for Vec<BigUint> {
 
 impl IntoR for Vec<Option<BigInt>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -405,10 +405,10 @@ impl IntoR for Vec<Option<BigInt>> {
 
 impl IntoR for Vec<Option<BigUint>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/num_complex_impl.rs
+++ b/miniextendr-api/src/optionals/num_complex_impl.rs
@@ -44,7 +44,7 @@ pub use num_complex::Complex;
 use crate::altrep_traits::NA_REAL;
 use crate::from_r::{SexpError, SexpLengthError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{Rcomplex, SEXP, SEXPTYPE, SexpExt};
+use crate::{Rcomplex, SEXP, SEXPTYPE, SexpExt};
 
 // region: Helper functions
 
@@ -123,10 +123,10 @@ impl TryFromSexp for Complex<f64> {
 
 impl IntoR for Complex<f64> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -173,10 +173,10 @@ impl TryFromSexp for Option<Complex<f64>> {
 
 impl IntoR for Option<Complex<f64>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -222,17 +222,17 @@ impl TryFromSexp for Vec<Complex<f64>> {
 
 impl IntoR for Vec<Complex<f64>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         use crate::sys::Rf_allocVector;
 
         let len = self.len();
-        let sexp = unsafe { Rf_allocVector(SEXPTYPE::CPLXSXP, len as crate::sys::R_xlen_t) };
+        let sexp = unsafe { Rf_allocVector(SEXPTYPE::CPLXSXP, len as crate::R_xlen_t) };
         let dst: &mut [Rcomplex] = unsafe { SexpExt::as_mut_slice(&sexp) };
 
         for (i, c) in self.into_iter().enumerate() {
@@ -277,17 +277,17 @@ impl TryFromSexp for Vec<Option<Complex<f64>>> {
 
 impl IntoR for Vec<Option<Complex<f64>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         use crate::sys::Rf_allocVector;
 
         let len = self.len();
-        let sexp = unsafe { Rf_allocVector(SEXPTYPE::CPLXSXP, len as crate::sys::R_xlen_t) };
+        let sexp = unsafe { Rf_allocVector(SEXPTYPE::CPLXSXP, len as crate::R_xlen_t) };
         let dst: &mut [Rcomplex] = unsafe { SexpExt::as_mut_slice(&sexp) };
 
         for (i, opt) in self.into_iter().enumerate() {

--- a/miniextendr-api/src/optionals/ordered_float_impl.rs
+++ b/miniextendr-api/src/optionals/ordered_float_impl.rs
@@ -16,7 +16,7 @@ pub use ordered_float::OrderedFloat;
 use crate::coerce::{Coerce, CoerceError, TryCoerce};
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Coerce/TryCoerce impls for OrderedFloat
 
@@ -208,10 +208,10 @@ impl TryFromSexp for Vec<Option<OrderedFloat<f32>>> {
 
 impl IntoR for OrderedFloat<f64> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -221,10 +221,10 @@ impl IntoR for OrderedFloat<f64> {
 
 impl IntoR for OrderedFloat<f32> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -234,10 +234,10 @@ impl IntoR for OrderedFloat<f32> {
 
 impl IntoR for Option<OrderedFloat<f64>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -247,10 +247,10 @@ impl IntoR for Option<OrderedFloat<f64>> {
 
 impl IntoR for Option<OrderedFloat<f32>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -260,10 +260,10 @@ impl IntoR for Option<OrderedFloat<f32>> {
 
 impl IntoR for Vec<OrderedFloat<f64>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -276,10 +276,10 @@ impl IntoR for Vec<OrderedFloat<f64>> {
 
 impl IntoR for Vec<OrderedFloat<f32>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -292,10 +292,10 @@ impl IntoR for Vec<OrderedFloat<f32>> {
 
 impl IntoR for Vec<Option<OrderedFloat<f64>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -308,10 +308,10 @@ impl IntoR for Vec<Option<OrderedFloat<f64>>> {
 
 impl IntoR for Vec<Option<OrderedFloat<f32>>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/rayon_bridge.rs
+++ b/miniextendr-api/src/optionals/rayon_bridge.rs
@@ -143,7 +143,7 @@
 //! ```ignore
 //! // UNSAFE: _unchecked variants don't route to main thread
 //! data.par_iter().map(|x| {
-//!     unsafe { sys::SEXP::scalar_real_unchecked(*x) }  // UB! No routing
+//!     unsafe { SEXP::scalar_real_unchecked(*x) }  // UB! No routing
 //! }).collect()
 //! ```
 //!
@@ -193,8 +193,8 @@
 //! on primitive types (`i32`, `f64`, `bool`, etc.) and standard Rust collections.
 
 use crate::IntoR;
-use crate::sys::{RNativeType, SEXP, SexpExt};
 use crate::worker::with_r_thread;
+use crate::{RNativeType, SEXP, SexpExt};
 
 #[cfg(feature = "rayon")]
 pub use rayon;
@@ -267,7 +267,7 @@ where
     // Allocate, protect, and get data pointer on the R main thread
     use crate::worker::Sendable;
     let (sexp, Sendable(ptr)) = with_r_thread(move || unsafe {
-        let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, len as crate::sys::R_xlen_t);
+        let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, len as crate::R_xlen_t);
         crate::sys::Rf_protect_unchecked(sexp);
         let ptr = T::dataptr_mut(sexp);
         (sexp, Sendable(ptr))
@@ -582,8 +582,7 @@ where
     // Allocate, set dims, protect, and get data pointer on the R main thread
     use crate::worker::Sendable;
     let (sexp, Sendable(ptr)) = with_r_thread(move || unsafe {
-        let sexp =
-            crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, total_len as crate::sys::R_xlen_t);
+        let sexp = crate::sys::Rf_allocVector_unchecked(T::SEXP_TYPE, total_len as crate::R_xlen_t);
         crate::sys::Rf_protect_unchecked(sexp);
 
         let (dim_sexp, dim_s) = crate::into_r::alloc_r_vector_unchecked::<i32>(NDIM);
@@ -1269,10 +1268,8 @@ pub trait ParCollectR: rayon::iter::IndexedParallelIterator + Sized {
         // Allocate, protect, and get data pointer on the R main thread
         use crate::worker::Sendable;
         let (sexp, Sendable(ptr)) = with_r_thread(move || unsafe {
-            let sexp = crate::sys::Rf_allocVector_unchecked(
-                Self::Item::SEXP_TYPE,
-                len as crate::sys::R_xlen_t,
-            );
+            let sexp =
+                crate::sys::Rf_allocVector_unchecked(Self::Item::SEXP_TYPE, len as crate::R_xlen_t);
             crate::sys::Rf_protect_unchecked(sexp);
             let ptr = Self::Item::dataptr_mut(sexp);
             (sexp, Sendable(ptr))

--- a/miniextendr-api/src/optionals/regex_impl.rs
+++ b/miniextendr-api/src/optionals/regex_impl.rs
@@ -60,8 +60,8 @@
 
 pub use regex::Regex;
 
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
-use crate::sys::SEXP;
 
 // region: Scalar conversions
 

--- a/miniextendr-api/src/optionals/rust_decimal_impl.rs
+++ b/miniextendr-api/src/optionals/rust_decimal_impl.rs
@@ -49,7 +49,7 @@ pub use rust_decimal::Decimal;
 use crate::coerce::{Coerce, CoerceError, TryCoerce};
 use crate::from_r::{SexpError, SexpNaError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use std::str::FromStr;
 
 // region: Coerce/TryCoerce impls for Decimal
@@ -286,10 +286,10 @@ impl TryFromSexp for Vec<Option<Decimal>> {
 
 impl IntoR for Decimal {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -299,10 +299,10 @@ impl IntoR for Decimal {
 
 impl IntoR for Option<Decimal> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -312,10 +312,10 @@ impl IntoR for Option<Decimal> {
 
 impl IntoR for Vec<Decimal> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -328,10 +328,10 @@ impl IntoR for Vec<Decimal> {
 
 impl IntoR for Vec<Option<Decimal>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/serde_impl.rs
+++ b/miniextendr-api/src/optionals/serde_impl.rs
@@ -182,7 +182,8 @@ impl JsonOptions {
 use crate::from_r::{SexpError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::Rf_allocVector;
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use crate::{
     impl_option_try_from_sexp, impl_vec_option_try_from_sexp_list, impl_vec_try_from_sexp_list,
 };
@@ -590,10 +591,10 @@ impl_vec_option_try_from_sexp_list!(JsonValue);
 
 impl IntoR for JsonValue {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -603,26 +604,26 @@ impl IntoR for JsonValue {
 
 impl IntoR for Option<JsonValue> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         match self {
             Some(value) => json_value_to_sexp(&value),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
 
 impl IntoR for Vec<JsonValue> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -646,10 +647,10 @@ impl IntoR for Vec<JsonValue> {
 
 impl IntoR for Vec<Option<JsonValue>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -663,7 +664,7 @@ impl IntoR for Vec<Option<JsonValue>> {
         for (i, value) in self.iter().enumerate() {
             let elem = match value {
                 Some(v) => json_value_to_sexp(v),
-                None => crate::sys::SEXP::nil(),
+                None => crate::SEXP::nil(),
             };
             sexp.get()
                 .set_vector_elt(isize::try_from(i).expect("index overflow"), elem)
@@ -702,7 +703,7 @@ fn json_discriminant(v: &JsonValue) -> u8 {
 
 fn json_value_to_sexp(value: &JsonValue) -> SEXP {
     match value {
-        JsonValue::Null => crate::sys::SEXP::nil(),
+        JsonValue::Null => crate::SEXP::nil(),
         JsonValue::Bool(b) => {
             let sexp = unsafe { Rf_allocVector(SEXPTYPE::LGLSXP, 1) };
             sexp.set_logical_elt(0, if *b { 1 } else { 0 });

--- a/miniextendr-api/src/optionals/tabled_impl.rs
+++ b/miniextendr-api/src/optionals/tabled_impl.rs
@@ -49,7 +49,8 @@ pub use tabled::{Table, Tabled};
 
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::Rf_allocVector;
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Helper functions
 
@@ -194,10 +195,10 @@ pub fn table_to_string_styled<T: Tabled>(rows: &[T], style: &str) -> String {
 
 impl IntoR for Table {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     /// Convert a Table to an R character scalar.

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -53,7 +53,8 @@ pub use time::{Date, OffsetDateTime};
 use crate::cached_class::set_posixct_utc;
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Unix epoch as an OffsetDateTime constant.
 const UNIX_EPOCH: OffsetDateTime = time::macros::datetime!(1970-01-01 0:00 UTC);
@@ -108,10 +109,10 @@ impl TryFromSexp for OffsetDateTime {
 
 impl IntoR for OffsetDateTime {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -180,10 +181,10 @@ impl TryFromSexp for Option<OffsetDateTime> {
 
 impl IntoR for Option<OffsetDateTime> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -246,10 +247,10 @@ impl TryFromSexp for Vec<OffsetDateTime> {
 
 impl IntoR for Vec<OffsetDateTime> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -313,10 +314,10 @@ impl TryFromSexp for Vec<Option<OffsetDateTime>> {
 
 impl IntoR for Vec<Option<OffsetDateTime>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -384,10 +385,10 @@ impl TryFromSexp for Date {
 
 impl IntoR for Date {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -452,10 +453,10 @@ impl TryFromSexp for Option<Date> {
 
 impl IntoR for Option<Date> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -517,10 +518,10 @@ impl TryFromSexp for Vec<Date> {
 
 impl IntoR for Vec<Date> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -579,10 +580,10 @@ impl TryFromSexp for Vec<Option<Date>> {
 
 impl IntoR for Vec<Option<Date>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/tinyvec_impl.rs
+++ b/miniextendr-api/src/optionals/tinyvec_impl.rs
@@ -65,7 +65,7 @@ pub use tinyvec::{Array, ArrayVec, TinyVec};
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 // region: Blanket implementations for TinyVec and ArrayVec
 //
@@ -210,7 +210,7 @@ where
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(tv) => tv.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 
@@ -218,7 +218,7 @@ where
     unsafe fn try_into_sexp_unchecked(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(tv) => unsafe { tv.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 }
@@ -259,7 +259,7 @@ where
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(av) => av.into_sexp(),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 
@@ -267,7 +267,7 @@ where
     unsafe fn try_into_sexp_unchecked(self) -> Result<SEXP, Self::Error> {
         Ok(match self {
             Some(av) => unsafe { av.into_sexp_unchecked() },
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         })
     }
 }

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -68,7 +68,8 @@ use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str};
 use crate::gc_protect::OwnedProtect;
 use crate::impl_option_try_from_sexp;
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::Rf_allocVector;
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Helper functions
 
@@ -207,10 +208,10 @@ impl TryFromSexp for Vec<Option<TomlValue>> {
 
 impl IntoR for TomlValue {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     /// Convert a TOML value to an R object.
@@ -229,26 +230,26 @@ impl IntoR for TomlValue {
 
 impl IntoR for Option<TomlValue> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
         match self {
             Some(value) => toml_value_to_sexp(&value),
-            None => crate::sys::SEXP::nil(),
+            None => crate::SEXP::nil(),
         }
     }
 }
 
 impl IntoR for Vec<TomlValue> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -272,10 +273,10 @@ impl IntoR for Vec<TomlValue> {
 
 impl IntoR for Vec<Option<TomlValue>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -289,7 +290,7 @@ impl IntoR for Vec<Option<TomlValue>> {
         for (i, value) in self.iter().enumerate() {
             let elem = match value {
                 Some(v) => toml_value_to_sexp(v),
-                None => crate::sys::SEXP::nil(),
+                None => crate::SEXP::nil(),
             };
             sexp.get()
                 .set_vector_elt(isize::try_from(i).expect("index overflow"), elem)
@@ -475,11 +476,10 @@ fn array_to_sexp(arr: &[TomlValue]) -> SEXP {
                         isize::try_from(arr.len()).expect("length exceeds R_xlen_t"),
                     ))
                 };
-                let dst: &mut [crate::sys::RLogical] =
-                    unsafe { SexpExt::as_mut_slice(&sexp.get()) };
+                let dst: &mut [crate::RLogical] = unsafe { SexpExt::as_mut_slice(&sexp.get()) };
                 for (i, v) in arr.iter().enumerate() {
                     if let TomlValue::Boolean(b) = v {
-                        dst[i] = crate::sys::RLogical::from(*b);
+                        dst[i] = crate::RLogical::from(*b);
                     }
                 }
                 return sexp.get();

--- a/miniextendr-api/src/optionals/url_impl.rs
+++ b/miniextendr-api/src/optionals/url_impl.rs
@@ -44,7 +44,7 @@ use crate::from_r::{
     SexpError, SexpLengthError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str,
 };
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Scalar conversions
 
@@ -83,10 +83,10 @@ impl TryFromSexp for Url {
 
 impl IntoR for Url {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -137,10 +137,10 @@ impl TryFromSexp for Option<Url> {
 
 impl IntoR for Option<Url> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -169,7 +169,7 @@ impl TryFromSexp for Vec<Url> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for Vec<Url>",
@@ -194,10 +194,10 @@ impl TryFromSexp for Vec<Url> {
 
 impl IntoR for Vec<Url> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -227,7 +227,7 @@ impl TryFromSexp for Vec<Option<Url>> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
             if charsxp == SEXP::na_string() {
                 result.push(None);
             } else {
@@ -250,10 +250,10 @@ impl TryFromSexp for Vec<Option<Url>> {
 
 impl IntoR for Vec<Option<Url>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/optionals/uuid_impl.rs
+++ b/miniextendr-api/src/optionals/uuid_impl.rs
@@ -37,7 +37,7 @@ pub use uuid::Uuid;
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Scalar conversions
 
@@ -52,10 +52,10 @@ impl TryFromSexp for Uuid {
 
 impl IntoR for Uuid {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -82,10 +82,10 @@ impl TryFromSexp for Option<Uuid> {
 
 impl IntoR for Option<Uuid> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -115,7 +115,7 @@ impl TryFromSexp for Vec<Uuid> {
         let mut result = Vec::with_capacity(len);
 
         for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::sys::R_xlen_t);
+            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
 
             // Check for NA
             if charsxp == SEXP::na_string() {
@@ -139,10 +139,10 @@ impl TryFromSexp for Vec<Uuid> {
 
 impl IntoR for Vec<Uuid> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {
@@ -176,10 +176,10 @@ impl TryFromSexp for Vec<Option<Uuid>> {
 
 impl IntoR for Vec<Option<Uuid>> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         self.try_into_sexp()
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/prelude.rs
+++ b/miniextendr-api/src/prelude.rs
@@ -77,12 +77,15 @@ pub use crate::{r_print, r_println, r_warning};
 // region: Safe R-value surface
 //
 // `SEXP` is the central newtype; `SexpExt` is the ergonomic extension trait
-// that provides the safe higher-level methods. Raw FFI vocabulary
-// (`SEXPTYPE`, `R_xlen_t`, `RLogical`, `Rboolean`, `Rcomplex`, `RNativeType`)
-// is **not** re-exported here — those are low-level types that user code
-// should reach for explicitly via `miniextendr_api::sys::*` when genuinely
-// needed (rare; common in tests and macro-generated code). The prelude is
-// for the abstraction surface, not the raw R C API.
+// that provides the safe higher-level methods. The type vocabulary
+// (`SEXPTYPE`, `R_xlen_t`, `RLogical`, `Rboolean`, `Rcomplex`, `RNativeType`,
+// …) is **not** re-exported here — those are lower-level types that user
+// code should reach for explicitly at the crate root
+// (`miniextendr_api::SEXPTYPE`, `miniextendr_api::R_xlen_t`, …) when
+// genuinely needed (rare; common in tests and macro-generated code).
+// `miniextendr_api::sys::*` is the raw-FFI escape hatch — `extern
+// "C-unwind"` symbols and the ALTREP method type aliases only. The prelude
+// is for the abstraction surface, not the raw R C API.
 pub use crate::{SEXP, SexpExt};
 // endregion
 

--- a/miniextendr-api/src/progress.rs
+++ b/miniextendr-api/src/progress.rs
@@ -54,7 +54,8 @@ use std::io;
 
 use crate::connection::{RStderr, RStdout, Rconn};
 use crate::into_r::IntoR;
-use crate::sys::{R_PreserveObject, R_ReleaseObject, SEXP, SexpExt};
+use crate::sys::{R_PreserveObject, R_ReleaseObject};
+use crate::{SEXP, SexpExt};
 
 // region: TermKind — precomputed dispatch kind
 

--- a/miniextendr-api/src/protect_pool.rs
+++ b/miniextendr-api/src/protect_pool.rs
@@ -40,10 +40,8 @@
 //! No external dependencies for slot management. The generation counter per slot
 //! detects stale keys. Single free list for VECSXP slot reuse.
 
-use crate::sys::{
-    R_PreserveObject, R_ReleaseObject, R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP,
-    SEXPTYPE, SexpExt,
-};
+use crate::sys::{R_PreserveObject, R_ReleaseObject, Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 use std::marker::PhantomData;
 use std::rc::Rc;
 

--- a/miniextendr-api/src/r_memory.rs
+++ b/miniextendr-api/src/r_memory.rs
@@ -73,7 +73,8 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::sys::{self, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{self};
+use crate::{SEXP, SEXPREC, SEXPTYPE, SexpExt};
 
 /// Offset in bytes from SEXP address to data pointer for standard (non-ALTREP) vectors.
 ///
@@ -188,7 +189,7 @@ pub unsafe fn try_recover_r_sexp(
 
     // Compute candidate SEXP by subtracting header size.
     // wrapping_byte_sub is defined behavior for all pointer arithmetic.
-    let candidate_ptr = (data_ptr as *mut sys::SEXPREC).wrapping_byte_sub(offset);
+    let candidate_ptr = (data_ptr as *mut SEXPREC).wrapping_byte_sub(offset);
 
     let candidate = SEXP(candidate_ptr);
 

--- a/miniextendr-api/src/rarray.rs
+++ b/miniextendr-api/src/rarray.rs
@@ -85,7 +85,7 @@
 
 use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{self, RNativeType, SEXP, SEXPTYPE, SexpExt};
+use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use core::marker::PhantomData;
 
 // region: Type aliases
@@ -625,12 +625,12 @@ impl<T: RNativeType, const NDIM: usize> RArray<T, NDIM> {
             .expect("array total length overflows usize");
 
         assert!(
-            total_len <= sys::R_xlen_t::MAX as usize,
+            total_len <= R_xlen_t::MAX as usize,
             "array total length {total_len} exceeds R_xlen_t::MAX"
         );
 
         // Allocate the vector
-        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, total_len as sys::R_xlen_t) };
+        let sexp = unsafe { sys::Rf_allocVector(T::SEXP_TYPE, total_len as R_xlen_t) };
 
         // Set dimensions
         unsafe { set_dims::<NDIM>(sexp, &dims) };
@@ -686,8 +686,9 @@ impl<T: RNativeType, const NDIM: usize> TryFromSexp for RArray<T, NDIM> {
 // but can be coerced from one. The RArray wraps the source SEXP directly (zero-copy).
 // Note: as_slice() is not available for coerced types - use to_vec_coerced() instead.
 
+use crate::RLogical;
 use crate::coerce::TryCoerce;
-use crate::sys::RLogical;
+use crate::sys::{self};
 
 /// Helper to validate all elements can be coerced.
 fn validate_coercion<S, T>(slice: &[S]) -> Result<(), SexpError>
@@ -793,10 +794,10 @@ impl_rarray_try_from_sexp_coerce!(RLogical => bool);
 
 impl<T: RNativeType, const NDIM: usize> IntoR for RArray<T, NDIM> {
     type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::sys::SEXP, Self::Error> {
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
     }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::sys::SEXP, Self::Error> {
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     fn into_sexp(self) -> SEXP {

--- a/miniextendr-api/src/raw_conversions.rs
+++ b/miniextendr-api/src/raw_conversions.rs
@@ -60,7 +60,8 @@ use std::mem;
 
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
-use crate::sys::{RAW, Rf_allocVector, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{RAW, Rf_allocVector};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 // region: Error type
 

--- a/miniextendr-api/src/refcount_protect.rs
+++ b/miniextendr-api/src/refcount_protect.rs
@@ -50,10 +50,8 @@
 //! These use ahash instead of SipHash for improved throughput. Not DOS-resistant,
 //! but suitable for local, non-hostile environments.
 
-use crate::sys::{
-    R_PreserveObject, R_ReleaseObject, R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP,
-    SEXPTYPE, SexpExt,
-};
+use crate::sys::{R_PreserveObject, R_ReleaseObject, Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;

--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -1101,11 +1101,9 @@ fn scan_digits(haystack: &[u8], from: usize) -> Option<usize> {
 /// `path_sexp` must be a valid STRSXP of length >= 1.
 #[cfg(not(target_arch = "wasm32"))]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn miniextendr_write_wrappers(
-    path_sexp: crate::sys::SEXP,
-) -> crate::sys::SEXP {
+pub unsafe extern "C" fn miniextendr_write_wrappers(path_sexp: crate::SEXP) -> crate::SEXP {
     unsafe {
-        use crate::sys::{SEXP, SexpExt};
+        use crate::{SEXP, SexpExt};
 
         let char_sexp = path_sexp.string_elt_unchecked(0);
         let c_str = std::ffi::CStr::from_ptr(char_sexp.r_char_unchecked());
@@ -1131,11 +1129,9 @@ pub unsafe extern "C" fn miniextendr_write_wrappers(
 /// `path_sexp` must be a valid STRSXP of length >= 1.
 #[cfg(not(target_arch = "wasm32"))]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn miniextendr_write_wasm_registry(
-    path_sexp: crate::sys::SEXP,
-) -> crate::sys::SEXP {
+pub unsafe extern "C" fn miniextendr_write_wasm_registry(path_sexp: crate::SEXP) -> crate::SEXP {
     unsafe {
-        use crate::sys::{SEXP, SexpExt};
+        use crate::{SEXP, SexpExt};
 
         let char_sexp = path_sexp.string_elt_unchecked(0);
         let c_str = std::ffi::CStr::from_ptr(char_sexp.r_char_unchecked());

--- a/miniextendr-api/src/s4_helpers.rs
+++ b/miniextendr-api/src/s4_helpers.rs
@@ -29,7 +29,7 @@
 /// }
 /// ```
 use crate::expression::{RCall, REnv};
-use crate::sys::{SEXP, SexpExt};
+use crate::{SEXP, SexpExt};
 use std::ffi::CStr;
 
 /// Get the `methods` package namespace for evaluating S4 functions.

--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 
 use super::error::RSerdeError;
 use crate::altrep_traits::{NA_LOGICAL, NA_REAL};
-use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use serde::ser::{self, Serialize};
 
 /// Generate serde `Serializer` error stubs for methods that should reject non-struct input.
@@ -2176,7 +2177,7 @@ unsafe fn column_to_sexp(col: &ColumnBuffer, nrow: usize) -> SEXP {
     unsafe {
         match col {
             ColumnBuffer::Logical(v) => {
-                let (sexp, dst) = alloc_r_vector::<crate::sys::RLogical>(nrow);
+                let (sexp, dst) = alloc_r_vector::<crate::RLogical>(nrow);
                 let dst_i32: &mut [i32] =
                     std::slice::from_raw_parts_mut(dst.as_mut_ptr().cast::<i32>(), nrow);
                 dst_i32.copy_from_slice(v);
@@ -2232,7 +2233,7 @@ unsafe fn column_to_sexp(col: &ColumnBuffer, nrow: usize) -> SEXP {
                     Some(s) => s.is_nil(),
                 });
                 if all_null {
-                    let (sexp, dst) = alloc_r_vector::<crate::sys::RLogical>(nrow);
+                    let (sexp, dst) = alloc_r_vector::<crate::RLogical>(nrow);
                     let dst_i32: &mut [i32] =
                         std::slice::from_raw_parts_mut(dst.as_mut_ptr().cast::<i32>(), nrow);
                     dst_i32.fill(NA_LOGICAL);

--- a/miniextendr-api/src/serde/dataframe_de.rs
+++ b/miniextendr-api/src/serde/dataframe_de.rs
@@ -59,7 +59,7 @@ use super::error::RSerdeError;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use crate::dataframe::DataFrameView;
 use crate::from_r::charsxp_to_str;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, Visitor};
 
 // region: public API

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -6,7 +6,7 @@
 use super::error::RSerdeError;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use crate::from_r::charsxp_to_str;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 
 /// Deserializer that converts R SEXP to Rust values.

--- a/miniextendr-api/src/serde/json_string.rs
+++ b/miniextendr-api/src/serde/json_string.rs
@@ -6,10 +6,10 @@
 //!
 //! Requires the `serde_json` feature.
 
+use crate::SEXP;
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::into_r::IntoR;
 use crate::into_r_error::IntoRError;
-use crate::sys::SEXP;
 
 // region: AsJson — T: Serialize → R character (compact JSON)
 

--- a/miniextendr-api/src/serde/ser.rs
+++ b/miniextendr-api/src/serde/ser.rs
@@ -6,7 +6,8 @@
 use super::error::RSerdeError;
 use crate::gc_protect::OwnedProtect;
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt};
+use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use serde::ser::{self, Serialize};
 
 /// Serializer that converts Rust values directly to R SEXP.

--- a/miniextendr-api/src/serde/traits.rs
+++ b/miniextendr-api/src/serde/traits.rs
@@ -6,7 +6,7 @@
 use super::de::RDeserializer;
 use super::error::RSerdeError;
 use super::ser::RSerializer;
-use crate::sys::SEXP;
+use crate::SEXP;
 
 /// Adapter trait for direct R serialization (Rust -> R SEXP).
 ///

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -33,7 +33,7 @@
 use crate::coerce::TryCoerce;
 use crate::from_r::TryFromSexp;
 use crate::into_r::IntoR;
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Convert `i64` to R integer, panicking if outside i32 range.
 ///

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -4,11 +4,11 @@
 
 use std::borrow::Cow;
 
+use crate::SEXPTYPE::STRSXP;
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
 use crate::gc_protect::{OwnedProtect, ProtectScope, Protected};
 use crate::into_r::IntoR;
-use crate::sys::SEXPTYPE::STRSXP;
-use crate::sys::{SEXP, SexpExt};
+use crate::{SEXP, SexpExt};
 
 /// Owned handle to an R character vector (`STRSXP`).
 ///

--- a/miniextendr-api/src/sys.rs
+++ b/miniextendr-api/src/sys.rs
@@ -56,20 +56,13 @@
 /// Raw ALTREP C API method type aliases.
 pub mod altrep;
 
-// Re-export the core type vocabulary so `sys::Foo` paths used inside this
-// crate and in macro-generated code keep resolving even though the types
-// live in their own modules. These are the same symbols as the crate-root
-// re-exports.
-pub use crate::sexp::{SEXP, SEXPREC};
-pub use crate::sexp_ext::SexpExt;
-pub use crate::sexp_types::{
-    CE_UTF8, R_CFinalizer_t, R_xlen_t, RLogical, RNativeType, Rboolean, Rbyte, Rcomplex, SEXPTYPE,
-    cetype_t,
-};
-// `PairListExt` is `pub(crate)`; re-export with the same visibility so
-// `crate::sys::PairListExt` resolves for in-crate callers but isn't part of
-// the public API surface.
-pub(crate) use crate::sexp_ext::PairListExt;
+// `extern "C-unwind"` signatures below reference the type vocabulary by
+// bare name. Bring it into scope as a private `use` (NOT `pub use`) — the
+// vocab's canonical home is the crate root (`crate::SEXP`, etc.) and
+// `crate::sexp_types` for the niche helpers. Adding these to the public
+// API of `sys::` would re-create the bridge.
+use crate::sexp::SEXP;
+use crate::sexp_types::{R_CFinalizer_t, R_xlen_t, Rboolean, Rbyte, Rcomplex, SEXPTYPE, cetype_t};
 
 // region: Connections types (gated behind `connections` feature)
 // WARNING: R's connection API is explicitly marked as UNSTABLE.

--- a/miniextendr-api/src/trait_abi.rs
+++ b/miniextendr-api/src/trait_abi.rs
@@ -142,8 +142,8 @@ pub use conv::{check_arity, extract_arg, from_sexp, nil, rf_error, to_sexp, try_
 // with the reconstructed RCondition if the shim returned a tagged error SEXP.
 pub use crate::condition::repanic_if_rust_error;
 
+use crate::SEXP;
 use crate::abi::mx_tag;
-use crate::sys::SEXP;
 use std::os::raw::c_void;
 
 // region: TraitView - Trait for macro-generated View structs

--- a/miniextendr-api/src/trait_abi/ccall.rs
+++ b/miniextendr-api/src/trait_abi/ccall.rs
@@ -20,8 +20,8 @@
 //!
 //! All wrapper functions must be called from R's main thread.
 
+use crate::SEXP;
 use crate::abi::{mx_erased, mx_tag};
-use crate::sys::SEXP;
 use std::os::raw::c_void;
 
 // region: Direct extern declarations to mx_abi.rs functions (same .so)

--- a/miniextendr-api/src/trait_abi/conv.rs
+++ b/miniextendr-api/src/trait_abi/conv.rs
@@ -29,7 +29,7 @@
 //! [`TryFromSexp`]: crate::TryFromSexp
 //! [`IntoR`]: crate::IntoR
 
-use crate::sys::SEXP;
+use crate::SEXP;
 
 /// Raise an R error with the given message.
 ///
@@ -70,7 +70,7 @@ pub unsafe fn rf_error(msg: &str) -> ! {
 /// R's `NULL` value (`R_NilValue`)
 #[inline]
 pub unsafe fn nil() -> SEXP {
-    crate::sys::SEXP::nil()
+    crate::SEXP::nil()
 }
 
 /// Convert an R SEXP to a Rust type, aborting via `Rf_error` on failure.

--- a/miniextendr-api/src/txt_progress_bar.rs
+++ b/miniextendr-api/src/txt_progress_bar.rs
@@ -27,7 +27,8 @@
 use std::marker::PhantomData;
 
 use crate::gc_protect::OwnedProtect;
-use crate::sys::{R_PreserveObject, R_ReleaseObject, SEXP, SexpExt};
+use crate::sys::{R_PreserveObject, R_ReleaseObject};
+use crate::{SEXP, SexpExt};
 
 // region: RTxtProgressBar struct
 
@@ -290,8 +291,8 @@ impl RTxtProgressBarBuilder {
 // # Safety
 // Must be called from the R main thread.
 unsafe fn build_inner(opts: RTxtProgressBarBuilder) -> RTxtProgressBar {
+    use crate::SEXP;
     use crate::expression::{RCall, REnv};
-    use crate::sys::SEXP;
 
     unsafe {
         // Resolve the utils namespace — utils is always loaded (base default).
@@ -342,8 +343,8 @@ unsafe fn build_inner(opts: RTxtProgressBarBuilder) -> RTxtProgressBar {
 // # Safety
 // Must be called from the R main thread.
 unsafe fn set_txt_progress_bar_inner(sexp: SEXP, value: f64) -> Result<(), String> {
+    use crate::SEXP;
     use crate::expression::RCall;
-    use crate::sys::SEXP;
 
     unsafe {
         let val_sexp = OwnedProtect::new(SEXP::scalar_real(value));

--- a/miniextendr-api/src/typed_list.rs
+++ b/miniextendr-api/src/typed_list.rs
@@ -34,7 +34,7 @@
 
 use crate::from_r::{SexpError, TryFromSexp};
 use crate::list::{List, ListFromSexpError};
-use crate::sys::{SEXP, SEXPTYPE, SexpExt};
+use crate::{SEXP, SEXPTYPE, SexpExt};
 use std::collections::HashSet;
 use std::ffi::CStr;
 

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -70,8 +70,8 @@ use std::{
 // region: raise_rust_condition_via_stop — Approach 3 for ALTREP RUnwind path
 
 /// Cached `stop` symbol (permanently interned via `Rf_install`).
-fn stop_sym() -> crate::sys::SEXP {
-    static CACHE: OnceLock<crate::sys::SEXP> = OnceLock::new();
+fn stop_sym() -> crate::SEXP {
+    static CACHE: OnceLock<crate::SEXP> = OnceLock::new();
     *CACHE.get_or_init(|| unsafe { crate::sys::Rf_install(c"stop".as_ptr()) })
 }
 
@@ -104,12 +104,11 @@ fn stop_sym() -> crate::sys::SEXP {
 pub(crate) unsafe fn raise_rust_condition_via_stop(
     message: &str,
     class: Option<&str>,
-    call: Option<crate::sys::SEXP>,
+    call: Option<crate::SEXP>,
 ) -> ! {
-    use crate::sys::{
-        CE_UTF8, R_BaseEnv, Rf_allocVector, Rf_eval, Rf_lang2, Rf_mkCharCE, Rf_protect, SEXP,
-        SEXPTYPE, SexpExt,
-    };
+    use crate::sexp_types::CE_UTF8;
+    use crate::sys::{R_BaseEnv, Rf_allocVector, Rf_eval, Rf_lang2, Rf_mkCharCE, Rf_protect};
+    use crate::{SEXP, SEXPTYPE, SexpExt};
 
     unsafe {
         // Build the class vector: c([custom_class,] "rust_error", "simpleError", "error", "condition")
@@ -179,7 +178,8 @@ pub(crate) unsafe fn raise_rust_condition_via_stop(
 
 // endregion
 
-use crate::sys::{self, R_ContinueUnwind, R_UnwindProtect_C_unwind, Rboolean, SEXP};
+use crate::sys::{self, R_ContinueUnwind, R_UnwindProtect_C_unwind};
+use crate::{Rboolean, SEXP};
 
 /// Global continuation token for R_UnwindProtect.
 ///
@@ -281,11 +281,11 @@ where
         match catch_unwind(AssertUnwindSafe(f)) {
             Ok(result) => {
                 data.result = Some(result);
-                crate::sys::SEXP::nil()
+                crate::SEXP::nil()
             }
             Err(payload) => {
                 data.panic_payload = Some(payload);
-                crate::sys::SEXP::nil()
+                crate::SEXP::nil()
             }
         }
     }

--- a/miniextendr-api/src/vctrs.rs
+++ b/miniextendr-api/src/vctrs.rs
@@ -5,13 +5,14 @@
 //!
 //! No runtime initialization is required — construction helpers use only base R FFI.
 
-use crate::sys::SEXP;
+use crate::SEXP;
 
 // region: Construction helpers (Phase A)
 
 use crate::gc_protect::OwnedProtect;
 use crate::list::List;
-use crate::sys::{R_xlen_t, Rf_allocVector, SEXPTYPE, SexpExt};
+use crate::sys::Rf_allocVector;
+use crate::{R_xlen_t, SEXPTYPE, SexpExt};
 
 /// Error type for vctrs object construction.
 ///
@@ -487,7 +488,7 @@ pub fn new_list_of(
 
     // Set size attribute if provided
     if let Some(s) = size {
-        let size_sexp = crate::sys::SEXP::scalar_integer(s);
+        let size_sexp = crate::SEXP::scalar_integer(s);
         data.set_attr(crate::cached_class::size_symbol(), size_sexp);
     }
 

--- a/miniextendr-api/src/wasm_registry_writer.rs
+++ b/miniextendr-api/src/wasm_registry_writer.rs
@@ -100,11 +100,8 @@ fn format_body(
     let mut out = String::new();
 
     writeln!(&mut out, "use ::miniextendr_api::abi::mx_tag;").unwrap();
-    writeln!(
-        &mut out,
-        "use ::miniextendr_api::sys::{{R_CallMethodDef, SEXP}};"
-    )
-    .unwrap();
+    writeln!(&mut out, "use ::miniextendr_api::SEXP;").unwrap();
+    writeln!(&mut out, "use ::miniextendr_api::sys::R_CallMethodDef;").unwrap();
     writeln!(
         &mut out,
         "use ::miniextendr_api::registry::{{AltrepRegistration, TraitDispatchEntry}};"

--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -63,7 +63,8 @@
 use std::sync::OnceLock;
 use std::thread;
 
-use crate::sys::{self, SEXP};
+use crate::SEXP;
+use crate::sys::{self};
 
 static R_MAIN_THREAD_ID: OnceLock<thread::ThreadId> = OnceLock::new();
 
@@ -347,7 +348,8 @@ mod worker_channel {
     use std::thread;
 
     use super::Sendable;
-    use crate::sys::{self, Rboolean, SEXP};
+    use crate::sys;
+    use crate::{Rboolean, SEXP};
 
     type AnyJob = Box<dyn FnOnce() + Send>;
 

--- a/miniextendr-api/tests/altrep_extract.rs
+++ b/miniextendr-api/tests/altrep_extract.rs
@@ -77,7 +77,7 @@ struct CustomStorageData {
 /// This is a compile-time test only — runtime testing requires a full ALTREP registration
 /// path that bypasses ExternalPtr, which is future work.
 impl AltrepExtract for CustomStorageData {
-    unsafe fn altrep_extract_ref(x: miniextendr_api::sys::SEXP) -> &'static Self {
+    unsafe fn altrep_extract_ref(x: miniextendr_api::SEXP) -> &'static Self {
         // In a real implementation, this would extract data from the SEXP directly
         // (e.g., from an INTSXP stored in data1). For compile-time testing, we just
         // prove the trait is implementable.
@@ -85,7 +85,7 @@ impl AltrepExtract for CustomStorageData {
         panic!("compile-time only — not callable without R runtime")
     }
 
-    unsafe fn altrep_extract_mut(x: miniextendr_api::sys::SEXP) -> &'static mut Self {
+    unsafe fn altrep_extract_mut(x: miniextendr_api::SEXP) -> &'static mut Self {
         let _ = x;
         panic!("compile-time only — not callable without R runtime")
     }

--- a/miniextendr-api/tests/bytes.rs
+++ b/miniextendr-api/tests/bytes.rs
@@ -52,8 +52,9 @@ fn bytes_empty() {
 #[test]
 fn bytes_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
@@ -77,8 +78,9 @@ fn bytes_from_raw_vector() {
 #[test]
 fn bytesmut_from_raw_vector() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 4));
@@ -122,8 +124,8 @@ fn option_bytes_none() {
         let opt: Option<Bytes> = None;
         let sexp = opt.into_sexp();
 
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::SEXPTYPE;
         assert!(sexp.is_nil());
         assert_eq!(sexp.type_of(), SEXPTYPE::NILSXP);
     });

--- a/miniextendr-api/tests/dataframe_de.rs
+++ b/miniextendr-api/tests/dataframe_de.rs
@@ -661,7 +661,8 @@ fn flat_field_with_underscore_fails_when_visitor_expects_flat_name() {
 #[test]
 fn non_dataframe_input_is_error() {
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::SEXPTYPE;
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
         // Allocate a plain list (not a data.frame)
         let list_sexp = unsafe {
             let s = Rf_allocVector(SEXPTYPE::VECSXP, 2);
@@ -688,9 +689,10 @@ fn non_dataframe_input_is_error() {
 
 mod factor_tests {
     use super::*;
+    use miniextendr_api::SEXPTYPE;
     use miniextendr_api::factor::{build_factor, build_levels_sexp};
     use miniextendr_api::prelude::{SEXP, SexpExt};
-    use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+    use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
     /// Build a one-column data.frame whose sole column is an R factor.
     ///

--- a/miniextendr-api/tests/fixed_arrays.rs
+++ b/miniextendr-api/tests/fixed_arrays.rs
@@ -46,8 +46,9 @@ fn fixed_array_f64_roundtrip() {
 #[test]
 fn fixed_array_length_mismatch_error() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create R vector with 5 elements

--- a/miniextendr-api/tests/from_r.rs
+++ b/miniextendr-api/tests/from_r.rs
@@ -6,7 +6,8 @@ use miniextendr_api::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use miniextendr_api::coerce::Coerced;
 use miniextendr_api::from_r::{SexpError, TryFromSexp};
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::sys::{R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use miniextendr_api::{R_xlen_t, SEXPTYPE};
 use std::collections::{BTreeSet, HashSet};
 
 #[derive(Default)]
@@ -263,7 +264,7 @@ fn aho_corasick_option_from_nil() {
     use miniextendr_api::aho_corasick_impl::AhoCorasick;
 
     r_test_utils::with_r_thread(|| {
-        let nil = miniextendr_api::sys::SEXP::nil();
+        let nil = miniextendr_api::SEXP::nil();
         let opt: Option<AhoCorasick> = TryFromSexp::try_from_sexp(nil).unwrap();
         assert!(opt.is_none());
     });
@@ -315,7 +316,7 @@ fn aho_corasick_vec_option_from_list() {
         let mut guard = ProtectCount::default();
         unsafe {
             let patterns1 = make_str_vec(&[Some("hello")], &mut guard);
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let patterns2 = make_str_vec(&[Some("world")], &mut guard);
             let list = make_list(&[patterns1, nil, patterns2], &mut guard);
 
@@ -337,7 +338,7 @@ fn json_value_option_from_nil() {
     use miniextendr_api::serde_impl::JsonValue;
 
     r_test_utils::with_r_thread(|| {
-        let nil = miniextendr_api::sys::SEXP::nil();
+        let nil = miniextendr_api::SEXP::nil();
         let opt: Option<JsonValue> = TryFromSexp::try_from_sexp(nil).unwrap();
         assert!(opt.is_none());
     });
@@ -393,7 +394,7 @@ fn json_value_vec_option_from_list() {
         unsafe {
             // Create R objects: logical -> JSON bool, NULL -> None, integer -> JSON number
             let bool_sexp = guard.protect(SEXP::scalar_logical(true)); // -> JSON true
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let int_sexp = guard.protect(SEXP::scalar_integer(42)); // -> JSON 42
             let list = make_list(&[bool_sexp, nil, int_sexp], &mut guard);
 
@@ -415,7 +416,7 @@ fn toml_value_option_from_nil() {
     use miniextendr_api::toml_impl::TomlValue;
 
     r_test_utils::with_r_thread(|| {
-        let nil = miniextendr_api::sys::SEXP::nil();
+        let nil = miniextendr_api::SEXP::nil();
         let opt: Option<TomlValue> = TryFromSexp::try_from_sexp(nil).unwrap();
         assert!(opt.is_none());
     });
@@ -449,7 +450,7 @@ fn bitvec_option_from_nil() {
     use miniextendr_api::bitvec_impl::RBitVec;
 
     r_test_utils::with_r_thread(|| {
-        let nil = miniextendr_api::sys::SEXP::nil();
+        let nil = miniextendr_api::SEXP::nil();
         let opt: Option<RBitVec> = TryFromSexp::try_from_sexp(nil).unwrap();
         assert!(opt.is_none());
     });
@@ -483,7 +484,7 @@ fn bitvec_msb0_option_from_nil() {
     use miniextendr_api::bitvec_impl::{BitVec, Msb0};
 
     r_test_utils::with_r_thread(|| {
-        let nil = miniextendr_api::sys::SEXP::nil();
+        let nil = miniextendr_api::SEXP::nil();
         let opt: Option<BitVec<u8, Msb0>> = TryFromSexp::try_from_sexp(nil).unwrap();
         assert!(opt.is_none());
     });
@@ -526,7 +527,7 @@ fn aho_corasick_unchecked_option() {
             assert!(opt.is_some());
 
             // Test with nil
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let opt_nil: Option<AhoCorasick> = TryFromSexp::try_from_sexp_unchecked(nil).unwrap();
             assert!(opt_nil.is_none());
         }
@@ -560,7 +561,7 @@ fn json_value_unchecked_vec_option() {
         let mut guard = ProtectCount::default();
         unsafe {
             let int_sexp = guard.protect(SEXP::scalar_integer(100));
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let list = make_list(&[int_sexp, nil], &mut guard);
 
             let vec: Vec<Option<JsonValue>> = TryFromSexp::try_from_sexp_unchecked(list).unwrap();
@@ -584,7 +585,7 @@ fn bitvec_unchecked_option() {
             assert!(opt.is_some());
             assert_eq!(opt.unwrap().len(), 2);
 
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let opt_nil: Option<RBitVec> = TryFromSexp::try_from_sexp_unchecked(nil).unwrap();
             assert!(opt_nil.is_none());
         }
@@ -658,7 +659,7 @@ fn option_slice_arbitrary_lifetime() {
             assert_eq!(slice.len(), 2);
 
             // Test None case
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let opt_nil: Option<&[i32]> = TryFromSexp::try_from_sexp(nil).unwrap();
             assert!(opt_nil.is_none());
         }
@@ -679,7 +680,7 @@ fn option_slice_mut_arbitrary_lifetime() {
             assert_eq!(slice[1], 10);
 
             // Test None case
-            let nil = miniextendr_api::sys::SEXP::nil();
+            let nil = miniextendr_api::SEXP::nil();
             let opt_nil: Option<&mut [i32]> = TryFromSexp::try_from_sexp(nil).unwrap();
             assert!(opt_nil.is_none());
         }

--- a/miniextendr-api/tests/gc_protect.rs
+++ b/miniextendr-api/tests/gc_protect.rs
@@ -5,9 +5,10 @@
 
 mod r_test_utils;
 
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::gc_protect::{OwnedProtect, ProtectScope, Protected, tls};
 use miniextendr_api::prelude::SEXP;
-use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+use miniextendr_api::sys::Rf_allocVector;
 
 // region: Balance tests
 
@@ -239,7 +240,7 @@ fn owned_protect_deref() {
         let guard = OwnedProtect::new(SEXP::scalar_real(std::f64::consts::PI));
 
         // Deref to get &SEXP
-        let sexp: &miniextendr_api::sys::SEXP = &guard;
+        let sexp: &miniextendr_api::SEXP = &guard;
         assert!(!sexp.is_null());
     });
 }

--- a/miniextendr-api/tests/into_r.rs
+++ b/miniextendr-api/tests/into_r.rs
@@ -5,7 +5,7 @@ mod r_test_utils;
 use miniextendr_api::altrep_traits::NA_LOGICAL;
 use miniextendr_api::into_r::IntoR;
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::sys::{R_xlen_t, RLogical, Rboolean, SEXPTYPE};
+use miniextendr_api::{R_xlen_t, RLogical, Rboolean, SEXPTYPE};
 
 fn scalar_logical(sexp: SEXP) -> i32 {
     sexp.logical_elt(0)

--- a/miniextendr-api/tests/list.rs
+++ b/miniextendr-api/tests/list.rs
@@ -61,7 +61,7 @@ fn names_as_vec(list: List) -> Vec<String> {
     (0..len)
         .map(|i| {
             names
-                .string_elt_str(i as miniextendr_api::sys::R_xlen_t)
+                .string_elt_str(i as miniextendr_api::R_xlen_t)
                 .unwrap_or("")
                 .to_string()
         })

--- a/miniextendr-api/tests/nalgebra_generic.rs
+++ b/miniextendr-api/tests/nalgebra_generic.rs
@@ -12,8 +12,9 @@ use miniextendr_api::{DMatrix, DVector, SMatrix, SVector};
 fn dvector_i32_blanket_impl() {
     // Verify blanket impl works for i32 (not just f64)
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
@@ -55,8 +56,9 @@ fn dvector_f64_roundtrip() {
 fn dmatrix_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x3 matrix
@@ -90,8 +92,9 @@ fn dmatrix_i32_blanket_impl() {
 fn dmatrix_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw bytes)
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x2 raw matrix
@@ -151,8 +154,9 @@ fn svector_f64_roundtrip() {
 #[test]
 fn svector_i32_from_r() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 3x1 integer matrix (column vector)
@@ -177,8 +181,9 @@ fn svector_i32_from_r() {
 #[test]
 fn svector_length_mismatch() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 4x1 matrix, but try to convert to SVector<f64, 3>
@@ -225,8 +230,9 @@ fn smatrix_f64_roundtrip() {
 #[test]
 fn smatrix_i32_from_r() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x2 integer matrix
@@ -255,8 +261,9 @@ fn smatrix_i32_from_r() {
 #[test]
 fn smatrix_dimension_mismatch() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 3x3 matrix, but try to convert to SMatrix<f64, 2, 2>

--- a/miniextendr-api/tests/ndarray_all_types.rs
+++ b/miniextendr-api/tests/ndarray_all_types.rs
@@ -12,9 +12,8 @@ use miniextendr_api::{Array0, Array1, Array2};
 fn array1_all_rnative_types() {
     // Verify Array1 blanket impl works for all RNativeType: i32, f64, u8, RLogical
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::sys::{
-            RLogical, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE, SexpExt,
-        };
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+        use miniextendr_api::{RLogical, SEXPTYPE, SexpExt};
 
         unsafe {
             // i32
@@ -70,8 +69,8 @@ fn array1_all_rnative_types() {
 fn array0_scalar_all_types() {
     // Verify Array0 (scalar) works for all types
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::RLogical;
         use miniextendr_api::prelude::SEXP;
-        use miniextendr_api::sys::RLogical;
 
         // i32 scalar
         let sexp_int = SEXP::scalar_integer(42);
@@ -95,8 +94,9 @@ fn array0_scalar_all_types() {
 fn array2_u8_blanket_impl() {
     // Verify Array2 works for u8 (raw matrices)
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x2 raw matrix
@@ -125,8 +125,9 @@ fn array2_u8_blanket_impl() {
 fn arrayd_i32_from_vector() {
     // Test ArrayD created from R vector (1D)
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
         use ndarray::ArrayD;
 
         unsafe {

--- a/miniextendr-api/tests/ndarray_generic.rs
+++ b/miniextendr-api/tests/ndarray_generic.rs
@@ -12,8 +12,9 @@ use miniextendr_api::{Array0, Array1, Array2, Array3, ArrayD};
 fn array1_i32_blanket_impl() {
     // Verify blanket impl works for i32
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 4));
@@ -40,8 +41,9 @@ fn array1_i32_blanket_impl() {
 fn array1_u8_blanket_impl() {
     // Verify blanket impl works for u8 (raw)
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
@@ -66,8 +68,9 @@ fn array1_u8_blanket_impl() {
 fn array2_i32_blanket_impl() {
     // Verify blanket impl works for i32 matrices
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocMatrix, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x3 matrix
@@ -96,8 +99,9 @@ fn array2_i32_blanket_impl() {
 fn array3_i32_blanket_impl() {
     // Verify blanket impl works for 3D arrays
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 2x3x2 = 12 element 3D array
@@ -162,8 +166,9 @@ fn array1_f64_roundtrip() {
 fn arrayd_dynamic_dims() {
     // Test ArrayD with dynamic number of dimensions
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             // Create 3D array: 2x3x2
@@ -198,7 +203,8 @@ fn arrayd_dynamic_dims() {
 fn array_blanket_coverage_all_rnative_types() {
     // Verify blanket impl works for all RNativeType: i32, f64, u8, RLogical
     r_test_utils::with_r_thread(|| {
-        use miniextendr_api::sys::{RLogical, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+        use miniextendr_api::{RLogical, SEXPTYPE};
         use ndarray::Array1;
 
         unsafe {

--- a/miniextendr-api/tests/ppsize_limit.rs
+++ b/miniextendr-api/tests/ppsize_limit.rs
@@ -19,8 +19,9 @@ use miniextendr_api::gc_protect::ProtectScope;
 use miniextendr_api::list::{List, ListBuilder};
 use miniextendr_api::prelude::SexpExt;
 use miniextendr_api::strvec::StrVecBuilder;
-use miniextendr_api::sys::{self, Rf_allocVector, SEXPTYPE};
+use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::thread::RThreadBuilder;
+use miniextendr_api::{SEXP, SEXPTYPE};
 
 // region: R initialization with small ppsize
 
@@ -180,7 +181,7 @@ fn list_builder_bounded_stack() {
         let builder = ListBuilder::new(&scope, 50);
 
         for i in 0..50 {
-            let child = scope.protect_raw(sys::SEXP::scalar_integer(i as i32));
+            let child = scope.protect_raw(SEXP::scalar_integer(i as i32));
             builder.set(i, child);
         }
 
@@ -239,7 +240,7 @@ fn list_set_elt_constant_stack() {
 
         // Use set_elt which internally protects/unprotects
         for i in 0..80 {
-            let child = sys::SEXP::scalar_integer(i as i32);
+            let child = SEXP::scalar_integer(i as i32);
             list.set_elt(i, child);
         }
 
@@ -273,7 +274,7 @@ fn nested_list_under_constraint() {
             // Fill the inner list using set_elt (constant stack per element)
             let inner = List::from_raw(slot.get());
             for j in 0..10 {
-                inner.set_elt(j, sys::SEXP::scalar_integer((i * 10 + j) as i32));
+                inner.set_elt(j, SEXP::scalar_integer((i * 10 + j) as i32));
             }
 
             // Set into outer list

--- a/miniextendr-api/tests/refcount_protect.rs
+++ b/miniextendr-api/tests/refcount_protect.rs
@@ -2,9 +2,10 @@
 
 mod r_test_utils;
 
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::prelude::SEXP;
 use miniextendr_api::refcount_protect::RefCountedArena;
-use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+use miniextendr_api::sys::Rf_allocVector;
 
 // region: Basic protection tests
 

--- a/miniextendr-api/tests/roundtrip_properties.rs
+++ b/miniextendr-api/tests/roundtrip_properties.rs
@@ -49,7 +49,7 @@ where
 /// for vector types (INTSXP, REALSXP, LGLSXP, STRSXP) are unprotected and
 /// may be collected before `try_from_sexp()` reads them. This wrapper adds
 /// `Rf_protect` / `Rf_unprotect` around the roundtrip.
-unsafe fn protected_roundtrip<T: TryFromSexp>(sexp: miniextendr_api::sys::SEXP) -> T
+unsafe fn protected_roundtrip<T: TryFromSexp>(sexp: miniextendr_api::SEXP) -> T
 where
     T::Error: std::fmt::Debug,
 {

--- a/miniextendr-api/tests/serde_streaming.rs
+++ b/miniextendr-api/tests/serde_streaming.rs
@@ -9,12 +9,12 @@
 mod r_test_utils;
 
 use miniextendr_api::IntoR as _;
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::prelude::SexpExt as _;
 use miniextendr_api::serde::{
     DataFrameBuilder, DispatchNames, RSerdeError, TypeSpec, dispatch_to_dataframes,
     iter_to_dataframe, vec_to_dataframe,
 };
-use miniextendr_api::sys::SEXPTYPE;
 use serde::Serialize;
 
 // region: round-trip equivalence with vec_to_dataframe

--- a/miniextendr-api/tests/std_collections.rs
+++ b/miniextendr-api/tests/std_collections.rs
@@ -87,8 +87,9 @@ fn cow_slice_owned() {
 #[test]
 fn cow_slice_from_r() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         unsafe {
             let sexp = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));

--- a/miniextendr-api/tests/tinyvec.rs
+++ b/miniextendr-api/tests/tinyvec.rs
@@ -122,8 +122,9 @@ fn arrayvec_capacity_ok() {
 #[test]
 fn arrayvec_capacity_error() {
     r_test_utils::with_r_thread(|| {
+        use miniextendr_api::SEXPTYPE;
         use miniextendr_api::prelude::SexpExt;
-        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+        use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 
         // Create R vector with 10 elements
         let sexp = unsafe {

--- a/miniextendr-bench/benches/altrep.rs
+++ b/miniextendr-bench/benches/altrep.rs
@@ -1,9 +1,9 @@
 //! ALTREP benchmarks.
 
 use miniextendr_api::IntoR;
+use miniextendr_api::SexpExt;
 use miniextendr_api::altrep_data::{AltIntegerData, AltRealData, AltrepDataptr, AltrepLen};
 use miniextendr_api::sys;
-use miniextendr_api::sys::SexpExt;
 use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];

--- a/miniextendr-bench/benches/altrep_advanced.rs
+++ b/miniextendr-bench/benches/altrep_advanced.rs
@@ -10,8 +10,7 @@ use miniextendr_api::altrep_data::{
     AltComplexData, AltIntegerData, AltRealData, AltStringData, AltrepDataptr, AltrepLen,
 };
 use miniextendr_api::sys;
-use miniextendr_api::sys::Rcomplex;
-use miniextendr_api::sys::SexpExt;
+use miniextendr_api::{R_xlen_t, Rcomplex, SexpExt};
 use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
@@ -185,7 +184,7 @@ mod guard_modes {
         let sexp = data.into_sexp();
         let mut sum = 0i64;
         for i in 0..len {
-            sum += sexp.integer_elt(i as sys::R_xlen_t) as i64;
+            sum += sexp.integer_elt(i as R_xlen_t) as i64;
         }
         divan::black_box(sum);
     }
@@ -198,7 +197,7 @@ mod guard_modes {
         let sexp = data.into_sexp();
         let mut sum = 0i64;
         for i in 0..len {
-            sum += sexp.integer_elt(i as sys::R_xlen_t) as i64;
+            sum += sexp.integer_elt(i as R_xlen_t) as i64;
         }
         divan::black_box(sum);
     }
@@ -211,7 +210,7 @@ mod guard_modes {
         let sexp = data.into_sexp();
         let mut sum = 0i64;
         for i in 0..len {
-            sum += sexp.integer_elt(i as sys::R_xlen_t) as i64;
+            sum += sexp.integer_elt(i as R_xlen_t) as i64;
         }
         divan::black_box(sum);
     }
@@ -223,7 +222,7 @@ mod guard_modes {
         let sexp = miniextendr_bench::fixtures().int_vec(size_idx);
         let mut sum = 0i64;
         for i in 0..len {
-            sum += sexp.integer_elt(i as sys::R_xlen_t) as i64;
+            sum += sexp.integer_elt(i as R_xlen_t) as i64;
         }
         divan::black_box(sum);
     }
@@ -254,7 +253,7 @@ mod materialization {
         let sexp = (BenchIntVec { data }).into_sexp();
         let mut sum: i64 = 0;
         for i in 0..len {
-            sum += sexp.integer_elt(i as sys::R_xlen_t) as i64;
+            sum += sexp.integer_elt(i as R_xlen_t) as i64;
         }
         divan::black_box(sum);
     }
@@ -419,7 +418,7 @@ mod complex_altrep {
         let sexp = (BenchComplex { data }).into_sexp();
         let mut sum_r = 0.0f64;
         for i in 0..len {
-            sum_r += sexp.complex_elt(i as sys::R_xlen_t).r;
+            sum_r += sexp.complex_elt(i as R_xlen_t).r;
         }
         divan::black_box(sum_r);
     }
@@ -481,7 +480,7 @@ mod zero_alloc {
         let sexp = data.into_sexp();
         let mut sum = 0.0f64;
         for i in 0..len {
-            sum += sexp.real_elt(i as sys::R_xlen_t);
+            sum += sexp.real_elt(i as R_xlen_t);
         }
         divan::black_box(sum);
     }
@@ -494,7 +493,7 @@ mod zero_alloc {
         let sexp = (BenchRealVec { data }).into_sexp();
         let mut sum = 0.0f64;
         for i in 0..len {
-            sum += sexp.real_elt(i as sys::R_xlen_t);
+            sum += sexp.real_elt(i as R_xlen_t);
         }
         divan::black_box(sum);
     }

--- a/miniextendr-bench/benches/altrep_iter.rs
+++ b/miniextendr-bench/benches/altrep_iter.rs
@@ -1,7 +1,7 @@
 //! Iterator-backed ALTREP benchmarks.
 
+use miniextendr_api::SexpExt;
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen};
-use miniextendr_api::sys::SexpExt;
 use miniextendr_api::{IntoR, IterIntData};
 use miniextendr_bench::raw_ffi;
 

--- a/miniextendr-bench/benches/coerce.rs
+++ b/miniextendr-bench/benches/coerce.rs
@@ -7,7 +7,7 @@
 
 use miniextendr_api::TryFromSexp;
 use miniextendr_api::coerce::{Coerce, TryCoerce};
-use miniextendr_api::sys::{SEXPTYPE, SexpExt};
+use miniextendr_api::{SEXPTYPE, SexpExt};
 use miniextendr_bench::SIZES;
 
 fn main() {
@@ -136,7 +136,7 @@ fn vec_real_to_int_rust_coerce(size_idx: usize) {
 /// Direct: LGLSXP -> &[RLogical]
 #[divan::bench(args = [0, 1, 2, 3, 4])]
 fn vec_lgl_direct(size_idx: usize) {
-    use miniextendr_api::sys::RLogical;
+    use miniextendr_api::RLogical;
     let sexp = fixtures().lgl_vec(size_idx);
     let slice: &[RLogical] = TryFromSexp::try_from_sexp(sexp).unwrap();
     divan::black_box(slice);
@@ -154,7 +154,7 @@ fn vec_lgl_to_int_r_coerce(size_idx: usize) {
 /// R-coerced: INTSXP -> LGLSXP -> &[RLogical]
 #[divan::bench(args = [0, 1, 2, 3, 4])]
 fn vec_int_to_lgl_r_coerce(size_idx: usize) {
-    use miniextendr_api::sys::RLogical;
+    use miniextendr_api::RLogical;
     let sexp = fixtures().int_vec(size_idx);
     let coerced = sexp.coerce(SEXPTYPE::LGLSXP);
     let slice: &[RLogical] = TryFromSexp::try_from_sexp(coerced).unwrap();

--- a/miniextendr-bench/benches/connections.rs
+++ b/miniextendr-bench/benches/connections.rs
@@ -5,11 +5,11 @@
 //! read/write operations.
 
 #[cfg(feature = "connections")]
+use miniextendr_api::SEXP;
+#[cfg(feature = "connections")]
 use miniextendr_api::connection::{
     RConnectionIo, Rconn, get_connection, read_connection, write_connection,
 };
-#[cfg(feature = "connections")]
-use miniextendr_api::sys;
 #[cfg(feature = "connections")]
 use miniextendr_bench::raw_ffi;
 #[cfg(feature = "connections")]
@@ -17,7 +17,7 @@ use std::io::Cursor;
 
 #[cfg(feature = "connections")]
 struct ProtectedConn {
-    sexp: sys::SEXP,
+    sexp: SEXP,
 }
 
 #[cfg(feature = "connections")]
@@ -31,7 +31,7 @@ impl Drop for ProtectedConn {
 
 /// Build a connection and open it so read/write operations work.
 #[cfg(feature = "connections")]
-unsafe fn open_connection(sexp: sys::SEXP) {
+unsafe fn open_connection(sexp: SEXP) {
     unsafe {
         let handle = get_connection(sexp).cast::<Rconn>();
         if let Some(open_fn) = (*handle).open {

--- a/miniextendr-bench/benches/dataframe.rs
+++ b/miniextendr-bench/benches/dataframe.rs
@@ -4,7 +4,7 @@
 //! conversion for named structs, enums with field-union alignment, and
 //! varying row/column counts.
 
-use miniextendr_api::sys::SEXP;
+use miniextendr_api::SEXP;
 use miniextendr_api::{DataFrameRow, IntoDataFrame, IntoList, IntoR};
 
 fn main() {

--- a/miniextendr-bench/benches/externalptr.rs
+++ b/miniextendr-bench/benches/externalptr.rs
@@ -194,7 +194,7 @@ fn baseline_box_large() {
 // region: Type-erased checks + downcasts
 
 struct ProtectedSexp {
-    sexp: miniextendr_api::sys::SEXP,
+    sexp: miniextendr_api::SEXP,
 }
 
 impl Drop for ProtectedSexp {

--- a/miniextendr-bench/benches/factor.rs
+++ b/miniextendr-bench/benches/factor.rs
@@ -7,8 +7,8 @@
 //! Key finding: ~4x speedup for single value conversions (the primary use case).
 //! Vector conversions show minimal difference since vector allocation dominates.
 
+use miniextendr_api::SEXP;
 use miniextendr_api::factor::{build_factor, build_levels_sexp};
-use miniextendr_api::sys::SEXP;
 use miniextendr_api::{FactorVec, IntoR, MatchArg, RFactor};
 
 fn main() {

--- a/miniextendr-bench/benches/ffi_calls.rs
+++ b/miniextendr-bench/benches/ffi_calls.rs
@@ -3,7 +3,7 @@
 //! Measures the cost of calling R C-API functions through checked vs unchecked
 //! wrappers.
 
-use miniextendr_api::sys::{self, SEXP, SEXPTYPE, SexpExt};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 use miniextendr_bench::SIZES;
 use miniextendr_bench::raw_ffi;
 
@@ -17,7 +17,7 @@ fn main() {
 #[divan::bench(args = SIZES)]
 fn alloc_intsxp(n: usize) -> SEXP {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, n as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, n as R_xlen_t);
         divan::black_box(sexp)
     }
 }
@@ -25,7 +25,7 @@ fn alloc_intsxp(n: usize) -> SEXP {
 #[divan::bench(args = SIZES)]
 fn alloc_realsxp(n: usize) -> SEXP {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::REALSXP, n as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::REALSXP, n as R_xlen_t);
         divan::black_box(sexp)
     }
 }
@@ -33,7 +33,7 @@ fn alloc_realsxp(n: usize) -> SEXP {
 #[divan::bench(args = SIZES)]
 fn alloc_lglsxp(n: usize) -> SEXP {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::LGLSXP, n as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::LGLSXP, n as R_xlen_t);
         divan::black_box(sexp)
     }
 }
@@ -41,7 +41,7 @@ fn alloc_lglsxp(n: usize) -> SEXP {
 #[divan::bench(args = SIZES)]
 fn alloc_rawsxp(n: usize) -> SEXP {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::RAWSXP, n as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::RAWSXP, n as R_xlen_t);
         divan::black_box(sexp)
     }
 }
@@ -49,7 +49,7 @@ fn alloc_rawsxp(n: usize) -> SEXP {
 #[divan::bench(args = SIZES)]
 fn alloc_strsxp(n: usize) -> SEXP {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::STRSXP, n as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t);
         divan::black_box(sexp)
     }
 }

--- a/miniextendr-bench/benches/from_r.rs
+++ b/miniextendr-bench/benches/from_r.rs
@@ -2,8 +2,8 @@
 //!
 //! Measures the cost of converting R SEXP values to Rust types.
 
+use miniextendr_api::SexpExt;
 use miniextendr_api::TryFromSexp;
-use miniextendr_api::sys::SexpExt;
 use miniextendr_bench::raw_ffi;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 

--- a/miniextendr-bench/benches/gc_protect.rs
+++ b/miniextendr-bench/benches/gc_protect.rs
@@ -14,10 +14,12 @@
 //! - `ListBuilder` vs manual list construction
 //! - `StrVecBuilder` vs manual string vector construction
 
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::gc_protect::{OwnedProtect, ProtectIndex, ProtectScope};
 use miniextendr_api::list::{List, ListAccumulator, ListBuilder, collect_list};
+use miniextendr_api::sexp_types::CE_UTF8;
 use miniextendr_api::strvec::{StrVec, StrVecBuilder};
-use miniextendr_api::sys::{self, Rf_allocVector, Rf_protect, Rf_unprotect, SEXPTYPE};
+use miniextendr_api::sys::{self, Rf_allocVector, Rf_protect, Rf_unprotect};
 use miniextendr_bench::raw_ffi;
 
 fn main() {
@@ -260,7 +262,7 @@ fn strvec_manual_construction(size_idx: usize) {
 
         for i in 0..n {
             // UNSAFE: charsxp unprotected - GC risk! See doc comment above.
-            let charsxp = raw_ffi::Rf_mkCharLenCE("hello".as_ptr().cast(), 5, sys::CE_UTF8);
+            let charsxp = raw_ffi::Rf_mkCharLenCE("hello".as_ptr().cast(), 5, CE_UTF8);
             raw_ffi::SET_STRING_ELT(vec, i, charsxp);
         }
 
@@ -301,11 +303,7 @@ fn build_named_list_realistic() {
         // Logical
         builder.set(2, scope.protect_raw(raw_ffi::Rf_ScalarLogical(1)));
         // String - protect CHARSXP before passing to Rf_ScalarString
-        let s = scope.protect_raw(raw_ffi::Rf_mkCharLenCE(
-            "test".as_ptr().cast(),
-            4,
-            sys::CE_UTF8,
-        ));
+        let s = scope.protect_raw(raw_ffi::Rf_mkCharLenCE("test".as_ptr().cast(), 4, CE_UTF8));
         builder.set(3, scope.protect_raw(raw_ffi::Rf_ScalarString(s)));
         // Nested list
         let inner = ListBuilder::new(&scope, 2);

--- a/miniextendr-bench/benches/gc_protection_compare.rs
+++ b/miniextendr-bench/benches/gc_protection_compare.rs
@@ -8,7 +8,8 @@
 //! See `plans/gc-protection-benchmarks.md`.
 
 use miniextendr_api::protect_pool::ProtectPool;
-use miniextendr_api::sys::{self, R_PreserveObject, R_ReleaseObject, SEXP};
+use miniextendr_api::sys::{self, R_PreserveObject, R_ReleaseObject};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE};
 use miniextendr_bench::pool_prototypes::{
     BTreeMapPool, DequePool, HashMapPool, IndexMapPool, SlotmapPool, VecPool,
 };
@@ -407,7 +408,7 @@ mod bursty {
         let sexps = unsafe { prealloc_sexps(burst * rounds) };
 
         bencher.bench_local(|| unsafe {
-            let mut kept: Vec<sys::SEXP> = Vec::new();
+            let mut kept: Vec<SEXP> = Vec::new();
             for round in 0..rounds {
                 for i in 0..burst {
                     R_PreserveObject(sexps[round * burst + i]);
@@ -461,7 +462,7 @@ mod replace_in_loop {
         bencher.bench_local(|| unsafe {
             let slot = pool.insert(sexps[0]);
             for &s in &sexps[1..] {
-                raw_ffi::SET_VECTOR_ELT(pool.backing, slot as sys::R_xlen_t, s);
+                raw_ffi::SET_VECTOR_ELT(pool.backing, slot as R_xlen_t, s);
             }
             pool.release(slot);
         });
@@ -878,7 +879,7 @@ mod gc_and_memory {
         bencher.bench_local(|| unsafe {
             for (i, &s) in sexps.iter().enumerate() {
                 let slot = pool.insert(s);
-                divan::black_box(raw_ffi::Rf_allocVector(sys::SEXPTYPE::INTSXP, 10));
+                divan::black_box(raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, 10));
                 pool.release(slot);
                 _ = i;
             }

--- a/miniextendr-bench/benches/into_r.rs
+++ b/miniextendr-bench/benches/into_r.rs
@@ -3,7 +3,7 @@
 //! Measures the cost of converting Rust types to R SEXP values.
 
 use miniextendr_api::IntoR;
-use miniextendr_api::sys::SEXP;
+use miniextendr_api::SEXP;
 use miniextendr_bench::{LARGE_SIZES, SIZES};
 
 fn main() {
@@ -103,7 +103,7 @@ fn slice_f64(bencher: divan::Bencher, n: usize) {
 
 // region: Vector conversions - logical (RLogical)
 
-use miniextendr_api::sys::RLogical;
+use miniextendr_api::RLogical;
 
 fn make_logical_vec(n: usize) -> Vec<RLogical> {
     (0..n)

--- a/miniextendr-bench/benches/list.rs
+++ b/miniextendr-bench/benches/list.rs
@@ -5,8 +5,8 @@
 //! - positional lookup baseline (`List::get_index`)
 //! - derive-driven struct ↔ list conversions (`IntoList` / `TryFromList`)
 
+use miniextendr_api::SEXP;
 use miniextendr_api::list::{IntoList as IntoListTrait, List, TryFromList as TryFromListTrait};
-use miniextendr_api::sys;
 use miniextendr_bench::raw_ffi;
 
 fn main() {
@@ -89,7 +89,7 @@ fn derive_into_list_tuple() {
 }
 
 struct ProtectedSexp {
-    sexp: sys::SEXP,
+    sexp: SEXP,
 }
 
 impl Drop for ProtectedSexp {

--- a/miniextendr-bench/benches/raw_access.rs
+++ b/miniextendr-bench/benches/raw_access.rs
@@ -6,7 +6,7 @@
 //! misaligned 0x1 sentinel for empty vector data pointers).
 
 use miniextendr_api::IntoR;
-use miniextendr_api::sys::{SEXP, SexpExt};
+use miniextendr_api::{SEXP, SexpExt};
 use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];

--- a/miniextendr-bench/benches/refcount_protect.rs
+++ b/miniextendr-bench/benches/refcount_protect.rs
@@ -11,11 +11,12 @@
 //! - Release order flexibility
 //! - High iteration counts
 
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::gc_protect::ProtectScope;
 use miniextendr_api::refcount_protect::{
     HashMapArena, RefCountedArena, ThreadLocalArena, ThreadLocalArenaOps, ThreadLocalHashArena,
 };
-use miniextendr_api::sys::{self, Rf_allocVector, SEXPTYPE};
+use miniextendr_api::sys::{self, Rf_allocVector};
 use miniextendr_bench::raw_ffi;
 
 fn main() {

--- a/miniextendr-bench/benches/rffi_checked.rs
+++ b/miniextendr-bench/benches/rffi_checked.rs
@@ -1,6 +1,6 @@
 //! Checked vs unchecked FFI wrapper benchmarks.
 
-use miniextendr_api::sys::{self, SEXPTYPE};
+use miniextendr_api::{R_xlen_t, SEXPTYPE};
 use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
@@ -48,7 +48,7 @@ fn xlength_unchecked(size_idx: usize) {
 #[divan::bench(args = ALLOC_SIZES)]
 fn alloc_vector_checked(len: usize) {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, len as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, len as R_xlen_t);
         divan::black_box(sexp);
     }
 }
@@ -56,7 +56,7 @@ fn alloc_vector_checked(len: usize) {
 #[divan::bench(args = ALLOC_SIZES)]
 fn alloc_vector_unchecked(len: usize) {
     unsafe {
-        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, len as sys::R_xlen_t);
+        let sexp = raw_ffi::Rf_allocVector(SEXPTYPE::INTSXP, len as R_xlen_t);
         divan::black_box(sexp);
     }
 }

--- a/miniextendr-bench/benches/sexp_ext.rs
+++ b/miniextendr-bench/benches/sexp_ext.rs
@@ -1,6 +1,6 @@
 //! SexpExt helper benchmarks.
 
-use miniextendr_api::sys::{self, SexpExt};
+use miniextendr_api::{SEXPTYPE, SexpExt};
 use miniextendr_bench::raw_ffi;
 
 const SIZE_INDICES: &[usize] = &[0, 2, 4];
@@ -36,7 +36,7 @@ fn sexp_is_integer_ext() {
 #[divan::bench]
 fn sexp_is_integer_type_of() {
     let sexp = miniextendr_bench::fixtures().int_vec(2);
-    let out = sexp.type_of() == sys::SEXPTYPE::INTSXP;
+    let out = sexp.type_of() == SEXPTYPE::INTSXP;
     divan::black_box(out);
 }
 

--- a/miniextendr-bench/benches/strict.rs
+++ b/miniextendr-bench/benches/strict.rs
@@ -9,9 +9,9 @@
 //! RAWSXP/LGLSXP and panic instead of widening.
 
 use miniextendr_api::IntoR;
+use miniextendr_api::SEXP;
 use miniextendr_api::from_r::TryFromSexp;
 use miniextendr_api::strict;
-use miniextendr_api::sys::SEXP;
 
 const VEC_SIZES: &[usize] = &[1, 1_000, 10_000];
 

--- a/miniextendr-bench/benches/strings.rs
+++ b/miniextendr-bench/benches/strings.rs
@@ -4,7 +4,8 @@
 //! - Into R (empty strings): `R_BlankString` vs `Rf_mkCharLenCE(ptr, 0, CE_UTF8)`
 //! - From R: `CStr::from_ptr` (strlen scan) vs LENGTH-based slice construction
 
-use miniextendr_api::sys::{self, SEXP};
+use miniextendr_api::SEXP;
+use miniextendr_api::sexp_types::CE_UTF8;
 use miniextendr_bench::SIZES;
 use miniextendr_bench::raw_ffi;
 
@@ -23,7 +24,7 @@ fn fixtures() -> miniextendr_bench::Fixtures {
 /// Current approach: Rf_mkCharLenCE with length 0
 #[divan::bench]
 fn into_r_empty_mkcharlen() -> SEXP {
-    unsafe { raw_ffi::Rf_mkCharLenCE(b"".as_ptr().cast(), 0, sys::CE_UTF8) }
+    unsafe { raw_ffi::Rf_mkCharLenCE(b"".as_ptr().cast(), 0, CE_UTF8) }
 }
 
 /// Alternative: R_BlankString static (no FFI call, just static access)
@@ -43,7 +44,7 @@ fn into_r_str_mkcharlen(bencher: divan::Bencher, n: usize) {
         divan::black_box(raw_ffi::Rf_mkCharLenCE(
             s.as_ptr().cast(),
             n as i32,
-            sys::CE_UTF8,
+            CE_UTF8,
         ))
     });
 }

--- a/miniextendr-bench/benches/translate.rs
+++ b/miniextendr-bench/benches/translate.rs
@@ -1,6 +1,7 @@
 use std::ffi::CStr;
 
-use miniextendr_api::sys::{self, SEXP};
+use miniextendr_api::SEXP;
+use miniextendr_api::sys;
 use miniextendr_bench::raw_ffi;
 
 fn main() {

--- a/miniextendr-bench/benches/typed_list.rs
+++ b/miniextendr-bench/benches/typed_list.rs
@@ -6,8 +6,8 @@
 //! (`@exact`) mode.
 
 use miniextendr_api::list::List;
-use miniextendr_api::sys::{self, SEXP, SEXPTYPE, SexpExt};
 use miniextendr_api::typed_list::{TypeSpec, TypedEntry, TypedListSpec, validate_list};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 use miniextendr_bench::raw_ffi;
 
 fn main() {
@@ -20,20 +20,14 @@ fn main() {
 /// Build a named VECSXP with `n` numeric(1) entries named "f0", "f1", ..., "f{n-1}".
 fn make_numeric_list(n: usize) -> SEXP {
     unsafe {
-        let list = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(
-            SEXPTYPE::VECSXP,
-            n as sys::R_xlen_t,
-        ));
-        let names = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(
-            SEXPTYPE::STRSXP,
-            n as sys::R_xlen_t,
-        ));
+        let list = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, n as R_xlen_t));
+        let names = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t));
 
         for i in 0..n {
-            list.set_vector_elt(i as sys::R_xlen_t, SEXP::scalar_real(i as f64));
+            list.set_vector_elt(i as R_xlen_t, SEXP::scalar_real(i as f64));
 
             let key = format!("f{i}");
-            names.set_string_elt(i as sys::R_xlen_t, SEXP::charsxp(&key));
+            names.set_string_elt(i as R_xlen_t, SEXP::charsxp(&key));
         }
 
         list.set_names(names);
@@ -89,14 +83,8 @@ fn make_mixed_spec(n: usize) -> TypedListSpec {
 /// Build a named list with mixed types matching `make_mixed_spec`.
 fn make_mixed_list(n: usize) -> SEXP {
     unsafe {
-        let list = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(
-            SEXPTYPE::VECSXP,
-            n as sys::R_xlen_t,
-        ));
-        let names = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(
-            SEXPTYPE::STRSXP,
-            n as sys::R_xlen_t,
-        ));
+        let list = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, n as R_xlen_t));
+        let names = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t));
 
         for i in 0..n {
             let val = match i % 4 {
@@ -105,10 +93,10 @@ fn make_mixed_list(n: usize) -> SEXP {
                 2 => SEXP::scalar_string_from_str("x"),
                 _ => SEXP::scalar_logical(true),
             };
-            list.set_vector_elt(i as sys::R_xlen_t, val);
+            list.set_vector_elt(i as R_xlen_t, val);
 
             let key = format!("f{i}");
-            names.set_string_elt(i as sys::R_xlen_t, SEXP::charsxp(&key));
+            names.set_string_elt(i as R_xlen_t, SEXP::charsxp(&key));
         }
 
         list.set_names(names);

--- a/miniextendr-bench/benches/wrappers.rs
+++ b/miniextendr-bench/benches/wrappers.rs
@@ -9,7 +9,9 @@
 //! - `argument_coercion`: wrapper path with type coercion
 //! - `class_methods`: Env/R6/S3/S4/S7-style method invocation overhead
 
-use miniextendr_api::sys::{self, SexpExt};
+use miniextendr_api::sexp_types::CE_UTF8;
+use miniextendr_api::sys;
+use miniextendr_api::{SEXP, SEXPTYPE, SexpExt};
 use miniextendr_bench::raw_ffi;
 use std::os::raw::c_char;
 
@@ -26,12 +28,7 @@ enum ParseStatus {
 }
 
 unsafe extern "C" {
-    fn R_ParseVector(
-        text: sys::SEXP,
-        n: i32,
-        status: *mut ParseStatus,
-        srcfile: sys::SEXP,
-    ) -> sys::SEXP;
+    fn R_ParseVector(text: SEXP, n: i32, status: *mut ParseStatus, srcfile: SEXP) -> SEXP;
 }
 
 /// RAII guard that calls `Rf_unprotect(n)` on drop.
@@ -57,19 +54,16 @@ impl Drop for ProtectGuard {
 
 /// Pre-parsed R expression with protection.
 struct ParsedExpr {
-    expr: sys::SEXP,
+    expr: SEXP,
     _guard: ProtectGuard,
 }
 
 /// Parse an R string into a protected expression ready for `Rf_eval`.
 unsafe fn parse_and_protect(code: &str) -> ParsedExpr {
     unsafe {
-        let code_sexp = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(sys::SEXPTYPE::STRSXP, 1));
-        let charsxp = raw_ffi::Rf_mkCharLenCE(
-            code.as_ptr().cast::<c_char>(),
-            code.len() as i32,
-            sys::CE_UTF8,
-        );
+        let code_sexp = raw_ffi::Rf_protect(raw_ffi::Rf_allocVector(SEXPTYPE::STRSXP, 1));
+        let charsxp =
+            raw_ffi::Rf_mkCharLenCE(code.as_ptr().cast::<c_char>(), code.len() as i32, CE_UTF8);
         raw_ffi::SET_STRING_ELT(code_sexp, 0, charsxp);
 
         let mut status = ParseStatus::PARSE_NULL;
@@ -95,7 +89,7 @@ unsafe fn parse_and_protect(code: &str) -> ParsedExpr {
 }
 
 /// Evaluate an R code string and return the result (unprotected).
-unsafe fn r_eval_string(code: &str) -> sys::SEXP {
+unsafe fn r_eval_string(code: &str) -> SEXP {
     unsafe {
         let parsed = parse_and_protect(code);
         raw_ffi::Rf_eval(parsed.expr, raw_ffi::R_GlobalEnv)

--- a/miniextendr-bench/src/lib.rs
+++ b/miniextendr-bench/src/lib.rs
@@ -18,7 +18,7 @@
 use std::os::raw::c_char;
 use std::sync::OnceLock;
 
-use miniextendr_api::sys::{self, SEXP};
+use miniextendr_api::{R_xlen_t, SEXP, cetype_t};
 
 pub mod bench_plan;
 pub mod pool_prototypes;
@@ -202,7 +202,7 @@ unsafe fn init_fixtures_once() {
         use crate::raw_ffi::{
             INTEGER, LOGICAL, RAW, REAL, Rf_allocMatrix, Rf_allocVector, Rf_mkCharLenCE, Rf_protect,
         };
-        use miniextendr_api::sys::{SEXPTYPE, SexpExt};
+        use miniextendr_api::{SEXPTYPE, SexpExt};
 
         // UTF-8 string.
         let utf8_charsxp = SEXP::charsxp("hello");
@@ -212,7 +212,7 @@ unsafe fn init_fixtures_once() {
         let latin1_charsxp = Rf_mkCharLenCE(
             latin1_bytes.as_ptr().cast::<c_char>(),
             latin1_bytes.len() as i32,
-            sys::cetype_t::CE_LATIN1,
+            cetype_t::CE_LATIN1,
         );
 
         // STRSXP(1) wrappers to mirror the `TryFromSexp` path.
@@ -230,7 +230,7 @@ unsafe fn init_fixtures_once() {
 
         for (i, &size) in SIZES.iter().enumerate() {
             // Integer vector filled with 0..size
-            let int_vec = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, size as sys::R_xlen_t));
+            let int_vec = Rf_protect(Rf_allocVector(SEXPTYPE::INTSXP, size as R_xlen_t));
             let int_ptr = INTEGER(int_vec);
             for j in 0..size {
                 *int_ptr.add(j) = j as i32;
@@ -238,7 +238,7 @@ unsafe fn init_fixtures_once() {
             int_vecs[i] = int_vec;
 
             // Real vector filled with 0.0..size as f64
-            let real_vec = Rf_protect(Rf_allocVector(SEXPTYPE::REALSXP, size as sys::R_xlen_t));
+            let real_vec = Rf_protect(Rf_allocVector(SEXPTYPE::REALSXP, size as R_xlen_t));
             let real_ptr = REAL(real_vec);
             for j in 0..size {
                 *real_ptr.add(j) = j as f64;
@@ -246,7 +246,7 @@ unsafe fn init_fixtures_once() {
             real_vecs[i] = real_vec;
 
             // Logical vector with alternating TRUE/FALSE
-            let lgl_vec = Rf_protect(Rf_allocVector(SEXPTYPE::LGLSXP, size as sys::R_xlen_t));
+            let lgl_vec = Rf_protect(Rf_allocVector(SEXPTYPE::LGLSXP, size as R_xlen_t));
             let lgl_ptr = LOGICAL(lgl_vec);
             for j in 0..size {
                 *lgl_ptr.add(j) = (j % 2) as i32;
@@ -254,7 +254,7 @@ unsafe fn init_fixtures_once() {
             lgl_vecs[i] = lgl_vec;
 
             // Raw vector filled with 0..255 cycling
-            let raw_vec = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, size as sys::R_xlen_t));
+            let raw_vec = Rf_protect(Rf_allocVector(SEXPTYPE::RAWSXP, size as R_xlen_t));
             let raw_ptr = RAW(raw_vec);
             for j in 0..size {
                 *raw_ptr.add(j) = (j % 256) as u8;
@@ -274,13 +274,13 @@ unsafe fn init_fixtures_once() {
         // Named lists for list/map conversion benchmarks
         let mut named_list_i32 = [SEXP::null(); 3];
         for (idx, &len) in NAMED_LIST_SIZES.iter().enumerate() {
-            let list = Rf_protect(Rf_allocVector(SEXPTYPE::VECSXP, len as sys::R_xlen_t));
-            let names = Rf_protect(Rf_allocVector(SEXPTYPE::STRSXP, len as sys::R_xlen_t));
+            let list = Rf_protect(Rf_allocVector(SEXPTYPE::VECSXP, len as R_xlen_t));
+            let names = Rf_protect(Rf_allocVector(SEXPTYPE::STRSXP, len as R_xlen_t));
 
             for i in 0..len {
-                list.set_vector_elt(i as sys::R_xlen_t, SEXP::scalar_integer(i as i32));
+                list.set_vector_elt(i as R_xlen_t, SEXP::scalar_integer(i as i32));
                 let key = format!("k{i}");
-                names.set_string_elt(i as sys::R_xlen_t, SEXP::charsxp(&key));
+                names.set_string_elt(i as R_xlen_t, SEXP::charsxp(&key));
             }
 
             list.set_names(names);

--- a/miniextendr-bench/src/pool_prototypes.rs
+++ b/miniextendr-bench/src/pool_prototypes.rs
@@ -9,9 +9,8 @@
 //! thread with valid SEXP arguments. These are benchmark prototypes, not public API.
 #![allow(clippy::missing_safety_doc)]
 
-use miniextendr_api::sys::{
-    self, R_PreserveObject, R_ReleaseObject, Rf_protect, Rf_unprotect, SEXP, SexpExt,
-};
+use miniextendr_api::sys::{R_PreserveObject, R_ReleaseObject, Rf_protect, Rf_unprotect};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt};
 use std::collections::VecDeque;
 
 // region: VecPool — Vec<usize> free list (LIFO reuse)
@@ -30,8 +29,7 @@ impl VecPool {
     pub unsafe fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         unsafe {
-            let backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, capacity as sys::R_xlen_t);
+            let backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, capacity as R_xlen_t);
             R_PreserveObject(backing);
             Self {
                 backing,
@@ -54,34 +52,29 @@ impl VecPool {
             self.len += 1;
             s
         };
-        self.backing.set_vector_elt(slot as sys::R_xlen_t, sexp);
+        self.backing.set_vector_elt(slot as R_xlen_t, sexp);
         slot
     }
 
     #[inline]
     pub unsafe fn release(&mut self, slot: usize) {
-        self.backing
-            .set_vector_elt(slot as sys::R_xlen_t, SEXP::nil());
+        self.backing.set_vector_elt(slot as R_xlen_t, SEXP::nil());
         self.free_list.push(slot);
     }
 
     #[inline]
     pub unsafe fn get(&self, slot: usize) -> SEXP {
-        self.backing.vector_elt(slot as sys::R_xlen_t)
+        self.backing.vector_elt(slot as R_xlen_t)
     }
 
     unsafe fn grow(&mut self) {
         let new_cap = self.capacity * 2;
         unsafe {
-            let new_backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, new_cap as sys::R_xlen_t);
+            let new_backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, new_cap as R_xlen_t);
             Rf_protect(new_backing);
             R_PreserveObject(new_backing);
             for i in 0..self.capacity {
-                new_backing.set_vector_elt(
-                    i as sys::R_xlen_t,
-                    self.backing.vector_elt(i as sys::R_xlen_t),
-                );
+                new_backing.set_vector_elt(i as R_xlen_t, self.backing.vector_elt(i as R_xlen_t));
             }
             R_ReleaseObject(self.backing);
             Rf_unprotect(1);
@@ -116,8 +109,7 @@ impl DequePool {
     pub unsafe fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         unsafe {
-            let backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, capacity as sys::R_xlen_t);
+            let backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, capacity as R_xlen_t);
             R_PreserveObject(backing);
             Self {
                 backing,
@@ -140,29 +132,24 @@ impl DequePool {
             self.len += 1;
             s
         };
-        self.backing.set_vector_elt(slot as sys::R_xlen_t, sexp);
+        self.backing.set_vector_elt(slot as R_xlen_t, sexp);
         slot
     }
 
     #[inline]
     pub unsafe fn release(&mut self, slot: usize) {
-        self.backing
-            .set_vector_elt(slot as sys::R_xlen_t, SEXP::nil());
+        self.backing.set_vector_elt(slot as R_xlen_t, SEXP::nil());
         self.free_list.push_back(slot);
     }
 
     unsafe fn grow(&mut self) {
         let new_cap = self.capacity * 2;
         unsafe {
-            let new_backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, new_cap as sys::R_xlen_t);
+            let new_backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, new_cap as R_xlen_t);
             Rf_protect(new_backing);
             R_PreserveObject(new_backing);
             for i in 0..self.capacity {
-                new_backing.set_vector_elt(
-                    i as sys::R_xlen_t,
-                    self.backing.vector_elt(i as sys::R_xlen_t),
-                );
+                new_backing.set_vector_elt(i as R_xlen_t, self.backing.vector_elt(i as R_xlen_t));
             }
             R_ReleaseObject(self.backing);
             Rf_unprotect(1);
@@ -204,8 +191,7 @@ impl SlotmapPool {
     pub unsafe fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         unsafe {
-            let backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, capacity as sys::R_xlen_t);
+            let backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, capacity as R_xlen_t);
             R_PreserveObject(backing);
             Self {
                 backing,
@@ -229,15 +215,14 @@ impl SlotmapPool {
             self.next_slot += 1;
             s
         };
-        self.backing.set_vector_elt(slot as sys::R_xlen_t, sexp);
+        self.backing.set_vector_elt(slot as R_xlen_t, sexp);
         self.slots.insert(slot)
     }
 
     #[inline]
     pub unsafe fn release(&mut self, key: ProtectKey) {
         if let Some(slot) = self.slots.remove(key) {
-            self.backing
-                .set_vector_elt(slot as sys::R_xlen_t, SEXP::nil());
+            self.backing.set_vector_elt(slot as R_xlen_t, SEXP::nil());
             self.free_slots.push(slot);
         }
     }
@@ -245,21 +230,17 @@ impl SlotmapPool {
     #[inline]
     pub fn get(&self, key: ProtectKey) -> Option<SEXP> {
         let &slot = self.slots.get(key)?;
-        Some(self.backing.vector_elt(slot as sys::R_xlen_t))
+        Some(self.backing.vector_elt(slot as R_xlen_t))
     }
 
     unsafe fn grow(&mut self) {
         let new_cap = self.capacity * 2;
         unsafe {
-            let new_backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, new_cap as sys::R_xlen_t);
+            let new_backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, new_cap as R_xlen_t);
             Rf_protect(new_backing);
             R_PreserveObject(new_backing);
             for i in 0..self.capacity {
-                new_backing.set_vector_elt(
-                    i as sys::R_xlen_t,
-                    self.backing.vector_elt(i as sys::R_xlen_t),
-                );
+                new_backing.set_vector_elt(i as R_xlen_t, self.backing.vector_elt(i as R_xlen_t));
             }
             R_ReleaseObject(self.backing);
             Rf_unprotect(1);
@@ -293,8 +274,7 @@ impl KeyedBacking {
     unsafe fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         unsafe {
-            let backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, capacity as sys::R_xlen_t);
+            let backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, capacity as R_xlen_t);
             R_PreserveObject(backing);
             Self {
                 backing,
@@ -321,33 +301,28 @@ impl KeyedBacking {
 
     #[inline]
     unsafe fn set(&self, slot: usize, sexp: SEXP) {
-        self.backing.set_vector_elt(slot as sys::R_xlen_t, sexp);
+        self.backing.set_vector_elt(slot as R_xlen_t, sexp);
     }
 
     #[inline]
     unsafe fn get(&self, slot: usize) -> SEXP {
-        self.backing.vector_elt(slot as sys::R_xlen_t)
+        self.backing.vector_elt(slot as R_xlen_t)
     }
 
     #[inline]
     unsafe fn clear_slot(&mut self, slot: usize) {
-        self.backing
-            .set_vector_elt(slot as sys::R_xlen_t, SEXP::nil());
+        self.backing.set_vector_elt(slot as R_xlen_t, SEXP::nil());
         self.free_slots.push(slot);
     }
 
     unsafe fn grow(&mut self) {
         let new_cap = self.capacity * 2;
         unsafe {
-            let new_backing =
-                crate::raw_ffi::Rf_allocVector(sys::SEXPTYPE::VECSXP, new_cap as sys::R_xlen_t);
+            let new_backing = crate::raw_ffi::Rf_allocVector(SEXPTYPE::VECSXP, new_cap as R_xlen_t);
             Rf_protect(new_backing);
             R_PreserveObject(new_backing);
             for i in 0..self.capacity {
-                new_backing.set_vector_elt(
-                    i as sys::R_xlen_t,
-                    self.backing.vector_elt(i as sys::R_xlen_t),
-                );
+                new_backing.set_vector_elt(i as R_xlen_t, self.backing.vector_elt(i as R_xlen_t));
             }
             R_ReleaseObject(self.backing);
             Rf_unprotect(1);

--- a/miniextendr-bench/src/raw_ffi.rs
+++ b/miniextendr-bench/src/raw_ffi.rs
@@ -3,7 +3,7 @@
 //! These re-declare R C API functions that miniextendr-api has privatized.
 //! Bench code needs direct access to measure overhead of safe wrappers.
 
-use miniextendr_api::sys::{R_xlen_t, Rboolean, Rcomplex, SEXP, SEXPTYPE};
+use miniextendr_api::{R_xlen_t, Rboolean, Rcomplex, SEXP, SEXPTYPE};
 
 #[allow(non_snake_case, dead_code)]
 unsafe extern "C-unwind" {
@@ -28,7 +28,7 @@ unsafe extern "C-unwind" {
     pub fn Rf_mkCharLenCE(
         s: *const std::os::raw::c_char,
         len: i32,
-        encoding: miniextendr_api::sys::cetype_t,
+        encoding: miniextendr_api::cetype_t,
     ) -> SEXP;
     pub fn Rf_isNewList(s: SEXP) -> Rboolean;
     pub fn Rf_setAttrib(vec: SEXP, name: SEXP, val: SEXP) -> SEXP;

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -143,18 +143,19 @@ pub(crate) fn generate_direct_altrep_registration(
         impl ::miniextendr_api::IntoR for #ident #ty_generics #where_clause {
             type Error = ::core::convert::Infallible;
 
-            fn try_into_sexp(self) -> ::core::result::Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> ::core::result::Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
-            unsafe fn try_into_sexp_unchecked(self) -> ::core::result::Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> ::core::result::Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(unsafe { self.into_sexp_unchecked() })
             }
 
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 use ::miniextendr_api::altrep_registration::RegisterAltrep;
                 use ::miniextendr_api::externalptr::ExternalPtr;
-                use ::miniextendr_api::sys::{SEXP, Rf_protect, Rf_unprotect};
+                use ::miniextendr_api::SEXP;
+                use ::miniextendr_api::sys::{Rf_protect, Rf_unprotect};
 
                 let ext_ptr = ExternalPtr::new(self);
                 let cls = Self::get_or_init_class();
@@ -167,7 +168,7 @@ pub(crate) fn generate_direct_altrep_registration(
                 }
             }
 
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 use ::miniextendr_api::altrep_registration::RegisterAltrep;
                 use ::miniextendr_api::externalptr::ExternalPtr;
                 use ::miniextendr_api::sys::{Rf_protect_unchecked, Rf_unprotect_unchecked};
@@ -179,7 +180,7 @@ pub(crate) fn generate_direct_altrep_registration(
                     Rf_protect_unchecked(data1);
                     let altrep = cls.new_altrep_unchecked(
                         data1,
-                        ::miniextendr_api::sys::SEXP::nil(),
+                        ::miniextendr_api::SEXP::nil(),
                     );
                     Rf_unprotect_unchecked(1);
                     altrep
@@ -194,13 +195,13 @@ pub(crate) fn generate_direct_altrep_registration(
         impl ::miniextendr_api::TryFromSexp for #ref_ident {
             type Error = ::miniextendr_api::SexpTypeError;
 
-            fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> ::core::result::Result<Self, Self::Error> {
-                use ::miniextendr_api::sys::SEXPTYPE;
+            fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> ::core::result::Result<Self, Self::Error> {
+                use ::miniextendr_api::SEXPTYPE;
 
-                if !::miniextendr_api::sys::SexpExt::is_altrep(&sexp) {
+                if !::miniextendr_api::SexpExt::is_altrep(&sexp) {
                     return Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::INTSXP,
-                        actual: ::miniextendr_api::sys::SexpExt::type_of(&sexp),
+                        actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     });
                 }
 
@@ -208,7 +209,7 @@ pub(crate) fn generate_direct_altrep_registration(
                     Some(ptr) => Ok(#ref_ident(ptr)),
                     None => Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::EXTPTRSXP,
-                        actual: ::miniextendr_api::sys::SexpExt::type_of(&sexp),
+                        actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     }),
                 }
             }
@@ -228,13 +229,13 @@ pub(crate) fn generate_direct_altrep_registration(
         impl ::miniextendr_api::TryFromSexp for #mut_ident {
             type Error = ::miniextendr_api::SexpTypeError;
 
-            fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> ::core::result::Result<Self, Self::Error> {
-                use ::miniextendr_api::sys::SEXPTYPE;
+            fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> ::core::result::Result<Self, Self::Error> {
+                use ::miniextendr_api::SEXPTYPE;
 
-                if !::miniextendr_api::sys::SexpExt::is_altrep(&sexp) {
+                if !::miniextendr_api::SexpExt::is_altrep(&sexp) {
                     return Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::INTSXP,
-                        actual: ::miniextendr_api::sys::SexpExt::type_of(&sexp),
+                        actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     });
                 }
 
@@ -242,7 +243,7 @@ pub(crate) fn generate_direct_altrep_registration(
                     Some(ptr) => Ok(#mut_ident(ptr)),
                     None => Err(::miniextendr_api::SexpTypeError {
                         expected: SEXPTYPE::EXTPTRSXP,
-                        actual: ::miniextendr_api::sys::SexpExt::type_of(&sexp),
+                        actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     }),
                 }
             }

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -720,13 +720,13 @@ pub fn derive_altrep_complex(input: syn::DeriveInput) -> syn::Result<TokenStream
         quote! { ::miniextendr_api::altrep_data::AltComplexData },
         |elt_field, elt_delegate| {
             if let Some(d) = elt_delegate {
-                quote! { fn elt(&self, i: usize) -> ::miniextendr_api::sys::Rcomplex { self.#d.elt(i) } }
+                quote! { fn elt(&self, i: usize) -> ::miniextendr_api::Rcomplex { self.#d.elt(i) } }
             } else if let Some(f) = elt_field {
-                quote! { fn elt(&self, _i: usize) -> ::miniextendr_api::sys::Rcomplex { self.#f } }
+                quote! { fn elt(&self, _i: usize) -> ::miniextendr_api::Rcomplex { self.#f } }
             } else {
                 quote! {
-                    fn elt(&self, _i: usize) -> ::miniextendr_api::sys::Rcomplex {
-                        ::miniextendr_api::sys::Rcomplex { r: f64::NAN, i: f64::NAN }
+                    fn elt(&self, _i: usize) -> ::miniextendr_api::Rcomplex {
+                        ::miniextendr_api::Rcomplex { r: f64::NAN, i: f64::NAN }
                     }
                 }
             }
@@ -735,7 +735,7 @@ pub fn derive_altrep_complex(input: syn::DeriveInput) -> syn::Result<TokenStream
             macro_base: "impl_altcomplex_from_data",
             dataptr_macro: Some((
                 "__impl_altvec_dataptr",
-                Some(quote! { ::miniextendr_api::sys::Rcomplex }),
+                Some(quote! { ::miniextendr_api::Rcomplex }),
             )),
             string_dataptr: false,
             subset: true,
@@ -772,14 +772,14 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
 
         let elt_impl = if let Some(ref elt_field) = attrs.elt_field {
             quote! {
-                fn elt(&self, i: usize) -> ::miniextendr_api::sys::SEXP {
+                fn elt(&self, i: usize) -> ::miniextendr_api::SEXP {
                     self.#elt_field[i]
                 }
             }
         } else {
             quote! {
-                fn elt(&self, _i: usize) -> ::miniextendr_api::sys::SEXP {
-                    ::miniextendr_api::sys::SEXP::nil()
+                fn elt(&self, _i: usize) -> ::miniextendr_api::SEXP {
+                    ::miniextendr_api::SEXP::nil()
                 }
             }
         };
@@ -817,10 +817,10 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
                 ::miniextendr_api::__impl_altrep_base!(#name #ty_generics, #guard, with_serialize);
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics #where_clause {}
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltList for #name #ty_generics #where_clause {
-                    fn elt(x: ::miniextendr_api::sys::SEXP, i: ::miniextendr_api::sys::R_xlen_t) -> ::miniextendr_api::sys::SEXP {
+                    fn elt(x: ::miniextendr_api::SEXP, i: ::miniextendr_api::R_xlen_t) -> ::miniextendr_api::SEXP {
                         unsafe { ::miniextendr_api::altrep_data1_as::<#name #ty_generics>(x) }
                             .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
-                            .unwrap_or(::miniextendr_api::sys::SEXP::nil())
+                            .unwrap_or(::miniextendr_api::SEXP::nil())
                     }
                 }
                 ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);
@@ -830,10 +830,10 @@ pub fn derive_altrep_list(input: syn::DeriveInput) -> syn::Result<TokenStream> {
                 ::miniextendr_api::__impl_altrep_base!(#name #ty_generics, with_serialize);
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics #where_clause {}
                 impl #impl_generics ::miniextendr_api::altrep_traits::AltList for #name #ty_generics #where_clause {
-                    fn elt(x: ::miniextendr_api::sys::SEXP, i: ::miniextendr_api::sys::R_xlen_t) -> ::miniextendr_api::sys::SEXP {
+                    fn elt(x: ::miniextendr_api::SEXP, i: ::miniextendr_api::R_xlen_t) -> ::miniextendr_api::SEXP {
                         unsafe { ::miniextendr_api::altrep_data1_as::<#name #ty_generics>(x) }
                             .map(|d| <#name #ty_generics as ::miniextendr_api::altrep_data::AltListData>::elt(&*d, i.max(0) as usize))
-                            .unwrap_or(::miniextendr_api::sys::SEXP::nil())
+                            .unwrap_or(::miniextendr_api::SEXP::nil())
                     }
                 }
                 ::miniextendr_api::impl_inferbase_list!(#name #ty_generics);

--- a/miniextendr-macros/src/c_wrapper_builder.rs
+++ b/miniextendr-macros/src/c_wrapper_builder.rs
@@ -269,11 +269,11 @@ impl CWrapperContext {
         let mut sexp_idents: Vec<syn::Ident> = Vec::new();
 
         // First param is always __miniextendr_call for error context
-        c_params.push(quote!(__miniextendr_call: ::miniextendr_api::sys::SEXP));
+        c_params.push(quote!(__miniextendr_call: ::miniextendr_api::SEXP));
 
         // For instance methods, add self_sexp parameter
         if self.has_self {
-            c_params.push(quote!(self_sexp: ::miniextendr_api::sys::SEXP));
+            c_params.push(quote!(self_sexp: ::miniextendr_api::SEXP));
         }
 
         // Add regular parameters
@@ -290,7 +290,7 @@ impl CWrapperContext {
                     format_ident!("arg_{}", idx)
                 };
 
-                c_params.push(quote!(#param_ident: ::miniextendr_api::sys::SEXP));
+                c_params.push(quote!(#param_ident: ::miniextendr_api::SEXP));
                 rust_args.push(ident.clone());
                 sexp_idents.push(param_ident);
             }
@@ -406,7 +406,7 @@ impl CWrapperContext {
                 #[doc = #source_loc_doc]
                 #[doc = concat!("Generated from source file `", file!(), "`.")]
                 #[unsafe(no_mangle)]
-                #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::sys::SEXP {
+                #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::SEXP {
                     unsafe { ::miniextendr_api::sys::GetRNGstate(); }
                     let __result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
                         #unwind_protect_fn(
@@ -434,7 +434,7 @@ impl CWrapperContext {
                 #[doc = #source_loc_doc]
                 #[doc = concat!("Generated from source file `", file!(), "`.")]
                 #[unsafe(no_mangle)]
-                #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::sys::SEXP {
+                #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::SEXP {
                     #unwind_protect_fn(
                         || {
                             #pre_call_checks
@@ -523,7 +523,7 @@ impl CWrapperContext {
             #[doc = #source_loc_doc]
             #[doc = concat!("Generated from source file `", file!(), "`.")]
             #[unsafe(no_mangle)]
-            #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::sys::SEXP {
+            #vis extern "C-unwind" fn #c_ident #generics(#(#c_params),*) -> ::miniextendr_api::SEXP {
                 #rng_get
                 let __miniextendr_panic_result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(move || {
                     #pre_call_checks
@@ -567,7 +567,7 @@ impl CWrapperContext {
             ReturnHandling::Unit => {
                 quote! {
                     #call_expr;
-                    ::miniextendr_api::sys::SEXP::nil()
+                    ::miniextendr_api::SEXP::nil()
                 }
             }
             ReturnHandling::RawSexp => {
@@ -600,7 +600,7 @@ impl CWrapperContext {
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                         );
                     }
-                    ::miniextendr_api::sys::SEXP::nil()
+                    ::miniextendr_api::SEXP::nil()
                 }
             }
             ReturnHandling::OptionSexp => {
@@ -650,7 +650,7 @@ impl CWrapperContext {
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                         );
                     }
-                    ::miniextendr_api::sys::SEXP::nil()
+                    ::miniextendr_api::SEXP::nil()
                 }
             }
             ReturnHandling::ResultSexp => {
@@ -686,7 +686,7 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     match __result {
                         Ok(#result_ident) => #conversion,
-                        Err(()) => ::miniextendr_api::sys::SEXP::nil(),
+                        Err(()) => ::miniextendr_api::SEXP::nil(),
                     }
                 }
             }
@@ -739,7 +739,7 @@ impl CWrapperContext {
                     #call_expr;
                 };
                 let convert = quote! {
-                    ::miniextendr_api::sys::SEXP::nil()
+                    ::miniextendr_api::SEXP::nil()
                 };
                 (worker, convert)
             }
@@ -794,7 +794,7 @@ impl CWrapperContext {
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                         )
                     } else {
-                        ::miniextendr_api::sys::SEXP::nil()
+                        ::miniextendr_api::SEXP::nil()
                     }
                 };
                 (worker, convert)
@@ -851,7 +851,7 @@ impl CWrapperContext {
                 let worker = quote! { #call_expr };
                 let convert = quote! {
                     match __miniextendr_result {
-                        Ok(()) => ::miniextendr_api::sys::SEXP::nil(),
+                        Ok(()) => ::miniextendr_api::SEXP::nil(),
                         Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                         ),
@@ -899,7 +899,7 @@ impl CWrapperContext {
                 let convert = quote! {
                     match __miniextendr_result {
                         Ok(#result_ident) => #unwind_fn(|| #conversion, None),
-                        Err(()) => ::miniextendr_api::sys::SEXP::nil(),
+                        Err(()) => ::miniextendr_api::SEXP::nil(),
                     }
                 };
                 (worker, convert)
@@ -1030,7 +1030,7 @@ impl CWrapperContext {
 
         // Build func_ptr_def for transmute
         let func_ptr_def: Vec<syn::Type> = (0..num_args)
-            .map(|_| syn::parse_quote!(::miniextendr_api::sys::SEXP))
+            .map(|_| syn::parse_quote!(::miniextendr_api::SEXP))
             .collect();
 
         let item_label = if let Some(ref type_ident) = self.type_context {
@@ -1060,7 +1060,7 @@ impl CWrapperContext {
                 ::miniextendr_api::sys::R_CallMethodDef {
                     name: #c_ident_name.as_ptr(),
                     fun: Some(std::mem::transmute::<
-                        unsafe extern "C-unwind" fn(#(#func_ptr_def),*) -> ::miniextendr_api::sys::SEXP,
+                        unsafe extern "C-unwind" fn(#(#func_ptr_def),*) -> ::miniextendr_api::SEXP,
                         unsafe extern "C-unwind" fn() -> *mut ::std::os::raw::c_void
                     >(#c_ident)),
                     numArgs: #num_args_lit,

--- a/miniextendr-macros/src/dataframe_derive.rs
+++ b/miniextendr-macros/src/dataframe_derive.rs
@@ -808,22 +808,22 @@ pub fn derive_dataframe_row(input: DeriveInput) -> syn::Result<TokenStream> {
             type Error = std::convert::Infallible;
 
             #[inline]
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
             #[inline]
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::convert::IntoDataFrame::into_data_frame(self).into_sexp()
             }
 
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::convert::IntoDataFrame::into_data_frame(self).into_sexp()
             }
         }
@@ -1254,7 +1254,7 @@ fn derive_struct_dataframe(
                         let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
                         let mut __df_pairs: Vec<(
                             String,
-                            ::miniextendr_api::sys::SEXP,
+                            ::miniextendr_api::SEXP,
                         )> = Vec::new();
                         #tag_push_pair
                         #(#pair_pushes)*

--- a/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
+++ b/miniextendr-macros/src/dataframe_derive/enum_expansion.rs
@@ -998,7 +998,7 @@ pub(super) fn derive_enum_dataframe(
                         let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
                         let mut __df_pairs: Vec<(
                             String,
-                            ::miniextendr_api::sys::SEXP,
+                            ::miniextendr_api::SEXP,
                         )> = Vec::new();
                         #tag_push_pair
                         #(#static_pair_pushes)*
@@ -1024,7 +1024,7 @@ pub(super) fn derive_enum_dataframe(
                         let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
                         // Explicit type annotation so the vec![] case (unit-only enum
                         // with no columns and no tag) doesn't hit E0282 inference failure.
-                        let __pairs: Vec<(&str, ::miniextendr_api::sys::SEXP)> = vec![
+                        let __pairs: Vec<(&str, ::miniextendr_api::SEXP)> = vec![
                             #tag_pair
                             #(#col_pairs),*
                         ];
@@ -1759,10 +1759,10 @@ pub(super) fn derive_enum_dataframe(
                     // Used when a unit-only enum value is returned directly from a #[miniextendr] fn.
                     impl ::miniextendr_api::IntoR for #row_name {
                         type Error = ::std::convert::Infallible;
-                        fn try_into_sexp(self) -> ::std::result::Result<::miniextendr_api::sys::SEXP, Self::Error> {
+                        fn try_into_sexp(self) -> ::std::result::Result<::miniextendr_api::SEXP, Self::Error> {
                             use ::std::sync::OnceLock;
                             const LEVELS: &[&str] = &[#(#variant_strs_lit),*];
-                            static LEVELS_CACHE: OnceLock<::miniextendr_api::sys::SEXP> =
+                            static LEVELS_CACHE: OnceLock<::miniextendr_api::SEXP> =
                                 OnceLock::new();
                             let levels = *LEVELS_CACHE.get_or_init(|| {
                                 ::miniextendr_api::factor::build_levels_sexp_cached(LEVELS)
@@ -1809,7 +1809,7 @@ pub(super) fn derive_enum_dataframe(
                         for #row_name #ty_generics #where_clause
                     {
                         type Error = ::std::convert::Infallible;
-                        fn try_into_sexp(self) -> ::std::result::Result<::miniextendr_api::sys::SEXP, Self::Error> {
+                        fn try_into_sexp(self) -> ::std::result::Result<::miniextendr_api::SEXP, Self::Error> {
                             const LEVELS: &[&str] = &[#(#variant_strs_lit),*];
                             let idx: i32 = match self {
                                 #(#row_name::#variant_idents => #indices,)*
@@ -2287,7 +2287,7 @@ fn generate_split_method(
                         // unprotects after each variant data.frame is built.
                         let #df_var = unsafe {
                             let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
-                            let mut #pairs_var: Vec<(String, ::miniextendr_api::sys::SEXP)> = Vec::new();
+                            let mut #pairs_var: Vec<(String, ::miniextendr_api::SEXP)> = Vec::new();
                             #(#static_pushes)*
                             ::miniextendr_api::list::List::from_raw_pairs(#pairs_var)
                                 .set_class_str(&["data.frame"])

--- a/miniextendr-macros/src/externalptr_derive.rs
+++ b/miniextendr-macros/src/externalptr_derive.rs
@@ -419,7 +419,8 @@ fn generate_getter_body(
     // Helper: generate the pointer extraction code for Box<dyn Any> storage.
     // R_ExternalPtrAddr returns *mut Box<dyn Any>; we downcast to &T.
     let extract_ref = quote::quote! {
-        use ::miniextendr_api::sys::{R_ExternalPtrAddr, SEXP};
+        use ::miniextendr_api::SEXP;
+        use ::miniextendr_api::sys::R_ExternalPtrAddr;
         let any_raw = R_ExternalPtrAddr(x) as *mut Box<dyn ::std::any::Any>;
         if any_raw.is_null() {
             return SEXP::nil();
@@ -443,7 +444,7 @@ fn generate_getter_body(
         }
         SlotKind::ScalarInt => {
             quote::quote! {
-                use ::miniextendr_api::sys::SEXP;
+                use ::miniextendr_api::SEXP;
                 unsafe {
                     #extract_ref
                     SEXP::scalar_integer(data.#field_name)
@@ -452,7 +453,7 @@ fn generate_getter_body(
         }
         SlotKind::ScalarReal => {
             quote::quote! {
-                use ::miniextendr_api::sys::SEXP;
+                use ::miniextendr_api::SEXP;
                 unsafe {
                     #extract_ref
                     SEXP::scalar_real(data.#field_name)
@@ -461,7 +462,7 @@ fn generate_getter_body(
         }
         SlotKind::ScalarLogical => {
             quote::quote! {
-                use ::miniextendr_api::sys::SEXP;
+                use ::miniextendr_api::SEXP;
                 unsafe {
                     #extract_ref
                     SEXP::scalar_logical(data.#field_name)
@@ -470,7 +471,7 @@ fn generate_getter_body(
         }
         SlotKind::ScalarRaw => {
             quote::quote! {
-                use ::miniextendr_api::sys::SEXP;
+                use ::miniextendr_api::SEXP;
                 unsafe {
                     #extract_ref
                     SEXP::scalar_raw(data.#field_name)
@@ -534,7 +535,7 @@ fn generate_setter_body(
         }
         SlotKind::ScalarInt => {
             quote::quote! {
-                use ::miniextendr_api::sys::SexpExt;
+                use ::miniextendr_api::SexpExt;
                 unsafe {
                     #extract_mut
                     data.#field_name = value.as_integer().unwrap_or(::miniextendr_api::altrep_traits::NA_INTEGER);
@@ -544,7 +545,7 @@ fn generate_setter_body(
         }
         SlotKind::ScalarReal => {
             quote::quote! {
-                use ::miniextendr_api::sys::SexpExt;
+                use ::miniextendr_api::SexpExt;
                 unsafe {
                     #extract_mut
                     data.#field_name = value.as_real().unwrap_or(::miniextendr_api::altrep_traits::NA_REAL);
@@ -554,7 +555,7 @@ fn generate_setter_body(
         }
         SlotKind::ScalarLogical => {
             quote::quote! {
-                use ::miniextendr_api::sys::SexpExt;
+                use ::miniextendr_api::SexpExt;
                 unsafe {
                     #extract_mut
                     data.#field_name = value.as_logical().unwrap_or(false);
@@ -564,7 +565,7 @@ fn generate_setter_body(
         }
         SlotKind::ScalarRaw => {
             quote::quote! {
-                use ::miniextendr_api::sys::{SexpExt, SEXPTYPE};
+                use ::miniextendr_api::{SexpExt, SEXPTYPE};
                 unsafe {
                     #extract_mut
                     let raw_vec = value.coerce(SEXPTYPE::RAWSXP);
@@ -994,8 +995,8 @@ NULL
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn #getter_fn_name(
-                x: ::miniextendr_api::sys::SEXP
-            ) -> ::miniextendr_api::sys::SEXP {
+                x: ::miniextendr_api::SEXP
+            ) -> ::miniextendr_api::SEXP {
                 #getter_body
             }
         });
@@ -1008,9 +1009,9 @@ NULL
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn #setter_fn_name(
-                x: ::miniextendr_api::sys::SEXP,
-                value: ::miniextendr_api::sys::SEXP,
-            ) -> ::miniextendr_api::sys::SEXP {
+                x: ::miniextendr_api::SEXP,
+                value: ::miniextendr_api::SEXP,
+            ) -> ::miniextendr_api::SEXP {
                 #setter_body
             }
         });

--- a/miniextendr-macros/src/factor_derive.rs
+++ b/miniextendr-macros/src/factor_derive.rs
@@ -259,16 +259,16 @@ fn derive_simple_factor(
         impl #impl_generics ::miniextendr_api::IntoR for #name #ty_generics #where_clause {
             type Error = std::convert::Infallible;
 
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
-                static LEVELS_CACHE: ::std::sync::OnceLock<::miniextendr_api::sys::SEXP> =
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
+                static LEVELS_CACHE: ::std::sync::OnceLock<::miniextendr_api::SEXP> =
                     ::std::sync::OnceLock::new();
                 let levels = *LEVELS_CACHE.get_or_init(|| {
                     ::miniextendr_api::build_levels_sexp_cached(
@@ -282,7 +282,7 @@ fn derive_simple_factor(
         impl #impl_generics ::miniextendr_api::TryFromSexp for #name #ty_generics #where_clause {
             type Error = ::miniextendr_api::SexpError;
 
-            fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> Result<Self, Self::Error> {
+            fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> Result<Self, Self::Error> {
                 ::miniextendr_api::factor_from_sexp(sexp)
             }
         }
@@ -483,16 +483,16 @@ fn derive_interaction_factor(
         impl #impl_generics ::miniextendr_api::IntoR for #name #ty_generics #where_clause {
             type Error = std::convert::Infallible;
 
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
-                static LEVELS_CACHE: ::std::sync::OnceLock<::miniextendr_api::sys::SEXP> =
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
+                static LEVELS_CACHE: ::std::sync::OnceLock<::miniextendr_api::SEXP> =
                     ::std::sync::OnceLock::new();
                 let levels = *LEVELS_CACHE.get_or_init(|| {
                     ::miniextendr_api::build_levels_sexp_cached(
@@ -506,7 +506,7 @@ fn derive_interaction_factor(
         impl #impl_generics ::miniextendr_api::TryFromSexp for #name #ty_generics #where_clause {
             type Error = ::miniextendr_api::SexpError;
 
-            fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> Result<Self, Self::Error> {
+            fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> Result<Self, Self::Error> {
                 ::miniextendr_api::factor_from_sexp(sexp)
             }
         }

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1869,21 +1869,21 @@ pub fn derive_rnative_type(input: proc_macro::TokenStream) -> proc_macro::TokenS
     };
 
     let expanded = quote::quote! {
-        impl #impl_generics ::miniextendr_api::sys::RNativeType for #name #ty_generics #where_clause {
+        impl #impl_generics ::miniextendr_api::RNativeType for #name #ty_generics #where_clause {
             const SEXP_TYPE: ::miniextendr_api::SEXPTYPE =
-                <#inner_ty as ::miniextendr_api::sys::RNativeType>::SEXP_TYPE;
+                <#inner_ty as ::miniextendr_api::RNativeType>::SEXP_TYPE;
 
             #[inline]
             unsafe fn dataptr_mut(sexp: ::miniextendr_api::SEXP) -> *mut Self {
                 // Newtype is repr(transparent), so we can cast the pointer
                 unsafe {
-                    <#inner_ty as ::miniextendr_api::sys::RNativeType>::dataptr_mut(sexp).cast()
+                    <#inner_ty as ::miniextendr_api::RNativeType>::dataptr_mut(sexp).cast()
                 }
             }
 
             #[inline]
             fn elt(sexp: ::miniextendr_api::SEXP, i: isize) -> Self {
-                let val = <#inner_ty as ::miniextendr_api::sys::RNativeType>::elt(sexp, i);
+                let val = <#inner_ty as ::miniextendr_api::RNativeType>::elt(sexp, i);
                 #elt_ctor
             }
         }
@@ -2495,13 +2495,13 @@ pub fn typed_list(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// # Supported element types
 ///
 /// v1 supports column element types that implement
-/// `miniextendr_api::sys::RNativeType`:
+/// `miniextendr_api::RNativeType`:
 ///
 /// - `i32` — `INTSXP`
 /// - `f64` — `REALSXP`
 /// - `u8` — `RAWSXP`
-/// - `miniextendr_api::sys::RLogical` — `LGLSXP`
-/// - `miniextendr_api::sys::Rcomplex` — `CPLXSXP`
+/// - `miniextendr_api::RLogical` — `LGLSXP`
+/// - `miniextendr_api::Rcomplex` — `CPLXSXP`
 ///
 /// `String`/`&str` column types are not yet supported (character vectors
 /// don't expose a contiguous slice). `bool` is also not yet supported as

--- a/miniextendr-macros/src/list_derive.rs
+++ b/miniextendr-macros/src/list_derive.rs
@@ -322,22 +322,22 @@ pub fn derive_prefer_list(input: DeriveInput) -> syn::Result<TokenStream> {
             type Error = std::convert::Infallible;
 
             #[inline]
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
             #[inline]
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::list::IntoList::into_list(self).into_sexp()
             }
 
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::list::IntoList::into_list(self).into_sexp()
             }
         }
@@ -362,22 +362,22 @@ pub fn derive_prefer_externalptr(input: DeriveInput) -> syn::Result<TokenStream>
             type Error = std::convert::Infallible;
 
             #[inline]
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
             #[inline]
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::externalptr::ExternalPtr::new(self).into_sexp()
             }
 
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::externalptr::ExternalPtr::new(self).into_sexp()
             }
         }
@@ -402,22 +402,22 @@ pub fn derive_prefer_data_frame(input: DeriveInput) -> syn::Result<TokenStream> 
             type Error = std::convert::Infallible;
 
             #[inline]
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
             #[inline]
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::convert::IntoDataFrame::into_data_frame(self).into_sexp()
             }
 
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::convert::IntoDataFrame::into_data_frame(self).into_sexp()
             }
         }
@@ -443,24 +443,24 @@ pub fn derive_prefer_rnative(input: DeriveInput) -> syn::Result<TokenStream> {
             type Error = std::convert::Infallible;
 
             #[inline]
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
             #[inline]
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
             #[inline]
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::into_r::IntoR::into_sexp(
                     ::miniextendr_api::convert::AsRNative(self)
                 )
             }
 
             #[inline]
-            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::sys::SEXP {
+            unsafe fn into_sexp_unchecked(self) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::into_r::IntoR::into_sexp_unchecked(
                     ::miniextendr_api::convert::AsRNative(self)
                 )

--- a/miniextendr-macros/src/match_arg_derive.rs
+++ b/miniextendr-macros/src/match_arg_derive.rs
@@ -214,7 +214,7 @@ pub fn derive_match_arg(input: DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics ::miniextendr_api::TryFromSexp for #name #ty_generics #where_clause {
             type Error = ::miniextendr_api::SexpError;
 
-            fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> Result<Self, Self::Error> {
+            fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> Result<Self, Self::Error> {
                 ::miniextendr_api::match_arg_from_sexp(sexp).map_err(Into::into)
             }
         }
@@ -222,15 +222,15 @@ pub fn derive_match_arg(input: DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics ::miniextendr_api::IntoR for #name #ty_generics #where_clause {
             type Error = std::convert::Infallible;
 
-            fn try_into_sexp(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            fn try_into_sexp(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 Ok(self.into_sexp())
             }
 
-            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::sys::SEXP, Self::Error> {
+            unsafe fn try_into_sexp_unchecked(self) -> Result<::miniextendr_api::SEXP, Self::Error> {
                 self.try_into_sexp()
             }
 
-            fn into_sexp(self) -> ::miniextendr_api::sys::SEXP {
+            fn into_sexp(self) -> ::miniextendr_api::SEXP {
                 use ::miniextendr_api::match_arg::MatchArg;
                 self.to_choice().into_sexp()
             }

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -2720,8 +2720,8 @@ fn generate_method_match_arg_helpers(
             #[allow(non_snake_case)]
             #[unsafe(no_mangle)]
             pub extern "C-unwind" fn #helper_fn_ident(
-                __miniextendr_call: ::miniextendr_api::sys::SEXP,
-            ) -> ::miniextendr_api::sys::SEXP {
+                __miniextendr_call: ::miniextendr_api::SEXP,
+            ) -> ::miniextendr_api::SEXP {
                 ::miniextendr_api::choices_sexp::<#choices_ty>()
             }
 
@@ -2734,8 +2734,8 @@ fn generate_method_match_arg_helpers(
                     name: #helper_c_name.as_ptr(),
                     fun: Some(::std::mem::transmute::<
                         unsafe extern "C-unwind" fn(
-                            ::miniextendr_api::sys::SEXP,
-                        ) -> ::miniextendr_api::sys::SEXP,
+                            ::miniextendr_api::SEXP,
+                        ) -> ::miniextendr_api::SEXP,
                         unsafe extern "C-unwind" fn() -> *mut ::std::os::raw::c_void,
                     >(#helper_fn_ident)),
                     numArgs: 1i32,
@@ -3023,7 +3023,7 @@ pub fn generate_as_coercion_trait_impls(parsed_impl: &ParsedImpl) -> TokenStream
                 ::core::result::Result<::miniextendr_api::List, ::miniextendr_api::as_coerce::AsCoerceError>
             },
             _ => quote! {
-                ::core::result::Result<::miniextendr_api::sys::SEXP, ::miniextendr_api::as_coerce::AsCoerceError>
+                ::core::result::Result<::miniextendr_api::SEXP, ::miniextendr_api::as_coerce::AsCoerceError>
             },
         };
 

--- a/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
@@ -485,8 +485,8 @@ fn generate_concrete_vtable_shims(
             unsafe extern "C" fn #shim_name(
                 data: *mut ::std::os::raw::c_void,
                 argc: i32,
-                argv: *const ::miniextendr_api::sys::SEXP,
-            ) -> ::miniextendr_api::sys::SEXP {
+                argv: *const ::miniextendr_api::SEXP,
+            ) -> ::miniextendr_api::SEXP {
                 unsafe {
                     ::miniextendr_api::trait_abi::check_arity(argc, #expected_argc, #method_name_str);
                 }

--- a/miniextendr-macros/src/miniextendr_trait.rs
+++ b/miniextendr-macros/src/miniextendr_trait.rs
@@ -448,7 +448,7 @@ fn generate_trait_abi(trait_item: &ItemTrait) -> TokenStream {
                 /// - `sexp` must be a valid R external pointer (EXTPTRSXP)
                 /// - Must be called on R's main thread
                 #[inline]
-                pub unsafe fn try_from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> Option<Self> {
+                pub unsafe fn try_from_sexp(sexp: ::miniextendr_api::SEXP) -> Option<Self> {
                     <Self as ::miniextendr_api::TraitView>::try_from_sexp(sexp)
                 }
 
@@ -458,7 +458,7 @@ fn generate_trait_abi(trait_item: &ItemTrait) -> TokenStream {
                 ///
                 /// Same as `try_from_sexp`.
                 #[inline]
-                pub unsafe fn from_sexp(sexp: ::miniextendr_api::sys::SEXP) -> Self {
+                pub unsafe fn from_sexp(sexp: ::miniextendr_api::SEXP) -> Self {
                     Self::try_from_sexp(sexp)
                         .expect(concat!("Object does not implement ", #trait_name_str, " trait"))
                 }
@@ -629,7 +629,7 @@ fn generate_view_method(method: &MethodInfo) -> Option<TokenStream> {
     // Generate vtable call
     let vtable_call = if argc > 0 {
         quote::quote! {
-            let args: [::miniextendr_api::sys::SEXP; #argc as usize] = [#(#arg_conversions),*];
+            let args: [::miniextendr_api::SEXP; #argc as usize] = [#(#arg_conversions),*];
             ((*self.vtable).#method_name)(self.data, #argc, args.as_ptr())
         }
     } else {
@@ -797,8 +797,8 @@ fn generate_method_shim(
         unsafe extern "C" fn #shim_name<#(#trait_type_params,)* #impl_t: #trait_bound #(+ #impl_bounds)*>(
             data: *mut ::std::os::raw::c_void,
             argc: i32,
-            argv: *const ::miniextendr_api::sys::SEXP,
-        ) -> ::miniextendr_api::sys::SEXP
+            argv: *const ::miniextendr_api::SEXP,
+        ) -> ::miniextendr_api::SEXP
         #where_clause
         {
             // Check arity (before unwind protect - uses r_stop which doesn't return)

--- a/miniextendr-macros/src/return_type_analysis.rs
+++ b/miniextendr-macros/src/return_type_analysis.rs
@@ -170,7 +170,7 @@ fn analyze_option_type(
         *ctx.is_invisible = true;
         quote::quote! {
             match #rust_result_ident {
-                Some(()) => ::miniextendr_api::sys::SEXP::nil(),
+                Some(()) => ::miniextendr_api::SEXP::nil(),
                 None => ::miniextendr_api::error_value::make_rust_condition_value(
                     #option_none_error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                 ),
@@ -183,7 +183,7 @@ fn analyze_option_type(
         quote::quote! {
             match #rust_result_ident {
                 Some(v) => v,
-                None => ::miniextendr_api::sys::SEXP::nil(),
+                None => ::miniextendr_api::SEXP::nil(),
             }
         }
     } else {
@@ -229,7 +229,7 @@ fn analyze_result_type(
         if ok_is_unit {
             // Result<(), ()> - invisible, always returns NULL
             *ctx.is_invisible = true;
-            quote::quote! { ::miniextendr_api::sys::SEXP::nil() }
+            quote::quote! { ::miniextendr_api::SEXP::nil() }
         } else {
             // Result<T, ()> - convert to Result<T, NullOnErr> and use IntoR
             // IntoR for Result<T, NullOnErr> returns NULL on Err
@@ -260,7 +260,7 @@ fn analyze_result_type(
         *ctx.is_invisible = true;
         quote::quote! {
             match #rust_result_ident {
-                Ok(()) => ::miniextendr_api::sys::SEXP::nil(),
+                Ok(()) => ::miniextendr_api::SEXP::nil(),
                 Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
                 ),

--- a/miniextendr-macros/src/typed_dataframe.rs
+++ b/miniextendr-macros/src/typed_dataframe.rs
@@ -167,9 +167,9 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
     let col_fields = fields.iter().map(|f| {
         let col_ident = format_ident!("{}_col", f.name);
         if f.optional {
-            quote! { #col_ident: ::std::option::Option<::miniextendr_api::sys::SEXP> }
+            quote! { #col_ident: ::std::option::Option<::miniextendr_api::SEXP> }
         } else {
-            quote! { #col_ident: ::miniextendr_api::sys::SEXP }
+            quote! { #col_ident: ::miniextendr_api::SEXP }
         }
     });
 
@@ -185,7 +185,7 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
                 pub fn #method_ident(&self) -> ::std::option::Option<&[#elem_ty]> {
                     self.#col_ident.map(|col| unsafe {
                         let len = self.nrow;
-                        let ptr = <#elem_ty as ::miniextendr_api::sys::RNativeType>::dataptr_mut(col)
+                        let ptr = <#elem_ty as ::miniextendr_api::RNativeType>::dataptr_mut(col)
                             as *const #elem_ty;
                         if len == 0 { &[] } else { ::std::slice::from_raw_parts(ptr, len) }
                     })
@@ -198,7 +198,7 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
                 pub fn #method_ident(&self) -> &[#elem_ty] {
                     unsafe {
                         let len = self.nrow;
-                        let ptr = <#elem_ty as ::miniextendr_api::sys::RNativeType>::dataptr_mut(self.#col_ident)
+                        let ptr = <#elem_ty as ::miniextendr_api::RNativeType>::dataptr_mut(self.#col_ident)
                             as *const #elem_ty;
                         if len == 0 { &[] } else { ::std::slice::from_raw_parts(ptr, len) }
                     }
@@ -214,12 +214,12 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
         let elem_ty = &f.elem_ty;
         if f.optional {
             quote! {
-                let #col_ident: ::std::option::Option<::miniextendr_api::sys::SEXP> = {
+                let #col_ident: ::std::option::Option<::miniextendr_api::SEXP> = {
                     match view.column_raw(#name_str) {
                         ::std::option::Option::None => ::std::option::Option::None,
                         ::std::option::Option::Some(col) => {
-                            let actual = ::miniextendr_api::sys::SexpExt::type_of(&col);
-                            let expected = <#elem_ty as ::miniextendr_api::sys::RNativeType>::SEXP_TYPE;
+                            let actual = ::miniextendr_api::SexpExt::type_of(&col);
+                            let expected = <#elem_ty as ::miniextendr_api::RNativeType>::SEXP_TYPE;
                             if actual != expected {
                                 __errs.push(::std::format!(
                                     "column `{}`: expected {} ({:?}), got {:?}",
@@ -238,20 +238,20 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
             }
         } else {
             quote! {
-                let #col_ident: ::miniextendr_api::sys::SEXP = {
+                let #col_ident: ::miniextendr_api::SEXP = {
                     match view.column_raw(#name_str) {
                         ::std::option::Option::None => {
                             __errs.push(::std::format!(
                                 "missing required column `{}` (expected {} / {:?})",
                                 #name_str,
                                 ::std::stringify!(#elem_ty),
-                                <#elem_ty as ::miniextendr_api::sys::RNativeType>::SEXP_TYPE,
+                                <#elem_ty as ::miniextendr_api::RNativeType>::SEXP_TYPE,
                             ));
-                            ::miniextendr_api::sys::SEXP::nil()
+                            ::miniextendr_api::SEXP::nil()
                         }
                         ::std::option::Option::Some(col) => {
-                            let actual = ::miniextendr_api::sys::SexpExt::type_of(&col);
-                            let expected = <#elem_ty as ::miniextendr_api::sys::RNativeType>::SEXP_TYPE;
+                            let actual = ::miniextendr_api::SexpExt::type_of(&col);
+                            let expected = <#elem_ty as ::miniextendr_api::RNativeType>::SEXP_TYPE;
                             if actual != expected {
                                 __errs.push(::std::format!(
                                     "column `{}`: expected {} ({:?}), got {:?}",
@@ -299,7 +299,7 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
         #(#attrs)*
         #[allow(non_snake_case)]
         #vis struct #name {
-            sexp: ::miniextendr_api::sys::SEXP,
+            sexp: ::miniextendr_api::SEXP,
             nrow: usize,
             #( #col_fields, )*
         }
@@ -315,7 +315,7 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
 
             /// The backing SEXP (preserves the data.frame class attribute).
             #[inline]
-            pub fn as_sexp(&self) -> ::miniextendr_api::sys::SEXP { self.sexp }
+            pub fn as_sexp(&self) -> ::miniextendr_api::SEXP { self.sexp }
 
             #( #accessors )*
         }
@@ -324,9 +324,9 @@ pub fn expand_typed_dataframe(input: TypedDataframeInput) -> TokenStream {
             type Error = ::miniextendr_api::from_r::SexpError;
 
             fn try_from_sexp(
-                sexp: ::miniextendr_api::sys::SEXP,
+                sexp: ::miniextendr_api::SEXP,
             ) -> ::std::result::Result<Self, Self::Error> {
-                use ::miniextendr_api::sys::SexpExt as _;
+                use ::miniextendr_api::SexpExt as _;
 
                 // 1. Must be a data.frame.
                 if !sexp.is_data_frame() {

--- a/miniextendr-macros/src/vctrs_derive.rs
+++ b/miniextendr-macros/src/vctrs_derive.rs
@@ -217,13 +217,13 @@ fn extract_fields(input: &DeriveInput) -> syn::Result<Vec<FieldInfo>> {
 /// corresponding `SEXPTYPE` token stream. Returns `None` for unrecognized types.
 fn base_to_sexptype(base: &str) -> Option<TokenStream> {
     match base {
-        "double" | "numeric" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::REALSXP }),
-        "integer" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::INTSXP }),
-        "logical" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::LGLSXP }),
-        "character" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::STRSXP }),
-        "raw" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::RAWSXP }),
-        "list" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::VECSXP }),
-        "record" => Some(quote! { ::miniextendr_api::sys::SEXPTYPE::VECSXP }),
+        "double" | "numeric" => Some(quote! { ::miniextendr_api::SEXPTYPE::REALSXP }),
+        "integer" => Some(quote! { ::miniextendr_api::SEXPTYPE::INTSXP }),
+        "logical" => Some(quote! { ::miniextendr_api::SEXPTYPE::LGLSXP }),
+        "character" => Some(quote! { ::miniextendr_api::SEXPTYPE::STRSXP }),
+        "raw" => Some(quote! { ::miniextendr_api::SEXPTYPE::RAWSXP }),
+        "list" => Some(quote! { ::miniextendr_api::SEXPTYPE::VECSXP }),
+        "record" => Some(quote! { ::miniextendr_api::SEXPTYPE::VECSXP }),
         _ => None,
     }
 }
@@ -925,7 +925,7 @@ pub fn derive_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics ::miniextendr_api::vctrs::VctrsClass for #name #ty_generics #where_clause {
             const CLASS_NAME: &'static str = #class_name;
             const KIND: ::miniextendr_api::vctrs::VctrsKind = #kind;
-            const BASE_TYPE: Option<::miniextendr_api::sys::SEXPTYPE> = Some(#sexptype);
+            const BASE_TYPE: Option<::miniextendr_api::SEXPTYPE> = Some(#sexptype);
             const INHERIT_BASE_TYPE: bool = #inherit_base;
             const ABBR: Option<&'static str> = #abbr;
         }
@@ -948,7 +948,7 @@ pub fn derive_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
 
                 quote! {
                     impl #impl_generics ::miniextendr_api::vctrs::IntoVctrs for #name #ty_generics #where_clause {
-                        fn into_vctrs(self) -> Result<::miniextendr_api::sys::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
+                        fn into_vctrs(self) -> Result<::miniextendr_api::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
                             use ::miniextendr_api::IntoR;
 
                             // Get attrs before moving fields out of self
@@ -962,7 +962,7 @@ pub fn derive_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
                             // SAFETY: into_vctrs runs on the R main thread.
                             let fields = unsafe {
                                 let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
-                                let pairs: Vec<(&str, ::miniextendr_api::sys::SEXP)> = vec![
+                                let pairs: Vec<(&str, ::miniextendr_api::SEXP)> = vec![
                                     #( (#field_names, __scope.protect_raw(self.#field_idents.into_sexp())), )*
                                 ];
                                 ::miniextendr_api::list::List::from_raw_pairs(pairs)
@@ -983,7 +983,7 @@ pub fn derive_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
                 // new_list_of requires: List, Option<SEXP> ptype, Option<i32> size, &[&str] class, &[(&str, SEXP)] attrs
                 quote! {
                     impl #impl_generics ::miniextendr_api::vctrs::IntoVctrs for #name #ty_generics #where_clause {
-                        fn into_vctrs(self) -> Result<::miniextendr_api::sys::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
+                        fn into_vctrs(self) -> Result<::miniextendr_api::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
                             use ::miniextendr_api::IntoR;
                             use ::miniextendr_api::list::List;
 
@@ -1009,7 +1009,7 @@ pub fn derive_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
                 // For simple vctrs (double, integer, etc.)
                 quote! {
                     impl #impl_generics ::miniextendr_api::vctrs::IntoVctrs for #name #ty_generics #where_clause {
-                        fn into_vctrs(self) -> Result<::miniextendr_api::sys::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
+                        fn into_vctrs(self) -> Result<::miniextendr_api::SEXP, ::miniextendr_api::vctrs::VctrsBuildError> {
                             use ::miniextendr_api::IntoR;
 
                             // Get attrs before moving data out of self

--- a/miniextendr-macros/tests/ui/extern_missing_no_mangle.rs
+++ b/miniextendr-macros/tests/ui/extern_missing_no_mangle.rs
@@ -2,7 +2,7 @@
 
 use miniextendr_macros::miniextendr;
 #[miniextendr]
-extern "C-unwind" fn C_bad(_x: miniextendr_api::sys::SEXP) -> miniextendr_api::sys::SEXP {
+extern "C-unwind" fn C_bad(_x: miniextendr_api::SEXP) -> miniextendr_api::SEXP {
     _x
 }
 

--- a/miniextendr-macros/tests/ui/extern_non_sexp_param.rs
+++ b/miniextendr-macros/tests/ui/extern_non_sexp_param.rs
@@ -3,7 +3,7 @@
 use miniextendr_macros::miniextendr;
 #[miniextendr]
 #[unsafe(no_mangle)]
-extern "C-unwind" fn C_bad(_x: i32) -> miniextendr_api::sys::SEXP {
+extern "C-unwind" fn C_bad(_x: i32) -> miniextendr_api::SEXP {
     std::ptr::null_mut()
 }
 

--- a/miniextendr-macros/tests/ui/extern_non_sexp_return.rs
+++ b/miniextendr-macros/tests/ui/extern_non_sexp_return.rs
@@ -3,7 +3,7 @@
 use miniextendr_macros::miniextendr;
 #[miniextendr]
 #[unsafe(no_mangle)]
-extern "C-unwind" fn C_bad(_x: miniextendr_api::sys::SEXP) -> i32 {
+extern "C-unwind" fn C_bad(_x: miniextendr_api::SEXP) -> i32 {
     0
 }
 

--- a/miniextendr-macros/tests/ui/extern_variadic.rs
+++ b/miniextendr-macros/tests/ui/extern_variadic.rs
@@ -4,7 +4,7 @@ use miniextendr_macros::miniextendr;
 
 #[miniextendr]
 #[unsafe(no_mangle)]
-extern "C-unwind" fn C_bad(_dots: &miniextendr_api::Dots) -> miniextendr_api::sys::SEXP {
+extern "C-unwind" fn C_bad(_dots: &miniextendr_api::Dots) -> miniextendr_api::SEXP {
     std::ptr::null_mut()
 }
 

--- a/miniextendr-macros/tests/ui/fn_s3_missing_class.rs
+++ b/miniextendr-macros/tests/ui/fn_s3_missing_class.rs
@@ -3,7 +3,7 @@
 use miniextendr_macros::miniextendr;
 
 #[miniextendr(s3(generic = "print"))]
-fn print_myclass(x: miniextendr_api::sys::SEXP) -> miniextendr_api::sys::SEXP {
+fn print_myclass(x: miniextendr_api::SEXP) -> miniextendr_api::SEXP {
     x
 }
 

--- a/miniextendr-macros/tests/ui/fn_s3_unknown_option.rs
+++ b/miniextendr-macros/tests/ui/fn_s3_unknown_option.rs
@@ -3,7 +3,7 @@
 use miniextendr_macros::miniextendr;
 
 #[miniextendr(s3(class = "foo", unknown = "bar"))]
-fn print_foo(x: miniextendr_api::sys::SEXP) -> miniextendr_api::sys::SEXP {
+fn print_foo(x: miniextendr_api::SEXP) -> miniextendr_api::SEXP {
     x
 }
 

--- a/rpkg/src/rust/altrep_condition_tests.rs
+++ b/rpkg/src/rust/altrep_condition_tests.rs
@@ -8,7 +8,7 @@
 
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen};
 use miniextendr_api::miniextendr;
-use miniextendr_api::{AltrepInteger, IntoR, sys::SEXP};
+use miniextendr_api::{AltrepInteger, IntoR, SEXP};
 
 // region: PanickingAltrep — plain panic from elt(), guard = RUnwind (default)
 

--- a/rpkg/src/rust/altrep_sexp_tests.rs
+++ b/rpkg/src/rust/altrep_sexp_tests.rs
@@ -1,7 +1,7 @@
 use miniextendr_api::IntoR;
 use miniextendr_api::altrep_sexp::{AltrepSexp, ensure_materialized};
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::sys::SEXPTYPE;
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::miniextendr;
 
 /// Check if a SEXP is ALTREP and return info about it.

--- a/rpkg/src/rust/arrow_adapter_tests.rs
+++ b/rpkg/src/rust/arrow_adapter_tests.rs
@@ -233,7 +233,7 @@ pub fn arrow_date_len(v: miniextendr_api::arrow_impl::Date32Array) -> i32 {
 /// Test POSIXct roundtrip through Arrow TimestampSecondArray.
 /// @param v R POSIXct SEXP to convert to Arrow timestamp.
 #[miniextendr]
-pub fn arrow_posixct_roundtrip(v: miniextendr_api::sys::SEXP) -> miniextendr_api::sys::SEXP {
+pub fn arrow_posixct_roundtrip(v: miniextendr_api::SEXP) -> miniextendr_api::SEXP {
     use miniextendr_api::arrow_impl::posixct_to_timestamp;
     use miniextendr_api::into_r::IntoR;
     let arr = posixct_to_timestamp(v).expect("posixct_to_timestamp failed");
@@ -243,7 +243,7 @@ pub fn arrow_posixct_roundtrip(v: miniextendr_api::sys::SEXP) -> miniextendr_api
 /// Test getting the length of a POSIXct converted to Arrow timestamp.
 /// @param v R POSIXct SEXP to convert to Arrow timestamp.
 #[miniextendr]
-pub fn arrow_posixct_len(v: miniextendr_api::sys::SEXP) -> i32 {
+pub fn arrow_posixct_len(v: miniextendr_api::SEXP) -> i32 {
     use miniextendr_api::arrow_impl::posixct_to_timestamp;
     let arr = posixct_to_timestamp(v).expect("posixct_to_timestamp failed");
     arr.len() as i32

--- a/rpkg/src/rust/arrow_na_tests.rs
+++ b/rpkg/src/rust/arrow_na_tests.rs
@@ -366,7 +366,7 @@ pub fn arrow_na_f64_stale_bitmap_demo(n: i32) -> Vec<f64> {
 
     // Fill with non-NA values
     for i in 0..n {
-        miniextendr_api::sys::SexpExt::set_real_elt(&sexp, i as isize, (i + 1) as f64);
+        miniextendr_api::SexpExt::set_real_elt(&sexp, i as isize, (i + 1) as f64);
     }
 
     // Create Arrow array — bitmap says "no nulls" (all values are valid)
@@ -375,7 +375,7 @@ pub fn arrow_na_f64_stale_bitmap_demo(n: i32) -> Vec<f64> {
     let arr = Float64Array::new(scalar_buffer, None); // None = no nulls
 
     // Now mutate the R buffer AFTER Arrow array was created
-    miniextendr_api::sys::SexpExt::set_real_elt(
+    miniextendr_api::SexpExt::set_real_elt(
         &sexp,
         1, // set index 1 to NA
         miniextendr_api::altrep_traits::NA_REAL,

--- a/rpkg/src/rust/as_coerce_tests.rs
+++ b/rpkg/src/rust/as_coerce_tests.rs
@@ -5,8 +5,8 @@
 
 use miniextendr_api::as_coerce::AsCoerceError;
 use miniextendr_api::{
-    ExternalPtr, IntoR, List, ListBuilder, OwnedProtect, ProtectScope, SEXP, miniextendr, sys,
-    sys::SexpExt,
+    ExternalPtr, IntoR, List, ListBuilder, OwnedProtect, ProtectScope, SEXP, SEXPTYPE,
+    SexpExt, miniextendr, sys,
 };
 
 /// Test struct for as.<class> coercion methods.
@@ -114,8 +114,8 @@ impl AsCoerceTestData {
 
         // Create a character vector of length 1
         unsafe {
-            let result = OwnedProtect::new(sys::Rf_allocVector(sys::SEXPTYPE::STRSXP, 1));
-            result.get().set_string_elt(0, sys::SEXP::charsxp(&desc));
+            let result = OwnedProtect::new(sys::Rf_allocVector(SEXPTYPE::STRSXP, 1));
+            result.get().set_string_elt(0, SEXP::charsxp(&desc));
             Ok(result.into_sexp())
         }
     }

--- a/rpkg/src/rust/coerce_tests.rs
+++ b/rpkg/src/rust/coerce_tests.rs
@@ -86,7 +86,7 @@ pub fn test_coerce_widen(x: i32) -> f64 {
 /// Test coercion from Rboolean to i32 via Coerce trait.
 /// @param x Logical scalar input.
 #[miniextendr]
-pub fn test_coerce_bool_to_int(x: miniextendr_api::sys::Rboolean) -> i32 {
+pub fn test_coerce_bool_to_int(x: miniextendr_api::Rboolean) -> i32 {
     x.coerce()
 }
 

--- a/rpkg/src/rust/conversion_tests.rs
+++ b/rpkg/src/rust/conversion_tests.rs
@@ -83,15 +83,15 @@ pub fn test_u8_add_one(x: u8) -> u8 {
 /// Test logical scalar identity roundtrip.
 /// @param x Logical scalar input.
 #[miniextendr]
-pub fn test_logical_identity(x: miniextendr_api::sys::Rboolean) -> miniextendr_api::sys::Rboolean {
+pub fn test_logical_identity(x: miniextendr_api::Rboolean) -> miniextendr_api::Rboolean {
     x
 }
 
 /// Test logical negation (TRUE becomes FALSE and vice versa).
 /// @param x Logical scalar input.
 #[miniextendr]
-pub fn test_logical_not(x: miniextendr_api::sys::Rboolean) -> miniextendr_api::sys::Rboolean {
-    use miniextendr_api::sys::Rboolean;
+pub fn test_logical_not(x: miniextendr_api::Rboolean) -> miniextendr_api::Rboolean {
+    use miniextendr_api::Rboolean;
     match x {
         Rboolean::TRUE => Rboolean::FALSE,
         _ => Rboolean::TRUE,
@@ -103,10 +103,10 @@ pub fn test_logical_not(x: miniextendr_api::sys::Rboolean) -> miniextendr_api::s
 /// @param b Logical scalar.
 #[miniextendr]
 pub fn test_logical_and(
-    a: miniextendr_api::sys::Rboolean,
-    b: miniextendr_api::sys::Rboolean,
-) -> miniextendr_api::sys::Rboolean {
-    use miniextendr_api::sys::Rboolean;
+    a: miniextendr_api::Rboolean,
+    b: miniextendr_api::Rboolean,
+) -> miniextendr_api::Rboolean {
+    use miniextendr_api::Rboolean;
     match (a, b) {
         (Rboolean::TRUE, Rboolean::TRUE) => Rboolean::TRUE,
         _ => Rboolean::FALSE,
@@ -206,7 +206,7 @@ pub fn test_u8_slice_sum(x: &'static [u8]) -> i32 {
 /// Test getting the length of an RLogical slice.
 /// @param x Logical vector input.
 #[miniextendr]
-pub fn test_logical_slice_len(x: &'static [miniextendr_api::sys::RLogical]) -> i32 {
+pub fn test_logical_slice_len(x: &'static [miniextendr_api::RLogical]) -> i32 {
     x.len() as i32
 }
 
@@ -214,9 +214,9 @@ pub fn test_logical_slice_len(x: &'static [miniextendr_api::sys::RLogical]) -> i
 /// @param x Logical vector input.
 #[miniextendr]
 pub fn test_logical_slice_any_true(
-    x: &'static [miniextendr_api::sys::RLogical],
-) -> miniextendr_api::sys::Rboolean {
-    use miniextendr_api::sys::Rboolean;
+    x: &'static [miniextendr_api::RLogical],
+) -> miniextendr_api::Rboolean {
+    use miniextendr_api::Rboolean;
     if x.iter().any(|v| v.to_option_bool() == Some(true)) {
         Rboolean::TRUE
     } else {
@@ -228,9 +228,9 @@ pub fn test_logical_slice_any_true(
 /// @param x Logical vector input.
 #[miniextendr]
 pub fn test_logical_slice_all_true(
-    x: &'static [miniextendr_api::sys::RLogical],
-) -> miniextendr_api::sys::Rboolean {
-    use miniextendr_api::sys::Rboolean;
+    x: &'static [miniextendr_api::RLogical],
+) -> miniextendr_api::Rboolean {
+    use miniextendr_api::Rboolean;
     if x.iter().all(|v| v.to_option_bool() == Some(true)) {
         Rboolean::TRUE
     } else {

--- a/rpkg/src/rust/conversions.rs
+++ b/rpkg/src/rust/conversions.rs
@@ -1,7 +1,7 @@
 //! Comprehensive conversions matrix for [`#[miniextendr]`](miniextendr_api::miniextendr) arguments and returns.
 
 use miniextendr_api::prelude::SEXP;
-use miniextendr_api::sys::{RLogical, Rboolean};
+use miniextendr_api::{RLogical, Rboolean};
 use miniextendr_api::{IntoR, ListMut, miniextendr};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
@@ -1503,7 +1503,7 @@ pub fn conv_as_named_list_array() -> AsNamedList<[(String, f64); 2]> {
 
 /// Return test: `AsNamedList` with heterogeneous SEXP values -> R named list.
 #[miniextendr]
-pub fn conv_as_named_list_heterogeneous() -> AsNamedList<Vec<(String, miniextendr_api::sys::SEXP)>>
+pub fn conv_as_named_list_heterogeneous() -> AsNamedList<Vec<(String, miniextendr_api::SEXP)>>
 {
     use miniextendr_api::IntoR;
     AsNamedList(vec![
@@ -1591,14 +1591,14 @@ pub fn conv_as_named_list_ext_trait() -> AsNamedList<Vec<(&'static str, i32)>> {
 
 /// Return test: `AsNamedList` from a borrowed slice -> R named list via SEXP.
 #[miniextendr]
-pub fn conv_as_named_list_slice() -> miniextendr_api::sys::SEXP {
+pub fn conv_as_named_list_slice() -> miniextendr_api::SEXP {
     let pairs: &[(&str, i32)] = &[("x", 10), ("y", 20), ("z", 30)];
     AsNamedList(pairs).into_sexp()
 }
 
 /// Return test: `AsNamedVector` from a borrowed slice -> R named double vector via SEXP.
 #[miniextendr]
-pub fn conv_as_named_vector_slice() -> miniextendr_api::sys::SEXP {
+pub fn conv_as_named_vector_slice() -> miniextendr_api::SEXP {
     let pairs: &[(&str, f64)] = &[("a", 1.5), ("b", 2.5)];
     AsNamedVector(pairs).into_sexp()
 }

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -282,7 +282,7 @@ pub struct WithOptMapAsList {
 
 impl IntoList for WithOptMapAsList {
     fn into_list(self) -> miniextendr_api::List {
-        use miniextendr_api::{IntoR, sys::SEXP};
+        use miniextendr_api::{IntoR, SEXP};
         let counts_sexp = match self.counts {
             Some(m) => m.into_list().into_sexp(),
             None => SEXP::nil(),

--- a/rpkg/src/rust/gc_protect_tests.rs
+++ b/rpkg/src/rust/gc_protect_tests.rs
@@ -3,7 +3,8 @@
 //! These tests verify that the protection APIs work correctly.
 
 use miniextendr_api::prelude::SexpExt;
-use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+use miniextendr_api::SEXPTYPE;
+use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::gc_protect::ProtectScope;
 use miniextendr_api::list::{List, ListBuilder};
 use miniextendr_api::miniextendr;

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::sys::SEXPTYPE;
+use miniextendr_api::SEXPTYPE;
 use miniextendr_api::into_r::IntoR;
 use miniextendr_api::{IntoRAltrep, miniextendr};
 #[cfg(feature = "jiff")]
@@ -1192,7 +1192,8 @@ pub fn gc_stress_factor_labels() -> i32 {
     use crate::serde::Deserialize;
     use miniextendr_api::factor::{build_factor, build_levels_sexp};
     use miniextendr_api::prelude::{SEXP, SexpExt};
-    use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+    use miniextendr_api::SEXPTYPE;
+    use miniextendr_api::sys::Rf_allocVector;
     use miniextendr_api::gc_protect::OwnedProtect;
     use miniextendr_api::serde::dataframe_to_vec;
 
@@ -1343,8 +1344,6 @@ pub fn gc_stress_typed_dataframe() {
     // Optional column was absent in this fixture.
     assert!(theoph.flag().is_none());
 
-    drop(theoph);
-    drop(df);
     drop(scope);
 
     // Now repeat the dance with the optional column populated, so the

--- a/rpkg/src/rust/identical_tests.rs
+++ b/rpkg/src/rust/identical_tests.rs
@@ -11,7 +11,7 @@ use miniextendr_api::miniextendr;
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn C_test_sexp_equality(x: SEXP, y: SEXP) -> SEXP {
     use miniextendr_api::prelude::SexpExt;
-    use miniextendr_api::sys::Rboolean;
+    use miniextendr_api::Rboolean;
     use miniextendr_api::gc_protect::ProtectScope;
 
     let pointer_eq = x == y;

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -328,10 +328,10 @@ impl AltIntegerData for ConstantIntData {
 
 // Serialization support: save as [value, len], reconstruct on load
 impl miniextendr_api::altrep_data::AltrepSerialize for ConstantIntData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         vec![self.value, self.len as i32].into_sexp()
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         let v: Vec<i32> = miniextendr_api::TryFromSexp::try_from_sexp(state).ok()?;
         if v.len() != 2 {
             return None;
@@ -970,7 +970,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for LogicalVecData {
         const NA_LOGICAL: i32 = i32::MIN;
         unsafe {
             use miniextendr_api::prelude::SexpExt;
-            use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+            use miniextendr_api::SEXPTYPE;
+            use miniextendr_api::sys::Rf_allocVector;
             let n = self.data.len();
             let state = Rf_allocVector(SEXPTYPE::LGLSXP, n as isize);
             for (i, v) in self.data.iter().enumerate() {
@@ -1098,7 +1099,7 @@ pub fn repeating_raw(pattern: &[u8], n: i32) -> SEXP {
 // -----------------------------------------------------------------------------
 
 use miniextendr_api::altrep_data::AltComplexData;
-use miniextendr_api::sys::Rcomplex;
+use miniextendr_api::Rcomplex;
 
 #[derive(miniextendr_api::AltrepComplex)]
 #[altrep(class = "UnitCircle", manual)]
@@ -1223,10 +1224,10 @@ impl miniextendr_api::altrep_data::AltrepDataptr<i32> for SimpleVecIntData {
 }
 
 impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecIntData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         <Vec<i32> as miniextendr_api::altrep_data::AltrepSerialize>::serialized_state(&self.data)
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         <Vec<i32> as miniextendr_api::altrep_data::AltrepSerialize>::unserialize(state)
             .map(|data| Self { data })
     }
@@ -1259,12 +1260,12 @@ impl AltStringData for StringVecData {
 }
 
 impl miniextendr_api::altrep_data::AltrepSerialize for StringVecData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         <Vec<Option<String>> as miniextendr_api::altrep_data::AltrepSerialize>::serialized_state(
             &self.data,
         )
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         <Vec<Option<String>> as miniextendr_api::altrep_data::AltrepSerialize>::unserialize(state)
             .map(|data| Self { data })
     }
@@ -1305,10 +1306,10 @@ impl miniextendr_api::altrep_data::AltrepDataptr<u8> for SimpleVecRawData {
 }
 
 impl miniextendr_api::altrep_data::AltrepSerialize for SimpleVecRawData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         <Vec<u8> as miniextendr_api::altrep_data::AltrepSerialize>::serialized_state(&self.data)
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         <Vec<u8> as miniextendr_api::altrep_data::AltrepSerialize>::unserialize(state)
             .map(|data| Self { data })
     }
@@ -1350,10 +1351,10 @@ impl miniextendr_api::altrep_data::AltrepDataptr<f64> for InferredVecRealData {
 }
 
 impl miniextendr_api::altrep_data::AltrepSerialize for InferredVecRealData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         <Vec<f64> as miniextendr_api::altrep_data::AltrepSerialize>::serialized_state(&self.data)
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         <Vec<f64> as miniextendr_api::altrep_data::AltrepSerialize>::unserialize(state)
             .map(|data| Self { data })
     }
@@ -1395,10 +1396,10 @@ impl miniextendr_api::altrep_data::AltrepDataptr<i32> for BoxedIntsData {
 }
 
 impl miniextendr_api::altrep_data::AltrepSerialize for BoxedIntsData {
-    fn serialized_state(&self) -> miniextendr_api::sys::SEXP {
+    fn serialized_state(&self) -> miniextendr_api::SEXP {
         <Box<[i32]> as miniextendr_api::altrep_data::AltrepSerialize>::serialized_state(&self.data)
     }
-    fn unserialize(state: miniextendr_api::sys::SEXP) -> Option<Self> {
+    fn unserialize(state: miniextendr_api::SEXP) -> Option<Self> {
         <Box<[i32]> as miniextendr_api::altrep_data::AltrepSerialize>::unserialize(state)
             .map(|data| Self { data })
     }
@@ -1538,7 +1539,7 @@ pub struct ListData {
 impl Drop for ListData {
     fn drop(&mut self) {
         unsafe {
-            if self.list != miniextendr_api::sys::SEXP::nil() {
+            if self.list != miniextendr_api::SEXP::nil() {
                 miniextendr_api::sys::R_ReleaseObject(self.list);
             }
         }
@@ -1554,7 +1555,7 @@ impl AltrepLen for ListData {
 impl AltListData for ListData {
     fn elt(&self, i: usize) -> SEXP {
         use miniextendr_api::prelude::SexpExt;
-        self.list.vector_elt(i as miniextendr_api::sys::R_xlen_t)
+        self.list.vector_elt(i as miniextendr_api::R_xlen_t)
     }
 }
 

--- a/rpkg/src/rust/misc_tests.rs
+++ b/rpkg/src/rust/misc_tests.rs
@@ -18,5 +18,5 @@ pub fn underscore_it_all(_: i32, _: f64) {}
 /// Test returning a scalar integer SEXP directly.
 #[miniextendr]
 pub fn do_nothing() -> SEXP {
-    miniextendr_api::sys::SEXP::scalar_integer(42)
+    miniextendr_api::SEXP::scalar_integer(42)
 }

--- a/rpkg/src/rust/native_sexp_altrep_fixture.rs
+++ b/rpkg/src/rust/native_sexp_altrep_fixture.rs
@@ -48,9 +48,8 @@ use std::sync::OnceLock;
 
 use miniextendr_api::altrep::RegisterAltrep;
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepDataptr, AltrepExtract, AltrepLen};
-use miniextendr_api::sys::{
-    DATAPTR_RO, R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE, SexpExt as _,
-};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt as _};
+use miniextendr_api::sys::{DATAPTR_RO, Rf_allocVector, Rf_protect, Rf_unprotect};
 use miniextendr_api::into_r::IntoR;
 use miniextendr_api::{impl_inferbase_integer, miniextendr};
 

--- a/rpkg/src/rust/nonapi.rs
+++ b/rpkg/src/rust/nonapi.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C-unwind" fn C_test_spawn_with_r_lean_stack() -> SEXP {
     .expect("failed to spawn");
 
     let result = handle.join().expect("thread panicked");
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test StackCheckGuard with Rust's default 2 MiB stack.
@@ -39,5 +39,5 @@ pub unsafe extern "C-unwind" fn C_test_stack_check_guard_lean() -> SEXP {
     });
 
     let result = handle.join().expect("thread panicked");
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }

--- a/rpkg/src/rust/panic_tests.rs
+++ b/rpkg/src/rust/panic_tests.rs
@@ -220,7 +220,7 @@ pub extern "C-unwind" fn C_just_panic() -> SEXP {
 pub extern "C-unwind" fn C_panic_and_catch() -> SEXP {
     let result = std::panic::catch_unwind(|| panic!("just panic, no capture"));
     let _ = dbg!(result);
-    ::miniextendr_api::sys::SEXP::nil()
+    ::miniextendr_api::SEXP::nil()
 }
 
 /// Test a direct Rf_error call via raw FFI.
@@ -244,7 +244,7 @@ pub extern "C-unwind" fn C_r_error_in_catch() -> SEXP {
             crate::raw_ffi::Rf_error(c"arg1".as_ptr())
         }))
         .unwrap();
-        miniextendr_api::sys::SEXP::nil()
+        miniextendr_api::SEXP::nil()
     }
 }
 
@@ -288,7 +288,7 @@ pub extern "C-unwind" fn C_r_print_in_thread() -> SEXP {
     .join();
 
     match result {
-        Ok(()) => miniextendr_api::sys::SEXP::nil(),
+        Ok(()) => miniextendr_api::SEXP::nil(),
         Err(e) => panic!("{}", extract_panic_message(e)),
     }
 }

--- a/rpkg/src/rust/thread_tests.rs
+++ b/rpkg/src/rust/thread_tests.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C-unwind" fn C_test_r_thread_builder() -> SEXP {
         .expect("failed to spawn thread");
 
     let result = handle.join().expect("thread panicked");
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test RThreadBuilder spawn_join convenience method.
@@ -46,5 +46,5 @@ pub unsafe extern "C-unwind" fn C_test_r_thread_builder_spawn_join() -> SEXP {
         })
         .expect("thread failed");
 
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }

--- a/rpkg/src/rust/unwind_protect_tests.rs
+++ b/rpkg/src/rust/unwind_protect_tests.rs
@@ -32,7 +32,7 @@ pub extern "C-unwind" fn C_unwind_protect_normal() -> SEXP {
         || {
             let _a = SimpleDropMsg("stack resource");
             let _b = Box::new(SimpleDropMsg("heap resource"));
-            ::miniextendr_api::sys::SEXP::scalar_integer(42)
+            ::miniextendr_api::SEXP::scalar_integer(42)
         },
         None,
     )

--- a/rpkg/src/rust/vctrs_class_example.rs
+++ b/rpkg/src/rust/vctrs_class_example.rs
@@ -14,7 +14,8 @@
 
 use crate::raw_ffi::Rf_duplicate;
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::sys::{Rf_allocVector, SEXPTYPE};
+use miniextendr_api::SEXPTYPE;
+use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::gc_protect::OwnedProtect;
 use miniextendr_api::miniextendr;
 use miniextendr_api::vctrs::new_vctr;

--- a/rpkg/src/rust/vctrs_derive_example.rs
+++ b/rpkg/src/rust/vctrs_derive_example.rs
@@ -65,7 +65,7 @@ impl DerivedPercent {
 /// @param x Numeric values (as proportions).
 /// @return A derived_percent vector.
 #[miniextendr]
-pub fn new_derived_percent(x: Vec<f64>) -> Result<miniextendr_api::sys::SEXP, String> {
+pub fn new_derived_percent(x: Vec<f64>) -> Result<miniextendr_api::SEXP, String> {
     let percent = DerivedPercent::new(x);
     percent.into_vctrs().map_err(|e| e.to_string())
 }
@@ -119,7 +119,7 @@ impl DerivedRational {
 pub fn new_derived_rational(
     n: Vec<i32>,
     d: Vec<i32>,
-) -> Result<miniextendr_api::sys::SEXP, String> {
+) -> Result<miniextendr_api::SEXP, String> {
     let rational = DerivedRational::new(n, d)?;
     rational.into_vctrs().map_err(|e| e.to_string())
 }
@@ -161,8 +161,8 @@ impl DerivedIntLists {
 /// @return A derived_int_lists list_of vector.
 #[miniextendr]
 pub fn new_derived_int_lists(
-    x: miniextendr_api::sys::SEXP,
-) -> Result<miniextendr_api::sys::SEXP, String> {
+    x: miniextendr_api::SEXP,
+) -> Result<miniextendr_api::SEXP, String> {
     use miniextendr_api::from_r::TryFromSexp;
     let lists: Vec<Vec<i32>> = TryFromSexp::try_from_sexp(x).map_err(|e| format!("{:?}", e))?;
     let int_lists = DerivedIntLists::new(lists);
@@ -204,7 +204,7 @@ impl DerivedPoint {
 /// @param y Y coordinates.
 /// @return A derived_point record vector with proxy methods.
 #[miniextendr]
-pub fn new_derived_point(x: Vec<f64>, y: Vec<f64>) -> Result<miniextendr_api::sys::SEXP, String> {
+pub fn new_derived_point(x: Vec<f64>, y: Vec<f64>) -> Result<miniextendr_api::SEXP, String> {
     let point = DerivedPoint::new(x, y)?;
     point.into_vctrs().map_err(|e| e.to_string())
 }
@@ -233,7 +233,7 @@ impl DerivedTemp {
 /// @param x Temperature values.
 /// @return A derived_temp vector.
 #[miniextendr]
-pub fn new_derived_temp(x: Vec<f64>) -> Result<miniextendr_api::sys::SEXP, String> {
+pub fn new_derived_temp(x: Vec<f64>) -> Result<miniextendr_api::SEXP, String> {
     let temp = DerivedTemp::new(x);
     temp.into_vctrs().map_err(|e| e.to_string())
 }

--- a/rpkg/src/rust/wasm_registry.rs
+++ b/rpkg/src/rust/wasm_registry.rs
@@ -4,7 +4,7 @@
 // wasm32-* targets in place of the linkme distributed_slices.
 //
 // generator-version: 1
-// content-hash:      ded03a6ab22b68a2
+// content-hash:      a6219f56435c215a
 
 use ::miniextendr_api::abi::mx_tag;
 use ::miniextendr_api::SEXP;

--- a/rpkg/src/rust/wasm_registry.rs
+++ b/rpkg/src/rust/wasm_registry.rs
@@ -7,7 +7,8 @@
 // content-hash:      ded03a6ab22b68a2
 
 use ::miniextendr_api::abi::mx_tag;
-use ::miniextendr_api::sys::{R_CallMethodDef, SEXP};
+use ::miniextendr_api::SEXP;
+use ::miniextendr_api::sys::R_CallMethodDef;
 use ::miniextendr_api::registry::{AltrepRegistration, TraitDispatchEntry};
 use ::core::ffi::c_void;
 

--- a/rpkg/src/rust/worker_tests.rs
+++ b/rpkg/src/rust/worker_tests.rs
@@ -30,7 +30,7 @@ pub extern "C-unwind" fn C_worker_drop_on_success() -> SEXP {
         let _b = Box::new(SimpleDropMsg("worker: heap resource"));
         42
     });
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test that RAII destructors run when the worker thread panics.
@@ -63,7 +63,7 @@ pub extern "C-unwind" fn C_test_worker_simple() -> SEXP {
         let b = 32;
         a + b
     });
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 // endregion
 
@@ -78,12 +78,12 @@ pub extern "C-unwind" fn C_test_worker_with_r_thread() -> SEXP {
         let value = 123;
         // Call R API on main thread, return i32 (Send)
         with_r_thread(move || {
-            let sexp = miniextendr_api::sys::SEXP::scalar_integer(value);
+            let sexp = miniextendr_api::SEXP::scalar_integer(value);
             sexp.as_integer().unwrap()
         })
     });
     // Convert to SEXP on main thread after run_on_worker returns
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test multiple sequential with_r_thread calls from a single worker job.
@@ -365,7 +365,7 @@ pub extern "C-unwind" fn C_test_multiple_extptrs_from_worker() -> SEXP {
 #[miniextendr]
 pub fn test_main_thread_r_api() -> i32 {
     // This runs on main thread, can call R API directly
-    let sexp = miniextendr_api::sys::SEXP::scalar_integer(42);
+    let sexp = miniextendr_api::SEXP::scalar_integer(42);
     sexp.as_integer().unwrap()
 }
 
@@ -402,7 +402,7 @@ pub extern "C-unwind" fn C_test_wrong_thread_r_api() -> SEXP {
         // With worker-thread: routed to main thread via with_r_thread.
         // Without worker-thread: run_on_worker is a stub, runs inline on main thread.
         // Either way, this should succeed (not panic).
-        let _ = miniextendr_api::sys::SEXP::scalar_integer(42);
+        let _ = miniextendr_api::SEXP::scalar_integer(42);
     });
     SEXP::nil()
 }
@@ -414,7 +414,7 @@ pub extern "C-unwind" fn C_test_wrong_thread_r_api() -> SEXP {
 fn helper_r_call_value(value: i32) -> i32 {
     with_r_thread(move || {
         // Create SEXP on main thread, extract value, return i32
-        let sexp = miniextendr_api::sys::SEXP::scalar_integer(value * 2);
+        let sexp = miniextendr_api::SEXP::scalar_integer(value * 2);
         sexp.as_integer().unwrap()
     })
 }
@@ -425,7 +425,7 @@ fn helper_r_call_value(value: i32) -> i32 {
 #[allow(non_snake_case)]
 pub extern "C-unwind" fn C_test_nested_helper_from_worker() -> SEXP {
     let result = run_on_worker_or_error(|| helper_r_call_value(21));
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test calling multiple with_r_thread helpers sequentially from the worker.
@@ -438,7 +438,7 @@ pub extern "C-unwind" fn C_test_nested_multiple_helpers() -> SEXP {
         let v2 = helper_r_call_value(20);
         v1 + v2
     });
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test nested with_r_thread calls (inner call runs directly since already on main thread).
@@ -452,7 +452,7 @@ pub extern "C-unwind" fn C_test_nested_with_r_thread() -> SEXP {
             with_r_thread(|| 42i32)
         })
     });
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test calling a worker-strategy function (add) from the main thread.
@@ -463,7 +463,7 @@ pub extern "C-unwind" fn C_test_call_worker_fn_from_main() -> SEXP {
     // Call add() which uses worker strategy internally
     // This should work: we're on main thread, add() spawns worker job
     let result = add(10, 32);
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test nested worker calls that use with_r_thread helpers and return doubled values.
@@ -480,7 +480,7 @@ pub extern "C-unwind" fn C_test_nested_worker_calls() -> SEXP {
         val * 2
     });
     // Convert to SEXP on main thread
-    miniextendr_api::sys::SEXP::scalar_integer(result)
+    miniextendr_api::SEXP::scalar_integer(result)
 }
 
 /// Test that an R error in a nested with_r_thread call drops resources on both threads.
@@ -557,6 +557,6 @@ pub extern "C-unwind" fn C_test_deep_with_r_thread_sequence() -> SEXP {
         sum
     });
 
-    miniextendr_api::sys::SEXP::scalar_integer(sum)
+    miniextendr_api::SEXP::scalar_integer(sum)
 }
 // endregion

--- a/rpkg/src/rust/zero_copy_tests.rs
+++ b/rpkg/src/rust/zero_copy_tests.rs
@@ -150,7 +150,7 @@ mod arrow {
     #[miniextendr]
     pub fn zero_copy_arrow_f64_altrep(
         x: miniextendr_api::arrow_impl::Float64Array,
-    ) -> miniextendr_api::sys::SEXP {
+    ) -> miniextendr_api::SEXP {
         use miniextendr_api::IntoRAltrep;
         // Compute creates a Rust-owned buffer (not R-backed)
         let computed: miniextendr_api::arrow_impl::Float64Array =
@@ -163,7 +163,7 @@ mod arrow {
     #[miniextendr]
     pub fn zero_copy_arrow_i32_altrep(
         x: miniextendr_api::arrow_impl::Int32Array,
-    ) -> miniextendr_api::sys::SEXP {
+    ) -> miniextendr_api::SEXP {
         use miniextendr_api::IntoRAltrep;
         let computed: miniextendr_api::arrow_impl::Int32Array =
             x.iter().map(|v| v.map(|i| i + 100)).collect();
@@ -173,7 +173,7 @@ mod arrow {
     /// Create a Vec<f64> ALTREP (not Arrow, just plain Rust vec).
     /// @export
     #[miniextendr]
-    pub fn zero_copy_vec_f64_altrep(n: i32) -> miniextendr_api::sys::SEXP {
+    pub fn zero_copy_vec_f64_altrep(n: i32) -> miniextendr_api::SEXP {
         use miniextendr_api::IntoRAltrep;
         let data: Vec<f64> = (0..n).map(|i| i as f64 * 1.5).collect();
         data.into_sexp_altrep()
@@ -183,14 +183,14 @@ mod arrow {
     /// Tests the alloc_r_backed_buffer → pointer recovery round-trip.
     /// @export
     #[miniextendr]
-    pub fn zero_copy_alloc_r_backed(n: i32) -> miniextendr_api::sys::SEXP {
+    pub fn zero_copy_alloc_r_backed(n: i32) -> miniextendr_api::SEXP {
         use miniextendr_api::into_r::IntoR;
         use miniextendr_api::optionals::arrow_impl::alloc_r_backed_buffer;
         let n = n as usize;
         let (buffer, sexp) = unsafe { alloc_r_backed_buffer::<f64>(n) };
         // Fill via SexpExt element setters
         for i in 0..n {
-            miniextendr_api::sys::SexpExt::set_real_elt(&sexp, i as isize, (i + 1) as f64 * 100.0);
+            miniextendr_api::SexpExt::set_real_elt(&sexp, i as isize, (i + 1) as f64 * 100.0);
         }
         let values =
             miniextendr_api::optionals::arrow_impl::arrow_buffer::ScalarBuffer::<f64>::from(buffer);
@@ -201,7 +201,7 @@ mod arrow {
     /// Slice a Float64Array and return it — recovery should fail (different pointer).
     /// @export
     #[miniextendr]
-    pub fn zero_copy_arrow_f64_sliced(x: miniextendr_api::sys::SEXP) -> bool {
+    pub fn zero_copy_arrow_f64_sliced(x: miniextendr_api::SEXP) -> bool {
         use miniextendr_api::arrow_impl::Float64Array;
         use miniextendr_api::from_r::TryFromSexp;
         use miniextendr_api::into_r::IntoR;

--- a/tests/cross-package/consumer.pkg/src/rust/lib.rs
+++ b/tests/cross-package/consumer.pkg/src/rust/lib.rs
@@ -6,7 +6,7 @@
 // - Verifies trait dispatch works across package boundaries
 // - Implements its own Counter (DoubleCounter) for bidirectional testing
 
-use miniextendr_api::{ExternalPtr, sys::SEXP, sys::SexpExt, miniextendr, trait_abi::ccall};
+use miniextendr_api::{ExternalPtr, SEXP, SexpExt, miniextendr, trait_abi::ccall};
 
 miniextendr_api::miniextendr_init!();
 
@@ -62,7 +62,7 @@ pub fn has_class(x: SEXP, class_name: String) -> bool {
     }
     let len = class_attr.len();
     for i in 0..len {
-        if let Some(name) = class_attr.string_elt_str(i as miniextendr_api::sys::R_xlen_t)
+        if let Some(name) = class_attr.string_elt_str(i as miniextendr_api::R_xlen_t)
             && name == class_name
         {
             return true;

--- a/tests/cross-package/consumer/lib.rs
+++ b/tests/cross-package/consumer/lib.rs
@@ -5,7 +5,7 @@
 // - Provides generic functions that work with any Counter implementation
 // - Can operate on objects created by producer package
 
-use miniextendr_api::{miniextendr, externalptr::ErasedExternalPtr, sys::SEXP};
+use miniextendr_api::{miniextendr, externalptr::ErasedExternalPtr, SEXP};
 
 // region: Shared trait definition (must match producer exactly)
 

--- a/tests/cross-package/producer.pkg/src/rust/lib.rs
+++ b/tests/cross-package/producer.pkg/src/rust/lib.rs
@@ -8,7 +8,7 @@
 // - S7-style: S7Point
 // - Trait dispatch: SimpleCounter implements shared Counter trait
 
-use miniextendr_api::{ExternalPtr, sys::SEXP, miniextendr, trait_abi::ccall};
+use miniextendr_api::{ExternalPtr, SEXP, miniextendr, trait_abi::ccall};
 // Condition macros — use fully-qualified paths to avoid module/macro name collision
 // (pub mod error and pub mod condition at crate root shadow the macros if imported).
 


### PR DESCRIPTION
PR #675 split `miniextendr-api/src/ffi.rs` into `sys/sexp/sexp_ext/sexp_types` but kept `pub use crate::sexp::{SEXP, SEXPREC}` + the rest of the type vocabulary re-exported from `sys::`, so `sys::SEXP` / `sys::SEXPTYPE` etc. still resolved. That was a backwards-source-compat bridge in an unreleased project — exactly what the root `CLAUDE.md` says we don't do. This PR finishes the migration.

<details>
<summary>🤖 Detail (AI-generated)</summary>

## What changed

- Deleted the `pub use crate::sexp::{SEXP, SEXPREC}` / `pub use crate::sexp_ext::SexpExt` / `pub use crate::sexp_types::{...}` / `pub(crate) use crate::sexp_ext::PairListExt` bridge from `miniextendr-api/src/sys.rs:63-72`. The vocabulary now lives only at the crate root (and `crate::sexp_types::CE_UTF8` for the niche constant).
- Replaced `crate::sys::TYPE` with `crate::TYPE` across miniextendr-api (~1366 references), `::miniextendr_api::sys::TYPE` with `::miniextendr_api::TYPE` in `quote!` blocks across miniextendr-macros (~153 references in proc-macro output), and the same in miniextendr-bench (~91), `rpkg/src/rust/` (~74), and `tests/cross-package/`.
- Added a private (non-`pub`) `use crate::sexp::SEXP; use crate::sexp_types::{...}` inside `sys.rs` so the `extern "C-unwind"` signatures still type-check. This is local to the file — the symbols are NOT re-exported under `sys::`.
- Split mixed-vocab-and-FFI brace imports like `use crate::sys::{SEXP, Rf_protect, ...}` into a vocab line + an FFI line — vocab from `crate::`, FFI from `crate::sys::`.
- Also picked up `$crate::sys::{SEXPTYPE, SexpExt}` paths inside `miniextendr-api/src/from_r.rs` `macro_rules!` bodies that emit into downstream crates; those now emit `$crate::{SEXPTYPE, SexpExt}`.

## Drive-by

- `rpkg/src/rust/gc_stress_fixtures.rs:1346`: removed `drop(theoph); drop(df);` — pre-existing `clippy::drop_non_drop` failure on main; not caused by this PR but blocked `cargo clippy -- -D warnings` locally.

## Verification

```
cargo check --workspace --all-targets                                          # clean
cargo clippy --workspace --all-targets --locked -- -D warnings                 # clippy_default — clean
cargo clippy --workspace --all-targets --locked --features <ci clippy_all set> # clippy_all   — clean
cargo fmt --all --check                                                        # clean
(cd rpkg/src/rust && cargo clippy --all-targets -- -D warnings)                # clean
(cd tests/cross-package/producer.pkg/src/rust && cargo check --all-targets)    # clean
(cd tests/cross-package/consumer.pkg/src/rust && cargo check --all-targets)    # clean
```

## Follow-up

- Refs #738 — CI's `Install rv` recipe has no error checking; transient flake silently produces a non-gzip download and fails the `Bootstrap Vendor Test` job. Spotted on the run for the PR #675 merge (commit `1d3d5051`) itself.

</details>

## Test plan
- [ ] CI green on the new sweep (`Cross-Package Trait ABI`, `R tests / Linux`, `R CMD check`, `clippy_default`, `clippy_all`)
- [ ] No `sys::SEXP` / `sys::SEXPTYPE` / `sys::R_xlen_t` paths surface in any rustdoc / generated R wrappers
- [ ] downstream consumer crates (rpkg + cross-package) build clean against the new public surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)