### PR TITLE
build(just,ci): cover cargo-revendor in lint/clippy/doc/fmt sweeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,23 @@ jobs:
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all.log"
         shell: bash
 
+      # cargo-revendor is a standalone workspace excluded from the root
+      # workspace, so the `--workspace` clippy steps above never reach it
+      # (#778). It has no R linkage, so it lints without configure/R setup.
+      - name: Clippy (cargo-revendor)
+        id: clippy_revendor
+        continue-on-error: true
+        run: cargo clippy --manifest-path cargo-revendor/Cargo.toml --all-targets --locked -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_revendor.log"
+        shell: bash
+
+      - name: Rustdoc (cargo-revendor)
+        id: doc_revendor
+        continue-on-error: true
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --document-private-items --manifest-path cargo-revendor/Cargo.toml --locked 2>&1 | tee "$RUNNER_TEMP/doc_revendor.log"
+        shell: bash
+
       - name: Fail if any Rust check failed
         if: always()
         shell: bash
@@ -260,10 +277,14 @@ jobs:
           rustfmt="${{ steps.rustfmt.outcome }}"
           clippy_default="${{ steps.clippy_default.outcome }}"
           clippy_all="${{ steps.clippy_all.outcome }}"
+          clippy_revendor="${{ steps.clippy_revendor.outcome }}"
+          doc_revendor="${{ steps.doc_revendor.outcome }}"
 
-          echo "rustfmt:         $rustfmt"
-          echo "clippy_default:  $clippy_default"
-          echo "clippy_all:      $clippy_all"
+          echo "rustfmt:          $rustfmt"
+          echo "clippy_default:   $clippy_default"
+          echo "clippy_all:       $clippy_all"
+          echo "clippy_revendor:  $clippy_revendor"
+          echo "doc_revendor:     $doc_revendor"
           echo
 
           dump_failed() {
@@ -280,9 +301,11 @@ jobs:
             fi
           }
 
-          dump_failed rustfmt         "$rustfmt"
-          dump_failed clippy_default  "$clippy_default"
-          dump_failed clippy_all      "$clippy_all"
+          dump_failed rustfmt          "$rustfmt"
+          dump_failed clippy_default   "$clippy_default"
+          dump_failed clippy_all       "$clippy_all"
+          dump_failed clippy_revendor  "$clippy_revendor"
+          dump_failed doc_revendor     "$doc_revendor"
 
           if [[ "$failed" -ne 0 ]]; then
             echo "::error::One or more Rust checks failed (output dumped above)"

--- a/justfile
+++ b/justfile
@@ -202,6 +202,7 @@ check *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo check --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo check --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo check --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    cargo check --benches --tests --examples --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
     @just cargo-lock-restore
 
 # Build all crates
@@ -220,6 +221,7 @@ clippy *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo clippy --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    cargo clippy --benches --tests --examples --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
     @just cargo-lock-restore
 
 # Run miniextendr-lint on rpkg (checks #[miniextendr] consistency)
@@ -253,6 +255,7 @@ doc-check *cargo_flags: configure-all
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo doc --no-deps --document-private-items --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo doc --no-deps --document-private-items --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo doc --no-deps --document-private-items --manifest-path="$root/rpkg/src/rust/Cargo.toml" --config "patch.crates-io.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.crates-io.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.crates-io.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    cargo doc --no-deps --document-private-items --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
     @just cargo-lock-restore
 
 # Build and open documentation
@@ -262,6 +265,7 @@ doc *cargo_flags: configure-all
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo doc --document-private-items --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo doc --document-private-items --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo doc --document-private-items --manifest-path="$root/rpkg/src/rust/Cargo.toml" --config "patch.crates-io.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.crates-io.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.crates-io.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    cargo doc --document-private-items --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
     @just cargo-lock-restore
     if command -v open >/dev/null 2>&1; then \
       open rpkg/src/rust/target/doc/rpkg/index.html >/dev/null 2>&1 || \
@@ -277,6 +281,7 @@ fmt-check *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}} -- --check)
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}} -- --check)
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/rpkg/src/rust/Cargo.toml" {{cargo_flags}} -- --check)
+    cargo fmt --all --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}} -- --check
 
 # Format all code
 alias cargo-fmt := fmt
@@ -285,6 +290,7 @@ fmt *cargo_flags:
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && cargo fmt --all --manifest-path="$root/rpkg/src/rust/Cargo.toml" {{cargo_flags}})
+    cargo fmt --all --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
 
 # Run tests
 alias cargo-test := test


### PR DESCRIPTION
<!-- TODO: your framing paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `cargo-revendor/` is a standalone workspace excluded from the miniextendr workspace, so the `just` sweep recipes (root + `rpkg/src/rust` + `tests/cross-package/*`) and CI's `--workspace` clippy silently skipped it — exactly the doc/lint/clippy/fmt blind spot #778 describes (the 6 prior rustdoc warnings were only caught by hand).
- **justfile**: added a `--manifest-path cargo-revendor/Cargo.toml` pass to `check`, `clippy`, `doc-check`, `doc`, `fmt-check`, and `fmt`, mirroring the existing `revendor-build` / `revendor-test` invocation style (no `--workspace`, no patch config — cargo-revendor is a self-contained `[package]`).
- **CI** (`.github/workflows/ci.yml`, "Rust lint" job): rustfmt already runs via `just fmt-check`, so it now covers cargo-revendor automatically. Added explicit `Clippy (cargo-revendor)` (`--all-targets --locked -D warnings`) and `Rustdoc (cargo-revendor)` (`RUSTDOCFLAGS=-D warnings`) steps and wired both into the failure aggregator. cargo-revendor has no R linkage, so the steps need no `configure`/R setup.

Closes #778.

## Test plan
- [x] `cargo-revendor` is currently clean under `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` (so the new gates start green).
- [x] `just --list` parses; dry-run of each edited recipe shows the cargo-revendor invocation in the expansion.
- [x] `just fmt-check` passes end-to-end (now includes the cargo-revendor fmt pass).
- [x] `ci.yml` validates as YAML; new step ids (`clippy_revendor`/`doc_revendor`) match their `tee` log filenames and the `dump_failed` aggregator entries.

## Notes
- CI has no pre-existing rustdoc job for the *workspace* either, so the rustdoc gate here is cargo-revendor-specific (added directly to the lint job since cargo-revendor doc-builds without R). Extending a `-D warnings` rustdoc gate to the rest of the workspace in CI would be a separate enhancement.
- `check`/`build` for cargo-revendor are already covered by `revendor-build`/`revendor-test`; the `check` recipe addition here is for parity, the lint-relevant additions are `clippy`/`doc`/`fmt`.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>