### PR TITLE
fix(webr): resurrect docker-webr-smoke (configure dir + S7 dep + stale-object scrub)

### DIFF
--- a/Dockerfile.webr
+++ b/Dockerfile.webr
@@ -48,6 +48,15 @@ RUN ARCH="$(dpkg --print-architecture)" \
 # uses for fast iteration). Build-dep-free — single binary install via cargo.
 RUN cargo install cargo-limit --locked --version "0.0.13"
 
+# miniextendr's hard R `Imports` (rpkg/DESCRIPTION) must be present in the
+# native R so Phase 1 of the webR smoke (`tests/webr-smoke.sh`: native
+# `R CMD INSTALL` running the cdylib wrapper-gen pass) and CI tier 2 (#491)
+# can resolve them. The base webR image ships cli / lifecycle / R6 / vctrs but
+# not S7; install the full hard set so the smoke doesn't depend on the base
+# image's exact package roster. `methods` is part of base R. The posit PM
+# `__linux__/noble` repo serves binaries, so this is a fast layer.
+RUN /opt/R/current/bin/Rscript -e 'install.packages(c("cli", "lifecycle", "R6", "S7", "vctrs"), repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
+
 # Sanity checks — fail the build immediately if the inherited toolchain
 # regressed or our layered tools are missing, instead of debugging a weird
 # later failure inside a working container.
@@ -58,6 +67,7 @@ RUN set -eux \
     && emcc --version >/dev/null \
     && /opt/R/current/bin/R --version >/dev/null \
     && Rscript -e 'stopifnot(requireNamespace("rwasm", quietly=TRUE))' \
+    && /opt/R/current/bin/Rscript -e 'stopifnot(requireNamespace("S7", quietly=TRUE))' \
     && just --version >/dev/null \
     && autoconf --version >/dev/null \
     && command -v cargo-lcheck >/dev/null \

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -108,12 +108,12 @@ cleanup() {
     if [[ $_cleanup_done -eq 1 ]]; then return; fi
     _cleanup_done=1
 
-    log "Running cleanup: restoring native Makevars..."
+    log "Running cleanup: scrubbing build objects + restoring native Makevars..."
     docker_run "
         set -euo pipefail
-        cd /work
-        bash rpkg/configure 2>/dev/null || true
-    " || warn "Cleanup configure failed — rpkg/src/Makevars may still be in wasm-mode. Run: bash rpkg/configure"
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && bash ./configure ) 2>/dev/null || true
+    " || warn "Cleanup configure failed — rpkg/src/Makevars may still be in wasm-mode. Run: cd rpkg && bash ./configure"
 
     if [[ $KEEP -eq 0 ]]; then
         log "Removing ${SMOKE_TMP} inside container..."
@@ -170,11 +170,17 @@ phase_native_install() {
     docker_run "
         set -euo pipefail
         mkdir -p ${SMOKE_TMP}/native-lib
-        cd /work
-        bash rpkg/configure
+        # Scrub stale build objects: the bind-mounted /work is shared with the
+        # host, so host-arch (e.g. macOS arm64) *.o/*.so from a prior
+        # 'just rcmdinstall' have newer mtimes than their .c sources. R then
+        # skips recompiling and the native build links the wrong object format
+        # ('unknown file type'). cargo's target dir is triple-namespaced, so it
+        # is unaffected.
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && bash ./configure )
         ${R_NATIVE_EXE} CMD INSTALL --no-test-load \
             --library=${SMOKE_TMP}/native-lib \
-            rpkg
+            /work/rpkg
     "
 
     # Verify wasm_registry.rs was regenerated (content-hash must not be stub value)
@@ -202,8 +208,10 @@ phase_wasm_build() {
     log "Running wasm32 R CMD INSTALL inside container..."
     docker_run "
         set -euo pipefail
-        cd /work
-        CC=emcc bash rpkg/configure
+        # Scrub Phase 1's native objects so emcc recompiles .c -> wasm .o
+        # (same stale-mtime trap as Phase 1, but native-poisoning-wasm here).
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && CC=emcc bash ./configure )
         WASM_TOOLS=${WASM_TOOLS} \
         R_SOURCE=${R_SOURCE} \
         R_MAKEVARS_USER=${WEBR_VARS_MK} \


### PR DESCRIPTION
The webR local-dev smoke (`just docker-webr-smoke`) had bit-rotted into a no-op — three layered failures, each gating the next, all unrelated to #494's actual question. Repairing them here as prerequisite infrastructure so the smoke (and the upcoming **#491 CI tier-2** that will be modelled on the same path) actually runs. Validated empirically across four smoke attempts during diagnosis. Refs **#470** (umbrella), **#491**.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Each fix was discovered only after the prior one was in place, so the smoke had been silently dead-on-arrival despite `docs/WEBR.md` claiming "supported for local dev":

**1. `configure.ac` directory guard tripped on every smoke run**

All three configure invocations (cleanup L114, Phase 1 L174, Phase 2 L206) did `cd /work; bash rpkg/configure` from the monorepo root. `configure.ac`'s guard (`! -f DESCRIPTION || ! -f NAMESPACE`) demands cwd=rpkg. The guard was added after the smoke script was written, and the script never caught up. Changed to scoped subshells: `( cd /work/rpkg && bash ./configure )`. `docker_run` already sets `-w /work`, so the explicit `cd /work` was redundant and was dropped along with the fix.

**2. Native R missing S7 in the image**

Phase 1's `R CMD INSTALL` failed with `dependency 'S7' is not available`. The base webR image ships cli, lifecycle, R6, vctrs already, but S7 is the one missing hard `Imports` from `rpkg/DESCRIPTION`. Added an `install.packages` layer to `Dockerfile.webr` covering the full hard set (binaries from posit PM noble, ~7s) plus a sanity-check (`requireNamespace("S7")`) that will fail the image build if it ever goes missing again.

**3. Cross-platform stale-object contamination via the bind-mount**

`rpkg/src/*.o` from a prior host-side `just rcmdinstall` (Mach-O arm64) persist in the bind-mounted source tree with mtimes newer than the .c sources. The container's Linux R then skipped recompilation and the cargo build linked arm64 objects into x86_64 build-scripts: `rust-lld: error: stub.o: unknown file type`. The same trap applies in reverse between Phase 1 (Linux .o) and Phase 2 (wasm .o). The smoke now scrubs `*.o`/`*.so` before each phase and on cleanup, so it is hermetic w.r.t. cross-platform build-artifact bleed.

## Test plan

- [x] Smoke attempt 1 (pre-PR): fast-failed on configure-dir guard → fix 1 applied
- [x] Smoke attempt 2 (post-fix-1): proceeded past configure, failed on S7 dep → fix 2 applied + image rebuilt
- [x] Smoke attempt 3 (post-fix-2): proceeded past dep check, failed on stale arm64 .o `unknown file type` → fix 3 applied
- [x] Smoke attempt 4 (post-fix-3): proceeded into the full native cargo build (compiling arrow, datafusion, ...) — fix 3 confirmed working
- [ ] End-to-end load verification deferred: local validation exhausted host disk during the full-feature build (datafusion + arrow under amd64 emulation) and crashed Docker Desktop's daemon. The empirical validator for end-to-end load is the upcoming **#491 CI tier-2** job on GitHub's amd64 runners, where this PR's fixes are prerequisite.

## Notes

- Independent of **#494** (side-module `RUSTFLAGS`). The PIC flag is on a separate stacked branch and will land alongside `#491`.
- No change to native dev loop or to the wasm32 cargo-check (`webr.yml` tier 1). `Dockerfile.webr` is bumped, so a fresh `just docker-webr-build` is needed before the next `docker-webr-smoke`/`docker-webr-shell` (the layer is fast, posit PM serves binaries).

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>