### PR TITLE
test(macros): regenerate stale extern_* UI snapshots (sys::SEXP re-export drift)

### DIFF
--- a/miniextendr-macros/tests/ui/extern_missing_no_mangle.stderr
+++ b/miniextendr-macros/tests/ui/extern_missing_no_mangle.stderr
@@ -4,5 +4,5 @@ error: extern "C-unwind" functions need a visible C symbol for R's .Call interfa
          - `#[export_name = "my_symbol"]` (custom symbol name)
  --> tests/ui/extern_missing_no_mangle.rs:5:1
   |
-5 | extern "C-unwind" fn C_bad(_x: miniextendr_api::sys::SEXP) -> miniextendr_api::sys::SEXP {
+5 | extern "C-unwind" fn C_bad(_x: miniextendr_api::SEXP) -> miniextendr_api::SEXP {
   | ^^^^^^

--- a/miniextendr-macros/tests/ui/extern_non_sexp_param.stderr
+++ b/miniextendr-macros/tests/ui/extern_non_sexp_param.stderr
@@ -1,5 +1,5 @@
 error: extern function parameters must be SEXP - .Call passes all arguments as SEXP
  --> tests/ui/extern_non_sexp_param.rs:6:32
   |
-6 | extern "C-unwind" fn C_bad(_x: i32) -> miniextendr_api::sys::SEXP {
+6 | extern "C-unwind" fn C_bad(_x: i32) -> miniextendr_api::SEXP {
   |                                ^^^

--- a/miniextendr-macros/tests/ui/extern_non_sexp_return.stderr
+++ b/miniextendr-macros/tests/ui/extern_non_sexp_return.stderr
@@ -1,5 +1,5 @@
 error: extern "C-unwind" functions must return SEXP, found `i32`. R's .Call interface expects SEXP return values. Change the return type to `miniextendr_api::SEXP`, or remove `extern "C-unwind"` to let the macro handle type conversion.
- --> tests/ui/extern_non_sexp_return.rs:6:63
+ --> tests/ui/extern_non_sexp_return.rs:6:58
   |
-6 | extern "C-unwind" fn C_bad(_x: miniextendr_api::sys::SEXP) -> i32 {
-  |                                                               ^^^
+6 | extern "C-unwind" fn C_bad(_x: miniextendr_api::SEXP) -> i32 {
+  |                                                          ^^^

--- a/miniextendr-macros/tests/ui/extern_variadic.stderr
+++ b/miniextendr-macros/tests/ui/extern_variadic.stderr
@@ -1,5 +1,5 @@
 error: extern functions cannot use Dots; use `...` syntax in non-extern #[miniextendr] functions instead
  --> tests/ui/extern_variadic.rs:7:35
   |
-7 | extern "C-unwind" fn C_bad(_dots: &miniextendr_api::Dots) -> miniextendr_api::sys::SEXP {
+7 | extern "C-unwind" fn C_bad(_dots: &miniextendr_api::Dots) -> miniextendr_api::SEXP {
   |                                   ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- Four `extern_*` UI test snapshots in `miniextendr-macros/tests/ui/` were stale: they expected `miniextendr_api::sys::SEXP` in compiler output but the test `.rs` files (which represent the actual code under test) already use the re-exported `miniextendr_api::SEXP` path. This caused all four to fail with a path-text mismatch on clean `main`.
- Regenerated with `TRYBUILD=overwrite cargo test -p miniextendr-macros`. Only the `sys::SEXP` → `SEXP` path string changed (plus the column offset shift in `extern_non_sexp_return.stderr` that follows from the shorter type name). No source or logic changes.
- This unblocks #765 and #770 from having to carry this incidental snapshot fixup in their feature diffs.

## Files changed

- `miniextendr-macros/tests/ui/extern_missing_no_mangle.stderr`
- `miniextendr-macros/tests/ui/extern_non_sexp_param.stderr`
- `miniextendr-macros/tests/ui/extern_non_sexp_return.stderr`
- `miniextendr-macros/tests/ui/extern_variadic.stderr`

## Test plan

- [x] `cargo test -p miniextendr-macros` passes (all 125 UI tests green, 320 unit tests green)
- [x] `git diff --name-only` shows exactly these 4 `.stderr` files and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)