### PR TITLE
refactor(coerce): collapse scalar coercion macros (impl_try_narrow! / impl_widen!)

### DIFF
--- a/miniextendr-api/src/coerce.rs
+++ b/miniextendr-api/src/coerce.rs
@@ -146,6 +146,42 @@ impl_identity!(u8);
 impl_identity!(Rcomplex);
 // endregion
 
+// region: Scalar coercion macros (shared by the widening / narrowing blocks below)
+
+/// Implement infallible widening `Coerce<$to>` for each `$from => $to` pair via `Into`.
+///
+/// For widenings that have no `From` impl (platform-dependent `isize`/`usize`,
+/// lossy int→float), write the `impl Coerce` by hand with an `as` cast instead.
+macro_rules! impl_widen {
+    ($($from:ty => $to:ty),+ $(,)?) => {
+        $(
+            impl Coerce<$to> for $from {
+                #[inline(always)]
+                fn coerce(self) -> $to {
+                    self.into()
+                }
+            }
+        )+
+    };
+}
+
+/// Implement fallible narrowing `TryCoerce<$target>` for each `$from` via
+/// `try_into` (overflow → `CoerceError::Overflow`).
+macro_rules! impl_try_narrow {
+    ($target:ty; $($from:ty),+ $(,)?) => {
+        $(
+            impl TryCoerce<$target> for $from {
+                type Error = CoerceError;
+                #[inline]
+                fn try_coerce(self) -> Result<$target, CoerceError> {
+                    self.try_into().map_err(|_| CoerceError::Overflow)
+                }
+            }
+        )+
+    };
+}
+// endregion
+
 // region: Widening conversions (blanket impls using marker traits)
 
 /// Blanket impl: Any type that widens to i32 can be coerced to i32.
@@ -173,40 +209,7 @@ impl<T: crate::markers::WidensToF64> Coerce<f64> for T {
 
 // region: Widening from u8 to larger integer/float types
 
-impl Coerce<i64> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> i64 {
-        self.into()
-    }
-}
-
-impl Coerce<isize> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> isize {
-        self.into()
-    }
-}
-
-impl Coerce<u64> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> u64 {
-        self.into()
-    }
-}
-
-impl Coerce<usize> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> usize {
-        self.into()
-    }
-}
-
-impl Coerce<f32> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> f32 {
-        self.into()
-    }
-}
+impl_widen!(u8 => i64, u8 => isize, u8 => u64, u8 => usize, u8 => f32);
 
 impl Coerce<f32> for i32 {
     #[inline(always)]
@@ -530,158 +533,32 @@ impl TryCoerce<bool> for crate::RLogical {
 
 // region: Narrowing to i32 (fallible)
 
-macro_rules! impl_try_i32 {
-    ($t:ty) => {
-        impl TryCoerce<i32> for $t {
-            type Error = CoerceError;
-            #[inline]
-            fn try_coerce(self) -> Result<i32, CoerceError> {
-                self.try_into().map_err(|_| CoerceError::Overflow)
-            }
-        }
-    };
-}
-
-impl_try_i32!(u32);
-impl_try_i32!(u64);
-impl_try_i32!(usize);
-impl_try_i32!(i64);
-impl_try_i32!(isize);
+impl_try_narrow!(i32; u32, u64, usize, i64, isize);
 // endregion
 
 // region: Narrowing to u8 (fallible)
 
-macro_rules! impl_try_u8 {
-    ($t:ty) => {
-        impl TryCoerce<u8> for $t {
-            type Error = CoerceError;
-            #[inline]
-            fn try_coerce(self) -> Result<u8, CoerceError> {
-                self.try_into().map_err(|_| CoerceError::Overflow)
-            }
-        }
-    };
-}
-
-impl_try_u8!(i8);
-impl_try_u8!(i16);
-impl_try_u8!(i32);
-impl_try_u8!(i64);
-impl_try_u8!(u16);
-impl_try_u8!(u32);
-impl_try_u8!(u64);
-impl_try_u8!(usize);
-impl_try_u8!(isize);
+impl_try_narrow!(u8; i8, i16, i32, i64, u16, u32, u64, usize, isize);
 // endregion
 
 // region: Widening to u16/i16/u32 (infallible)
 
-impl Coerce<u16> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> u16 {
-        self.into()
-    }
-}
-
-impl Coerce<i16> for i8 {
-    #[inline(always)]
-    fn coerce(self) -> i16 {
-        self.into()
-    }
-}
-
-impl Coerce<i16> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> i16 {
-        self.into()
-    }
-}
-
-impl Coerce<u32> for u8 {
-    #[inline(always)]
-    fn coerce(self) -> u32 {
-        self.into()
-    }
-}
-
-impl Coerce<u32> for u16 {
-    #[inline(always)]
-    fn coerce(self) -> u32 {
-        self.into()
-    }
-}
+impl_widen!(u8 => u16, i8 => i16, u8 => i16, u8 => u32, u16 => u32);
 // endregion
 
 // region: Narrowing to u16 (fallible)
 
-macro_rules! impl_try_u16 {
-    ($t:ty) => {
-        impl TryCoerce<u16> for $t {
-            type Error = CoerceError;
-            #[inline]
-            fn try_coerce(self) -> Result<u16, CoerceError> {
-                self.try_into().map_err(|_| CoerceError::Overflow)
-            }
-        }
-    };
-}
-
-impl_try_u16!(i8);
-impl_try_u16!(i16);
-impl_try_u16!(i32);
-impl_try_u16!(i64);
-impl_try_u16!(u32);
-impl_try_u16!(u64);
-impl_try_u16!(usize);
-impl_try_u16!(isize);
+impl_try_narrow!(u16; i8, i16, i32, i64, u32, u64, usize, isize);
 // endregion
 
 // region: Narrowing to i16 (fallible)
 
-macro_rules! impl_try_i16 {
-    ($t:ty) => {
-        impl TryCoerce<i16> for $t {
-            type Error = CoerceError;
-            #[inline]
-            fn try_coerce(self) -> Result<i16, CoerceError> {
-                self.try_into().map_err(|_| CoerceError::Overflow)
-            }
-        }
-    };
-}
-
-impl_try_i16!(i32);
-impl_try_i16!(i64);
-impl_try_i16!(u16);
-impl_try_i16!(u32);
-impl_try_i16!(u64);
-impl_try_i16!(usize);
-impl_try_i16!(isize);
+impl_try_narrow!(i16; i32, i64, u16, u32, u64, usize, isize);
 // endregion
 
 // region: Narrowing to i8 (fallible)
 
-macro_rules! impl_try_i8 {
-    ($t:ty) => {
-        impl TryCoerce<i8> for $t {
-            type Error = CoerceError;
-            #[inline]
-            fn try_coerce(self) -> Result<i8, CoerceError> {
-                self.try_into().map_err(|_| CoerceError::Overflow)
-            }
-        }
-    };
-}
-
-impl_try_i8!(i16);
-impl_try_i8!(i32);
-impl_try_i8!(i64);
-impl_try_i8!(u8);
-impl_try_i8!(u16);
-impl_try_i8!(u32);
-impl_try_i8!(u64);
-impl_try_i8!(usize);
-impl_try_i8!(isize);
+impl_try_narrow!(i8; i16, i32, i64, u8, u16, u32, u64, usize, isize);
 // endregion
 
 // region: Float to smaller integers (fallible)


### PR DESCRIPTION
First consolidation PR from the audit (#835). Pure mechanical macro dedup in `coerce.rs`, no behaviour change — verified by diffing the rustdoc impl inventory before/after (byte-identical) plus clippy and the coerce unit tests.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Collapses the five byte-identical narrowing macros (`impl_try_i32` / `_u8` / `_u16` / `_i16` / `_i8`) into one target-parameterised `impl_try_narrow!($target; $($from),+)`.
- Collapses the infallible `Into`-based widening one-liners into `impl_widen!($from => $to, …)`.
- Leaves the lossy `as`-cast widenings (`i32 → f32`, `i32 → isize`, `f64 → f32`) hand-written — they have no `From` impl.
- Net −123 lines in `coerce.rs` (43 added, 166 removed).
- Audit references: Part 1 Finding 4 + Part 2 M4 (see #835).

## Test plan
- [x] `cargo clippy -p miniextendr-api --features <broad> --all-targets --locked -- -D warnings` — clean.
- [x] `cargo test -p miniextendr-api --lib coerce::` — 41 passed, 0 failed.
- [x] Regression oracle: regenerated the rustdoc impl inventory and diffed the `(trait, for-type)` set vs `origin/main` — **6080 impls, 0 added, 0 removed** (behavioural no-op).

## Notes
- The regression oracle is the audit tooling from #837 (`rustdoc_impl_inventory.py`); same-impl-set-fewer-macros is the invariant every consolidation PR in #835 must hold.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>