### PR TITLE
fix(wasm): keep miniextendr_force_link exported under -Zdefault-visibility=hidden

### DIFF
--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -2749,12 +2749,19 @@ pub fn miniextendr_init(input: proc_macro::TokenStream) -> proc_macro::TokenStre
             ::miniextendr_api::worker::miniextendr_runtime_shutdown();
         }
 
-        /// Linker anchor: stub.c references this symbol to force the linker to pull
-        /// in the user crate's archive member from the staticlib. With codegen-units = 1,
-        /// this single member contains all linkme distributed_slice entries.
-        /// The name is package-independent so stub.c doesn't need configure substitution.
+        /// Linker anchor: stub.c takes the address of this symbol to force the
+        /// linker to pull in the user crate's archive member from the staticlib.
+        /// With codegen-units = 1, this single member contains all linkme
+        /// distributed_slice entries. The name is package-independent so stub.c
+        /// doesn't need configure substitution.
+        ///
+        /// Defined as a function rather than a static so it stays exported under
+        /// the webR wasm RUSTFLAG -Zdefault-visibility=hidden, which keeps
+        /// no_mangle functions exported (like the R_init entry point) but hides
+        /// no_mangle statics. A hidden anchor breaks wasm side-module dlopen
+        /// (bad export type, undefined). See miniextendr webR notes (#494).
         #[unsafe(no_mangle)]
-        pub static miniextendr_force_link: ::std::ffi::c_char = 0;
+        pub extern "C" fn miniextendr_force_link() {}
     };
 
     expanded.into()

--- a/minirextendr/inst/templates/monorepo/rpkg/stub.c
+++ b/minirextendr/inst/templates/monorepo/rpkg/stub.c
@@ -9,5 +9,5 @@
 //
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!(), so this file works for any package without substitution.
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;

--- a/minirextendr/inst/templates/rpkg/stub.c
+++ b/minirextendr/inst/templates/rpkg/stub.c
@@ -9,5 +9,5 @@
 //
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!(), so this file works for any package without substitution.
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;

--- a/rpkg/src/stub.c
+++ b/rpkg/src/stub.c
@@ -9,5 +9,5 @@
 //
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!(), so this file works for any package without substitution.
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;

--- a/tests/cross-package/consumer.pkg/src/stub.c
+++ b/tests/cross-package/consumer.pkg/src/stub.c
@@ -9,5 +9,5 @@
 //
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!(), so this file works for any package without substitution.
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;

--- a/tests/cross-package/producer.pkg/src/stub.c
+++ b/tests/cross-package/producer.pkg/src/stub.c
@@ -9,5 +9,5 @@
 //
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!(), so this file works for any package without substitution.
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;

--- a/tests/model_project/src/stub.c
+++ b/tests/model_project/src/stub.c
@@ -4,5 +4,5 @@
 // miniextendr_force_link is a package-independent symbol emitted by
 // miniextendr_init!() that forces the linker to pull in the user crate's
 // archive member (containing all linkme distributed_slice entries).
-extern const char miniextendr_force_link;
-const void *miniextendr_anchor = &miniextendr_force_link;
+extern void miniextendr_force_link(void);
+void (*const miniextendr_anchor)(void) = miniextendr_force_link;


### PR DESCRIPTION
Fixes a regression from #751: wasm side-modules built for webR fail to load — `library()` of any wasm-built miniextendr package errors at `dlopen` with `bad export type for 'miniextendr_force_link': undefined`.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- #751 added `-Zdefault-visibility=hidden` to the webR wasm RUSTFLAGS to trim the side-module export table. That flag keeps `#[no_mangle] extern "C"` functions exported (`R_init_*`) but hides `#[no_mangle]` statics.
- `miniextendr_init!()` emits `miniextendr_force_link` as a `pub static`, and `stub.c` takes its address as the linker anchor. Under wasm the hidden static becomes an unresolvable GOT import, so the side-module fails to `dlopen`:
  ```
  Error: bad export type for 'miniextendr_force_link': undefined
  ```
- Fix: emit `miniextendr_force_link` as a `#[no_mangle] extern "C" fn` instead of a static, so it stays exported like the other entry points. Every `stub.c` now takes the function's address (`rpkg`, both minirextendr templates, the two cross-package test packages, and `tests/model_project`).
- Native builds are unaffected: taking a function's address forces archive-member extraction the same way the static reference did.

## Test plan
- [ ] `tests/webr-smoke.sh` (and the tier-2 wasm CI, #491): confirm `library(miniextendr)` loads under wasm, which is the check that should have caught the original regression.
- [ ] A native `R CMD INSTALL` of `rpkg` still links and loads (stub.c function-address reference).
- [ ] No wrapper/NAMESPACE regeneration is needed: `force_link` is not a `#[miniextendr]` item, so it does not change generated wrapper output.

## Notes
- Verified end-to-end downstream: a wasm-built consumer package (`miniRpkg`) loads in headless-Chrome webR after this change (`add(2,3)=5`, `hello()` greeting), where it failed before.
- Relates to #494 / #751.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
