### PR TITLE
ci: gate heap-checking test rounds behind `heap-check` PR label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,6 +835,15 @@ jobs:
         run: Rscript -e "testthat::test_local()"
 
       - name: Run tests with heap checking (3 rounds, randomized order)
+        # Heap checking (glibc MALLOC_CHECK_, 3 randomized rounds) is the
+        # GC-discipline guard, but it runs ~30+ min and reliably overruns the
+        # 45-min job budget (bumped 30 -> 45 in #732 and still cancelling).
+        # Gate it on PRs behind the `heap-check` label so routine PRs stay fast;
+        # still run it unconditionally on push-to-main, the weekly schedule, and
+        # manual dispatch so merged code keeps its GC safety net.
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'heap-check')
         working-directory: rpkg
         shell: bash
         env:


### PR DESCRIPTION
The heap-check step is the long pole that keeps red-X'ing the `CI Success` gate on PRs for a pure infra-duration reason (it overruns the r-tests 45-min budget — we already bumped it 30→45 in #732 and it still cancels). This makes it opt-in per-PR via a `heap-check` label, while keeping it always-on for main/scheduled runs so we don't lose GC coverage on merged code.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add an `if:` to the `Run tests with heap checking (3 rounds, randomized order)` step in `.github/workflows/ci.yml`:
  ```yaml
  if: >-
    github.event_name != 'pull_request' ||
    contains(github.event.pull_request.labels.*.name, 'heap-check')
  ```
- On PRs the step runs only when the `heap-check` label is present; routine PRs skip it and the r-tests job lands in ~30 min (install ~19 + tests ~9 + valgrind), under the 45-min budget.
- On `push` to main, the weekly `schedule`, and `workflow_dispatch` the step always runs, so merged code keeps its GC-discipline safety net.
- The regular `Run tests` step and the `Run ALTREP tests under Valgrind` step (`if: always()`, filtered + non-blocking) are unaffected and still run on every PR.
- Created the `heap-check` repo label.

## Test plan
- [ ] This PR (no label): `R tests / Linux` completes without the heap-check step and `CI Success` goes green.
- [ ] Applying the `heap-check` label and re-running includes the heap-check step.

## Notes
- Rationale for keeping it on main/schedule rather than removing it: the rounds catch GC-discipline regressions (`gctorture`/heap corruption) that R-release CI otherwise hides — see CLAUDE.md "Stress-test GC discipline".
- Does not change the 45-min `timeout-minutes`; if a labeled PR's heap rounds still overrun, that's a separate budget question.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>