### PR TITLE
experiment(wasm): drop PIC RUSTFLAG, observe Phase 2 outcome (#745)

### DIFF
--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2495,9 +2495,6 @@ fi
 
 
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-if test "$is_wasm_install" = true; then
-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
-fi
 
 
 

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -249,15 +249,15 @@ fi
 
 AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-dnl wasm32/webR side-modules require position-independent objects: webR's
-dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
-dnl object via emcc, and emscripten only accepts PIC input for a side module.
-dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
-dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
-dnl `cargo build --lib` archive that is never linked by cargo. See #494.
-if test "$is_wasm_install" = true; then
-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
-fi
+dnl EXPERIMENT (#745): the `-C relocation-model=pic` block previously
+dnl added here (commit e3910fc8, #494) is deliberately removed on this
+dnl branch to determine empirically whether emcc actually requires
+dnl explicit PIC from the Rust staticlib for the `-s SIDE_MODULE=1`
+dnl link. If tier-2 CI Phase 2 still completes, the flag was redundant
+dnl (emcc supplies PIC on its own or the staticlib is already PIC by
+dnl default for wasm32-unknown-emscripten) and we drop it permanently.
+dnl If Phase 2 fails at the emcc side-module link, the flag is
+dnl validated as necessary and we restore it.
 AC_SUBST([ENV_RUSTFLAGS])
 
 AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \


### PR DESCRIPTION
Empirical validation experiment for #745. PR #744 proved the `-C relocation-model=pic` flag added in #494 is *sufficient* for the emcc side-module link to succeed — it did not prove the flag is *necessary*. This branch removes it and lets tier-2 CI render a verdict at Phase 2.

I'm keeping this PR in draft. Plan:

- If tier-2 / Phase 2 succeeds → the flag was redundant, mark this PR ready for review and merge as the permanent removal.
- If tier-2 / Phase 2 fails at the emcc side-module link with a PIC-related diagnostic → the flag is locked in, close this PR with "validated, see #745", and the configure.ac block stays as-is on main.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `rpkg/configure.ac` — drops the `is_wasm_install` PIC block; replaces with a `dnl` comment narrating the experiment so future readers find context if they grep for `relocation-model`.
- `rpkg/configure` — regenerated via `autoconf`, three lines drop out cleanly.
- No source code or workflow changes; the change is isolated to one configure-time RUSTFLAG.

## Test plan
- [ ] tier-2 / Phase 1 (native install) still passes — unaffected.
- [ ] tier-2 / Phase 2 (wasm install via webr-vars.mk) — this is the verdict step.
- [ ] tier-2 / "Verify wasm side-module landed" — only runs if Phase 2 succeeds.

## Notes
- Hypothesis: rustc 1.84+ on `wasm32-unknown-emscripten` may emit PIC by default for the staticlib crate-type since wasm targets are inherently position-independent. If so the explicit flag is a no-op.
- Cost: one tier-2 CI run (~10–15 min).
- Reversal: if the experiment validates the flag, I'll close this PR and add a `dnl` line at the original site noting "validated in #745, do not remove without re-running the experiment".

Refs #745, builds on #494 + #744.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>