### PR TITLE
ci(fmt): rustfmt-check all manifests + sweep rpkg/src/rust drift (#785)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,10 +216,18 @@ jobs:
           shared-key: rust-lint
           cache-on-failure: true
 
+      # `just fmt-check` iterates every manifest (root workspace +
+      # rpkg/src/rust + tests/cross-package/*), not just the root workspace —
+      # the non-root manifests are separate cargo workspaces that `cargo fmt
+      # --all` alone never reaches. `cargo fmt --check` needs no dep
+      # resolution / .cargo/config.toml, so this runs without `just configure`.
+      - name: Install just
+        uses: taiki-e/install-action@just
+
       - name: Rustfmt
         id: rustfmt
         continue-on-error: true
-        run: cargo fmt --all -- --check 2>&1 | tee "$RUNNER_TEMP/rustfmt.log"
+        run: just fmt-check 2>&1 | tee "$RUNNER_TEMP/rustfmt.log"
         shell: bash
 
       - name: Clippy (default features)

--- a/rpkg/src/rust/altrep_sexp_tests.rs
+++ b/rpkg/src/rust/altrep_sexp_tests.rs
@@ -1,8 +1,8 @@
 use miniextendr_api::IntoR;
-use miniextendr_api::altrep_sexp::{AltrepSexp, ensure_materialized};
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::SEXPTYPE;
+use miniextendr_api::altrep_sexp::{AltrepSexp, ensure_materialized};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::{SEXP, SexpExt};
 
 /// Check if a SEXP is ALTREP and return info about it.
 ///

--- a/rpkg/src/rust/arrow_na_tests.rs
+++ b/rpkg/src/rust/arrow_na_tests.rs
@@ -13,8 +13,8 @@
 use miniextendr_api::arrow_impl::{
     Array, BooleanArray, Float64Array, Int32Array, RecordBatch, StringArray,
 };
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 // region: Float64Array NA patterns
 

--- a/rpkg/src/rust/as_coerce_tests.rs
+++ b/rpkg/src/rust/as_coerce_tests.rs
@@ -5,8 +5,8 @@
 
 use miniextendr_api::as_coerce::AsCoerceError;
 use miniextendr_api::{
-    ExternalPtr, IntoR, List, ListBuilder, OwnedProtect, ProtectScope, SEXP, SEXPTYPE,
-    SexpExt, miniextendr, sys,
+    ExternalPtr, IntoR, List, ListBuilder, OwnedProtect, ProtectScope, SEXP, SEXPTYPE, SexpExt,
+    miniextendr, sys,
 };
 
 /// Test struct for `as.<class>` coercion methods.

--- a/rpkg/src/rust/call_attribution_demo.rs
+++ b/rpkg/src/rust/call_attribution_demo.rs
@@ -5,8 +5,8 @@
 //! `extern "C-unwind"`, which has no generated R wrapper and so no call slot.
 //! The R-side error rendering is dramatically different.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 /// Wrapped path. The generated R wrapper passes `.call = match.call()` into the
 /// C entry; on panic, `Rf_errorcall(call, msg)` shows the user's call frame.

--- a/rpkg/src/rust/columnar_flatten_tests.rs
+++ b/rpkg/src/rust/columnar_flatten_tests.rs
@@ -550,18 +550,12 @@ struct BadRow {
 
 fn make_mixed_rows() -> Vec<Result<GoodRow, BadRow>> {
     vec![
-        Ok(GoodRow {
-            id: 1,
-            value: 1.0,
-        }),
+        Ok(GoodRow { id: 1, value: 1.0 }),
         Err(BadRow {
             id: 2,
             reason: "bad".into(),
         }),
-        Ok(GoodRow {
-            id: 3,
-            value: 3.0,
-        }),
+        Ok(GoodRow { id: 3, value: 3.0 }),
     ]
 }
 
@@ -572,14 +566,8 @@ fn make_mixed_rows() -> Vec<Result<GoodRow, BadRow>> {
 pub fn test_result_to_dataframe_auto_all_ok() -> DataFrameShape {
     use miniextendr_api::serde::ResultShape;
     let rows: Vec<Result<GoodRow, BadRow>> = vec![
-        Ok(GoodRow {
-            id: 1,
-            value: 1.0,
-        }),
-        Ok(GoodRow {
-            id: 2,
-            value: 2.0,
-        }),
+        Ok(GoodRow { id: 1, value: 1.0 }),
+        Ok(GoodRow { id: 2, value: 2.0 }),
     ];
     miniextendr_api::serde::result_to_dataframe(
         &rows,

--- a/rpkg/src/rust/connection_tests.rs
+++ b/rpkg/src/rust/connection_tests.rs
@@ -6,9 +6,9 @@
 #[cfg(feature = "connections")]
 use miniextendr_api::connection::{RConnectionImpl, RConnectionIo, RCustomConnection};
 #[cfg(feature = "connections")]
-use miniextendr_api::prelude::SEXP;
-#[cfg(feature = "connections")]
 use miniextendr_api::miniextendr;
+#[cfg(feature = "connections")]
+use miniextendr_api::prelude::SEXP;
 #[cfg(feature = "connections")]
 use std::io::Cursor;
 

--- a/rpkg/src/rust/conversions.rs
+++ b/rpkg/src/rust/conversions.rs
@@ -1,8 +1,8 @@
 //! Comprehensive conversions matrix for [`#[miniextendr]`](miniextendr_api::miniextendr) arguments and returns.
 
 use miniextendr_api::prelude::SEXP;
-use miniextendr_api::{RLogical, Rboolean};
 use miniextendr_api::{IntoR, ListMut, miniextendr};
+use miniextendr_api::{RLogical, Rboolean};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 // -----------------------------------------------------------------------------
@@ -1503,8 +1503,7 @@ pub fn conv_as_named_list_array() -> AsNamedList<[(String, f64); 2]> {
 
 /// Return test: `AsNamedList` with heterogeneous SEXP values -> R named list.
 #[miniextendr]
-pub fn conv_as_named_list_heterogeneous() -> AsNamedList<Vec<(String, miniextendr_api::SEXP)>>
-{
+pub fn conv_as_named_list_heterogeneous() -> AsNamedList<Vec<(String, miniextendr_api::SEXP)>> {
     use miniextendr_api::IntoR;
     AsNamedList(vec![
         ("name".into(), "Alice".to_string().into_sexp()),

--- a/rpkg/src/rust/externalptr_tests.rs
+++ b/rpkg/src/rust/externalptr_tests.rs
@@ -1,8 +1,8 @@
 //! Tests for ExternalPtr functionality.
 
 use miniextendr_api::externalptr::ErasedExternalPtr;
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 /// A simple test struct for ExternalPtr
 #[derive(miniextendr_api::ExternalPtr, Debug)]

--- a/rpkg/src/rust/gc_protect_tests.rs
+++ b/rpkg/src/rust/gc_protect_tests.rs
@@ -2,13 +2,13 @@
 //!
 //! These tests verify that the protection APIs work correctly.
 
-use miniextendr_api::prelude::SexpExt;
 use miniextendr_api::SEXPTYPE;
-use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::gc_protect::ProtectScope;
 use miniextendr_api::list::{List, ListBuilder};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SexpExt;
 use miniextendr_api::strvec::{StrVec, StrVecBuilder};
+use miniextendr_api::sys::Rf_allocVector;
 
 // region: ListBuilder tests
 

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -5,9 +5,9 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::SEXPTYPE;
 use miniextendr_api::into_r::IntoR;
+use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::{IntoRAltrep, miniextendr};
 #[cfg(feature = "jiff")]
 use miniextendr_api::{JiffZonedVec, Timestamp};
@@ -596,8 +596,8 @@ pub fn gc_stress_dataframe_to_vec_nested() -> i32 {
         .expect("gc_stress_dataframe_to_vec_nested: vec_to_dataframe failed")
         .into_sexp();
 
-    let back: Vec<Person> = dataframe_to_vec(sexp)
-        .expect("gc_stress_dataframe_to_vec_nested: dataframe_to_vec failed");
+    let back: Vec<Person> =
+        dataframe_to_vec(sexp).expect("gc_stress_dataframe_to_vec_nested: dataframe_to_vec failed");
 
     assert_eq!(back.len(), original.len());
     for (a, b) in original.iter().zip(back.iter()) {
@@ -776,7 +776,8 @@ pub fn gc_stress_builder_grow_schema() -> SEXP {
         if i >= 1 {
             row.insert("common".into(), i + 100);
         }
-        b.push(row).expect("gc_stress_builder_grow_schema: push failed");
+        b.push(row)
+            .expect("gc_stress_builder_grow_schema: push failed");
     }
     let df = b
         .finish()
@@ -858,10 +859,10 @@ pub fn gc_stress_borrowed_rows() -> i32 {
 /// gctorture no-arg fixture sweep.
 #[miniextendr]
 pub fn gc_stress_protect_discipline() {
+    use miniextendr_api::NamedVector;
     use miniextendr_api::factor::{FactorOptionVec, FactorVec};
     use miniextendr_api::into_r::IntoR as _;
     use miniextendr_api::match_arg::MatchArg;
-    use miniextendr_api::NamedVector;
 
     // FactorVec<Color> → build_factor_with_levels exercised on a no-cache path
     // (RFactor blanket through FactorVec).
@@ -1190,12 +1191,12 @@ pub fn gc_stress_split_collated() -> SEXP {
 #[miniextendr]
 pub fn gc_stress_factor_labels() -> i32 {
     use crate::serde::Deserialize;
-    use miniextendr_api::factor::{build_factor, build_levels_sexp};
-    use miniextendr_api::prelude::{SEXP, SexpExt};
     use miniextendr_api::SEXPTYPE;
-    use miniextendr_api::sys::Rf_allocVector;
+    use miniextendr_api::factor::{build_factor, build_levels_sexp};
     use miniextendr_api::gc_protect::OwnedProtect;
+    use miniextendr_api::prelude::{SEXP, SexpExt};
     use miniextendr_api::serde::dataframe_to_vec;
+    use miniextendr_api::sys::Rf_allocVector;
 
     #[derive(Deserialize, PartialEq, Debug)]
     #[serde(crate = "crate::serde")]

--- a/rpkg/src/rust/identical_tests.rs
+++ b/rpkg/src/rust/identical_tests.rs
@@ -1,8 +1,8 @@
 //! Tests for R_compute_identical and SEXP equality semantics.
 
+use miniextendr_api::miniextendr;
 use miniextendr_api::prelude::SEXP;
 use miniextendr_api::sys::{IDENT_USE_CLOENV, R_compute_identical};
-use miniextendr_api::miniextendr;
 
 /// Test SEXP pointer equality vs R_compute_identical semantic equality.
 /// @param x First SEXP to compare.
@@ -10,9 +10,9 @@ use miniextendr_api::miniextendr;
 #[miniextendr]
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn C_test_sexp_equality(x: SEXP, y: SEXP) -> SEXP {
-    use miniextendr_api::prelude::SexpExt;
     use miniextendr_api::Rboolean;
     use miniextendr_api::gc_protect::ProtectScope;
+    use miniextendr_api::prelude::SexpExt;
 
     let pointer_eq = x == y;
     let semantic_eq = unsafe { R_compute_identical(x, y, IDENT_USE_CLOENV) } != Rboolean::FALSE;

--- a/rpkg/src/rust/indicatif_adapter_tests.rs
+++ b/rpkg/src/rust/indicatif_adapter_tests.rs
@@ -1,9 +1,9 @@
 //! indicatif adapter tests — R connection-routed progress bar integration.
 
 use miniextendr_api::connection::{RNullConnection, RStderr};
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 use miniextendr_api::progress::{
     RTerm, term_like_connection, term_like_connection_with_hz, term_like_stderr,
     term_like_stderr_with_hz, term_like_stdout, term_like_stdout_with_hz,

--- a/rpkg/src/rust/interrupt_tests.rs
+++ b/rpkg/src/rust/interrupt_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for R interrupt checking.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 use miniextendr_api::unwind_protect::with_r_unwind_protect_or_raise;
 
 /// Test R_CheckUserInterrupt after a 2-second sleep.

--- a/rpkg/src/rust/into_r_as_tests.rs
+++ b/rpkg/src/rust/into_r_as_tests.rs
@@ -1,7 +1,7 @@
 //! Test fixtures for into_r_as module (IntoRAs trait).
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::into_r_as::IntoRAs;
+use miniextendr_api::prelude::SEXP;
 use miniextendr_api::prelude::*;
 
 /// Convert a `Vec<i64>` to R integer vector via `IntoRAs<i32>`.

--- a/rpkg/src/rust/jiff_adapter_tests.rs
+++ b/rpkg/src/rust/jiff_adapter_tests.rs
@@ -1,9 +1,9 @@
 //! Jiff adapter tests — roundtrip and extraction fixtures for all jiff types.
 use miniextendr_api::cached_class::set_posixct_utc;
-use miniextendr_api::prelude::SEXP;
-use miniextendr_api::sys::{Rf_protect, Rf_unprotect};
 use miniextendr_api::into_r::IntoR;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
+use miniextendr_api::sys::{Rf_protect, Rf_unprotect};
 use miniextendr_api::{
     AltRealData, AltrepLen, JiffDate, JiffDateTime, JiffTime, JiffTimestampVec, JiffZonedVec,
     SignedDuration, Span, Timestamp, Zoned,

--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -88,8 +88,8 @@
 
 use miniextendr_api::Altrep;
 use miniextendr_api::IntoR;
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 // Package initialization — generates R_init_miniextendr() entry point.
 // Replaces the previous entrypoint.c with a pure-Rust implementation.
@@ -221,6 +221,7 @@ mod num_traits_adapter_tests;
 mod ordered_float_adapter_tests;
 mod panic_telemetry_tests;
 mod panic_tests;
+mod pipe_builder_tests;
 mod protect_pool_tests;
 mod r6_default_tests;
 mod r6_noexport_field_tests;
@@ -234,7 +235,6 @@ mod rayon_tests;
 mod rdata_sidecar_tests;
 mod receiver_tests;
 mod refcount_protect_tests;
-mod pipe_builder_tests;
 #[cfg(feature = "regex")]
 mod regex_adapter_tests;
 mod rng_tests;
@@ -971,8 +971,8 @@ impl miniextendr_api::altrep_data::AltrepSerialize for LogicalVecData {
         // NA_LOGICAL in R is the same as NA_INTEGER = i32::MIN
         const NA_LOGICAL: i32 = i32::MIN;
         unsafe {
-            use miniextendr_api::prelude::SexpExt;
             use miniextendr_api::SEXPTYPE;
+            use miniextendr_api::prelude::SexpExt;
             use miniextendr_api::sys::Rf_allocVector;
             let n = self.data.len();
             let state = Rf_allocVector(SEXPTYPE::LGLSXP, n as isize);
@@ -1100,8 +1100,8 @@ pub fn repeating_raw(pattern: &[u8], n: i32) -> SEXP {
 // This demonstrates ALTREP for complex vectors
 // -----------------------------------------------------------------------------
 
-use miniextendr_api::altrep_data::AltComplexData;
 use miniextendr_api::Rcomplex;
+use miniextendr_api::altrep_data::AltComplexData;
 
 #[derive(miniextendr_api::AltrepComplex)]
 #[altrep(class = "UnitCircle", manual)]

--- a/rpkg/src/rust/misc_tests.rs
+++ b/rpkg/src/rust/misc_tests.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous test functions.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 // Test that wildcard `_` parameters work (transformed to synthetic names internally)
 #[miniextendr]

--- a/rpkg/src/rust/native_sexp_altrep_fixture.rs
+++ b/rpkg/src/rust/native_sexp_altrep_fixture.rs
@@ -48,9 +48,9 @@ use std::sync::OnceLock;
 
 use miniextendr_api::altrep::RegisterAltrep;
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepDataptr, AltrepExtract, AltrepLen};
-use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt as _};
-use miniextendr_api::sys::{DATAPTR_RO, Rf_allocVector, Rf_protect, Rf_unprotect};
 use miniextendr_api::into_r::IntoR;
+use miniextendr_api::sys::{DATAPTR_RO, Rf_allocVector, Rf_protect, Rf_unprotect};
+use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt as _};
 use miniextendr_api::{impl_inferbase_integer, miniextendr};
 
 // region: NativeSexpIntAltrep — ZST, all data in ALTREP data1

--- a/rpkg/src/rust/nonapi.rs
+++ b/rpkg/src/rust/nonapi.rs
@@ -1,5 +1,5 @@
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::thread::{StackCheckGuard, spawn_with_r};
 
 /// Non-API Thread Tests

--- a/rpkg/src/rust/panic_tests.rs
+++ b/rpkg/src/rust/panic_tests.rs
@@ -1,8 +1,8 @@
 //! Panic, drop, and R error handling tests.
 
+use miniextendr_api::miniextendr;
 use miniextendr_api::prelude::SEXP;
 use miniextendr_api::sys::Rf_error;
-use miniextendr_api::miniextendr;
 
 // region: MsgOnDrop for testing drop behavior
 

--- a/rpkg/src/rust/pipe_builder_tests.rs
+++ b/rpkg/src/rust/pipe_builder_tests.rs
@@ -72,7 +72,11 @@ impl GreetingBuilder {
     /// Takes `&self` (not `self`) so the R object remains valid afterwards, and
     /// returns a different type (`String`) converted to R via `IntoR`.
     pub fn build(&self) -> String {
-        let name = if self.name.is_empty() { "world" } else { &self.name };
+        let name = if self.name.is_empty() {
+            "world"
+        } else {
+            &self.name
+        };
         let greeting = format!("Hello, {}{}", name, self.punctuation);
         if self.loud {
             greeting.to_uppercase()

--- a/rpkg/src/rust/rayon_tests.rs
+++ b/rpkg/src/rust/rayon_tests.rs
@@ -1,11 +1,11 @@
 //! Tests for rayon parallel computation integration.
 
 #[cfg(feature = "rayon")]
-use miniextendr_api::prelude::SEXP;
-#[cfg(feature = "rayon")]
 use miniextendr_api::dataframe::DataFrame;
 #[cfg(feature = "rayon")]
 use miniextendr_api::miniextendr;
+#[cfg(feature = "rayon")]
+use miniextendr_api::prelude::SEXP;
 #[cfg(feature = "rayon")]
 use miniextendr_api::rayon_bridge::rayon::prelude::*;
 #[cfg(feature = "rayon")]
@@ -151,11 +151,12 @@ pub fn rayon_with_r_dataframe(n: i32) -> DataFrame {
 pub fn rayon_dataframe_wide(nrow: i32, ncol: i32) -> DataFrame {
     let mut builder = RDataFrameBuilder::new(nrow as usize);
     for j in 0..ncol as usize {
-        builder = builder.column::<f64>(format!("c{j}"), move |chunk: &mut [f64], offset: usize| {
-            for (i, slot) in chunk.iter_mut().enumerate() {
-                *slot = ((offset + i) * 1000 + j) as f64;
-            }
-        });
+        builder =
+            builder.column::<f64>(format!("c{j}"), move |chunk: &mut [f64], offset: usize| {
+                for (i, slot) in chunk.iter_mut().enumerate() {
+                    *slot = ((offset + i) * 1000 + j) as f64;
+                }
+            });
     }
     builder.build()
 }

--- a/rpkg/src/rust/rdata_sidecar_tests.rs
+++ b/rpkg/src/rust/rdata_sidecar_tests.rs
@@ -3,8 +3,8 @@
 //! This module tests the R-side sidecar accessor generation with different class systems.
 
 use miniextendr_api::externalptr::{ExternalPtr, RSidecar};
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 
 // region: Env (default) - standalone functions: Type_get_field(), Type_set_field()
 

--- a/rpkg/src/rust/rng_tests.rs
+++ b/rpkg/src/rust/rng_tests.rs
@@ -5,9 +5,9 @@
 //! - `#[miniextendr(rng)]` attribute on impl methods
 //! - Manual RNG management with `RngGuard` and `with_rng`
 
-use miniextendr_api::sys::{R_unif_index, exp_rand, norm_rand, unif_rand};
 use miniextendr_api::miniextendr;
 use miniextendr_api::rng::{RngGuard, with_rng};
+use miniextendr_api::sys::{R_unif_index, exp_rand, norm_rand, unif_rand};
 
 // region: Standalone function tests
 

--- a/rpkg/src/rust/thread_tests.rs
+++ b/rpkg/src/rust/thread_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for RThreadBuilder and thread safety.
 
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::thread::RThreadBuilder;
 
 /// Test RThreadBuilder spawn with explicit stack size and thread name.

--- a/rpkg/src/rust/unwind_protect_tests.rs
+++ b/rpkg/src/rust/unwind_protect_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for `with_r_unwind_protect_or_raise` mechanism.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 use miniextendr_api::unwind_protect::with_r_unwind_protect_or_raise;
 
 /// Simple RAII type that prints when dropped (without using with_r to avoid deadlocks).

--- a/rpkg/src/rust/vctrs_class_example.rs
+++ b/rpkg/src/rust/vctrs_class_example.rs
@@ -13,11 +13,11 @@
 //! Both are valid design choices - we chose to preserve the specialized type.
 
 use crate::raw_ffi::Rf_duplicate;
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::SEXPTYPE;
-use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::gc_protect::OwnedProtect;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::{SEXP, SexpExt};
+use miniextendr_api::sys::Rf_allocVector;
 use miniextendr_api::vctrs::new_vctr;
 
 // region: Constructor

--- a/rpkg/src/rust/vctrs_derive_example.rs
+++ b/rpkg/src/rust/vctrs_derive_example.rs
@@ -116,10 +116,7 @@ impl DerivedRational {
 /// @param d Denominator values.
 /// @return A derived_rational record vector.
 #[miniextendr]
-pub fn new_derived_rational(
-    n: Vec<i32>,
-    d: Vec<i32>,
-) -> Result<miniextendr_api::SEXP, String> {
+pub fn new_derived_rational(n: Vec<i32>, d: Vec<i32>) -> Result<miniextendr_api::SEXP, String> {
     let rational = DerivedRational::new(n, d)?;
     rational.into_vctrs().map_err(|e| e.to_string())
 }
@@ -160,9 +157,7 @@ impl DerivedIntLists {
 /// @param x A list of integer vectors.
 /// @return A derived_int_lists list_of vector.
 #[miniextendr]
-pub fn new_derived_int_lists(
-    x: miniextendr_api::SEXP,
-) -> Result<miniextendr_api::SEXP, String> {
+pub fn new_derived_int_lists(x: miniextendr_api::SEXP) -> Result<miniextendr_api::SEXP, String> {
     use miniextendr_api::from_r::TryFromSexp;
     let lists: Vec<Vec<i32>> = TryFromSexp::try_from_sexp(x).map_err(|e| format!("{:?}", e))?;
     let int_lists = DerivedIntLists::new(lists);

--- a/rpkg/src/rust/vctrs_tests.rs
+++ b/rpkg/src/rust/vctrs_tests.rs
@@ -2,9 +2,9 @@
 //!
 //! These functions are exposed to R for testing the vctrs integration.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::list::List;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 use miniextendr_api::vctrs::{VctrsBuildError, new_list_of, new_rcrd, new_vctr};
 
 // region: Construction helper tests

--- a/rpkg/src/rust/worker_tests.rs
+++ b/rpkg/src/rust/worker_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for worker thread (run_on_worker) and with_r_thread functionality.
 
-use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::{SEXP, SexpExt};
 use miniextendr_api::worker::{panic_message_to_r_error, run_on_worker, with_r_thread};
 
 use crate::externalptr_tests::{Counter, Point};
@@ -338,8 +338,8 @@ pub extern "C-unwind" fn C_test_multiple_extptrs_from_worker() -> SEXP {
 
     // Create ExternalPtrs on main thread
     use miniextendr_api::externalptr::ExternalPtr;
-    use miniextendr_api::prelude::SexpExt;
     use miniextendr_api::gc_protect::ProtectScope;
+    use miniextendr_api::prelude::SexpExt;
 
     unsafe {
         let scope = ProtectScope::new();

--- a/rpkg/src/rust/zero_copy_tests.rs
+++ b/rpkg/src/rust/zero_copy_tests.rs
@@ -3,8 +3,8 @@
 //! These fixtures verify that pointer recovery works: the SEXP returned by
 //! IntoR is the exact same SEXP that was passed to TryFromSexp.
 
-use miniextendr_api::prelude::SEXP;
 use miniextendr_api::miniextendr;
+use miniextendr_api::prelude::SEXP;
 use std::borrow::Cow;
 
 // region: Cow<[T]> round-trip identity
@@ -61,8 +61,8 @@ pub fn zero_copy_vec_cow_str_all_borrowed(x: Vec<Cow<'static, str>>) -> bool {
 
 #[cfg(feature = "arrow")]
 mod arrow {
-    use miniextendr_api::prelude::SEXP;
     use miniextendr_api::miniextendr;
+    use miniextendr_api::prelude::SEXP;
 
     /// Returns TRUE if Float64Array round-trip returns the same R object.
     /// @export


### PR DESCRIPTION
## Problem (#785)

CI's `rust-lint` job ran `cargo fmt --all -- --check`, which only covers the
**root workspace** (`miniextendr-{api,macros,engine,bench,lint,cli}`). The
`rpkg/src/rust/` package and the two `tests/cross-package/*` packages are
*separate* cargo manifests (their own `Cargo.toml` carrying the monorepo
`[patch."git+url"]` overrides), so `cargo fmt --all` never reached them — and
rustfmt drift accumulated there unnoticed (**~31 files** in `rpkg/src/rust/`,
import ordering / line-wrapping / a re-sorted `mod` declaration).

## Fix

- **Point the CI Rustfmt step at `just fmt-check`**, which already iterates
  every manifest (root + `rpkg/src/rust` + the two cross-package packages).
  This keeps the manifest list single-sourced in the `justfile` rather than
  duplicating it into the workflow (the drift-bait this issue is about).
- **Install `just` in `rust-lint`** — already a standard CI dependency
  (`taiki-e/install-action@just` is used by the R-package jobs).
- **One-time sweep** of the accumulated `rpkg/src/rust/` drift.

### Why this is safe to run without `just configure`

`cargo fmt --check` discovers targets and formats local source only — it needs
**no dependency resolution, no network, no `.cargo/config.toml`** (which is
configure-generated and gitignored for `rpkg/src/rust`). Verified directly:
with `rpkg/src/rust/.cargo/config.toml` removed, `cargo fmt --check` still runs
and reports drift correctly. After the sweep, `just fmt-check` is green across
all four manifests.

The 31 source-file changes are semantically neutral (rustfmt-only). Surfaced
while preparing #786 (unified DataFrame interface) and deliberately split out
to keep that feature PR clean.

Closes #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)