### PR TITLE
fix(wasm): gate host-only wrapper-diff helpers + cross-package wasm stubs (#493)

### DIFF
--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -78,10 +78,14 @@ just docker-webr-smoke         # full smoke: build wasm side-module + load in
 the container, then prints a testthat pass/fail/skip summary:
 
 1. **Native `R CMD INSTALL` of `rpkg`** against `/opt/R/current/bin/R` to run
-   the cdylib pass and regenerate `rpkg/src/rust/wasm_registry.rs` — the
-   committed version is a stub (zero-length slices, content-hash
-   `0000000000000000`). Without this step the wasm build technically
-   succeeds but the package registers zero R routines.
+   the cdylib pass and regenerate `rpkg/src/rust/wasm_registry.rs`. rpkg's
+   committed snapshot is a *real* one (it's committed in lockstep with the
+   wrapper / macro surface — see "Generated artifacts" in the root
+   `CLAUDE.md`), but this step guarantees it's fresh against the working
+   tree: a stale snapshot would register the wrong set of R routines under
+   wasm. (The cross-package fixtures under `tests/cross-package/` ship
+   deliberately *empty* stubs — content-hash `0000000000000000` — since
+   they're never deployed to webR; see #493.)
 2. **wasm32 install** — `CC=emcc bash rpkg/configure` followed by
    `R CMD INSTALL --no-test-load --no-staged-install` against
    `/opt/webr/host/R-4.5.1/bin/R` (webR's own host R) with

--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -960,6 +960,10 @@ pub fn write_r_wrappers_to_file(path: &str) {
 /// A match requires `(` + one or more non-`()`/non-newline chars + `.rs:` +
 /// ASCII digits + `:` + ASCII digits + `)`. Malformed or non-`.rs` patterns
 /// are left untouched.
+///
+/// Host-only: the sole caller is [`write_r_wrappers_to_file`], gated off on
+/// wasm32 (the cdylib wrapper-gen pass doesn't run there).
+#[cfg(not(target_arch = "wasm32"))]
 fn wrappers_semantically_equal(a: &str, b: &str) -> bool {
     normalize_source_locs(a) == normalize_source_locs(b)
 }
@@ -969,6 +973,7 @@ fn wrappers_semantically_equal(a: &str, b: &str) -> bool {
 /// Returns a [`std::borrow::Cow::Borrowed`] slice when no replacements are
 /// needed (zero-allocation fast path for the common case where the file has
 /// never been written or is truly unchanged).
+#[cfg(not(target_arch = "wasm32"))]
 fn normalize_source_locs(s: &str) -> std::borrow::Cow<'_, str> {
     // Fast path: bail early if there is no `.rs:` anywhere in the string.
     if !s.contains(".rs:") {
@@ -1052,6 +1057,7 @@ fn normalize_source_locs(s: &str) -> std::borrow::Cow<'_, str> {
 
 /// Find the first occurrence of `needle` in `haystack[from..]`.
 /// Returns the absolute index in `haystack`, or `None`.
+#[cfg(not(target_arch = "wasm32"))]
 #[inline]
 fn find_substr(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
     let window = haystack.get(from..)?;
@@ -1063,6 +1069,7 @@ fn find_substr(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
 
 /// Find the first byte equal to `needle` in `haystack[from..]`.
 /// Returns the absolute index, or `None`.
+#[cfg(not(target_arch = "wasm32"))]
 #[inline]
 fn memchr(haystack: &[u8], from: usize, needle: u8) -> Option<usize> {
     haystack[from..]
@@ -1074,6 +1081,7 @@ fn memchr(haystack: &[u8], from: usize, needle: u8) -> Option<usize> {
 /// Advance past a run of ASCII digits starting at `haystack[from]`.
 /// Returns the absolute index of the first non-digit byte, or `None` if
 /// there are no digits at `from` (empty run is not valid).
+#[cfg(not(target_arch = "wasm32"))]
 #[inline]
 fn scan_digits(haystack: &[u8], from: usize) -> Option<usize> {
     let start = haystack.get(from..)?;

--- a/tests/cross-package/consumer.pkg/src/rust/wasm_registry.rs
+++ b/tests/cross-package/consumer.pkg/src/rust/wasm_registry.rs
@@ -1,0 +1,22 @@
+// AUTO-GENERATED — DO NOT EDIT.
+//
+// generator-version: 1
+// content-hash:      0000000000000000
+//
+// THIS IS A STUB. The cross-package test crates (consumer.pkg / producer.pkg)
+// are native-only trait-ABI fixtures and are never deployed to webR. This file
+// exists solely so `cargo check --target wasm32-unknown-emscripten` can resolve
+// the wasm32-gated `mod __miniextendr_wasm_registry;` that `miniextendr_init!()`
+// emits (see miniextendr-macros/src/lib.rs). The three slices are intentionally
+// empty — a real snapshot is only produced for deployable crates by
+// `miniextendr_write_wasm_registry` during the host cdylib pass.
+//
+// See #493. Cross-crate trait dispatch under wasm_registry (#495) is the
+// follow-up that would make these slices non-empty.
+
+use ::miniextendr_api::registry::{AltrepRegistration, TraitDispatchEntry};
+use ::miniextendr_api::sys::R_CallMethodDef;
+
+pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[];
+pub static MX_ALTREP_REGISTRATIONS_WASM: &[AltrepRegistration] = &[];
+pub static MX_TRAIT_DISPATCH_WASM: &[TraitDispatchEntry] = &[];

--- a/tests/cross-package/producer.pkg/src/rust/wasm_registry.rs
+++ b/tests/cross-package/producer.pkg/src/rust/wasm_registry.rs
@@ -1,0 +1,22 @@
+// AUTO-GENERATED — DO NOT EDIT.
+//
+// generator-version: 1
+// content-hash:      0000000000000000
+//
+// THIS IS A STUB. The cross-package test crates (consumer.pkg / producer.pkg)
+// are native-only trait-ABI fixtures and are never deployed to webR. This file
+// exists solely so `cargo check --target wasm32-unknown-emscripten` can resolve
+// the wasm32-gated `mod __miniextendr_wasm_registry;` that `miniextendr_init!()`
+// emits (see miniextendr-macros/src/lib.rs). The three slices are intentionally
+// empty — a real snapshot is only produced for deployable crates by
+// `miniextendr_write_wasm_registry` during the host cdylib pass.
+//
+// See #493. Cross-crate trait dispatch under wasm_registry (#495) is the
+// follow-up that would make these slices non-empty.
+
+use ::miniextendr_api::registry::{AltrepRegistration, TraitDispatchEntry};
+use ::miniextendr_api::sys::R_CallMethodDef;
+
+pub static MX_CALL_DEFS_WASM: &[R_CallMethodDef] = &[];
+pub static MX_ALTREP_REGISTRATIONS_WASM: &[AltrepRegistration] = &[];
+pub static MX_TRAIT_DISPATCH_WASM: &[TraitDispatchEntry] = &[];


### PR DESCRIPTION
Tier A of the webR/wasm push (#470): three low-risk wasm32-hygiene fixes that need no Docker, batched so the empirical tiers (#494 → #491 → #492) start from a clean wasm32 build. Closes #493.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `miniextendr-api/src/registry.rs`: gate the 5 host-only wrapper-diff helpers (`wrappers_semantically_equal`, `normalize_source_locs`, `find_substr`, `memchr`, `scan_digits`) behind `cfg(not(target_arch = "wasm32"))`. Their only caller, `write_r_wrappers_to_file`, is already gated, so on wasm32 they were dead code emitting 5 warnings. The wasm32 CI job runs `cargo check` without `-D warnings`, so they passed silently.
- `tests/cross-package/{consumer,producer}.pkg/src/rust/wasm_registry.rs`: new empty stubs so `cargo check --target wasm32-unknown-emscripten` resolves the wasm32-gated `mod __miniextendr_wasm_registry;` that `miniextendr_init!()` emits. These crates are native-only trait-ABI fixtures, never deployed to webR, so the three slices are intentionally empty. Closes #493.
- `docs/WEBR.md`: fix doc-rot. The smoke-script Phase 1 description called the committed rpkg `wasm_registry.rs` a "stub (content-hash 0000…)", but main ships a real snapshot committed in lockstep with the macro surface. Reworded, and added a pointer to the genuinely-empty cross-package stubs.

## Test plan
- [x] `cargo check -p miniextendr-api --target wasm32-unknown-emscripten` → 0 warnings (was 5)
- [x] `cargo clippy -p miniextendr-api --all-targets --locked -- -D warnings` (native) passes
- [x] `cargo clippy -p miniextendr-api --target wasm32-unknown-emscripten --locked -- -D warnings` passes
- [x] `cargo check -p miniextendr-api --tests` (native) still compiles, confirming the gated helpers stay live for the `#[cfg(test)]` unit tests
- [x] `cargo fmt --all` clean

## Notes
- The cross-package stubs are validated structurally: they are byte-identical in shape to rpkg's working snapshot and reference the same `miniextendr-api` types that already compile for wasm32. A full wasm32 build of the cross-package crates is gated behind the webR Docker toolchain (the same path as rpkg), so it is not exercised here. The webR CI workflow only checks `miniextendr-api` for wasm32 today, not the cross-package crates.
- Cross-crate trait dispatch under wasm_registry (#495) is the follow-up that would make these stub slices non-empty.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>