### PR TITLE
fix(wasm): -Zdefault-visibility=hidden for webR export hygiene (#494)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -213,6 +213,22 @@ dnl It equals the Rust crate name (hyphens/dots → underscores)
 
 AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
+dnl wasm32/webR side-modules need two RUSTFLAGS adjustments.
+dnl
+dnl 1. -C relocation-model=pic
+dnl    webR's webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1`
+dnl    shared object via emcc, which only accepts position-independent input.
+dnl
+dnl 2. -Zdefault-visibility=hidden
+dnl    Without it, the Rust staticlib drags thousands of mangled stdlib/dep
+dnl    symbols into the side-module's EXPORT table and webR's dyn.load fails.
+dnl    Hiding all symbols by default leaves only your `#[no_mangle] extern "C"`
+dnl    entry points exported. This is a nightly -Z flag, but the wasm target
+dnl    already requires nightly via -Z build-std, so it adds no new constraint.
+dnl    (savvy's approach; endorsed by webR's maintainer, r-wasm/webr#532.)
+if test "$is_wasm_install" = true; then
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
+fi
 AC_SUBST([ENV_RUSTFLAGS])
 
 AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -265,6 +265,22 @@ dnl It equals the Rust crate name (hyphens/dots → underscores)
 
 AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
+dnl wasm32/webR side-modules need two RUSTFLAGS adjustments.
+dnl
+dnl 1. -C relocation-model=pic
+dnl    webR's webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1`
+dnl    shared object via emcc, which only accepts position-independent input.
+dnl
+dnl 2. -Zdefault-visibility=hidden
+dnl    Without it, the Rust staticlib drags thousands of mangled stdlib/dep
+dnl    symbols into the side-module's EXPORT table and webR's dyn.load fails.
+dnl    Hiding all symbols by default leaves only your `#[no_mangle] extern "C"`
+dnl    entry points exported. This is a nightly -Z flag, but the wasm target
+dnl    already requires nightly via -Z build-std, so it adds no new constraint.
+dnl    (savvy's approach; endorsed by webR's maintainer, r-wasm/webr#532.)
+if test "$is_wasm_install" = true; then
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
+fi
 AC_SUBST([ENV_RUSTFLAGS])
 
 AC_ARG_VAR([CARGO_HOME], [cargo registry/cache directory (defaults to ~/.cargo; \

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-27 03:03:21
-+++ b/monorepo/rpkg/configure.ac	2026-05-20 12:11:20
+--- a/monorepo/rpkg/configure.ac	2026-05-27 23:43:02
++++ b/monorepo/rpkg/configure.ac	2026-05-27 23:43:30
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -280,7 +280,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -248,15 +209,9 @@
+@@ -248,27 +209,22 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -288,18 +288,37 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
--dnl wasm32/webR side-modules require position-independent objects: webR's
--dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
--dnl object via emcc, and emscripten only accepts PIC input for a side module.
--dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
--dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
--dnl `cargo build --lib` archive that is never linked by cargo. See #494.
--if test "$is_wasm_install" = true; then
--  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
--fi
- AC_SUBST([ENV_RUSTFLAGS])
- 
-@@ -281,4 +236,8 @@
+-dnl wasm32/webR side-modules need two RUSTFLAGS adjustments. See #494.
++dnl wasm32/webR side-modules need two RUSTFLAGS adjustments.
+ dnl
+ dnl 1. -C relocation-model=pic
+ dnl    webR's webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1`
+ dnl    shared object via emcc, which only accepts position-independent input.
+-dnl    (`-s SIDE_MODULE=1` itself is an emcc *link* flag applied by R, not by
+-dnl    cargo — the staticlib is a `cargo build --lib` archive cargo never
+-dnl    links.) Likely already the wasm32-emscripten default; kept explicit
+-dnl    pending #745's runtime-load confirmation.
+ dnl
+ dnl 2. -Zdefault-visibility=hidden
+-dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+-dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
+-dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
+-dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all
+-dnl    symbols by default leaves only our `#[no_mangle] extern "C"` entry
+-dnl    points exported, so the default SIDE_MODULE=1 export set stays tiny.
+-dnl    This is savvy's approach (yutannihilation/savvy#372), endorsed by
+-dnl    webR's maintainer (r-wasm/webr#532). It is a nightly -Z flag, but the
+-dnl    wasm target already mandates nightly via -Z build-std, so it adds no
+-dnl    new constraint.
++dnl    Without it, the Rust staticlib drags thousands of mangled stdlib/dep
++dnl    symbols into the side-module's EXPORT table and webR's dyn.load fails.
++dnl    Hiding all symbols by default leaves only your `#[no_mangle] extern "C"`
++dnl    entry points exported. This is a nightly -Z flag, but the wasm target
++dnl    already requires nightly via -Z build-std, so it adds no new constraint.
++dnl    (savvy's approach; endorsed by webR's maintainer, r-wasm/webr#532.)
+ if test "$is_wasm_install" = true; then
+   ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
+@@ -296,4 +252,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -308,7 +327,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -288,21 +247,29 @@
+@@ -303,21 +263,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -348,7 +367,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -321,18 +288,20 @@
+@@ -336,18 +304,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -378,20 +397,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -561,4 +530,5 @@
+@@ -576,4 +546,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -791,5 +761,5 @@
+@@ -806,5 +777,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -807,13 +777,22 @@
+@@ -822,13 +793,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -417,8 +436,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-27 03:03:21
-+++ b/rpkg/configure.ac	2026-05-20 12:11:20
+--- a/rpkg/configure.ac	2026-05-27 23:43:02
++++ b/rpkg/configure.ac	2026-05-27 23:43:17
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -513,7 +532,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -248,15 +261,9 @@
+@@ -248,27 +261,22 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -521,18 +540,37 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +
  AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
  : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
--dnl wasm32/webR side-modules require position-independent objects: webR's
--dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
--dnl object via emcc, and emscripten only accepts PIC input for a side module.
--dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
--dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
--dnl `cargo build --lib` archive that is never linked by cargo. See #494.
--if test "$is_wasm_install" = true; then
--  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
--fi
- AC_SUBST([ENV_RUSTFLAGS])
- 
-@@ -281,4 +288,8 @@
+-dnl wasm32/webR side-modules need two RUSTFLAGS adjustments. See #494.
++dnl wasm32/webR side-modules need two RUSTFLAGS adjustments.
+ dnl
+ dnl 1. -C relocation-model=pic
+ dnl    webR's webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1`
+ dnl    shared object via emcc, which only accepts position-independent input.
+-dnl    (`-s SIDE_MODULE=1` itself is an emcc *link* flag applied by R, not by
+-dnl    cargo — the staticlib is a `cargo build --lib` archive cargo never
+-dnl    links.) Likely already the wasm32-emscripten default; kept explicit
+-dnl    pending #745's runtime-load confirmation.
+ dnl
+ dnl 2. -Zdefault-visibility=hidden
+-dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+-dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
+-dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
+-dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all
+-dnl    symbols by default leaves only our `#[no_mangle] extern "C"` entry
+-dnl    points exported, so the default SIDE_MODULE=1 export set stays tiny.
+-dnl    This is savvy's approach (yutannihilation/savvy#372), endorsed by
+-dnl    webR's maintainer (r-wasm/webr#532). It is a nightly -Z flag, but the
+-dnl    wasm target already mandates nightly via -Z build-std, so it adds no
+-dnl    new constraint.
++dnl    Without it, the Rust staticlib drags thousands of mangled stdlib/dep
++dnl    symbols into the side-module's EXPORT table and webR's dyn.load fails.
++dnl    Hiding all symbols by default leaves only your `#[no_mangle] extern "C"`
++dnl    entry points exported. This is a nightly -Z flag, but the wasm target
++dnl    already requires nightly via -Z build-std, so it adds no new constraint.
++dnl    (savvy's approach; endorsed by webR's maintainer, r-wasm/webr#532.)
+ if test "$is_wasm_install" = true; then
+   ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
+@@ -296,4 +304,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -541,7 +579,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -288,21 +299,29 @@
+@@ -303,21 +315,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -581,7 +619,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -321,18 +340,20 @@
+@@ -336,18 +356,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -611,20 +649,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -561,4 +582,5 @@
+@@ -576,4 +598,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -791,5 +813,5 @@
+@@ -806,5 +829,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -807,13 +829,22 @@
+@@ -822,13 +845,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2496,7 +2496,7 @@ fi
 
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
 if test "$is_wasm_install" = true; then
-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
 fi
 
 

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -249,14 +249,29 @@ fi
 
 AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 : ${ENV_RUSTFLAGS="$RUSTFLAGS"}
-dnl wasm32/webR side-modules require position-independent objects: webR's
-dnl webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1` shared
-dnl object via emcc, and emscripten only accepts PIC input for a side module.
-dnl `-s SIDE_MODULE=1` itself is an emcc *link* flag (applied by R via
-dnl webr-vars.mk, not by cargo) so it is NOT added here — the staticlib is a
-dnl `cargo build --lib` archive that is never linked by cargo. See #494.
+dnl wasm32/webR side-modules need two RUSTFLAGS adjustments. See #494.
+dnl
+dnl 1. -C relocation-model=pic
+dnl    webR's webr-vars.mk links the Rust staticlib into a `-s SIDE_MODULE=1`
+dnl    shared object via emcc, which only accepts position-independent input.
+dnl    (`-s SIDE_MODULE=1` itself is an emcc *link* flag applied by R, not by
+dnl    cargo — the staticlib is a `cargo build --lib` archive cargo never
+dnl    links.) Likely already the wasm32-emscripten default; kept explicit
+dnl    pending #745's runtime-load confirmation.
+dnl
+dnl 2. -Zdefault-visibility=hidden
+dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
+dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
+dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all
+dnl    symbols by default leaves only our `#[no_mangle] extern "C"` entry
+dnl    points exported, so the default SIDE_MODULE=1 export set stays tiny.
+dnl    This is savvy's approach (yutannihilation/savvy#372), endorsed by
+dnl    webR's maintainer (r-wasm/webr#532). It is a nightly -Z flag, but the
+dnl    wasm target already mandates nightly via -Z build-std, so it adds no
+dnl    new constraint.
 if test "$is_wasm_install" = true; then
-  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic"
+  ENV_RUSTFLAGS="$ENV_RUSTFLAGS -C relocation-model=pic -Zdefault-visibility=hidden"
 fi
 AC_SUBST([ENV_RUSTFLAGS])
 


### PR DESCRIPTION
Resolves the export-bloat half of #494. My earlier comment on #494 documented the empirical finding from the astra downstream: `-s SIDE_MODULE=1` drags ~3000 mangled Rust symbols into the side-module's EXPORT table and webR's `dyn.load` chokes. The fix is `-Zdefault-visibility=hidden` (savvy's approach, webR-maintainer-endorsed) — one global RUSTFLAG, no per-package `EXPORTED_FUNCTIONS` list.

The important part: I put this in the **minirextendr templates** too, not just rpkg. The templates were *stripping* the whole wasm RUSTFLAGS block, which is exactly why astra had to work around export bloat at the Makevars layer instead of inheriting a fix. With this, scaffolded packages get webR export hygiene out of the box — and astra can drop its `SIDE_MODULE=2` + `EXPORTED_FUNCTIONS` hack once it re-scaffolds or ports.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `rpkg/configure.ac` + `rpkg/configure` (autoconf): the `is_wasm_install` RUSTFLAGS block now appends `-Zdefault-visibility=hidden` alongside the existing `-C relocation-model=pic`.
- `minirextendr/inst/templates/rpkg/configure.ac` + `monorepo/rpkg/configure.ac`: same wasm RUSTFLAGS block added (these previously had no wasm flags — the block was stripped by `patches/templates.patch`).
- `patches/templates.patch`: regenerated via `just templates-approve`; `just templates-check` passes.

## Test plan
- [ ] tier-2 (`webr-install`) Phase 2 still links the side-module with the new flag (validates the flag is accepted by the webR nightly).
- [ ] `Sync Checks` / `templates-check` pass (no template drift).
- [ ] (cross-PR) Once tier-3 (#492) is green, confirm `library(miniextendr)` loads under webR Node — the runtime proof that the export table is now small enough for `dyn.load`. astra already validated this end-to-end with the equivalent narrowed exports.

## Notes
- The flag only activates under `is_wasm_install` (CC=emcc). Native builds — including native builds of scaffolded packages — are completely unaffected, so propagating to templates imposes no nightly requirement on non-webR users.
- `-C relocation-model=pic` is **retained**, not dropped. Tier-2 on PR #749 showed it's redundant for the *link*, but only tier-3 confirms runtime-load safety without it. Keeping it explicit is zero-cost (it's likely the wasm32-emscripten default anyway); dropping it is deferred to a follow-up once tier-3 is green (tracked in #745).
- This is the rpkg-side fix that lets the astra downstream delete its `-s SIDE_MODULE=2 -s EXPORTED_FUNCTIONS=_R_init_<pkg>,_R_unload_<pkg>` lines from `src/Makevars.in`.

Closes #494. Refs #470 (umbrella), #745 (PIC follow-up), #492 (tier-3 runtime validator).

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>