### PR TITLE
ci(webr): weekly mirror of ghcr.io/r-wasm/webr → ghcr.io/a2-ai/webr-mirror

### DIFF
--- a/.github/workflows/mirror-webr.yml
+++ b/.github/workflows/mirror-webr.yml
@@ -1,0 +1,102 @@
+name: Mirror webR base image
+
+# Closes #496. Pulls the upstream `ghcr.io/r-wasm/webr` digest currently pinned
+# in Dockerfile.webr and re-publishes it to `ghcr.io/a2-ai/webr-mirror`, so
+# CI's webR-tier-2/3 jobs (#491/#492) and our local dev image don't depend on
+# upstream registry availability or rate limits.
+#
+# Cadence model (per #496):
+#   - Dockerfile.webr's `WEBR_BASE` ARG is the single source of truth for which
+#     digest we want.
+#   - This cron just keeps that digest fresh in our mirror (idempotent re-push).
+#   - When upstream rolls and we want to consume the newer image, bump
+#     Dockerfile.webr's pin deliberately in a PR; next cron tick mirrors the
+#     new pin automatically. No floating tags.
+#
+# Cutover (one-time, after first successful run of this workflow):
+#   1. Make `ghcr.io/a2-ai/webr-mirror` public via the GitHub package settings
+#      (first push creates it as private, inheriting the source repo's perms).
+#   2. Switch consumers to the mirror by replacing `ghcr.io/r-wasm/webr@<digest>`
+#      with `ghcr.io/a2-ai/webr-mirror@<same-digest>` — the digest is content-
+#      addressable so the image bytes are identical. Affects Dockerfile.webr's
+#      `WEBR_BASE` default and `.github/workflows/webr.yml`'s `webr-install`
+#      container.
+
+on:
+  schedule:
+    - cron: '13 5 * * 1'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile.webr'
+      - '.github/workflows/mirror-webr.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mirror-webr
+  cancel-in-progress: false
+
+env:
+  DEST_REPO: ghcr.io/a2-ai/webr-mirror
+
+jobs:
+  mirror:
+    name: Copy pinned digest into ghcr.io/a2-ai/webr-mirror
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read pinned digest from Dockerfile.webr
+        id: pin
+        shell: bash
+        run: |
+          set -euo pipefail
+          src=$(grep -E '^ARG WEBR_BASE=' Dockerfile.webr | head -1 | sed -E 's/^ARG WEBR_BASE=//')
+          if [[ -z "$src" || "$src" != *"@sha256:"* ]]; then
+            echo "::error::Could not extract a digest-pinned WEBR_BASE from Dockerfile.webr (got: '$src')."
+            exit 1
+          fi
+          digest="${src##*@}"
+          short="${digest#sha256:}"
+          short12="${short:0:12}"
+          {
+            echo "src=$src"
+            echo "digest=$digest"
+            echo "short12=$short12"
+          } >>"$GITHUB_OUTPUT"
+          echo "Source pin:  $src"
+          echo "Full digest: $digest"
+          echo "Short tag:   $short12"
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | crane auth login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Copy pinned digest into mirror
+        run: |
+          set -euo pipefail
+          src='${{ steps.pin.outputs.src }}'
+          dest='${{ env.DEST_REPO }}:${{ steps.pin.outputs.short12 }}'
+          echo "Copying $src → $dest (digest preserved)"
+          crane copy "$src" "$dest"
+
+      - name: Verify mirror digest matches upstream pin
+        run: |
+          set -euo pipefail
+          dest='${{ env.DEST_REPO }}:${{ steps.pin.outputs.short12 }}'
+          got=$(crane digest "$dest")
+          want='${{ steps.pin.outputs.digest }}'
+          if [[ "$got" != "$want" ]]; then
+            echo "::error::Mirror digest drift — got $got, want $want."
+            exit 1
+          fi
+          echo "Mirror digest matches pin: $got"


### PR DESCRIPTION
Lands the mirror cron from #496. Keeps `WEBR_BASE` as the single source of truth for which digest we want and re-publishes that digest to `ghcr.io/a2-ai/webr-mirror` on a weekly schedule (and on-demand via `workflow_dispatch`). Consumer cutover (Dockerfile.webr default + `.github/workflows/webr.yml` container ref) intentionally stays out of this PR until the mirror has run once and the package is made public in the org's GHCR settings.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- New workflow `.github/workflows/mirror-webr.yml`:
  - Triggers: weekly cron (Mon 05:13 UTC), `workflow_dispatch`, and a path-filtered `push` on `main` (so edits to the workflow or to `Dockerfile.webr`'s pin re-mirror immediately without waiting a week).
  - Reads the `ARG WEBR_BASE=...@sha256:...` line from `Dockerfile.webr` (single source of truth for the pin), `crane copy`s the upstream digest into `ghcr.io/a2-ai/webr-mirror:<short12>`, and verifies the destination digest matches the source pin.
  - Uses `crane` via `imjasonh/setup-crane@v0.4` — no Docker daemon needed, and `crane copy` preserves manifests/digests so the mirror is byte-identical.
- No consumer changes in this PR. `Dockerfile.webr`'s `WEBR_BASE` default and `.github/workflows/webr.yml`'s `webr-install.container.image` still point at `ghcr.io/r-wasm/webr@<digest>`.

## Cadence model
- `Dockerfile.webr`'s `WEBR_BASE` arg is the single source of truth.
- This cron just keeps that digest fresh in our registry. When upstream rolls, we bump `WEBR_BASE` deliberately in a PR; the next cron tick mirrors the new pin.
- No floating `:latest`-style tag is published — every consumer-facing reference is digest-addressable.

## Cutover (follow-up, after first successful run)
1. Make `ghcr.io/a2-ai/webr-mirror` public via the GitHub package settings — the first push from this workflow creates it private by default.
2. In a follow-up PR, replace `ghcr.io/r-wasm/webr@<digest>` with `ghcr.io/a2-ai/webr-mirror@<same-digest>` in:
   - `Dockerfile.webr` (`WEBR_BASE` default)
   - `.github/workflows/webr.yml` (`webr-install.container.image`)
   The digest is content-addressable so image bytes are identical — just the registry prefix changes.

## Test plan
- [ ] Workflow lints clean (GitHub's actionlint runs as part of PR checks).
- [ ] After merge, trigger one `workflow_dispatch` run to seed the mirror.
- [ ] Confirm `crane digest ghcr.io/a2-ai/webr-mirror:0b9e6e411342` matches the digest in `Dockerfile.webr`'s `WEBR_BASE` pin.
- [ ] Mark the new package public in the org GHCR settings.
- [ ] Open the cutover PR.

## Notes
- The `push` trigger on `Dockerfile.webr` makes WEBR_BASE bumps self-mirroring — when a future PR lands a new pin, the next push-to-main fires the mirror without waiting for the Monday cron.
- `concurrency: { group: mirror-webr, cancel-in-progress: false }` so back-to-back triggers serialize rather than racing on the registry.

## Refs
- Closes #496
- Umbrella: #470
- Adjacent: #491 (tier 2 — #744 in flight) and #492 (tier 3) are the eventual high-volume consumers; mirror matters most once those land.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>