### PR TITLE
ci(webr): bump WEBR_BASE pin to webR v0.6.0 (R 4.6.0), fix mirror seeding (#755)

### DIFF
--- a/.github/workflows/mirror-webr.yml
+++ b/.github/workflows/mirror-webr.yml
@@ -42,6 +42,13 @@ concurrency:
 
 env:
   DEST_REPO: ghcr.io/a2-ai/webr-mirror
+  # Always seed FROM upstream by digest, never from the mirror. Post-cutover
+  # WEBR_BASE points at DEST_REPO itself (#755), so sourcing from WEBR_BASE
+  # verbatim would be a self-copy that can't seed a *new* digest. The digest
+  # is content-addressable, so upstream and mirror bytes are identical at the
+  # same sha256 — we just re-derive the upstream reference from the pinned
+  # digest below.
+  UPSTREAM_REPO: ghcr.io/r-wasm/webr
 
 jobs:
   mirror:
@@ -56,22 +63,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          src=$(grep -E '^ARG WEBR_BASE=' Dockerfile.webr | head -1 | sed -E 's/^ARG WEBR_BASE=//')
-          if [[ -z "$src" || "$src" != *"@sha256:"* ]]; then
-            echo "::error::Could not extract a digest-pinned WEBR_BASE from Dockerfile.webr (got: '$src')."
+          raw=$(grep -E '^ARG WEBR_BASE=' Dockerfile.webr | head -1 | sed -E 's/^ARG WEBR_BASE=//')
+          if [[ -z "$raw" || "$raw" != *"@sha256:"* ]]; then
+            echo "::error::Could not extract a digest-pinned WEBR_BASE from Dockerfile.webr (got: '$raw')."
             exit 1
           fi
-          digest="${src##*@}"
+          digest="${raw##*@}"
           short="${digest#sha256:}"
           short12="${short:0:12}"
+          # Source is upstream-by-digest regardless of which repo WEBR_BASE
+          # names (see UPSTREAM_REPO comment above).
+          src="${UPSTREAM_REPO}@${digest}"
           {
             echo "src=$src"
             echo "digest=$digest"
             echo "short12=$short12"
           } >>"$GITHUB_OUTPUT"
-          echo "Source pin:  $src"
-          echo "Full digest: $digest"
-          echo "Short tag:   $short12"
+          echo "WEBR_BASE pin:   $raw"
+          echo "Upstream source: $src"
+          echo "Full digest:     $digest"
+          echo "Short tag:        $short12"
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4

--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -101,9 +101,10 @@ jobs:
   #              Imports from repo.r-wasm.org, drives library(miniextendr).
   # Mirrors tests/webr-smoke.sh end-to-end. CI's amd64 runners have no Rosetta
   # and plenty of disk (the local arm64 dev path hits both limits). Phase 2
-  # is also the empirical validator for #494's `-C relocation-model=pic`
-  # flag: if the emcc side-module link rejects non-PIC objects, Phase 2
-  # fails here.
+  # is also the empirical validator for the side-module RUSTFLAGS
+  # (`-Zdefault-visibility=hidden`): if the emcc side-module link breaks under
+  # them, Phase 2 fails here. (#494's `-C relocation-model=pic` was validated
+  # here too, until #745 confirmed it redundant and dropped it.)
   #
   # The container image must stay digest-aligned with Dockerfile.webr's
   # WEBR_BASE — bump both together. The S7 + autoconf installs mirror the
@@ -118,7 +119,7 @@ jobs:
       # which `.github/workflows/mirror-webr.yml` keeps digest-aligned with
       # upstream ghcr.io/r-wasm/webr — image bytes are identical at this
       # sha256. Bump in lockstep with Dockerfile.webr's WEBR_BASE.
-      image: ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+      image: ghcr.io/a2-ai/webr-mirror@sha256:3fbf3dc3537c5b31bca94dd797dc25364693b18d71b1d0975f318fbfd6269d86
       # The mirror package is currently private; auth via the job's
       # GITHUB_TOKEN (workflow-level `packages: read` permission above).
       # Drop both once the package is made public via the org UI.
@@ -134,7 +135,7 @@ jobs:
     env:
       # Shared R library readable by BOTH R binaries in this job:
       #   Phase 1 native pass → /opt/R/current/bin/R
-      #   Phase 2 wasm pass   → /opt/webr/host/R-4.5.1/bin/R
+      #   Phase 2 wasm pass   → /opt/webr/host/R-4.6.0/bin/R
       # These two R installs have disjoint default library paths in the
       # webR base image, so without a shared R_LIBS_USER Phase 2's lazy-load
       # sub-R can't find transitive Imports (lifecycle → rlang) installed by
@@ -154,10 +155,10 @@ jobs:
           # Install via the host R that Phase 2 uses, so transitive deps land
           # in a library Phase 2's lazy-load will see. `dependencies = c(...)`
           # pulls rlang in via lifecycle/vctrs without us having to enumerate.
-          /opt/webr/host/R-4.5.1/bin/Rscript -e \
+          /opt/webr/host/R-4.6.0/bin/Rscript -e \
             'install.packages(c("cli","lifecycle","R6","S7","vctrs"), dependencies = c("Depends","Imports","LinkingTo"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest", lib=Sys.getenv("R_LIBS_USER"))'
           # Sanity-check the transitive set landed.
-          /opt/webr/host/R-4.5.1/bin/Rscript -e \
+          /opt/webr/host/R-4.6.0/bin/Rscript -e \
             'pkgs <- c("cli","lifecycle","rlang","R6","S7","vctrs"); miss <- setdiff(pkgs, rownames(installed.packages(lib.loc=Sys.getenv("R_LIBS_USER")))); if (length(miss)) stop("Missing: ", paste(miss, collapse=", "))'
 
       - name: Cache cargo registry + git
@@ -189,7 +190,7 @@ jobs:
           # A stub snapshot would be all-zero; the cdylib pass must rewrite it.
           test "$ch" != "0000000000000000"
 
-      - name: Phase 2 — wasm32 R CMD INSTALL (validates #494 PIC flag)
+      - name: Phase 2 — wasm32 R CMD INSTALL (validates side-module RUSTFLAGS)
         run: |
           set -euo pipefail
           rm -f rpkg/src/*.o rpkg/src/*.so
@@ -205,9 +206,9 @@ jobs:
           # comment). --no-byte-compile mirrors rwasm's flag set too.
           mkdir -p /tmp/wasm-lib
           WASM_TOOLS=/opt/webr/tools \
-          R_SOURCE=/opt/webr/R/build/R-4.5.1 \
+          R_SOURCE=/opt/webr/R/build/R-4.6.0 \
           R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk \
-          /opt/webr/host/R-4.5.1/bin/R CMD INSTALL \
+          /opt/webr/host/R-4.6.0/bin/R CMD INSTALL \
               --library=/tmp/wasm-lib \
               --no-docs --no-test-load --no-staged-install --no-byte-compile \
               rpkg

--- a/Dockerfile.webr
+++ b/Dockerfile.webr
@@ -24,8 +24,10 @@
 # insulates CI from upstream rolling the `:main` tag or pruning old
 # digests. Bump deliberately via PR: edit the digest here, then run the
 # mirror workflow (or wait for the weekly cron) before CI references
-# the new tag.
-ARG WEBR_BASE=ghcr.io/a2-ai/webr-mirror@sha256:0b9e6e41134275d186633cc0b2564f0d03c66b36c0412fdbae51c7572cdbdd40
+# the new tag. Prefer a *tagged release* digest over a `:main` snapshot —
+# the pin below is webR v0.6.0 (bundles R 4.6.0), not an orphaned `:main`
+# snapshot (see #755).
+ARG WEBR_BASE=ghcr.io/a2-ai/webr-mirror@sha256:3fbf3dc3537c5b31bca94dd797dc25364693b18d71b1d0975f318fbfd6269d86
 FROM ${WEBR_BASE}
 
 ARG JUST_VERSION=1.36.0

--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -14,11 +14,11 @@ webR Docker image.
 Tracking: umbrella #470. Shipped: tier 1/2/3 CI (#480 / #491 / #492),
 cross-package wasm stubs (#493), side-module `RUSTFLAGS`
 (`-Zdefault-visibility=hidden`, #494), `link_to_r()` wasm gating (#482), webR
-base-image mirror (#496), and the redundant `-C relocation-model=pic` flag
-dropped (#745). Open follow-ups: #495 (cross-crate trait dispatch), #752
-(dependency guidance — see "Dependencies and webR" below), #755 (pin a tagged
-base-image digest), #788 (arm64-native dev image), #747 (drop mirror creds once
-the GHCR package is public).
+base-image mirror (#496), the redundant `-C relocation-model=pic` flag
+dropped (#745), and the base-image pin bumped to a tagged webR v0.6.0 / R 4.6.0
+release (#755). Open follow-ups: #495 (cross-crate trait dispatch), #752
+(dependency guidance — see "Dependencies and webR" below), #788 (arm64-native
+dev image), #747 (drop mirror creds once the GHCR package is public).
 
 ## Target
 
@@ -94,9 +94,9 @@ the container, then prints a testthat pass/fail/skip summary:
    they're never deployed to webR; see #493.)
 2. **wasm32 install** — `CC=emcc bash rpkg/configure` followed by
    `R CMD INSTALL --no-test-load --no-staged-install` against
-   `/opt/webr/host/R-4.5.1/bin/R` (webR's own host R) with
+   `/opt/webr/host/R-4.6.0/bin/R` (webR's own host R) with
    `R_MAKEVARS_USER=/opt/webr/packages/webr-vars.mk`. Result lands at
-   `/opt/webr/wasm/R-4.5.1/lib/R/library/miniextendr/`.
+   `/opt/webr/wasm/R-4.6.0/lib/R/library/miniextendr/`.
 3. **webR Node session** — imports webR's bundled ESM directly from
    `file:///opt/webr/dist/webr.mjs` (see "The `/opt/webr/dist` import
    gotcha" below), NODEFS-mounts the wasm R lib tree, calls
@@ -141,11 +141,11 @@ right one:
 
 | Path | Use |
 |---|---|
-| `/opt/R/current/bin/R` | Native (rig-managed 4.5.1). Phase 1 of the smoke script — host cdylib + wrapper-gen. |
-| `/opt/webr/host/R-4.5.1/bin/R` | webR's own host R, configured for wasm cross-compilation. Phase 2 — wasm `R CMD INSTALL` with `webr-vars.mk`. |
-| `/opt/webr/wasm/R-4.5.1/lib/R/library/` | wasm R library tree where the side-module ends up. NODEFS-mounted into the webR Node session. |
+| `/opt/R/current/bin/R` | Native (rig-managed 4.6.0). Phase 1 of the smoke script — host cdylib + wrapper-gen. |
+| `/opt/webr/host/R-4.6.0/bin/R` | webR's own host R, configured for wasm cross-compilation. Phase 2 — wasm `R CMD INSTALL` with `webr-vars.mk`. |
+| `/opt/webr/wasm/R-4.6.0/lib/R/library/` | wasm R library tree where the side-module ends up. NODEFS-mounted into the webR Node session. |
 
-`R_SOURCE=/opt/webr/R/build/R-4.5.1` and `WASM_TOOLS=/opt/webr/tools` must
+`R_SOURCE=/opt/webr/R/build/R-4.6.0` and `WASM_TOOLS=/opt/webr/tools` must
 be exported during the wasm install — `webr-vars.mk` references both.
 
 ## Other webR build constraints
@@ -292,7 +292,7 @@ is what proves it *loads* in a real webR runtime.
 
 - Issue #470 — umbrella tracking issue for webR/WASM support.
 - Issue #495 — cross-crate trait dispatch; #752 — dependency guidance;
-  #755 — pin a tagged base-image digest; #788 — arm64-native dev image.
+  #788 — arm64-native dev image.
 - `tests/webr-node-smoke/smoke.mjs` — the CI tier-3 Node runner (single source
   of truth for the runtime smoke; `tests/webr-smoke.sh` Phase 3 invokes it).
 - `tests/webr-smoke.sh` — the local end-to-end smoke runner. Mirrors the green

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -26,7 +26,7 @@ MX_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ── Constants ───────────────────────────────────────────────────────────────
 
 IMAGE="miniextendr-webr-dev:latest"
-R_VERSION="4.5.1"
+R_VERSION="4.6.0"
 WEBR_ROOT="/opt/webr"
 R_HOST_EXE="${WEBR_ROOT}/host/R-${R_VERSION}/bin/R"
 R_NATIVE_EXE="/opt/R/current/bin/R"


### PR DESCRIPTION
Bumps our webR base image off the orphaned `:main` snapshot onto the tagged **v0.6.0** release (closes #755). While in the mirror, I found `mirror-webr.yml` could no longer seed a *new* upstream digest post-cutover — `WEBR_BASE` now points at the mirror itself, so the copy step was effectively a self-copy — so this fixes that too. v0.6.0 bundles **R 4.6.0** (up from 4.5.1), so the hardcoded host-R paths move in lockstep. The mirror has already been re-seeded with the v0.6.0 digest (workflow run on this branch), so tier-2/3 here run against the new image.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Pin `WEBR_BASE` → `ghcr.io/a2-ai/webr-mirror@sha256:3fbf3dc3…` (webR v0.6.0, a tagged release) in `Dockerfile.webr` and `webr.yml`'s `webr-install` container, replacing the orphaned `:main` snapshot `0b9e6e41…` that no upstream tag points at anymore. Closes #755.
- v0.6.0 bundles R 4.6.0 (was 4.5.1): update the version-pinned host-R paths (`/opt/webr/host/R-4.6.0`, `/opt/webr/R/build/R-4.6.0`) in `webr.yml`, the `R_VERSION` constant in `tests/webr-smoke.sh`, and the path table in `docs/WEBR.md`. (The native `/opt/R/current` path is version-agnostic via the symlink, so it's untouched.)
- Fix `mirror-webr.yml` to always seed FROM upstream `ghcr.io/r-wasm/webr@<digest>`. Post-cutover `WEBR_BASE` points at the mirror itself, so the previous "copy `WEBR_BASE` → mirror" was a self-copy that could not seed a new digest. The digest is content-addressable, so upstream and mirror bytes are identical at the same sha256; the workflow now re-derives the upstream reference from the pinned digest.
- Drop the stale `#494` PIC-flag framing in `webr.yml` now that #745 removed the flag; Phase 2 validates the side-module `RUSTFLAGS` (`-Zdefault-visibility=hidden`).
- `docs/WEBR.md` tracking: move #755 from open follow-ups to shipped.

## Test plan
- [x] Mirror re-seed: dispatched `mirror-webr.yml` on this branch; run 26665195617 succeeded. This proves the upstream-by-digest fix works — it seeded a digest the mirror did not have, which the old self-copy could not.
- [ ] tier-2 (`wasm32 R CMD INSTALL`) green against the v0.6.0 image — proves the side-module links under R 4.6.0 with the new host paths.
- [ ] tier-3 (Node webR `library()` load) green — proves it loads in the v0.6.0 runtime.

## Notes
- Revert is a two-file digest swap back to `0b9e6e41…` (the mirror still retains it).
- The `.mjs`/`.cjs` bundle question from #750 (whether v0.6.0 fixes the `__dirname` ESM issue, which would let `smoke.mjs` drop the `.cjs` indirection) is intentionally out of scope here. Tier-3's result on v0.6.0 will tell us; if it's fixed I'll file a follow-up to simplify `smoke.mjs`.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
