### PR TITLE
refactor(conversions): retire the Box<[…]> impl surface via Vec-delegating blankets

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -326,6 +326,33 @@ pub trait TryFromSexp: Sized {
     }
 }
 
+// region: Box<[T]> delegates to Vec<T>
+//
+// A boxed slice converts exactly like the owned vector — read the vector, then
+// `into_boxed_slice()` (an O(1), allocation-free shrink). This single blanket
+// replaces every hand-rolled / macro-generated `Box<[X]>` impl: any element
+// type whose `Vec<X>` is convertible gets `Box<[X]>` for free, inheriting the
+// vector impl's error type and NA semantics by construction.
+
+impl<T> TryFromSexp for Box<[T]>
+where
+    Vec<T>: TryFromSexp,
+{
+    type Error = <Vec<T> as TryFromSexp>::Error;
+
+    #[inline]
+    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        <Vec<T> as TryFromSexp>::try_from_sexp(sexp).map(|v| v.into_boxed_slice())
+    }
+
+    #[inline]
+    unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
+        unsafe { <Vec<T> as TryFromSexp>::try_from_sexp_unchecked(sexp) }
+            .map(|v| v.into_boxed_slice())
+    }
+}
+// endregion
+
 macro_rules! impl_try_from_sexp_scalar_native {
     ($t:ty, $sexptype:ident) => {
         impl TryFromSexp for $t {
@@ -1118,15 +1145,6 @@ impl TryFromSexp for Vec<bool> {
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
         Self::try_from_sexp(sexp)
-    }
-}
-
-impl TryFromSexp for Box<[bool]> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let vec: Vec<bool> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(vec.into_boxed_slice())
     }
 }
 // endregion

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -215,23 +215,4 @@ impl_vec_try_from_sexp_native!(f64);
 impl_vec_try_from_sexp_native!(u8);
 impl_vec_try_from_sexp_native!(RLogical);
 impl_vec_try_from_sexp_native!(crate::Rcomplex);
-
-macro_rules! impl_boxed_slice_try_from_sexp_native {
-    ($t:ty) => {
-        impl TryFromSexp for Box<[$t]> {
-            type Error = SexpTypeError;
-
-            fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let slice: &[$t] = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(slice.into())
-            }
-        }
-    };
-}
-
-impl_boxed_slice_try_from_sexp_native!(i32);
-impl_boxed_slice_try_from_sexp_native!(f64);
-impl_boxed_slice_try_from_sexp_native!(u8);
-impl_boxed_slice_try_from_sexp_native!(RLogical);
-impl_boxed_slice_try_from_sexp_native!(crate::Rcomplex);
 // endregion

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -143,18 +143,6 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
     }
 }
 
-/// Convert R character vector to `Box<[Cow<'static, str>]>` — zero-copy per element.
-///
-/// **Warning:** `NA_character_` values are converted to `Cow::Borrowed("")`.
-impl TryFromSexp for Box<[Cow<'static, str>]> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let vec: Vec<Cow<'static, str>> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(vec.into_boxed_slice())
-    }
-}
-
 /// Convert R character vector to `Vec<String>`.
 ///
 /// # NA and Encoding Handling
@@ -200,18 +188,6 @@ impl TryFromSexp for Vec<String> {
         }
 
         Ok(result)
-    }
-}
-
-/// Convert R character vector to `Box<[String]>`.
-///
-/// **Warning:** `NA_character_` values are converted to empty string `""`.
-impl TryFromSexp for Box<[String]> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let vec: Vec<String> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(vec.into_boxed_slice())
     }
 }
 

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -55,38 +55,6 @@ macro_rules! impl_vec_option_try_from_sexp {
 impl_vec_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
 impl_vec_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
 
-/// Macro for NA-aware `R vector → Box<[Option<T>]>` conversions.
-macro_rules! impl_boxed_slice_option_try_from_sexp {
-    ($t:ty, $sexptype:ident, $dataptr:ident, $is_na:expr) => {
-        impl TryFromSexp for Box<[Option<$t>]> {
-            type Error = SexpError;
-
-            fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::$sexptype {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::$sexptype,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let ptr = unsafe { crate::sys::$dataptr(sexp) };
-                let slice = unsafe { r_slice(ptr, len) };
-
-                Ok(slice
-                    .iter()
-                    .map(|&v| if $is_na(v) { None } else { Some(v) })
-                    .collect())
-            }
-        }
-    };
-}
-
-impl_boxed_slice_option_try_from_sexp!(f64, REALSXP, REAL, is_na_real);
-impl_boxed_slice_option_try_from_sexp!(i32, INTSXP, INTEGER, |v: i32| v == i32::MIN);
-
 /// Convert R logical vector (LGLSXP) to `Vec<Option<bool>>` with NA support.
 impl TryFromSexp for Vec<Option<bool>> {
     type Error = SexpError;
@@ -119,16 +87,6 @@ impl TryFromSexp for Vec<Option<bool>> {
         let slice: &[RLogical] = unsafe { sexp.as_slice_unchecked() };
 
         Ok(slice.iter().map(|v| v.to_option_bool()).collect())
-    }
-}
-
-/// Convert R logical vector (LGLSXP) to `Box<[Option<bool>]>` with NA support.
-impl TryFromSexp for Box<[Option<bool>]> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let vec: Vec<Option<bool>> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(vec.into_boxed_slice())
     }
 }
 
@@ -269,16 +227,6 @@ impl TryFromSexp for Vec<Option<String>> {
         }
 
         Ok(result)
-    }
-}
-
-/// Convert R character vector to `Box<[Option<String>]>` with NA support.
-impl TryFromSexp for Box<[Option<String>]> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let vec: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(vec.into_boxed_slice())
     }
 }
 

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -362,26 +362,33 @@ where
     }
 }
 
+// A boxed slice converts exactly like the owned vector. `into_vec()` is an
+// O(1), allocation-free widen, so this one blanket subsumes every per-element
+// `Box<[X]>` impl (native, String, Cow, bool, …): any `Vec<X>: IntoR` element
+// gets `Box<[X]>` for free, inheriting the vector impl's error type and path.
+// Coherence-equivalent to the prior `impl<T: RNativeType> IntoR for Box<[T]>`:
+// both occupy the whole `Box<[T]>` slot (where-clauses don't narrow overlap),
+// so concrete downstream `impl IntoR for Box<[Local]>` stays just as available.
 impl<T> IntoR for Box<[T]>
 where
-    T: crate::RNativeType,
+    Vec<T>: IntoR,
 {
-    type Error = std::convert::Infallible;
+    type Error = <Vec<T> as IntoR>::Error;
     #[inline]
     fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(unsafe { vec_to_sexp(&self) })
+        self.into_vec().try_into_sexp()
     }
     #[inline]
     unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(unsafe { vec_to_sexp_unchecked(&self) })
+        unsafe { self.into_vec().try_into_sexp_unchecked() }
     }
     #[inline]
     fn into_sexp(self) -> crate::SEXP {
-        unsafe { vec_to_sexp(&self) }
+        self.into_vec().into_sexp()
     }
     #[inline]
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        unsafe { vec_to_sexp_unchecked(&self) }
+        unsafe { self.into_vec().into_sexp_unchecked() }
     }
 }
 
@@ -1258,23 +1265,6 @@ impl IntoR for &[String] {
     }
 }
 
-/// Convert `Box<[String]>` to R character vector (STRSXP).
-impl IntoR for Box<[String]> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(unsafe { self.into_sexp_unchecked() })
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        str_iter_to_strsxp(self.iter().map(|s| s.as_str()))
-    }
-    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_str())) }
-    }
-}
-
 /// Convert &[&str] to R character vector (STRSXP).
 impl IntoR for &[&str] {
     type Error = std::convert::Infallible;
@@ -1295,23 +1285,6 @@ impl IntoR for &[&str] {
 
 /// Convert `Vec<Cow<'_, str>>` to R character vector (STRSXP).
 impl IntoR for Vec<std::borrow::Cow<'_, str>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(unsafe { self.into_sexp_unchecked() })
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        str_iter_to_strsxp(self.iter().map(|s| s.as_ref()))
-    }
-    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        unsafe { str_iter_to_strsxp_unchecked(self.iter().map(|s| s.as_ref())) }
-    }
-}
-
-/// Convert `Box<[Cow<'_, str>]>` to R character vector (STRSXP).
-impl IntoR for Box<[std::borrow::Cow<'_, str>]> {
     type Error = std::convert::Infallible;
     fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
         Ok(self.into_sexp())
@@ -1794,25 +1767,6 @@ impl IntoR for Vec<bool> {
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.into_iter().map(i32::from)) }
-    }
-}
-
-/// Convert `Box<[bool]>` to R logical vector.
-impl IntoR for Box<[bool]> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(unsafe { self.into_sexp_unchecked() })
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        let n = self.len();
-        logical_iter_to_lglsxp(n, self.iter().map(|&v| i32::from(v)))
-    }
-    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        let n = self.len();
-        unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&v| i32::from(v))) }
     }
 }
 


### PR DESCRIPTION
PR-2 of the conversion-dedup sprint (#835). Collapses the entire hand-rolled `Box<[…]>` conversion surface into one delegating blanket per direction — a boxed slice converts exactly like the owned `Vec`, so there is no reason to hand-roll or macro-generate a parallel impl for every element type. This also fixes the long-standing inconsistency where some `Box<[X]>` impls already delegated to `Vec` while others duplicated the `Vec` body verbatim.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Replaced two near-identical `*_boxed_slice_*` macros (`impl_boxed_slice_try_from_sexp_native!`, `impl_boxed_slice_option_try_from_sexp!`) plus ~12 hand-rolled `Box<[X]>` / `Box<[Option<X>]>` impls with one blanket per direction:
  - `impl<T> TryFromSexp for Box<[T]> where Vec<T>: TryFromSexp` (from_r.rs)
  - `impl<T> IntoR for Box<[T]> where Vec<T>: IntoR` (into_r.rs, replacing the old `impl<T: RNativeType> IntoR for Box<[T]>`)
- Each blanket inherits the corresponding `Vec<T>` impl's associated `Error` type (`SexpTypeError` / `SexpError` / `Infallible`) and NA semantics **by construction**, so behaviour is unchanged. `into_boxed_slice()` / `into_vec()` are both O(1), allocation-free.
- Coverage becomes a superset: every present and future `Vec<X>: {TryFromSexp,IntoR}` now yields `Box<[X]>` for free (e.g. the optionals: jiff, time, uuid, decimal, …).
- Net **−123 lines** (−163 / +40).

## Why it is coherence-safe
- **TryFromSexp:** there was no prior `Box<[T]>` blanket; the new one is the only `Box<[…]>` impl after the concrete ones are removed.
- **IntoR:** coherence-*neutral* vs the old `impl<T: RNativeType> IntoR for Box<[T]>` — both occupy the entire `Box<[T]>` slot (Rust ignores where-clauses when checking overlap), so a downstream `impl IntoR for Box<[Local]>` stays exactly as available as before. Unlike the `Vec<T>` case (two generic blankets `RNativeType` vs `MatchArg`), there is only one blanket on `Box<[T]>`.

## Test plan
- [x] `clippy_all` feature set, `--workspace --all-targets -D warnings`: clean (compiles every optional `Vec<T>` impl that now feeds the blanket)
- [x] `rpkg` `box_slice_tests` roundtrips — `Box<[f64/i32/String/bool/u8]>` and `Box<[Option<{f64,i32,String}>]>`, inbound and outbound
- [x] Full R suite: `FAIL 0 | PASS 6222`
- [x] Diff reviewed hunk-by-hunk: only `Box<[…]>` impls + the two macros removed; every adjacent `Vec<…>` / `&[…]` impl preserved

## Notes
- No new SEXP-across-allocation storage is introduced (pure delegation to pre-existing `Vec` paths), so no new `gctorture` fixture is required.
- No `#[miniextendr]` function surface changed → no wrapper / `NAMESPACE` / `man` regeneration.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>