### PR TITLE
fix(convert): reject NA logical in bare integer scalar coercion (#761)

### DIFF
--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -21,8 +21,21 @@
 
 use crate::altrep_traits::NA_INTEGER;
 use crate::coerce::TryCoerce;
-use crate::from_r::{SexpError, TryFromSexp, is_na_real};
+use crate::from_r::{SexpError, SexpNaError, TryFromSexp, is_na_real};
 use crate::{RLogical, SEXP, SEXPTYPE, SexpExt};
+
+/// NA-rejecting error for a logical (`LGLSXP`) scalar that holds `NA`.
+///
+/// The bare integer/float scalar paths must reject `NA_logical_` rather than
+/// silently coercing R's `NA_LOGICAL` sentinel (`i32::MIN`) into a finite
+/// number. Mirrors the guard the bare `i32` (`INTSXP`) impl already applies.
+#[inline]
+fn lglsxp_na_error() -> SexpError {
+    SexpNaError {
+        sexp_type: SEXPTYPE::LGLSXP,
+    }
+    .into()
+}
 
 #[inline]
 pub(crate) fn coerce_value<R, T>(value: R) -> Result<T, SexpError>
@@ -61,6 +74,9 @@ where
         }
         SEXPTYPE::LGLSXP => {
             let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
+            if value.is_na() {
+                return Err(lglsxp_na_error());
+            }
             coerce_value(value.to_i32())
         }
         _ => Err(SexpError::InvalidValue(format!(
@@ -96,6 +112,9 @@ where
         }
         SEXPTYPE::LGLSXP => {
             let value: RLogical = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
+            if value.is_na() {
+                return Err(lglsxp_na_error());
+            }
             coerce_value(value.to_i32())
         }
         _ => Err(SexpError::InvalidValue(format!(
@@ -318,6 +337,9 @@ impl TryFromSexp for f32 {
             }
             SEXPTYPE::LGLSXP => {
                 let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
+                if value.is_na() {
+                    return Err(lglsxp_na_error());
+                }
                 Ok(value.to_i32() as f32)
             }
             _ => Err(SexpError::InvalidValue(format!(
@@ -345,6 +367,9 @@ impl TryFromSexp for f32 {
             }
             SEXPTYPE::LGLSXP => {
                 let value: RLogical = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
+                if value.is_na() {
+                    return Err(lglsxp_na_error());
+                }
                 Ok(value.to_i32() as f32)
             }
             _ => Err(SexpError::InvalidValue(format!(
@@ -629,6 +654,9 @@ impl TryFromSexp for usize {
             SEXPTYPE::LGLSXP => {
                 use crate::coerce::TryCoerce;
                 let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
+                if value.is_na() {
+                    return Err(lglsxp_na_error());
+                }
                 value
                     .to_i32()
                     .try_coerce()
@@ -738,6 +766,9 @@ impl TryFromSexp for isize {
             SEXPTYPE::LGLSXP => {
                 use crate::coerce::Coerce;
                 let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
+                if value.is_na() {
+                    return Err(lglsxp_na_error());
+                }
                 Ok(value.to_i32().coerce())
             }
             _ => Err(SexpError::InvalidValue(format!(

--- a/miniextendr-api/tests/from_r.rs
+++ b/miniextendr-api/tests/from_r.rs
@@ -85,6 +85,7 @@ fn from_r_suite() {
         test_string_conversions();
         test_coerced_conversions();
         test_error_cases();
+        test_na_logical_bare_scalar_rejected();
     });
 }
 
@@ -238,6 +239,66 @@ fn test_error_cases() {
         let big_int = guard.protect(SEXP::scalar_integer(1000));
         let coerced_err: Result<Coerced<u8, i32>, SexpError> = TryFromSexp::try_from_sexp(big_int);
         assert!(matches!(coerced_err, Err(SexpError::InvalidValue(_))));
+    }
+}
+
+/// Regression test for #761: a bare integer / float scalar conversion from a
+/// `LGLSXP` holding `NA_logical_` must return `Err(SexpError::Na(_))`, NOT the
+/// silently-coerced `NA_LOGICAL` sentinel (`i32::MIN`). The `Option<T>` path
+/// must keep returning `Ok(None)`, and non-NA logicals must keep working.
+fn test_na_logical_bare_scalar_rejected() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let na_log = guard.protect(SEXP::scalar_logical_raw(NA_LOGICAL));
+        let true_log = guard.protect(SEXP::scalar_logical(true));
+        let false_log = guard.protect(SEXP::scalar_logical(false));
+
+        // The coerced multi-source integer/float targets (i64/u64/i8/i16/u16/
+        // u32/isize/usize/f32) accept a LGLSXP and must reject NA with
+        // SexpError::Na rather than coercing R's NA_LOGICAL sentinel
+        // (i32::MIN). Bare `i32`/`f64` are the *strict* native paths and
+        // reject LGLSXP outright (SexpError::Type), so they're not exercised
+        // here — only the coerced targets had the silent-passthrough bug.
+        let err = <i64 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "i64: {err:?}");
+        let err = <i8 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "i8: {err:?}");
+        let err = <i16 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "i16: {err:?}");
+        let err = <u16 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "u16: {err:?}");
+        let err = <u32 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "u32: {err:?}");
+        let err = <u64 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "u64: {err:?}");
+        let err = <f32 as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "f32: {err:?}");
+        let err = <usize as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "usize: {err:?}");
+        let err = <isize as TryFromSexp>::try_from_sexp(na_log).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "isize: {err:?}");
+
+        // The Option<T> path still maps NA logical to None.
+        let opt_i64: Option<i64> = TryFromSexp::try_from_sexp(na_log).unwrap();
+        assert!(opt_i64.is_none());
+        let opt_isize: Option<isize> = TryFromSexp::try_from_sexp(na_log).unwrap();
+        assert!(opt_isize.is_none());
+        let opt_usize: Option<usize> = TryFromSexp::try_from_sexp(na_log).unwrap();
+        assert!(opt_usize.is_none());
+        let opt_f32: Option<f32> = TryFromSexp::try_from_sexp(na_log).unwrap();
+        assert!(opt_f32.is_none());
+
+        // Non-NA logicals still coerce on the coerced path: TRUE -> 1, FALSE -> 0.
+        let one: i64 = TryFromSexp::try_from_sexp(true_log).unwrap();
+        let zero: i64 = TryFromSexp::try_from_sexp(false_log).unwrap();
+        assert_eq!(one, 1);
+        assert_eq!(zero, 0);
+        let one_f32: f32 = TryFromSexp::try_from_sexp(true_log).unwrap();
+        assert_eq!(one_f32, 1.0);
+        let zero_isize: isize = TryFromSexp::try_from_sexp(false_log).unwrap();
+        assert_eq!(zero_isize, 0);
+        let one_usize: usize = TryFromSexp::try_from_sexp(true_log).unwrap();
+        assert_eq!(one_usize, 1);
     }
 }
 


### PR DESCRIPTION
Bare integer/float `TryFromSexp` on the coerced multi-source scalar path silently returned R's `NA_LOGICAL` sentinel (`i32::MIN`, widened to e.g. `-2147483648i64`) instead of an error when an R `LGLSXP` held `NA_logical_`. A Rust `#[miniextendr]` function taking a bare `i64` would receive `-2147483648` for `NA`. This adds the missing NA guard.

<details>
<summary>AI-generated details</summary>

## What was wrong
The coerced scalar arm for `LGLSXP` read `RLogical`, called `to_i32()` (which returns `i32::MIN` for `NA`), then infallibly coerced it to the target type and returned `Ok(...)`. The `Option<T>` path already handled NA correctly (`Ok(None)`); only the bare-scalar path lacked the guard.

## The fix
Added a NA guard to every bare-scalar `LGLSXP` arm, returning `Err(SexpError::Na(SexpNaError { sexp_type: LGLSXP }))` — the same error shape the bare `i32` (INTSXP) impl already uses. Arms fixed:

- `try_from_sexp_numeric_scalar` + `_unchecked` (drives `i8`/`i16`/`u16`/`u32`/`i64`/`u64`)
- `f32` impl (checked + unchecked)
- `usize` impl
- `isize` impl

## Audit of sibling coerced arms
- **REALSXP**: safe. `NA_real_` is a NaN and `f64: TryCoerce<int>` already rejects NaN (`CoerceError::NaN`). No silent passthrough.
- **RAWSXP**: safe. R raw vectors have no NA.
- **bare `i32`/`f64`**: these are the *strict* native paths and reject `LGLSXP` outright with `SexpError::Type` — they were never on the coerced LGLSXP path, so the issue's "check i32 too" concern is moot.

No follow-up issue needed.

## Invariants preserved
- `Option<T>` from NA logical still returns `Ok(None)`.
- Non-NA logicals (`TRUE`/`FALSE`) still coerce to `1`/`0`.

## Tests
Added `test_na_logical_bare_scalar_rejected` in `miniextendr-api/tests/from_r.rs` asserting all coerced targets (`i64`/`u64`/`i8`/`i16`/`u16`/`u32`/`isize`/`usize`/`f32`) → `Err(Na)`, `Option<T>` → `Ok(None)`, and `TRUE`/`FALSE` → `Ok(1)`/`Ok(0)`.

`cargo test -p miniextendr-api`, `cargo fmt --all`, `clippy_default`, and `clippy_all` (`-D warnings`) all pass locally.

Closes #761
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)