### PR TITLE
fix(wasm): run worker inline on wasm (keep worker-thread feature)

### DIFF
--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -134,8 +134,9 @@ where
         return f();
     }
 
-    // Not on main thread — need worker-thread feature for routing
-    #[cfg(not(feature = "worker-thread"))]
+    // Not on main thread — need worker-thread routing (absent on wasm, where
+    // there is only the single R thread, so this branch is unreachable there).
+    #[cfg(not(all(feature = "worker-thread", not(target_family = "wasm"))))]
     {
         panic!(
             "with_r_thread called from a non-main thread without the `worker-thread` feature.\n\
@@ -147,7 +148,7 @@ where
         );
     }
 
-    #[cfg(feature = "worker-thread")]
+    #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
     {
         worker_channel::route_to_main_thread(f)
     }
@@ -200,12 +201,18 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    #[cfg(not(feature = "worker-thread"))]
+    // On wasm there is no worker thread even when the feature is enabled
+    // (R-on-wasm is single-threaded; emscripten has no usable pthreads), so we
+    // run inline — identical to a non-`worker-thread` build. The feature stays
+    // *enabled* on wasm so worker-gated routines still compile and the
+    // pre-generated `wasm_registry.rs` (built with the feature) has no dangling
+    // entries. See `worker_active` reasoning at the top of the worker functions.
+    #[cfg(not(all(feature = "worker-thread", not(target_family = "wasm"))))]
     {
         Ok(f())
     }
 
-    #[cfg(feature = "worker-thread")]
+    #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
     {
         let result = worker_channel::dispatch_to_worker(f);
         if let Err(ref msg) = result {
@@ -224,7 +231,9 @@ where
 pub extern "C-unwind" fn miniextendr_runtime_init() {
     static RUN_ONCE: std::sync::Once = std::sync::Once::new();
 
-    #[cfg(feature = "worker-thread")]
+    // wasm: never spawn a worker (single-threaded; spawning traps at load).
+    // Falls through to the inline init path below even with the feature on.
+    #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
     {
         RUN_ONCE.call_once_force(|x| {
             if x.is_poisoned() {
@@ -266,7 +275,7 @@ pub extern "C-unwind" fn miniextendr_runtime_init() {
         });
     }
 
-    #[cfg(not(feature = "worker-thread"))]
+    #[cfg(not(all(feature = "worker-thread", not(target_family = "wasm"))))]
     {
         RUN_ONCE.call_once(|| {
             let _ = R_MAIN_THREAD_ID.set(std::thread::current().id());
@@ -294,7 +303,9 @@ pub extern "C-unwind" fn miniextendr_runtime_init() {
 #[doc(hidden)]
 #[unsafe(no_mangle)]
 pub extern "C-unwind" fn miniextendr_runtime_shutdown() {
-    #[cfg(feature = "worker-thread")]
+    // wasm never spawns a worker, so there is nothing to join (and the channel
+    // was never initialised) — skip shutdown there even with the feature on.
+    #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
     {
         worker_channel::shutdown();
     }
@@ -306,11 +317,11 @@ pub extern "C-unwind" fn miniextendr_runtime_shutdown() {
 
 /// Check whether the current thread has a worker routing context.
 pub(crate) fn has_worker_context() -> bool {
-    #[cfg(feature = "worker-thread")]
+    #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
     {
         worker_channel::has_context()
     }
-    #[cfg(not(feature = "worker-thread"))]
+    #[cfg(not(all(feature = "worker-thread", not(target_family = "wasm"))))]
     {
         false
     }
@@ -337,8 +348,13 @@ fn assert_runtime_initialized() {
 // endregion
 
 // region: Worker channel infrastructure (only with worker-thread feature)
+//
+// Compiled only on non-wasm worker-thread builds. On wasm the feature stays
+// enabled (so worker-gated routines compile and `wasm_registry.rs` matches),
+// but every caller above takes the inline path, so this module is omitted to
+// avoid dead-code and to keep the single-threaded wasm side-module clean.
 
-#[cfg(feature = "worker-thread")]
+#[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]
 mod worker_channel {
     use std::any::Any;
     use std::cell::RefCell;


### PR DESCRIPTION
Stacks on #756. With #756 the wasm side-module loads, but `library()` still trapped at module init because the worker thread can't spawn on single-threaded webR. This makes the worker run inline on wasm while keeping the feature on, so registry parity holds. Together with #756 this gets rpkg loading **and running** under webR (verified via Node tier-3: library loads, version 0.1.0).

> Base is `fix/webr-force-link-visibility` (#756) so wasm CI stays green — on bare `main` this branch would hit the very `force_link` bug #756 fixes. Retarget to `main` after #756 merges.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- webR/wasm R is single-threaded (emscripten has no usable pthreads). The worker thread spawned at `miniextendr_runtime_init` traps at load with a `WebAssembly.Exception`, so `library()` of any wasm-built miniextendr package fails after the side-module otherwise loads.
- Gate every worker-spawning path in `miniextendr-api/src/worker.rs` on `all(feature = "worker-thread", not(target_family = "wasm"))` (negating the fallbacks) so wasm takes the existing inline `Ok(f())` path.
- The feature stays **enabled** on wasm so worker-gated routines still compile and the pre-generated `wasm_registry.rs` (built with the feature) has no dangling entries. Dropping the feature instead would skew the registry by ~31 `C_*` symbols.
- Native is unchanged: `not(target_family = "wasm")` is always true there, so the gates collapse to the original `feature = "worker-thread"` behavior. Test-only cfg sites stay on the plain feature (native-only, behaviorally identical).
- This is the third and last of the three independent root causes behind the wasm load failure: (1) `force_link` static→fn = #756; (2) registry/build feature parity (env invariant, CI shares `R_LIBS_USER`); (3) worker spawn = this PR.

## Test plan
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default) — clean
- [x] `cargo clippy ... --features <clippy_all list>` — clean
- [x] Native `cargo check -p miniextendr-api --features worker-thread` — clean (gates collapse to original)
- [x] wasm staticlib rebuild + side-module relink — 0 unresolved GOT.func; `C_test_worker_*` and `C_test_new_rcrd` both defined (registry parity intact)
- [x] Node tier-3 webR smoke — `library(miniextendr)` loads, version 0.1.0, "Tier-3 PASSED"
- [ ] CI `wasm32 R CMD INSTALL (tier 2)` on the stacked base

## Notes
- Why browser webR masked this: browser webR has pthreads (Web Worker + SharedArrayBuffer), so the spawn doesn't trap there — a downstream consumer loaded fine in headless Chrome without this fix. Node webR (and CI's tier-3) is single-threaded and does trap, which is why this is needed for #492.
- rayon also uses threads but initializes lazily (only on a parallel iterator, not at load), so it doesn't trap at `library()`; deferred unless it surfaces.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>