### PR TITLE
ci: bump R tests / Linux timeout 45 → 90 min (job outgrew its cap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,13 @@ jobs:
   r-tests:
     name: R tests / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # This job bundles unit tests + the 3-round randomized gctorture heap-check
+    # + the Valgrind ALTREP pass; the total runs ~47 min and outgrew the prior
+    # 45-min cap (itself a 30->45 bump in #732), so the tip-of-main run was
+    # being cancelled by timeout. Use the 90 min the other heavy jobs here use.
+    # If it overruns again, split the heap-check/Valgrind into their own job(s)
+    # rather than bumping a third time.
+    timeout-minutes: 90
     needs: changes
     if: needs.changes.outputs.r == 'true'
 


### PR DESCRIPTION
Heads up: this is a pre-existing CI issue I hit while wrapping up the webR cleanup, not part of that work. Our `R tests / Linux` job has been getting cancelled on every tip-of-main run — it bundles the unit tests, the 3-round randomized gctorture heap-check, and the Valgrind ALTREP pass into one job that runs ~47 min against a 45-min timeout (which was itself a 30→45 bump in #732). The job keeps outgrowing the cap. This bumps it to the 90 min the other heavy jobs here already use. Happy to instead split the heavy passes into their own job if you'd prefer that over a third bump — your call.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `.github/workflows/ci.yml` `r-tests` job (`R tests / Linux`): `timeout-minutes` 45 → 90.
- Root cause: the job runs unit tests + `Run tests with heap checking (3 rounds, randomized order)` + `Run ALTREP tests under Valgrind`. Combined runtime ~47 min > 45-min cap, so the job is cancelled by timeout and the `CI Success` gate fails.
- It is a duration-vs-timeout problem, not a hang: individual steps pass when they get the time (e.g. on the tip-of-main run, the unit-test and Valgrind steps completed; only the step still running at the 45-min wall was cut off).

## Evidence
- Tip of main `a98ffc57` `CI` run: every job green except `R tests / Linux` = cancelled (ran 22:59→23:46 ≈ 47 min) → `CI Success` = failure.
- A manual re-run of the failed jobs hit the same ~47-min wall, confirming it is reproducible, not transient.
- Earlier main commits that look "cancelled" in the run list were mostly *concurrency* cancellations (rapid back-to-back merges share one push concurrency group, so each supersedes the prior's in-flight run after a few minutes) — distinct from this timeout. The timeout only bites the commit that nothing supersedes.
- The timeout was already bumped once (30→45, #732), so the job has a history of outgrowing its cap.

## Test plan
- [ ] Merge, then the next main push that triggers `r-tests` (i.e. one that changes R-relevant paths) runs the job to completion within 90 min and `CI Success` goes green. (A CI-yml-only change like this PR does not itself trigger `r-tests` — the `changes.r` path filter gates it — so the bump can only be confirmed on a subsequent R-touching push.)

## Notes
- Alternative fix if you'd rather not keep bumping: split the heap-check and/or Valgrind passes into their own job(s) so the fast unit tests aren't gated behind ~45 min of GC/Valgrind, and/or move the heavy passes to the existing Saturday `schedule` cron.
- Orthogonal observation: in the Valgrind ALTREP step I saw a `load_all()` / `methods::setMethod()` error surface near the timeout cutoff, but the Valgrind step passes cleanly when it completes (it did on the tip-of-main run before the cut), so this is most likely a teardown artifact of the job being cancelled mid-run rather than a real failure. Worth a glance if it recurs once the timeout is bumped.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
