### PR TITLE
ci(webr): cargo-check cross-package crates on wasm32 (#493)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -70,6 +70,21 @@ jobs:
       - name: cargo check (miniextendr-api)
         run: cargo check -p miniextendr-api --target wasm32-unknown-emscripten
 
+      # Cross-package crates (#493) ship deliberately-empty wasm_registry.rs
+      # stubs so they can compile on wasm32. Without a CI check those stubs are
+      # dead weight that could silently rot when the macro cfg-gating changes.
+      # This compiles both standalone-workspace crates on wasm32 to guard the
+      # gating. It validates COMPILE only — runtime cross-crate trait dispatch
+      # under the wasm_registry codegen is the separate open follow-up (#495).
+      - name: cargo check (cross-package crates)
+        run: |
+          set -euo pipefail
+          for crate in tests/cross-package/producer.pkg tests/cross-package/consumer.pkg; do
+            echo "::group::$crate (wasm32)"
+            ( cd "$crate/src/rust" && cargo check --target wasm32-unknown-emscripten )
+            echo "::endgroup::"
+          done
+
       # rpkg/configure invokes ${R_HOME}/bin/Rscript directly for feature
       # detection (configure.ac:133, :275, :473). The dummy R_HOME has no
       # Rscript binary, so configure fails on this bare-ubuntu runner.


### PR DESCRIPTION
The cross-package wasm stubs from #493 were never actually exercised on wasm32 — `tests/cross-package/**` triggers the webR workflow, but the only crate checked on wasm32 was `miniextendr-api`. So the empty stubs were dead weight that could rot when the macro cfg-gating changes. This adds a tier-1 check that compiles both cross-package crates on wasm32. I verified locally that both compile clean.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add a `cargo check --target wasm32-unknown-emscripten` step to the `cargo-check` (tier-1) job for `producer.pkg` and `consumer.pkg` (both standalone-workspace crates under `tests/cross-package/`).
- Verified locally: `PRODUCER_EXIT=0`, `CONSUMER_EXIT=0`, ~8s each, with the committed empty `wasm_registry.rs` stubs in place.

## Test plan
- [ ] tier-1 `wasm32 check` job stays green with the new step.

## Notes
- This guards COMPILE only. The empty stubs mean each crate's `MX_TRAIT_DISPATCH` is empty, so runtime cross-crate trait dispatch under wasm is still unsolved — that is tracked separately in #495 and is not addressed here.
- Came out of the webR landing audit (P2): "either add a wasm check for the cross-package stubs or pull them." They compile, so guarding them is the better outcome; #495 owns the dispatch work the stubs ultimately serve.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
