### PR TITLE
build(makevars): portable POSIX make for wrapper-gen (drop ifeq/order-only)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -49,9 +49,10 @@ export CARGO_HOME
 # all must be defined FIRST to be the default target.
 # Depend on both $(SHLIB) and $(WRAPPERS_R) so that:
 #   1. Staticlib builds first ($(SHLIB) needs $(CARGO_AR)), warming the incremental cache
-#   2. On native: cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
-#   3. On native: R wrappers are generated from the cdylib
-#   On wasm32: $(WRAPPERS_R) has no cdylib prereq — pre-generated files are expected.
+#   2. cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
+#   3. R wrappers are generated from the cdylib
+#   On wasm32/tarball: the cdylib prereq's recipe is a no-op, so the committed
+#   wrappers are reused without building (or loading) a cdylib.
 all: $(SHLIB) $(WRAPPERS_R)
 	@# Source install: touch Cargo.toml so pkgbuild always thinks sources changed
 	@# (dev iteration with devtools::load_all() / install() relies on this).
@@ -117,7 +118,11 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# Three-way split on build mode:
+# Three-way split on build mode, branched at the shell level (not with GNU make
+# ifeq/ifndef conditionals) so this Makevars stays portable POSIX make and the
+# package needs no "SystemRequirements: GNU make". $(CARGO_CDYLIB) is always a
+# prerequisite, but its recipe is a no-op in the wasm32 / tarball-without-FORCE
+# modes (see below), so the cdylib is built only when this recipe loads it.
 #   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
@@ -126,54 +131,44 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             a tarball that was manually stripped of its wrappers file.
 #             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
-ifeq ($(IS_WASM_INSTALL),true)
-$(WRAPPERS_R):
-	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
-	@touch $(WRAPPERS_R)
-else ifeq ($(IS_TARBALL_INSTALL),true)
-ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
-$(WRAPPERS_R):
-	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
-	@if [ ! -f '$(WRAPPERS_R)' ]; then \
-	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	  exit 1; \
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
+	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
+	  touch '$(WRAPPERS_R)'; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
+	  if [ ! -f '$(WRAPPERS_R)' ]; then \
+	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	    exit 1; \
+	  fi; \
+	  touch '$(WRAPPERS_R)'; \
+	else \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  else \
+	    echo "Generating R wrappers + wasm_registry.rs..."; \
+	  fi; \
+	  _cdylib='$(CARGO_CDYLIB)'; \
+	  _wrappers='$(WRAPPERS_R)'; \
+	  _wasm_registry='$(WASM_REGISTRY_RS)'; \
+	  if command -v cygpath >/dev/null 2>&1; then \
+	    _cdylib=$$(cygpath -m "$$_cdylib"); \
+	    _wrappers=$$(cygpath -m "$$_wrappers"); \
+	    _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	  fi; \
+	  MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"; \
+	  echo "Removing cdylib to prevent linker collision with staticlib..."; \
+	  rm -f '$(CARGO_CDYLIB)'; \
 	fi
-	@touch $(WRAPPERS_R)
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "Generating R wrappers + wasm_registry.rs..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
+# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
+# modes reuse the committed wrappers and never need a cdylib.
+$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -49,9 +49,10 @@ export CARGO_HOME
 # all must be defined FIRST to be the default target.
 # Depend on both $(SHLIB) and $(WRAPPERS_R) so that:
 #   1. Staticlib builds first ($(SHLIB) needs $(CARGO_AR)), warming the incremental cache
-#   2. On native: cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
-#   3. On native: R wrappers are generated from the cdylib
-#   On wasm32: $(WRAPPERS_R) has no cdylib prereq — pre-generated files are expected.
+#   2. cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
+#   3. R wrappers are generated from the cdylib
+#   On wasm32/tarball: the cdylib prereq's recipe is a no-op, so the committed
+#   wrappers are reused without building (or loading) a cdylib.
 all: $(SHLIB) $(WRAPPERS_R)
 	@# Source install: touch Cargo.toml so pkgbuild always thinks sources changed
 	@# (dev iteration with devtools::load_all() / install() relies on this).
@@ -117,7 +118,11 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# Three-way split on build mode:
+# Three-way split on build mode, branched at the shell level (not with GNU make
+# ifeq/ifndef conditionals) so this Makevars stays portable POSIX make and the
+# package needs no "SystemRequirements: GNU make". $(CARGO_CDYLIB) is always a
+# prerequisite, but its recipe is a no-op in the wasm32 / tarball-without-FORCE
+# modes (see below), so the cdylib is built only when this recipe loads it.
 #   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
@@ -126,54 +131,44 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             a tarball that was manually stripped of its wrappers file.
 #             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
-ifeq ($(IS_WASM_INSTALL),true)
-$(WRAPPERS_R):
-	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
-	@touch $(WRAPPERS_R)
-else ifeq ($(IS_TARBALL_INSTALL),true)
-ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
-$(WRAPPERS_R):
-	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
-	@if [ ! -f '$(WRAPPERS_R)' ]; then \
-	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	  exit 1; \
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
+	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
+	  touch '$(WRAPPERS_R)'; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
+	  if [ ! -f '$(WRAPPERS_R)' ]; then \
+	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	    exit 1; \
+	  fi; \
+	  touch '$(WRAPPERS_R)'; \
+	else \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  else \
+	    echo "Generating R wrappers + wasm_registry.rs..."; \
+	  fi; \
+	  _cdylib='$(CARGO_CDYLIB)'; \
+	  _wrappers='$(WRAPPERS_R)'; \
+	  _wasm_registry='$(WASM_REGISTRY_RS)'; \
+	  if command -v cygpath >/dev/null 2>&1; then \
+	    _cdylib=$$(cygpath -m "$$_cdylib"); \
+	    _wrappers=$$(cygpath -m "$$_wrappers"); \
+	    _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	  fi; \
+	  MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"; \
+	  echo "Removing cdylib to prevent linker collision with staticlib..."; \
+	  rm -f '$(CARGO_CDYLIB)'; \
 	fi
-	@touch $(WRAPPERS_R)
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "Generating R wrappers + wasm_registry.rs..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
+# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
+# modes reuse the committed wrappers and never need a cdylib.
+$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -49,9 +49,10 @@ export CARGO_HOME
 # all must be defined FIRST to be the default target.
 # Depend on both $(SHLIB) and $(WRAPPERS_R) so that:
 #   1. Staticlib builds first ($(SHLIB) needs $(CARGO_AR)), warming the incremental cache
-#   2. On native: cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
-#   3. On native: R wrappers are generated from the cdylib
-#   On wasm32: $(WRAPPERS_R) has no cdylib prereq — pre-generated files are expected.
+#   2. cdylib builds second ($(WRAPPERS_R) needs $(CARGO_CDYLIB)), fast from warm cache
+#   3. R wrappers are generated from the cdylib
+#   On wasm32/tarball: the cdylib prereq's recipe is a no-op, so the committed
+#   wrappers are reused without building (or loading) a cdylib.
 all: $(SHLIB) $(WRAPPERS_R)
 	@# Source install: touch Cargo.toml so pkgbuild always thinks sources changed
 	@# (dev iteration with devtools::load_all() / install() relies on this).
@@ -117,7 +118,11 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 # wasm_registry.rs or the wasm32 build registers stale routines).
 # NAMESPACE is NOT generated here — use devtools::document() for that.
 #
-# Three-way split on build mode:
+# Three-way split on build mode, branched at the shell level (not with GNU make
+# ifeq/ifndef conditionals) so this Makevars stays portable POSIX make and the
+# package needs no "SystemRequirements: GNU make". $(CARGO_CDYLIB) is always a
+# prerequisite, but its recipe is a no-op in the wasm32 / tarball-without-FORCE
+# modes (see below), so the cdylib is built only when this recipe loads it.
 #   wasm32  : cdylib is a .wasm SIDE_MODULE that host R cannot dyn.load;
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
@@ -126,54 +131,44 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             a tarball that was manually stripped of its wrappers file.
 #             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
-ifeq ($(IS_WASM_INSTALL),true)
-$(WRAPPERS_R):
-	@echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"
-	@touch $(WRAPPERS_R)
-else ifeq ($(IS_TARBALL_INSTALL),true)
-ifndef MINIEXTENDR_FORCE_WRAPPER_GEN
-$(WRAPPERS_R):
-	@echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"
-	@if [ ! -f '$(WRAPPERS_R)' ]; then \
-	  echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	  exit 1; \
+$(WRAPPERS_R): $(CARGO_CDYLIB)
+	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
+	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
+	  touch '$(WRAPPERS_R)'; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
+	  if [ ! -f '$(WRAPPERS_R)' ]; then \
+	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
+	    exit 1; \
+	  fi; \
+	  touch '$(WRAPPERS_R)'; \
+	else \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  else \
+	    echo "Generating R wrappers + wasm_registry.rs..."; \
+	  fi; \
+	  _cdylib='$(CARGO_CDYLIB)'; \
+	  _wrappers='$(WRAPPERS_R)'; \
+	  _wasm_registry='$(WASM_REGISTRY_RS)'; \
+	  if command -v cygpath >/dev/null 2>&1; then \
+	    _cdylib=$$(cygpath -m "$$_cdylib"); \
+	    _wrappers=$$(cygpath -m "$$_wrappers"); \
+	    _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
+	  fi; \
+	  MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"; \
+	  echo "Removing cdylib to prevent linker collision with staticlib..."; \
+	  rm -f '$(CARGO_CDYLIB)'; \
 	fi
-	@touch $(WRAPPERS_R)
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
-else
-$(WRAPPERS_R): $(CARGO_CDYLIB)
-	@echo "Generating R wrappers + wasm_registry.rs..."
-	@_cdylib='$(CARGO_CDYLIB)'; \
-	_wrappers='$(WRAPPERS_R)'; \
-	_wasm_registry='$(WASM_REGISTRY_RS)'; \
-	if command -v cygpath >/dev/null 2>&1; then \
-	  _cdylib=$$(cygpath -m "$$_cdylib"); \
-	  _wrappers=$$(cygpath -m "$$_wrappers"); \
-	  _wasm_registry=$$(cygpath -m "$$_wasm_registry"); \
-	fi; \
-	MINIEXTENDR_CDYLIB_WRAPPERS=1 "$(R_HOME)/bin$(R_ARCH)/Rscript" -e "invisible(local({ lib <- dyn.load('$$_cdylib'); .Call(getNativeSymbolInfo('miniextendr_write_wrappers', lib), '$$_wrappers'); .Call(getNativeSymbolInfo('miniextendr_write_wasm_registry', lib), '$$_wasm_registry'); dyn.unload('$$_cdylib') }))"
-	@echo "Removing cdylib to prevent linker collision with staticlib..."
-	@rm -f '$(CARGO_CDYLIB)'
-endif
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) | $(CARGO_AR)
+# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
+# modes reuse the committed wrappers and never need a cdylib.
+$(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \


### PR DESCRIPTION
<TODO: replace this line with your one-paragraph framing in your own voice>

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Removed GNU-make-only constructs from `rpkg/src/Makevars.in` and both `minirextendr/inst/templates/.../Makevars.in`:
  - `ifeq / else ifeq / ifndef / else / endif` block that selected the `$(WRAPPERS_R)` recipe (and its prerequisite) per build mode.
  - Order-only prerequisite `| $(CARGO_AR)` on `$(CARGO_CDYLIB)` (also GNU-only, beyond what the original report flagged).
- `$(WRAPPERS_R)` is now one target whose recipe branches at the shell level on the already-configure-substituted `$(IS_WASM_INSTALL)` / `$(IS_TARBALL_INSTALL)` (plus the `MINIEXTENDR_FORCE_WRAPPER_GEN` env var for the tarball-debug override).
- `$(CARGO_CDYLIB)` stays a direct prerequisite, so the dev dependency graph is unchanged (no recursive make). Its build recipe early-exits as a no-op in wasm32 / tarball-without-FORCE modes, preserving the 10 to 30 second cdylib-build skip those modes rely on.
- All three `Makevars.in` files remain byte-identical (`just templates-check` still passes, the rpkg-to-template delta in `patches/templates.patch` is unchanged).
- No `configure.ac` change, so no `autoconf` regen and no risk of an autoconf-version-skew diff in `rpkg/configure`.
- Package declares no `SystemRequirements: GNU make`, so these were portability violations under Writing R Extensions 1.2.1.

## Test plan
- [x] GNU make parses both the `.in` and the configure-generated `rpkg/src/Makevars`.
- [x] `sh -n` on each recipe body, all build modes, passes.
- [x] Functional execution of each recipe with stubbed `Rscript` confirms correct branch selection across dev, wasm32, tarball, tarball-with-missing-wrappers (errors with exit 1), and tarball+FORCE.
- [x] All recipe lines start with a literal TAB; no col-0 GNU directives remain; no order-only `|` remains.
- [x] `just configure` and `just templates-check` pass in the worktree.
- [ ] Full cold \`R CMD INSTALL\` against R 4.6: not run locally (blocked on the fresh worktree's unsynced rv library, which is orthogonal to this change). CI should exercise it.

## Notes
- The cargo, cdylib, and \`Rscript\` invocations inside the dev path are byte-identical to before the rewrite. The only semantic change is that \`set -e\` now spans the whole recipe as a single shell invocation (previously each \`@\`-prefixed line was its own shell), which is strictly more robust under partial failure.
- Dropping the order-only \`|\` is beyond the two extensions the original report flagged. It is included because \`FORCE_CARGO\` is already a normal prerequisite of \`\$(CARGO_CDYLIB)\`, so \`\$(CARGO_AR)\` being order-only vs normal is behaviorally identical here. Happy to revert that part alone if you would rather keep the diff tightly scoped to \`ifeq\`.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>