### PR TITLE
refactor(into_r): fold infallible IntoR wrappers onto into_r_infallible! (#835)

### DIFF
--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -244,9 +244,6 @@ impl_scalar_into_r!(crate::Rcomplex, scalar_complex, scalar_complex_unchecked);
 /// into_r_infallible!(Vec<Uuid>,
 ///     |this| this.into_iter().map(|u| u.to_string()).collect::<Vec<_>>().into_sexp());
 /// ```
-// Every consumer lives in a feature-gated `optionals` module, so with no
-// optional features enabled the macro and its re-export are genuinely unused.
-#[allow(unused_macros)]
 macro_rules! into_r_infallible {
     ($ty:ty, |$recv:ident| $body:expr) => {
         impl $crate::into_r::IntoR for $ty {
@@ -1646,6 +1643,12 @@ impl IntoR for Vec<Vec<String>> {
 /// Macro for NA-aware `Vec<Option<T>> → R` vector conversions.
 ///
 /// Uses `alloc_r_vector` to get a mutable slice, then fills it.
+///
+/// Unlike the sibling `Vec<Option<T>>` macros (`impl_vec_option_smart_i64_into_r!`
+/// / `impl_vec_option_coerce_into_r!`, which route through `into_r_infallible!`
+/// and inherit the default-unchecked policy), this one is written out by hand
+/// because it carries a *real* `into_sexp_unchecked` path (`alloc_r_vector_unchecked`)
+/// that the others have no analogue for. The divergence is deliberate.
 macro_rules! impl_vec_option_into_r {
     ($t:ty, $na_value:expr) => {
         impl IntoR for Vec<Option<$t>> {
@@ -1688,41 +1691,32 @@ impl_vec_option_into_r!(i32, NA_INTEGER); // NA_integer_
 /// Allocates the R vector directly and coerces in-place — no intermediate Vec.
 macro_rules! impl_vec_option_smart_i64_into_r {
     ($t:ty, $fits_i32:expr) => {
-        impl IntoR for Vec<Option<$t>> {
-            type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-                Ok(self.into_sexp())
-            }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-                self.try_into_sexp()
-            }
-            fn into_sexp(self) -> crate::SEXP {
-                unsafe {
-                    if self.iter().all(|opt| match opt {
-                        Some(x) => $fits_i32(*x),
-                        None => true,
-                    }) {
-                        let (sexp, dst) = alloc_r_vector::<i32>(self.len());
-                        for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
-                            *slot = match val {
-                                Some(x) => x as i32,
-                                None => NA_INTEGER,
-                            };
-                        }
-                        sexp
-                    } else {
-                        let (sexp, dst) = alloc_r_vector::<f64>(self.len());
-                        for (slot, val) in dst.iter_mut().zip(self.into_iter()) {
-                            *slot = match val {
-                                Some(x) => x as f64,
-                                None => NA_REAL,
-                            };
-                        }
-                        sexp
-                    }
+        // Default-unchecked policy, single-sourced through `into_r_infallible!`
+        // (no bespoke unchecked path — the checked allocation is the only one).
+        into_r_infallible!(Vec<Option<$t>>, |this| unsafe {
+            if this.iter().all(|opt| match opt {
+                Some(x) => $fits_i32(*x),
+                None => true,
+            }) {
+                let (sexp, dst) = alloc_r_vector::<i32>(this.len());
+                for (slot, val) in dst.iter_mut().zip(this.into_iter()) {
+                    *slot = match val {
+                        Some(x) => x as i32,
+                        None => NA_INTEGER,
+                    };
                 }
+                sexp
+            } else {
+                let (sexp, dst) = alloc_r_vector::<f64>(this.len());
+                for (slot, val) in dst.iter_mut().zip(this.into_iter()) {
+                    *slot = match val {
+                        Some(x) => x as f64,
+                        None => NA_REAL,
+                    };
+                }
+                sexp
             }
-        }
+        });
     };
 }
 
@@ -1738,23 +1732,15 @@ impl_vec_option_smart_i64_into_r!(usize, |x: usize| x <= i32::MAX as usize);
 /// Delegates to the target type's `Vec<Option<$to>>` impl (which itself uses alloc_r_vector).
 macro_rules! impl_vec_option_coerce_into_r {
     ($from:ty => $to:ty) => {
-        impl IntoR for Vec<Option<$from>> {
-            type Error = std::convert::Infallible;
-            fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-                Ok(self.into_sexp())
-            }
-            unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-                self.try_into_sexp()
-            }
-            fn into_sexp(self) -> crate::SEXP {
-                // Delegate to the target Option type's impl (coerce inline)
-                let coerced: Vec<Option<$to>> = self
-                    .into_iter()
-                    .map(|opt| opt.map(|x| <$to>::from(x)))
-                    .collect();
-                coerced.into_sexp()
-            }
-        }
+        // Default-unchecked policy, single-sourced through `into_r_infallible!`;
+        // `into_sexp` delegates to the target `Vec<Option<$to>>` impl.
+        into_r_infallible!(Vec<Option<$from>>, |this| {
+            let coerced: Vec<Option<$to>> = this
+                .into_iter()
+                .map(|opt| opt.map(|x| <$to>::from(x)))
+                .collect();
+            coerced.into_sexp()
+        });
     };
 }
 
@@ -2137,32 +2123,21 @@ where
     }
 }
 
-/// Convert `Vec<Box<[String]>>` to R list of character vectors.
-impl IntoR for Vec<Box<[String]>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        unsafe {
-            let n = self.len();
-            let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
-            crate::sys::Rf_protect(list);
+// Convert `Vec<Box<[String]>>` to R list of character vectors.
+into_r_infallible!(Vec<Box<[String]>>, |this| unsafe {
+    let n = this.len();
+    let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n as crate::R_xlen_t);
+    crate::sys::Rf_protect(list);
 
-            for (i, boxed_slice) in self.into_iter().enumerate() {
-                let vec: Vec<String> = boxed_slice.into_vec();
-                let inner_sexp = vec.into_sexp();
-                list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
-            }
-
-            crate::sys::Rf_unprotect(1);
-            list
-        }
+    for (i, boxed_slice) in this.into_iter().enumerate() {
+        let vec: Vec<String> = boxed_slice.into_vec();
+        let inner_sexp = vec.into_sexp();
+        list.set_vector_elt(i as crate::R_xlen_t, inner_sexp);
     }
-}
+
+    crate::sys::Rf_unprotect(1);
+    list
+});
 
 /// Convert `Vec<[T; N]>` to R list of vectors.
 /// Each array becomes an R vector.
@@ -2250,19 +2225,10 @@ where
     }
 }
 
-/// Convert `Vec<Option<Vec<String>>>` to R list where `None` → NULL, `Some(v)` → character vector.
-impl IntoR for Vec<Option<Vec<String>>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        vec_option_of_into_r_to_list(self)
-    }
-}
+// Convert `Vec<Option<Vec<String>>>` to R list where `None` → NULL, `Some(v)` → character vector.
+into_r_infallible!(Vec<Option<Vec<String>>>, |this| {
+    vec_option_of_into_r_to_list(this)
+});
 
 /// Convert `Vec<Option<HashSet<T>>>` to R list where `None` → NULL, `Some(s)` → unordered vector.
 impl<T: crate::RNativeType + Eq + Hash> IntoR for Vec<Option<HashSet<T>>>
@@ -2281,19 +2247,10 @@ where
     }
 }
 
-/// Convert `Vec<Option<HashSet<String>>>` to R list where `None` → NULL, `Some(s)` → character vector.
-impl IntoR for Vec<Option<HashSet<String>>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        vec_option_of_into_r_to_list(self)
-    }
-}
+// Convert `Vec<Option<HashSet<String>>>` to R list where `None` → NULL, `Some(s)` → character vector.
+into_r_infallible!(Vec<Option<HashSet<String>>>, |this| {
+    vec_option_of_into_r_to_list(this)
+});
 
 /// Convert `Vec<Option<BTreeSet<T>>>` to R list where `None` → NULL, `Some(s)` → sorted vector.
 impl<T: crate::RNativeType + Ord> IntoR for Vec<Option<BTreeSet<T>>>
@@ -2312,19 +2269,10 @@ where
     }
 }
 
-/// Convert `Vec<Option<BTreeSet<String>>>` to R list where `None` → NULL, `Some(s)` → sorted character vector.
-impl IntoR for Vec<Option<BTreeSet<String>>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        vec_option_of_into_r_to_list(self)
-    }
-}
+// Convert `Vec<Option<BTreeSet<String>>>` to R list where `None` → NULL, `Some(s)` → sorted character vector.
+into_r_infallible!(Vec<Option<BTreeSet<String>>>, |this| {
+    vec_option_of_into_r_to_list(this)
+});
 
 /// Convert `Vec<Option<HashMap<String, V>>>` to R list where `None` → NULL, `Some(m)` → named list.
 impl<V: IntoR> IntoR for Vec<Option<HashMap<String, V>>> {
@@ -2370,21 +2318,11 @@ impl<T: crate::RNativeType> IntoR for Vec<Option<&[T]>> {
     }
 }
 
-/// Convert `Vec<Option<&[String]>>` to R list where `None` → NULL, `Some(s)` → character vector.
-///
-/// Borrowed analogue of `Vec<Option<Vec<String>>>`.
-impl IntoR for Vec<Option<&[String]>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        vec_option_of_into_r_to_list(self)
-    }
-}
+// Convert `Vec<Option<&[String]>>` to R list where `None` → NULL, `Some(s)` → character vector.
+// Borrowed analogue of `Vec<Option<Vec<String>>>`.
+into_r_infallible!(Vec<Option<&[String]>>, |this| vec_option_of_into_r_to_list(
+    this
+));
 
 // endregion
 
@@ -2426,37 +2364,17 @@ where
     }
 }
 
-/// Convert `Vec<HashSet<String>>` to R list of character vectors.
-impl IntoR for Vec<std::collections::HashSet<String>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        let converted: Vec<Vec<String>> =
-            self.into_iter().map(|s| s.into_iter().collect()).collect();
-        vec_of_into_r_to_list(converted)
-    }
-}
+// Convert `Vec<HashSet<String>>` to R list of character vectors.
+into_r_infallible!(Vec<std::collections::HashSet<String>>, |this| {
+    let converted: Vec<Vec<String>> = this.into_iter().map(|s| s.into_iter().collect()).collect();
+    vec_of_into_r_to_list(converted)
+});
 
-/// Convert `Vec<BTreeSet<String>>` to R list of character vectors.
-impl IntoR for Vec<std::collections::BTreeSet<String>> {
-    type Error = std::convert::Infallible;
-    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
-        Ok(self.into_sexp())
-    }
-    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
-        self.try_into_sexp()
-    }
-    fn into_sexp(self) -> crate::SEXP {
-        let converted: Vec<Vec<String>> =
-            self.into_iter().map(|s| s.into_iter().collect()).collect();
-        vec_of_into_r_to_list(converted)
-    }
-}
+// Convert `Vec<BTreeSet<String>>` to R list of character vectors.
+into_r_infallible!(Vec<std::collections::BTreeSet<String>>, |this| {
+    let converted: Vec<Vec<String>> = this.into_iter().map(|s| s.into_iter().collect()).collect();
+    vec_of_into_r_to_list(converted)
+});
 
 macro_rules! impl_vec_map_into_r {
     ($(#[$meta:meta])* $map_ty:ident) => {


### PR DESCRIPTION
Final tractable item of the #835 conversion-dedup sprint (audit Finding 5). Two things up front: the audit's headline fix for this finding (a sealed `IntoSexp` core trait plus a blanket `IntoR`) is coherence-infeasible, and the "~106 identical wrappers" turned out to be non-uniform by design (many carry a real `into_sexp_unchecked` path). So this is the targeted remainder: fold the genuinely-pure-boilerplate `IntoR` impls onto the existing `into_r_infallible!` helper (from #845) and make the three `Vec<Option<T>>` macros' unchecked policy intentional instead of accidental. Behavior-preserving, net negative.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Fold seven concrete `IntoR` impls (`Vec<Box<[String]>>`, `Vec<Option<{Vec,HashSet,BTreeSet,&[..]}<String>>>`, `Vec<{HashSet,BTreeSet}<String>>`) from the hand-written four-method wrapper onto `into_r_infallible!`. The macro emits the byte-identical wrapper (`try_into_sexp -> Ok(into_sexp())`, `try_into_sexp_unchecked -> self.try_into_sexp()`, `into_sexp_unchecked` = trait default); only the real `into_sexp` body is supplied, moved verbatim (`self` renamed to the bound receiver).
- Route the two default-unchecked `Vec<Option<T>>` macros (`impl_vec_option_smart_i64_into_r!`, `impl_vec_option_coerce_into_r!`) through `into_r_infallible!` so their unchecked policy is single-sourced through the canonical helper.
- Keep `impl_vec_option_into_r!` hand-written (it carries a genuine `alloc_r_vector_unchecked` path the other two have no analogue for) and document the deliberate divergence on its doc comment.
- Drop the now-stale `#[allow(unused_macros)]` on `into_r_infallible!` (it is now used in always-compiled core code), keeping the `#[allow(unused_imports)]` on the re-export (still consumed only by the feature-gated optionals).

## Why the audit's headline was not followed
- A sealed `IntoSexp` core trait with `impl<T: IntoSexp> IntoR for T` collides under E0119 with the existing `impl<T: MatchArg> IntoR for Vec<T>` (match_arg.rs); that conflict is exactly why the native `Vec<T>` impls are written concretely (documented at into_r.rs:348). Negative bounds are not stable, so the blanket is infeasible. The vehicle is the declarative macro.
- The unchecked axis is non-uniform on purpose: scalar / coerce / `Option<Rcomplex>` / `Vec<bool>` / `impl_vec_option_into_r!` carry real `*_unchecked` paths and are left untouched. #845 already folded the optional-type modules, so the genuinely-uniform remainder is small.

## Test plan
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default)
- [x] clippy_all with the curated feature list from `.github/workflows/ci.yml` (compiles the macro-routings and folds under the full matrix, incl. `connections`/`default-r6`/optionals)
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --locked` (only the pre-existing `miniextendr-macros` trybuild `ui` failure remains; reproduces on clean `main`, validated green by CI's Rust lint)
- [ ] `just devtools-test` FAIL 0
- [x] zero generated-file churn

## Notes
- Net negative (about -80 lines), single file, Rust-only, not `#[miniextendr]` surface, so no wrapper/NAMESPACE regen. The `(trait, for-type)` impl set is unchanged: the macro emits `impl IntoR for <same type>` for every folded case.
- Generic candidates (`Vec<Box<[T]>>`, `Vec<Option<Vec<T>>>`, `Vec<Option<HashMap<String, V>>>`, `impl_vec_map_into_r!`, etc.) are left as explicit impls on purpose: `into_r_infallible!` has no generic arm, and a bracket-delimited generic arm would read worse at the call site than the explicit impls.
- Closes out the tractable part of audit Finding 5 for #835; the sealed-trait infeasibility is recorded on the umbrella issue.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
