### PR TITLE
fix(configure): clear checkbashisms 'source' false-positive in scaffolded configure.ac (#829)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/configure.ac
+++ b/minirextendr/inst/templates/monorepo/rpkg/configure.ac
@@ -609,7 +609,7 @@ dnl   (cargo follows the git URL declared in Cargo.toml)
 dnl
 dnl WARNING: stale inst/vendor.tar.xz hazard.
 dnl   `just r-cmd-build` and `just r-cmd-check` create inst/vendor.tar.xz
-dnl   transiently and remove it via `trap ... EXIT`.  If the process is killed
+dnl   transiently and remove it via a `trap ... EXIT` handler; if the process is killed
 dnl   before the trap fires, the file is left behind.  Configure then detects
 dnl   it and sets IS_TARBALL_INSTALL=true, which (a) writes a tarball-mode
 dnl   config.toml here and (b) makes Makevars.in's post-build cleanup delete
@@ -705,7 +705,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -718,7 +718,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/minirextendr/inst/templates/rpkg/configure.ac
+++ b/minirextendr/inst/templates/rpkg/configure.ac
@@ -661,7 +661,7 @@ dnl   (cargo follows the git URL declared in Cargo.toml)
 dnl
 dnl WARNING: stale inst/vendor.tar.xz hazard.
 dnl   `just r-cmd-build` and `just r-cmd-check` create inst/vendor.tar.xz
-dnl   transiently and remove it via `trap ... EXIT`.  If the process is killed
+dnl   transiently and remove it via a `trap ... EXIT` handler; if the process is killed
 dnl   before the trap fires, the file is left behind.  Configure then detects
 dnl   it and sets IS_TARBALL_INSTALL=true, which (a) writes a tarball-mode
 dnl   config.toml here and (b) makes Makevars.in's post-build cleanup delete
@@ -757,7 +757,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -770,7 +770,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-29 21:33:05
-+++ b/monorepo/rpkg/bootstrap.R	2026-05-29 21:33:05
+--- a/monorepo/rpkg/bootstrap.R	2026-05-14 09:21:02
++++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
 @@ -1,119 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -130,8 +130,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
  
  if (.Platform$OS.type == "windows") {
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-05-29 23:07:52
-+++ b/monorepo/rpkg/configure.ac	2026-05-29 23:08:17
+--- a/monorepo/rpkg/configure.ac	2026-06-03 19:45:48
++++ b/monorepo/rpkg/configure.ac	2026-06-03 19:47:32
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -292,7 +292,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl wasm32/webR side-modules need one RUSTFLAGS adjustment.
  dnl
  dnl -Zdefault-visibility=hidden
--dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+-dnl    Without it, the Rust staticlib drags roughly 3000 mangled stdlib/dep symbols
 -dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
 -dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
 -dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all
@@ -436,8 +436,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-05-29 23:07:52
-+++ b/rpkg/configure.ac	2026-05-29 23:08:31
+--- a/rpkg/configure.ac	2026-06-03 19:45:48
++++ b/rpkg/configure.ac	2026-06-03 19:47:31
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -544,7 +544,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl wasm32/webR side-modules need one RUSTFLAGS adjustment.
  dnl
  dnl -Zdefault-visibility=hidden
--dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+-dnl    Without it, the Rust staticlib drags roughly 3000 mangled stdlib/dep symbols
 -dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
 -dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
 -dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -3985,7 +3985,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -3998,7 +3998,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
  ;;
     "lock-shape-check":C)

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -252,7 +252,7 @@ AC_ARG_VAR([ENV_RUSTFLAGS], [Rust compiler flags passed as RUSTFLAGS])
 dnl wasm32/webR side-modules need one RUSTFLAGS adjustment. See #494.
 dnl
 dnl -Zdefault-visibility=hidden
-dnl    Without it, the Rust staticlib drags ~3000 mangled stdlib/dep symbols
+dnl    Without it, the Rust staticlib drags roughly 3000 mangled stdlib/dep symbols
 dnl    into the side-module's EXPORT table. webR's JS-side dyn.load then fails
 dnl    (`TypeError: Cannot read properties of undefined` on the pinned emcc; a
 dnl    hard `emcc: error: invalid export name` on emcc 4.0.8+). Hiding all
@@ -637,7 +637,7 @@ dnl   (cargo follows the git URL declared in Cargo.toml)
 dnl
 dnl WARNING: stale inst/vendor.tar.xz hazard.
 dnl   `just r-cmd-build` and `just r-cmd-check` create inst/vendor.tar.xz
-dnl   transiently and remove it via `trap ... EXIT`.  If the process is killed
+dnl   transiently and remove it via a `trap ... EXIT` handler; if the process is killed
 dnl   before the trap fires, the file is left behind.  Configure then detects
 dnl   it and sets IS_TARBALL_INSTALL=true, which (a) writes a tarball-mode
 dnl   config.toml here and (b) makes Makevars.in's post-build cleanup delete
@@ -733,7 +733,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -746,7 +746,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/tests/cross-package/consumer.pkg/configure
+++ b/tests/cross-package/consumer.pkg/configure
@@ -3669,7 +3669,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode)"
+    echo "configure: wrote $RPKG_CFG (from-source mode)"
   fi
  ;;
     "cargo-lockfile-compat":C)

--- a/tests/cross-package/consumer.pkg/configure.ac
+++ b/tests/cross-package/consumer.pkg/configure.ac
@@ -39,7 +39,7 @@ RUST_SRC_DIR="$abs_rpkg_src/rust"
 dnl ---- install-mode detection ----
 dnl Single signal: presence of inst/vendor.tar.xz.
 dnl   Tarball install (R CMD INSTALL <built-tarball>): tarball is shipped inside
-dnl     the build artifact by `just vendor`. configure unpacks it, writes a
+dnl     the build artifact by `just vendor`; configure then unpacks it, writes a
 dnl     vendored cargo source replacement, and builds offline.
 dnl   Source install (R CMD INSTALL ., devtools::install, etc.):
 dnl     no tarball. configure leaves vendoring alone and lets cargo resolve
@@ -311,7 +311,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode)"
+    echo "configure: wrote $RPKG_CFG (from-source mode)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/tests/cross-package/producer.pkg/configure
+++ b/tests/cross-package/producer.pkg/configure
@@ -3669,7 +3669,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode)"
+    echo "configure: wrote $RPKG_CFG (from-source mode)"
   fi
  ;;
     "cargo-lockfile-compat":C)

--- a/tests/cross-package/producer.pkg/configure.ac
+++ b/tests/cross-package/producer.pkg/configure.ac
@@ -39,7 +39,7 @@ RUST_SRC_DIR="$abs_rpkg_src/rust"
 dnl ---- install-mode detection ----
 dnl Single signal: presence of inst/vendor.tar.xz.
 dnl   Tarball install (R CMD INSTALL <built-tarball>): tarball is shipped inside
-dnl     the build artifact by `just vendor`. configure unpacks it, writes a
+dnl     the build artifact by `just vendor`; configure then unpacks it, writes a
 dnl     vendored cargo source replacement, and builds offline.
 dnl   Source install (R CMD INSTALL ., devtools::install, etc.):
 dnl     no tarball. configure leaves vendoring alone and lets cargo resolve
@@ -311,7 +311,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode)"
+    echo "configure: wrote $RPKG_CFG (from-source mode)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"

--- a/tests/model_project/configure
+++ b/tests/model_project/configure
@@ -3721,7 +3721,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -3733,7 +3733,7 @@ printf '%s\n' "$as_me: executing $ac_file commands" >&6;}
       echo "[build]"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
  ;;
     "cargo-lockfile-compat":C)

--- a/tests/model_project/configure.ac
+++ b/tests/model_project/configure.ac
@@ -410,7 +410,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, monorepo override)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, monorepo override)"
 
   else
     {
@@ -422,7 +422,7 @@ AC_CONFIG_COMMANDS([cargo-config],
       echo "@<:@build@:>@"
       echo "target-dir = \"$CARGO_TARGET_DIR_CARGO\""
     } > "$RPKG_CFG"
-    echo "configure: wrote $RPKG_CFG (source mode, no monorepo siblings)"
+    echo "configure: wrote $RPKG_CFG (from-source mode, no monorepo siblings)"
   fi
 ],
 [IS_TARBALL_INSTALL="$IS_TARBALL_INSTALL"


### PR DESCRIPTION
Clears the spurious `checkBashisms` NOTE that shows up on a clean `R CMD check --as-cran` of every scaffolded package, by rewording the `(source mode...)` echo strings in `configure.ac` so they no longer read as the shell `source` builtin. Closes #829.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- **Root cause:** `R CMD check --as-cran` runs `checkbashisms` on `configure.ac` (it skips the generated `configure`, which carries the "Generated by GNU Autoconf" marker). The literal `(source` in `echo "configure: wrote ... (source mode, ...)"` reads as a subshell invoking the `source` builtin, so checkbashisms emits *"should be '.', not 'source'"*. Confirmed empirically: only the lines with `(source ` trip it; the `dnl ... In source mode` comments (where `source` is preceded by a word) do not.
- **Fix:** reword `(source mode...)` → `(from-source mode...)` everywhere. The `from-` prefix moves `source` out of command position, so checkbashisms no longer matches, while keeping the source/tarball symmetry with the adjacent `(tarball mode)` string. Applied to:
  - `rpkg/configure.ac` (master source) + regenerated `rpkg/configure`
  - `minirextendr/inst/templates/rpkg/configure.ac` and `.../monorepo/rpkg/configure.ac` (the scaffold templates the issue is about)
  - `tests/cross-package/{consumer,producer}.pkg/configure.ac` + regenerated `configure`
  - `tests/model_project/configure.ac` + regenerated `configure`
- **Sibling false-positives cleared in the same files** (checkbashisms misparsing m4 `dnl` comment prose, in categories R's `check.R` does *not* filter): a `~3000` tilde-expansion and `` `...`. Word `` sequences that read as the `.` source builtin. Left the `brace-expansion` hits (`{api,lint,macros}`, etc.) as-is because R's `check.R` explicitly filters that category, so they never produce a NOTE and the comments stay accurate.
- Re-approved `patches/templates.patch` (`just templates-approve`) for the rpkg-only tilde-comment edit; `just templates-check` passes.
- All `configure` files regenerated with autoconf 2.73 (matches the committed versions): the only diffs are the echo lines.

## Test plan
- [x] `checkbashisms -p -n` on all six `configure.ac` files: no `source`/tilde/sourced-script hits remain (only R-filtered `brace expansion`).
- [x] Faithful replay of `tools/R/check.R`'s bashism filter in R over all six files → **no NOTE** from any of them.
- [x] `just templates-check` passes (exit 0).
- [x] `autoconf` regeneration diffs limited to the reworded echo lines.
- [ ] CI `--as-cran` jobs green (note: GitHub runners may not have `checkbashisms` installed, in which case `--as-cran` reports "needs the checkbashisms script" rather than running it — the local verification above is the authoritative check for this NOTE).

## Notes
- The `patches/templates.patch` diff also shows refreshed header timestamps; that is inherent to `just templates-approve` regenerating from current file mtimes and does not affect the content-only comparison `templates-check`/CI performs.
- Per the issue, this is intentionally a scaffold/template wording change only — no behavior change, no source mutation at configure time.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>