### PR TITLE
feat(webr): tier-2 CI install + side-module PIC RUSTFLAGS (#491, #494)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -136,19 +136,19 @@ jobs:
           set -euo pipefail
           rm -f rpkg/src/*.o rpkg/src/*.so
           ( cd rpkg && CC=emcc bash ./configure )
-          # R_DEFAULT_PACKAGES=NULL: the byte-compile/lazy-load step at the
-          # tail of R CMD INSTALL runs under the *host* (Linux x86_64) R, but
-          # --library points at the wasm tree (wasm .so files). Without this,
-          # host R tries to dyn.load grDevices.so / methods.so / etc. from
-          # the wasm library at startup and dies with "invalid ELF header".
-          # Matches what rwasm's package-build path uses internally.
+          # --no-byte-compile: the byte-compile/lazy-load step at the tail
+          # of R CMD INSTALL runs under the *host* (Linux x86_64) R but
+          # --library points at the wasm tree, so host R tries to dyn.load
+          # the wasm grDevices.so / methods.so during startup and dies with
+          # "invalid ELF header". rwasm's package-build path uses the same
+          # --no-byte-compile flag for the same reason — matches upstream.
+          # (r-wasm/rwasm:R/build.R, R CMD INSTALL flag set.)
           WASM_TOOLS=/opt/webr/tools \
           R_SOURCE=/opt/webr/R/build/R-4.5.1 \
           R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk \
-          R_DEFAULT_PACKAGES=NULL \
           /opt/webr/host/R-4.5.1/bin/R CMD INSTALL \
               --library=/opt/webr/wasm/R-4.5.1/lib/R/library \
-              --no-docs --no-test-load --no-staged-install \
+              --no-docs --no-test-load --no-staged-install --no-byte-compile \
               rpkg
 
       - name: Verify wasm side-module landed

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -86,6 +86,12 @@ jobs:
     timeout-minutes: 90
     container:
       image: ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+    # The webR base image's /bin/sh is dash; every step here uses
+    # `set -euo pipefail` which is bash-only. Pin the shell at the job level
+    # so individual steps don't have to repeat `shell: bash`.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -107,7 +107,10 @@ jobs:
       - name: Install miniextendr's hard R Imports + autoconf
         run: |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends autoconf
+          # `file` is used by the "Verify wasm side-module landed" step below to
+          # confirm the output is wasm and not ELF; the webR base image doesn't
+          # ship it. `autoconf` is needed by rpkg/configure.
+          apt-get update && apt-get install -y --no-install-recommends autoconf file
           mkdir -p "$R_LIBS_USER"
           # Install via the host R that Phase 2 uses, so transitive deps land
           # in a library Phase 2's lazy-load will see. `dependencies = c(...)`

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -136,25 +136,31 @@ jobs:
           set -euo pipefail
           rm -f rpkg/src/*.o rpkg/src/*.so
           ( cd rpkg && CC=emcc bash ./configure )
-          # --no-byte-compile: the byte-compile/lazy-load step at the tail
-          # of R CMD INSTALL runs under the *host* (Linux x86_64) R but
-          # --library points at the wasm tree, so host R tries to dyn.load
-          # the wasm grDevices.so / methods.so during startup and dies with
-          # "invalid ELF header". rwasm's package-build path uses the same
-          # --no-byte-compile flag for the same reason — matches upstream.
-          # (r-wasm/rwasm:R/build.R, R CMD INSTALL flag set.)
+          # Install to an empty *host-side* temp library, NOT directly into
+          # /opt/webr/wasm/.../library. R CMD INSTALL's tail-end lazy-load
+          # spawns a sub-R that adds --library to .libPaths(), and if that
+          # path contains the wasm-built grDevices.so / methods.so the
+          # sub-R dies with 'invalid ELF header' on startup. rwasm uses
+          # the same pattern (install to tempfile() lib_dir, then copy
+          # the resulting tarball into place — r-wasm/rwasm:R/build.R, see
+          # the "empty library otherwise R might try to load wasm packages"
+          # comment). --no-byte-compile mirrors rwasm's flag set too.
+          mkdir -p /tmp/wasm-lib
           WASM_TOOLS=/opt/webr/tools \
           R_SOURCE=/opt/webr/R/build/R-4.5.1 \
           R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk \
           /opt/webr/host/R-4.5.1/bin/R CMD INSTALL \
-              --library=/opt/webr/wasm/R-4.5.1/lib/R/library \
+              --library=/tmp/wasm-lib \
               --no-docs --no-test-load --no-staged-install --no-byte-compile \
               rpkg
 
       - name: Verify wasm side-module landed
         run: |
           set -euo pipefail
-          libdir=/opt/webr/wasm/R-4.5.1/lib/R/library/miniextendr
+          libdir=/tmp/wasm-lib/miniextendr
           test -d "$libdir"
           ls -la "$libdir/libs/"
           file "$libdir/libs/"miniextendr.so
+          # Sanity: side-module must be wasm, not ELF (would mean Phase 2
+          # silently fell back to native compilation).
+          file "$libdir/libs/"miniextendr.so | grep -qi "WebAssembly\|wasm"

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -136,9 +136,16 @@ jobs:
           set -euo pipefail
           rm -f rpkg/src/*.o rpkg/src/*.so
           ( cd rpkg && CC=emcc bash ./configure )
+          # R_DEFAULT_PACKAGES=NULL: the byte-compile/lazy-load step at the
+          # tail of R CMD INSTALL runs under the *host* (Linux x86_64) R, but
+          # --library points at the wasm tree (wasm .so files). Without this,
+          # host R tries to dyn.load grDevices.so / methods.so / etc. from
+          # the wasm library at startup and dies with "invalid ELF header".
+          # Matches what rwasm's package-build path uses internally.
           WASM_TOOLS=/opt/webr/tools \
           R_SOURCE=/opt/webr/R/build/R-4.5.1 \
           R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk \
+          R_DEFAULT_PACKAGES=NULL \
           /opt/webr/host/R-4.5.1/bin/R CMD INSTALL \
               --library=/opt/webr/wasm/R-4.5.1/lib/R/library \
               --no-docs --no-test-load --no-staged-install \

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -92,6 +92,15 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      # Shared R library readable by BOTH R binaries in this job:
+      #   Phase 1 native pass → /opt/R/current/bin/R
+      #   Phase 2 wasm pass   → /opt/webr/host/R-4.5.1/bin/R
+      # These two R installs have disjoint default library paths in the
+      # webR base image, so without a shared R_LIBS_USER Phase 2's lazy-load
+      # sub-R can't find transitive Imports (lifecycle → rlang) installed by
+      # the setup step. Both Rs honour R_LIBS_USER ahead of their site lib.
+      R_LIBS_USER: /tmp/r-shared-lib
     steps:
       - uses: actions/checkout@v6
 
@@ -99,8 +108,15 @@ jobs:
         run: |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends autoconf
-          /opt/R/current/bin/Rscript -e \
-            'install.packages(c("cli","lifecycle","R6","S7","vctrs"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest")'
+          mkdir -p "$R_LIBS_USER"
+          # Install via the host R that Phase 2 uses, so transitive deps land
+          # in a library Phase 2's lazy-load will see. `dependencies = c(...)`
+          # pulls rlang in via lifecycle/vctrs without us having to enumerate.
+          /opt/webr/host/R-4.5.1/bin/Rscript -e \
+            'install.packages(c("cli","lifecycle","R6","S7","vctrs"), dependencies = c("Depends","Imports","LinkingTo"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest", lib=Sys.getenv("R_LIBS_USER"))'
+          # Sanity-check the transitive set landed.
+          /opt/webr/host/R-4.5.1/bin/Rscript -e \
+            'pkgs <- c("cli","lifecycle","rlang","R6","S7","vctrs"); miss <- setdiff(pkgs, rownames(installed.packages(lib.loc=Sys.getenv("R_LIBS_USER")))); if (length(miss)) stop("Missing: ", paste(miss, collapse=", "))'
 
       - name: Cache cargo registry + git
         uses: actions/cache@v4

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -64,6 +64,84 @@ jobs:
 
       # rpkg/configure invokes ${R_HOME}/bin/Rscript directly for feature
       # detection (configure.ac:133, :275, :473). The dummy R_HOME has no
-      # Rscript binary, so configure fails. Deferred to a follow-up that either
-      # adds r-lib/actions/setup-r@v2 or waits for the build.rs wasm32 guard
-      # (see #482). Only miniextendr-api is checked in tier 1.
+      # Rscript binary, so configure fails on this bare-ubuntu runner.
+      # Tier 2 (below) runs inside the webR container which has real R, so the
+      # full rpkg install path is exercised there instead.
+
+  # ── Tier 2: full wasm32 R CMD INSTALL inside webR's own container ─────────
+  # Closes #491. Runs Phase 1 (native install → regenerates wasm_registry.rs
+  # via the cdylib pass) + Phase 2 (CC=emcc wasm install via webr-vars.mk),
+  # mirroring tests/webr-smoke.sh. CI's amd64 runners have no Rosetta and
+  # plenty of disk (the local arm64 dev path hits both limits). This is also
+  # the empirical validator for #494's `-C relocation-model=pic` flag: if the
+  # emcc side-module link rejects non-PIC objects, Phase 2 fails here.
+  #
+  # The container image must stay digest-aligned with Dockerfile.webr's
+  # WEBR_BASE — bump both together. The S7 + autoconf installs mirror the
+  # Dockerfile.webr layers (Dockerfile.webr is the local dev image and bakes
+  # them in; CI installs inline so we don't need to publish miniextendr-webr-dev).
+  webr-install:
+    name: wasm32 R CMD INSTALL (tier 2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install miniextendr's hard R Imports + autoconf
+        run: |
+          set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends autoconf
+          /opt/R/current/bin/Rscript -e \
+            'install.packages(c("cli","lifecycle","R6","S7","vctrs"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest")'
+
+      - name: Cache cargo registry + git
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/cargo/registry
+            /usr/local/cargo/git
+          key: webr-tier2-cargo-${{ hashFiles('Cargo.lock', 'rpkg/src/rust/Cargo.lock') }}
+          restore-keys: |
+            webr-tier2-cargo-
+
+      - name: Phase 1 — native R CMD INSTALL (regenerate wasm_registry.rs)
+        run: |
+          set -euo pipefail
+          # Defensive scrub (matches tests/webr-smoke.sh); CI runners are
+          # ephemeral so the cross-platform stale-.o trap doesn't apply here,
+          # but staying byte-identical with the local smoke avoids drift.
+          rm -f rpkg/src/*.o rpkg/src/*.so
+          ( cd rpkg && bash ./configure )
+          mkdir -p /tmp/native-lib
+          /opt/R/current/bin/R CMD INSTALL --no-test-load --library=/tmp/native-lib rpkg
+
+      - name: Verify Phase 1 regenerated wasm_registry.rs
+        run: |
+          set -euo pipefail
+          ch=$(grep 'content-hash:' rpkg/src/rust/wasm_registry.rs | awk '{print $NF}')
+          echo "content-hash=$ch"
+          # A stub snapshot would be all-zero; the cdylib pass must rewrite it.
+          test "$ch" != "0000000000000000"
+
+      - name: Phase 2 — wasm32 R CMD INSTALL (validates #494 PIC flag)
+        run: |
+          set -euo pipefail
+          rm -f rpkg/src/*.o rpkg/src/*.so
+          ( cd rpkg && CC=emcc bash ./configure )
+          WASM_TOOLS=/opt/webr/tools \
+          R_SOURCE=/opt/webr/R/build/R-4.5.1 \
+          R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk \
+          /opt/webr/host/R-4.5.1/bin/R CMD INSTALL \
+              --library=/opt/webr/wasm/R-4.5.1/lib/R/library \
+              --no-docs --no-test-load --no-staged-install \
+              rpkg
+
+      - name: Verify wasm side-module landed
+        run: |
+          set -euo pipefail
+          libdir=/opt/webr/wasm/R-4.5.1/lib/R/library/miniextendr
+          test -d "$libdir"
+          ls -la "$libdir/libs/"
+          file "$libdir/libs/"miniextendr.so

--- a/Dockerfile.webr
+++ b/Dockerfile.webr
@@ -48,6 +48,15 @@ RUN ARCH="$(dpkg --print-architecture)" \
 # uses for fast iteration). Build-dep-free — single binary install via cargo.
 RUN cargo install cargo-limit --locked --version "0.0.13"
 
+# miniextendr's hard R `Imports` (rpkg/DESCRIPTION) must be present in the
+# native R so Phase 1 of the webR smoke (`tests/webr-smoke.sh`: native
+# `R CMD INSTALL` running the cdylib wrapper-gen pass) and CI tier 2 (#491)
+# can resolve them. The base webR image ships cli / lifecycle / R6 / vctrs but
+# not S7; install the full hard set so the smoke doesn't depend on the base
+# image's exact package roster. `methods` is part of base R. The posit PM
+# `__linux__/noble` repo serves binaries, so this is a fast layer.
+RUN /opt/R/current/bin/Rscript -e 'install.packages(c("cli", "lifecycle", "R6", "S7", "vctrs"), repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
+
 # Sanity checks — fail the build immediately if the inherited toolchain
 # regressed or our layered tools are missing, instead of debugging a weird
 # later failure inside a working container.
@@ -58,6 +67,7 @@ RUN set -eux \
     && emcc --version >/dev/null \
     && /opt/R/current/bin/R --version >/dev/null \
     && Rscript -e 'stopifnot(requireNamespace("rwasm", quietly=TRUE))' \
+    && /opt/R/current/bin/Rscript -e 'stopifnot(requireNamespace("S7", quietly=TRUE))' \
     && just --version >/dev/null \
     && autoconf --version >/dev/null \
     && command -v cargo-lcheck >/dev/null \

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-19 21:13:10
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-19 21:13:10
+--- a/monorepo/rpkg/bootstrap.R	2026-05-14 09:21:02
++++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-20 09:31:54
-+++ b/monorepo/rpkg/configure.ac	2026-05-20 09:34:34
+--- a/monorepo/rpkg/configure.ac	2026-05-27 03:03:21
++++ b/monorepo/rpkg/configure.ac	2026-05-20 12:11:20
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -280,7 +280,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -248,4 +209,7 @@
+@@ -248,15 +209,9 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -288,7 +288,18 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-@@ -272,4 +236,8 @@
+-dnl wasm32/webR side-modules require position-independent objects: webR's
+-dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
+-dnl object via emcc, and emscripten only accepts PIC input for a side module.
+-dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
+-dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
+-dnl `cargo build --lib` archive that is never linked by cargo. See #494.
+-if test "$is_wasm_install" = true; then
+-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+-fi
+ AC_SUBST([ENV_RUSTFLAGS])
+ 
+@@ -281,4 +236,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -297,7 +308,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -279,21 +247,29 @@
+@@ -288,21 +247,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -337,7 +348,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -312,18 +288,20 @@
+@@ -321,18 +288,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -367,20 +378,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -552,4 +530,5 @@
+@@ -561,4 +530,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -782,5 +761,5 @@
+@@ -791,5 +761,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -798,13 +777,22 @@
+@@ -807,13 +777,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -406,8 +417,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-20 09:31:54
-+++ b/rpkg/configure.ac	2026-05-20 09:33:40
+--- a/rpkg/configure.ac	2026-05-27 03:03:21
++++ b/rpkg/configure.ac	2026-05-20 12:11:20
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -502,7 +513,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -248,4 +261,7 @@
+@@ -248,15 +261,9 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -510,7 +521,18 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-@@ -272,4 +288,8 @@
+-dnl wasm32/webR side-modules require position-independent objects: webR's
+-dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
+-dnl object via emcc, and emscripten only accepts PIC input for a side module.
+-dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
+-dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
+-dnl `cargo build --lib` archive that is never linked by cargo. See #494.
+-if test "$is_wasm_install" = true; then
+-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+-fi
+ AC_SUBST([ENV_RUSTFLAGS])
+ 
+@@ -281,4 +288,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -519,7 +541,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -279,21 +299,29 @@
+@@ -288,21 +299,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -559,7 +581,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -312,18 +340,20 @@
+@@ -321,18 +340,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -589,20 +611,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -552,4 +582,5 @@
+@@ -561,4 +582,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -782,5 +813,5 @@
+@@ -791,5 +813,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -798,13 +829,22 @@
+@@ -807,13 +829,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2495,6 +2495,9 @@ fi
 
 
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
+if test "$is_wasm_install" = true; then
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+fi
 
 
 

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -249,6 +249,15 @@ fi
 
 AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
+dnl wasm32/webR side-modules require position-independent objects: webR's
+dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
+dnl object via emcc, and emscripten only accepts PIC input for a side module.
+dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
+dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
+dnl `cargo build --lib` archive that is never linked by cargo. See #494.
+if test "$is_wasm_install" = true; then
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+fi
 AC_SUBST([ENV_RUSTFLAGS])
 
 AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -108,12 +108,12 @@ cleanup() {
     if [[ $_cleanup_done -eq 1 ]]; then return; fi
     _cleanup_done=1
 
-    log "Running cleanup: restoring native Makevars..."
+    log "Running cleanup: scrubbing build objects + restoring native Makevars..."
     docker_run "
         set -euo pipefail
-        cd /work
-        bash rpkg/configure 2>/dev/null || true
-    " || warn "Cleanup configure failed — rpkg/src/Makevars may still be in wasm-mode. Run: bash rpkg/configure"
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && bash ./configure ) 2>/dev/null || true
+    " || warn "Cleanup configure failed — rpkg/src/Makevars may still be in wasm-mode. Run: cd rpkg && bash ./configure"
 
     if [[ $KEEP -eq 0 ]]; then
         log "Removing ${SMOKE_TMP} inside container..."
@@ -170,11 +170,17 @@ phase_native_install() {
     docker_run "
         set -euo pipefail
         mkdir -p ${SMOKE_TMP}/native-lib
-        cd /work
-        bash rpkg/configure
+        # Scrub stale build objects: the bind-mounted /work is shared with the
+        # host, so host-arch (e.g. macOS arm64) *.o/*.so from a prior
+        # 'just rcmdinstall' have newer mtimes than their .c sources. R then
+        # skips recompiling and the native build links the wrong object format
+        # ('unknown file type'). cargo's target dir is triple-namespaced, so it
+        # is unaffected.
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && bash ./configure )
         ${R_NATIVE_EXE} CMD INSTALL --no-test-load \
             --library=${SMOKE_TMP}/native-lib \
-            rpkg
+            /work/rpkg
     "
 
     # Verify wasm_registry.rs was regenerated (content-hash must not be stub value)
@@ -202,8 +208,10 @@ phase_wasm_build() {
     log "Running wasm32 R CMD INSTALL inside container..."
     docker_run "
         set -euo pipefail
-        cd /work
-        CC=emcc bash rpkg/configure
+        # Scrub Phase 1's native objects so emcc recompiles .c -> wasm .o
+        # (same stale-mtime trap as Phase 1, but native-poisoning-wasm here).
+        rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
+        ( cd /work/rpkg && CC=emcc bash ./configure )
         WASM_TOOLS=${WASM_TOOLS} \
         R_SOURCE=${R_SOURCE} \
         R_MAKEVARS_USER=${WEBR_VARS_MK} \

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -212,9 +212,13 @@ phase_wasm_build() {
         # (same stale-mtime trap as Phase 1, but native-poisoning-wasm here).
         rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
         ( cd /work/rpkg && CC=emcc bash ./configure )
+        # R_DEFAULT_PACKAGES=NULL: see .github/workflows/webr.yml. Byte-compile
+        # at the tail of INSTALL runs under host R; default packages live in
+        # the wasm library and are unloadable from x86_64.
         WASM_TOOLS=${WASM_TOOLS} \
         R_SOURCE=${R_SOURCE} \
         R_MAKEVARS_USER=${WEBR_VARS_MK} \
+        R_DEFAULT_PACKAGES=NULL \
         ${R_HOST_EXE} CMD INSTALL \
             --library=${R_WASM_LIB} \
             --no-docs --no-test-load --no-staged-install \

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -212,16 +212,27 @@ phase_wasm_build() {
         # (same stale-mtime trap as Phase 1, but native-poisoning-wasm here).
         rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
         ( cd /work/rpkg && CC=emcc bash ./configure )
-        # --no-byte-compile: byte-compile at the tail of INSTALL runs under
-        # host R against the wasm library tree → 'invalid ELF header' on
-        # auto-loaded default packages. Mirrors r-wasm/rwasm:R/build.R.
+        # Install to an empty host-side temp library, NOT directly into the
+        # wasm tree. INSTALL's tail-end lazy-load spawns a sub-R that adds
+        # --library to .libPaths(); if that path contains wasm grDevices.so
+        # the sub-R dies with 'invalid ELF header' on startup. rwasm uses
+        # tempfile() lib_dir for the same reason (see
+        # r-wasm/rwasm:R/build.R, 'empty library otherwise R might try to
+        # load wasm packages' comment), then copies into the final tree.
+        # --no-byte-compile mirrors rwasm's flag set.
+        rm -rf /tmp/wasm-lib && mkdir -p /tmp/wasm-lib
         WASM_TOOLS=${WASM_TOOLS} \
         R_SOURCE=${R_SOURCE} \
         R_MAKEVARS_USER=${WEBR_VARS_MK} \
         ${R_HOST_EXE} CMD INSTALL \
-            --library=${R_WASM_LIB} \
+            --library=/tmp/wasm-lib \
             --no-docs --no-test-load --no-staged-install --no-byte-compile \
             /work/rpkg
+        # Publish the wasm-installed package into the real wasm library so
+        # the Phase 3 Node runner (which FS.mounts ${R_WASM_LIB}) can find it.
+        mkdir -p ${R_WASM_LIB}
+        rm -rf ${R_WASM_LIB}/miniextendr
+        cp -a /tmp/wasm-lib/miniextendr ${R_WASM_LIB}/miniextendr
     "
 
     # Verify the wasm library was installed

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -212,16 +212,15 @@ phase_wasm_build() {
         # (same stale-mtime trap as Phase 1, but native-poisoning-wasm here).
         rm -f /work/rpkg/src/*.o /work/rpkg/src/*.so
         ( cd /work/rpkg && CC=emcc bash ./configure )
-        # R_DEFAULT_PACKAGES=NULL: see .github/workflows/webr.yml. Byte-compile
-        # at the tail of INSTALL runs under host R; default packages live in
-        # the wasm library and are unloadable from x86_64.
+        # --no-byte-compile: byte-compile at the tail of INSTALL runs under
+        # host R against the wasm library tree → 'invalid ELF header' on
+        # auto-loaded default packages. Mirrors r-wasm/rwasm:R/build.R.
         WASM_TOOLS=${WASM_TOOLS} \
         R_SOURCE=${R_SOURCE} \
         R_MAKEVARS_USER=${WEBR_VARS_MK} \
-        R_DEFAULT_PACKAGES=NULL \
         ${R_HOST_EXE} CMD INSTALL \
             --library=${R_WASM_LIB} \
-            --no-docs --no-test-load --no-staged-install \
+            --no-docs --no-test-load --no-staged-install --no-byte-compile \
             /work/rpkg
     "
 


### PR DESCRIPTION
Stacked on **#743** (smoke-harness repair). Two coupled commits: the `-C relocation-model=pic` flag that the side-module link needs, and a new `webr.yml` job that actually exercises it. Closes **#491** (CI tier-2 — `R CMD INSTALL` inside the webR container) and validates **#494** in the same PR — this PR's own CI run is the empirical answer the issue asks for. Refs **#470**.

Local validation was originally the plan, but the full-feature build (datafusion + arrow) under amd64 emulation on arm64 exhausted the host disk and crashed Docker Desktop's daemon mid-build. Pivoting to CI on native amd64 runners avoids both walls.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

**Commit 1: `-C relocation-model=pic` on the webR install path (#494)**

- `configure.ac` appends `-C relocation-model=pic` to `ENV_RUSTFLAGS` only when `IS_WASM_INSTALL=true`, after the user-overridable default-assign.
- Deliberately NOT adding `-C link-args=-s SIDE_MODULE=1` (the issue's original proposal): `SIDE_MODULE=1` is an emcc *link* flag already supplied by R via `webr-vars.mk` `LDFLAGS`, and the Rust staticlib (`cargo build --lib`) is an archive that cargo never links, so a link-arg there is a no-op at best. Only the PIC requirement is a genuine Rust-side concern (emcc rejects non-PIC inputs to a side-module link).
- `rpkg/configure` regenerated via `autoconf` (diff is exactly +3 lines).

**Commit 2: tier-2 CI job (#491)**

- New `webr-install` job in `.github/workflows/webr.yml` running inside the same digest-pinned `ghcr.io/r-wasm/webr` container that `Dockerfile.webr` uses.
- Runs the smoke's Phase 1 + Phase 2 directly:
  1. Native `R CMD INSTALL` (regenerates `wasm_registry.rs` via the cdylib pass), with a content-hash check that fails if Phase 1 didn't actually rewrite the snapshot.
  2. `CC=emcc R CMD INSTALL` against `/opt/webr/host/R-4.5.1/bin/R` with `webr-vars.mk` — the actual emcc side-module link. **Failure here without PIC is the #494 question being answered.**
- S7 + autoconf installs are inlined (no separate published image needed); they mirror the `Dockerfile.webr` layers, so a single PR keeps local + CI in sync.
- Cargo registry/git cache keyed on both workspace + `rpkg/src/rust` Cargo.lock to avoid cross-lockfile drift.
- `timeout-minutes: 90` is generous for a cold build; sccache is not wired in here (follow-up if iteration cost matters).

The Rscript-in-configure blocker that stops `rpkg` from joining tier 1 does not apply here — tier 2 runs inside a container that ships real R at `/opt/R/current` and `/opt/webr/host/R-4.5.1`.

## Test plan

- [ ] **CI's first run of this PR**: tier 1 (cargo check) stays green; tier 2 builds Phase 1 cleanly (cdylib + wrapper-gen, content-hash flips off `0000000000000000`).
- [ ] **CI tier 2's Phase 2 succeeds**: the emcc side-module link with PIC objects produces `libs/miniextendr.so` (wasm) at `/opt/webr/wasm/R-4.5.1/lib/R/library/miniextendr/`. The verification step `file libs/miniextendr.so` should report a `WebAssembly` binary.
- [ ] If Phase 2 fails despite PIC, the linker output tells us what else is missing (typically: `-fPIC` on the C shim object, additional emcc flags). #494 is then re-opened with the new data.

## Notes

- **Phase 3** (webR Node `library(miniextendr)` + testthat) is **not** in this PR — that is tier 3, tracked by **#492**. Tier 3 needs a Node + `@r-wasm/webr` setup that adds non-trivial workflow scaffolding; better as its own PR once Phase 2 is green.
- **Digest alignment**: the container image digest here must match `Dockerfile.webr`'s `WEBR_BASE`. Bumping one without the other is a footgun; flagging in this PR description so reviewers notice.
- **PIC flag validation**: filed as #745. Once this PR lands green, revert the configure.ac PIC block on a throwaway branch and let tier 2 re-run — if Phase 2 still passes, the flag is redundant and gets dropped. If it fails, the linker output gives us the concrete justification to put in a comment.
- **No `worker-thread` regression risk**: that feature is already wasm-gated in `Cargo.toml`; the `CARGO_FEATURES` line emitted by configure on wasm trims it out automatically.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>
