### PR TITLE
refactor(from_r): unify Vec<T>/Vec<Option<T>> numeric dispatch into one shell (#853)

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -1063,7 +1063,57 @@ where
         .collect()
 }
 
+/// Shared SEXP-dispatch shell for coerced numeric/logical/raw vectors.
+///
+/// Reads INTSXP/REALSXP/RAWSXP/LGLSXP and applies the per-element map. The only
+/// behavioural axis (NA policy) lives entirely in the four closures the caller
+/// passes, so the NA-unaware [`try_from_sexp_numeric_vec`] and the NA-aware
+/// `try_from_sexp_numeric_option_vec` (in [`na_vectors`]) share one dispatch.
+/// LGLSXP NA (`NA_LOGICAL`) and INTSXP NA (`i32::MIN`) round through as raw
+/// sentinels here; any NA-to-`None` policy is the caller's closure to encode.
+#[inline]
+pub(crate) fn from_numeric_vec_with<U, FI, FD, FR, FL>(
+    sexp: SEXP,
+    map_i32: FI,
+    map_f64: FD,
+    map_u8: FR,
+    map_lgl: FL,
+) -> Result<Vec<U>, SexpError>
+where
+    FI: Fn(i32) -> Result<U, SexpError>,
+    FD: Fn(f64) -> Result<U, SexpError>,
+    FR: Fn(u8) -> Result<U, SexpError>,
+    FL: Fn(RLogical) -> Result<U, SexpError>,
+{
+    let actual = sexp.type_of();
+    match actual {
+        SEXPTYPE::INTSXP => {
+            let slice: &[i32] = unsafe { sexp.as_slice() };
+            slice.iter().copied().map(map_i32).collect()
+        }
+        SEXPTYPE::REALSXP => {
+            let slice: &[f64] = unsafe { sexp.as_slice() };
+            slice.iter().copied().map(map_f64).collect()
+        }
+        SEXPTYPE::RAWSXP => {
+            let slice: &[u8] = unsafe { sexp.as_slice() };
+            slice.iter().copied().map(map_u8).collect()
+        }
+        SEXPTYPE::LGLSXP => {
+            let slice: &[RLogical] = unsafe { sexp.as_slice() };
+            slice.iter().copied().map(map_lgl).collect()
+        }
+        _ => Err(SexpError::InvalidValue(format!(
+            "expected integer, numeric, logical, or raw; got {:?}",
+            actual
+        ))),
+    }
+}
+
 /// Convert numeric/logical/raw vectors to `Vec<T>` with element-wise coercion.
+///
+/// NA-unaware: an R `NA` round-trips as the coerced sentinel rather than being
+/// rejected. Bind `Vec<Option<T>>` (see [`na_vectors`]) when the caller can pass NA.
 #[inline]
 fn try_from_sexp_numeric_vec<T>(sexp: SEXP) -> Result<Vec<T>, SexpError>
 where
@@ -1074,29 +1124,13 @@ where
     <f64 as TryCoerce<T>>::Error: std::fmt::Debug,
     <u8 as TryCoerce<T>>::Error: std::fmt::Debug,
 {
-    let actual = sexp.type_of();
-    match actual {
-        SEXPTYPE::INTSXP => {
-            let slice: &[i32] = unsafe { sexp.as_slice() };
-            coerce_slice_to_vec(slice)
-        }
-        SEXPTYPE::REALSXP => {
-            let slice: &[f64] = unsafe { sexp.as_slice() };
-            coerce_slice_to_vec(slice)
-        }
-        SEXPTYPE::RAWSXP => {
-            let slice: &[u8] = unsafe { sexp.as_slice() };
-            coerce_slice_to_vec(slice)
-        }
-        SEXPTYPE::LGLSXP => {
-            let slice: &[RLogical] = unsafe { sexp.as_slice() };
-            slice.iter().map(|v| coerce_value(v.to_i32())).collect()
-        }
-        _ => Err(SexpError::InvalidValue(format!(
-            "expected integer, numeric, logical, or raw; got {:?}",
-            actual
-        ))),
-    }
+    from_numeric_vec_with(
+        sexp,
+        coerce_value,
+        coerce_value,
+        coerce_value,
+        |v: RLogical| coerce_value(v.to_i32()),
+    )
 }
 
 /// Implement `TryFromSexp for Vec<$target>` by coercing from integer/real/logical/raw.

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -18,8 +18,8 @@
 
 use crate::coerce::TryCoerce;
 use crate::from_r::{
-    SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str, coerce_value, is_na_real,
-    r_slice,
+    SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str, coerce_value,
+    from_numeric_vec_with, is_na_real, r_slice,
 };
 use crate::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 
@@ -260,56 +260,32 @@ where
     <f64 as TryCoerce<T>>::Error: std::fmt::Debug,
     <u8 as TryCoerce<T>>::Error: std::fmt::Debug,
 {
-    let actual = sexp.type_of();
-    match actual {
-        SEXPTYPE::INTSXP => {
-            let slice: &[i32] = unsafe { sexp.as_slice() };
-            slice
-                .iter()
-                .map(|&v| {
-                    if v == crate::altrep_traits::NA_INTEGER {
-                        Ok(None)
-                    } else {
-                        coerce_value(v).map(Some)
-                    }
-                })
-                .collect()
-        }
-        SEXPTYPE::REALSXP => {
-            let slice: &[f64] = unsafe { sexp.as_slice() };
-            slice
-                .iter()
-                .map(|&v| {
-                    if is_na_real(v) {
-                        Ok(None)
-                    } else {
-                        coerce_value(v).map(Some)
-                    }
-                })
-                .collect()
-        }
-        SEXPTYPE::RAWSXP => {
-            let slice: &[u8] = unsafe { sexp.as_slice() };
-            slice.iter().map(|&v| coerce_value(v).map(Some)).collect()
-        }
-        SEXPTYPE::LGLSXP => {
-            let slice: &[RLogical] = unsafe { sexp.as_slice() };
-            slice
-                .iter()
-                .map(|&v| {
-                    if v.is_na() {
-                        Ok(None)
-                    } else {
-                        coerce_value(v.to_i32()).map(Some)
-                    }
-                })
-                .collect()
-        }
-        _ => Err(SexpError::InvalidValue(format!(
-            "expected integer, numeric, logical, or raw; got {:?}",
-            actual
-        ))),
-    }
+    from_numeric_vec_with(
+        sexp,
+        |v: i32| {
+            if v == crate::altrep_traits::NA_INTEGER {
+                Ok(None)
+            } else {
+                coerce_value(v).map(Some)
+            }
+        },
+        |v: f64| {
+            if is_na_real(v) {
+                Ok(None)
+            } else {
+                coerce_value(v).map(Some)
+            }
+        },
+        // RAWSXP has no NA in R: every byte is a value.
+        |v: u8| coerce_value(v).map(Some),
+        |v: RLogical| {
+            if v.is_na() {
+                Ok(None)
+            } else {
+                coerce_value(v.to_i32()).map(Some)
+            }
+        },
+    )
 }
 
 macro_rules! impl_vec_option_try_from_sexp_numeric {

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -800,6 +800,140 @@ fn na_vector_option_i32_empty_zero_sentinel() {
 
 // endregion
 
+// region: from_r — coerced multi-source vec shell (from_numeric_vec_with)
+//
+// The tests above hit the *native* Vec<Option<i32>>/Vec<Option<f64>> impls.
+// These exercise the *coerced* path (`try_from_sexp_numeric_{,option_}vec`,
+// served for i8/i16/i64/u16/u32/u64/isize/usize/f32) that both route through
+// the shared `from_numeric_vec_with` dispatch. They pin the previously
+// unverified REALSXP/LGLSXP option cells and the plain-path NA-round-through
+// contract that distinguishes the NA-unaware sibling from the NA-aware one.
+
+/// Coerced Vec<Option<i64>> from REALSXP: NA_real_ → None (bit-exact, not NaN).
+#[test]
+fn coerced_option_vec_i64_realsxp_na_becomes_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::REALSXP, 3));
+            let sl: &mut [f64] = s.as_mut_slice();
+            sl[0] = 1.0;
+            sl[1] = NA_REAL;
+            sl[2] = 3.0;
+            s
+        };
+        let v: Vec<Option<i64>> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, vec![Some(1i64), None, Some(3i64)]);
+    });
+}
+
+/// Coerced Vec<Option<i64>> from REALSXP: a regular NaN is Some, not None.
+#[test]
+fn coerced_option_vec_i64_realsxp_regular_nan_errors_not_na() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::REALSXP, 1));
+            let sl: &mut [f64] = s.as_mut_slice();
+            sl[0] = f64::NAN; // plain IEEE NaN, NOT NA_real_
+            s
+        };
+        // f64::NAN is not NA_real_, so the element is not None; coercing a NaN to
+        // an integer fails, so the whole conversion errors rather than dropping it.
+        let result: Result<Vec<Option<i64>>, SexpError> = TryFromSexp::try_from_sexp(s);
+        assert!(
+            matches!(result, Err(SexpError::InvalidValue(_))),
+            "regular NaN must not be treated as NA"
+        );
+    });
+}
+
+/// Coerced Vec<Option<i64>> from LGLSXP: NA_LOGICAL → None, TRUE → 1, FALSE → 0.
+#[test]
+fn coerced_option_vec_i64_lglsxp_na_becomes_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::LGLSXP, 3));
+            s.set_logical_elt(0, 1); // TRUE
+            s.set_logical_elt(1, NA_LOGICAL);
+            s.set_logical_elt(2, 0); // FALSE
+            s
+        };
+        let v: Vec<Option<i64>> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, vec![Some(1i64), None, Some(0i64)]);
+    });
+}
+
+/// Coerced Vec<Option<i64>> from RAWSXP: raw has no NA, every byte is Some.
+#[test]
+fn coerced_option_vec_i64_rawsxp_all_some() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::RAWSXP, 3));
+            let sl: &mut [u8] = s.as_mut_slice();
+            sl[0] = 1;
+            sl[1] = 2;
+            sl[2] = 255;
+            s
+        };
+        let v: Vec<Option<i64>> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, vec![Some(1i64), Some(2i64), Some(255i64)]);
+    });
+}
+
+/// Plain (NA-unaware) coerced Vec<i64> from INTSXP: NA_integer_ rounds THROUGH
+/// as the i32::MIN sentinel, it is not dropped. This is the footgun documented
+/// on the na_vectors sibling and the contract the Option path avoids.
+#[test]
+fn coerced_plain_vec_i64_intsxp_na_round_through() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::INTSXP, 3));
+            let sl: &mut [i32] = s.as_mut_slice();
+            sl[0] = 1;
+            sl[1] = NA_INTEGER;
+            sl[2] = 3;
+            s
+        };
+        let v: Vec<i64> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, vec![1i64, i32::MIN as i64, 3i64]);
+    });
+}
+
+/// Plain (NA-unaware) coerced Vec<i64> from LGLSXP: NA_LOGICAL reads via to_i32()
+/// and rounds through as i32::MIN; TRUE → 1, FALSE → 0.
+#[test]
+fn coerced_plain_vec_i64_lglsxp_na_round_through() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe {
+            let s = g.protect(Rf_allocVector(SEXPTYPE::LGLSXP, 3));
+            s.set_logical_elt(0, 1); // TRUE
+            s.set_logical_elt(1, NA_LOGICAL);
+            s.set_logical_elt(2, 0); // FALSE
+            s
+        };
+        let v: Vec<i64> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, vec![1i64, i32::MIN as i64, 0i64]);
+    });
+}
+
+/// Coerced vec shell rejects an unsupported SEXPTYPE with the shared error.
+#[test]
+fn coerced_vec_i64_wrong_type_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { g.protect(SEXP::scalar_string_from_str("nope")) };
+        let result: Result<Vec<i64>, SexpError> = TryFromSexp::try_from_sexp(s);
+        assert!(matches!(result, Err(SexpError::InvalidValue(_))));
+    });
+}
+
+// endregion
+
 // region: from_r.rs (root) — NA_real_ identity via roundtrip, Vec<bool>, i32 NA guard
 
 /// NA_real_ roundtrip: f64 from an NA scalar returns the NA bit pattern.


### PR DESCRIPTION
PR-7 of the #835 conversion-dedup sprint. `try_from_sexp_numeric_vec` and `try_from_sexp_numeric_option_vec` carried a byte-identical `match sexp.type_of()` dispatch over INTSXP/REALSXP/RAWSXP/LGLSXP, differing only in the per-element NA closure. This folds the shared shell into one `from_numeric_vec_with` helper and keeps both functions as thin wrappers, so every caller (the macros, the set helper, the `Box<[..]>` blanket) is untouched. Because it is behavioral (NA semantics), it ships with a Rust oracle for the SEXPTYPE x NA cells that were previously unverified. Closes #853.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add `pub(crate) from_numeric_vec_with<U, ..>` to `from_r.rs`: one SEXP-dispatch shell over INTSXP/REALSXP/RAWSXP/LGLSXP parameterized by four zero-capture per-element closures (one per SEXPTYPE). The single behavioral axis (NA policy) lives in the closures the caller passes.
- Re-express `try_from_sexp_numeric_vec` (`from_r.rs`) and `try_from_sexp_numeric_option_vec` (`from_r/na_vectors.rs`) as thin wrappers over the shell. Both public-fn names and signatures are unchanged, so all call sites (the `impl_vec_*` macros, `try_from_sexp_numeric_set`, the `Box<[..]>` blanket) are byte-identical.
- NA semantics reproduced verbatim: INTSXP NA is `i32::MIN` (`NA_INTEGER`); REALSXP NA is the bit-exact `is_na_real`, not `f64::is_nan` (a real NaN survives as `Some(NaN)` on the option path, and errors out rather than being treated as NA); RAWSXP has no NA; LGLSXP NA is `NA_LOGICAL` via `RLogical::is_na`, value read through `to_i32()`.
- The shared `_ =>` error string is now single-sourced instead of duplicated.
- Add seven Rust unit tests in `conversion_coverage.rs` covering the coerced `Vec<Option<i64>>` / `Vec<i64>` paths over REALSXP/LGLSXP/RAWSXP/INTSXP, including the bit-exact NaN-is-not-NA guard and the plain-path NA-round-through contract.

## Test plan
- [x] `cargo test --workspace --locked` (only the pre-existing `miniextendr-macros` trybuild `ui` failure remains; it reproduces on clean `main` and is local-toolchain `.stderr` drift, validated green by CI's Rust lint)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default)
- [x] clippy_all with the curated feature list from `.github/workflows/ci.yml`
- [x] `cargo fmt --all --check`
- [ ] `just devtools-test` FAIL 0
- [x] zero generated-file churn (no wrappers.R / NAMESPACE / man / wasm_registry change)

## Notes
- Free-function plumbing, not `#[miniextendr]` surface, so no wrapper/NAMESPACE regen. Source net is roughly flat (+10): the win is single-sourcing one dispatch shell plus its error string in place of two, with the shell carrying a doc comment that pins the NA-policy contract.
- The previously-verified cell was INTSXP-option only (`conv_vec_option_i64_roundtrip` in rpkg); the new Rust oracle closes the REALSXP/LGLSXP/RAWSXP gap with zero generated-file churn, which is why it lives in `conversion_coverage.rs` rather than as new rpkg fixtures.
- Disjoint from #845's `into_r_infallible!` (that was the IntoR / outbound side; this is the TryFromSexp / inbound side). Not to be confused with the dropped 7-shape forward macro.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
