### PR TITLE
ci(webr): cutover to ghcr.io/a2-ai/webr-mirror

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -30,6 +30,12 @@ on:
 
 permissions:
   contents: read
+  # Needed for the tier-2 job to pull ghcr.io/a2-ai/webr-mirror, which is
+  # currently a private GHCR package. The `credentials:` block on the job
+  # container reads $GITHUB_TOKEN with this scope. Once the mirror package
+  # is flipped public via the org UI, both this permission line and the
+  # `credentials:` block below can be dropped (tracked as follow-up).
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -85,7 +91,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
-      image: ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+      # Pulled from the mirror at ghcr.io/a2-ai/webr-mirror (closes #496),
+      # which `.github/workflows/mirror-webr.yml` keeps digest-aligned with
+      # upstream ghcr.io/r-wasm/webr — image bytes are identical at this
+      # sha256. Bump in lockstep with Dockerfile.webr's WEBR_BASE.
+      image: ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+      # The mirror package is currently private; auth via the job's
+      # GITHUB_TOKEN (workflow-level `packages: read` permission above).
+      # Drop both once the package is made public via the org UI.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     # The webR base image's /bin/sh is dash; every step here uses
     # `set -euo pipefail` which is bash-only. Pin the shell at the job level
     # so individual steps don't have to repeat `shell: bash`.

--- a/Dockerfile.webr
+++ b/Dockerfile.webr
@@ -2,9 +2,11 @@
 #
 # Local dev container for testing miniextendr R packages under webR.
 #
-# Inherits the upstream `ghcr.io/r-wasm/webr` image so we don't re-stage
-# Emscripten, flang, nightly Rust + `wasm32-unknown-emscripten` + `rust-src`,
-# or the host/wasm R trees. We layer just enough on top to run `just`-based
+# Inherits the webR base image (originally `ghcr.io/r-wasm/webr`, now pulled
+# via our digest-preserved mirror `ghcr.io/a2-ai/webr-mirror` — see
+# `.github/workflows/mirror-webr.yml`) so we don't re-stage Emscripten,
+# flang, nightly Rust + `wasm32-unknown-emscripten` + `rust-src`, or the
+# host/wasm R trees. We layer just enough on top to run `just`-based
 # workflows and have a comfortable interactive shell.
 #
 # Usage (local dev):
@@ -16,7 +18,14 @@
 #                via PR; webR's `:main` tag rolls without notice.
 #   JUST_VERSION — `just` release to install. Apt's version is too old.
 
-ARG WEBR_BASE=ghcr.io/r-wasm/webr@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+# Mirror lives at ghcr.io/a2-ai/webr-mirror; digest is preserved by
+# `.github/workflows/mirror-webr.yml` (closes #496), so the image bytes
+# are identical to ghcr.io/r-wasm/webr at the same sha256. Mirroring
+# insulates CI from upstream rolling the `:main` tag or pruning old
+# digests. Bump deliberately via PR: edit the digest here, then run the
+# mirror workflow (or wait for the weekly cron) before CI references
+# the new tag.
+ARG WEBR_BASE=ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
 FROM ${WEBR_BASE}
 
 ARG JUST_VERSION=1.36.0

--- a/justfile
+++ b/justfile
@@ -1249,9 +1249,11 @@ bump-version version:
 
 # ── Local webR/wasm dev container ────────────────────────────────────────────
 #
-# `Dockerfile.webr` inherits ghcr.io/r-wasm/webr (digest-pinned) and layers
-# `just`, `autoconf`, dev tools. See the Dockerfile header for what's already
-# in the base. Use this when reproducing webR/wasm32 build issues locally.
+# `Dockerfile.webr` inherits the webR base via ghcr.io/a2-ai/webr-mirror
+# (digest-pinned, identical bytes to upstream — see .github/workflows/mirror-webr.yml)
+# and layers `just`, `autoconf`, dev tools. See the Dockerfile header for
+# what's already in the base. Use this when reproducing webR/wasm32 build
+# issues locally.
 
 docker_webr_image := "miniextendr-webr-dev:latest"
 


### PR DESCRIPTION
Finishes the webR mirror story from #496 / #746. The mirror workflow seeded `ghcr.io/a2-ai/webr-mirror` with the same digest as upstream `ghcr.io/r-wasm/webr` (`sha256:0b9e6e411342...`), so this is purely flipping consumers over. Image bytes are byte-identical; CI behaviour should be unchanged.

The mirror package is private right now, so I'm carrying it across the line with a `credentials:` block + workflow-level `packages: read`. Once we flip the package public via the GHCR UI we can drop both — tracked in #747.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `Dockerfile.webr`: `WEBR_BASE` arg defaults to `ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e411342...` (same digest as before).
- `.github/workflows/webr.yml`:
  - workflow-level `permissions:` gains `packages: read`,
  - `webr-install.container:` swaps image to the mirror and adds a `credentials:` block auth'd via `${{ secrets.GITHUB_TOKEN }}`.
- Comment housekeeping in `justfile` + `Dockerfile.webr` headers so future readers understand the indirection.

## Test plan
- [ ] webR / wasm32 workflow runs against the new image on this PR.
- [ ] `cargo-check` job (no container) still passes (unrelated, but in the same workflow).
- [ ] Tier-2 run pulls `ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e411342...`, completes Phase 1 + Phase 2 + the wasm side-module verifier.

## Notes
- Digest is content-addressable, so the mirror's behaviour matches upstream exactly. If anything regresses, it's the auth path (private package + `credentials:`), not the image.
- Future bumps of `WEBR_BASE`: edit the digest in `Dockerfile.webr` + `webr.yml` together, then either run `mirror-webr.yml` manually (`gh workflow run mirror-webr.yml`) or wait for the weekly cron to seed the new digest in the mirror before CI references it.
- #747 is the follow-up to remove `packages: read` + `credentials:` once the GHCR package is public.

Refs #496, follows #746.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>