### PR TITLE
fix(api): drop dead fn-level unsafe(main_thread) from macro-coverage fixtures

### DIFF
--- a/miniextendr-api/src/macro_coverage/fn_matrix.rs
+++ b/miniextendr-api/src/macro_coverage/fn_matrix.rs
@@ -136,11 +136,6 @@ pub(crate) fn cov_fn_attr_check_interrupt(n: i32) -> i32 {
     n * 2
 }
 
-#[miniextendr(unsafe(main_thread))]
-pub(crate) fn cov_fn_attr_main_thread() -> i32 {
-    1
-}
-
 #[miniextendr(worker)]
 pub(crate) fn cov_fn_attr_worker(x: i32) -> i32 {
     x
@@ -197,13 +192,8 @@ pub(crate) fn cov_combo_worker_unwrap(x: i32) -> Result<i32, &'static str> {
     Ok(x)
 }
 
-#[miniextendr(unsafe(main_thread), check_interrupt)]
-pub(crate) fn cov_combo_mainthread_interrupt(x: i32) -> i32 {
-    x
-}
-
-#[miniextendr(unsafe(main_thread), visible, check_interrupt)]
-pub(crate) fn cov_combo_mainthread_visible_interrupt() {}
+#[miniextendr(visible, check_interrupt)]
+pub(crate) fn cov_combo_visible_interrupt() {}
 
 #[miniextendr(invisible, check_interrupt)]
 pub(crate) fn cov_combo_invisible_interrupt() -> i32 {


### PR DESCRIPTION
`macro_coverage/fn_matrix.rs` had 3 compile errors from `#[miniextendr(unsafe(main_thread))]` — the macro stopped accepting that fn-level syntax back in #245, but the coverage fixtures were never updated because nothing in CI compiles the `macro-coverage` feature (it's only reachable via `full`). Confirmed it fails on `origin/main` too, so it's a standalone pre-existing bug, not fallout from the sys split. This drops the dead references.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `unsafe(main_thread)` was removed as a dead fn-level option in #245 (`718083b9`); codegen had been suppressing it with `let _ = (...)`. Main-thread execution is now the emergent default for standalone `#[miniextendr]` fns, so there is no option left to cover.
- `cov_fn_attr_main_thread` removed (atomic fixture for the now-gone option).
- `cov_combo_mainthread_interrupt` removed (stripping the option leaves just `check_interrupt`, which is already covered atomically by `cov_fn_attr_check_interrupt`).
- `cov_combo_mainthread_visible_interrupt` renamed to `cov_combo_visible_interrupt` with `#[miniextendr(visible, check_interrupt)]`, a still-distinct, still-valid combination.
- Net `+2 / -12`, one file.

## Test plan
- [x] `cargo check -p miniextendr-api --features macro-coverage,worker-thread` — clean (the original 3 errors are gone; `macro-coverage` alone also needs `worker-thread` for the `worker` fixtures, which is what `full` enables).
- [x] `cargo fmt -p miniextendr-api -- --check` — clean.
- [x] No remaining `unsafe(main_thread)` / `mainthread` references in `fn_matrix.rs`; fixture names are not referenced anywhere else in the tree.

## Notes
- The module invariant ("every `MiniextendrFnAttrs` option has an atomic fixture") still holds — `main_thread` is no longer a field.
- Same root cause leaked into docs and rustdoc (`unsafe(main_thread)` shown on standalone-fn examples). Those are prose / `ignore` blocks, not compile errors, and touching `docs/` pulls in the docs to site regen, so they are tracked separately in #740 rather than bundled here.
- `unsafe(main_thread)` is still valid on impl/trait methods; this PR does not touch those.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>