### PR TITLE
ci: dedup cargo-revendor preamble into a composite action; reorder changes job

### DIFF
--- a/.github/actions/setup-vendor/action.yml
+++ b/.github/actions/setup-vendor/action.yml
@@ -1,0 +1,29 @@
+name: Set up cargo-revendor and vendor
+description: >-
+  Install cargo-revendor from the in-repo crate, then optionally run
+  `just configure` + `just vendor` to seal the offline vendor tarball.
+  Centralises the install + configure + vendor preamble shared by the
+  R CMD check jobs in ci.yml (see issue #850). Requires `just` and a Rust
+  toolchain to already be on PATH (install them in the calling job first).
+inputs:
+  configure-and-vendor:
+    description: >-
+      When 'true' (default), run `just configure` then `just vendor` after
+      installing cargo-revendor. Set to 'false' for jobs that only need the
+      cargo-revendor binary (bootstrap-vendor-test) or that drive configure
+      and vendor as separate, non-adjacent steps themselves (sync-checks).
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Install cargo-revendor
+      shell: bash
+      run: cargo install --path cargo-revendor
+
+    - name: Configure and vendor
+      if: inputs.configure-and-vendor == 'true'
+      shell: bash
+      run: |
+        just configure
+        just vendor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,64 @@ jobs:
           echo "Versions match!"
 
   # ===========================================================================
+  # Change detection (path-based gating)
+  # ===========================================================================
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      r: ${{ steps.filter.outputs.r }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Determine changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '.cargo/**'
+              - '.github/workflows/**'
+              - 'justfile'
+            r:
+              - 'rpkg/**'
+              - 'minirextendr/**'
+              - 'tests/cross-package/**'
+              - 'miniextendr-api/**'
+              - 'miniextendr-macros/**'
+              - 'miniextendr-engine/**'
+              - 'miniextendr-lint/**'
+              - '**/*.R'
+              - '**/*.r'
+              - '**/configure.ac'
+              - '**/configure'
+              - '**/*.in'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '.cargo/**'
+              - '.github/workflows/**'
+              - 'justfile'
+            docs:
+              - 'rpkg/man/**'
+              - '**/*.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'README*'
+              - 'docs/**'
+
+  # ===========================================================================
   # Sync checks (vendor, templates, lint parser)
   # ===========================================================================
   sync-checks:
@@ -146,8 +204,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
+      - name: Set up cargo-revendor (install only)
+        uses: ./.github/actions/setup-vendor
+        with:
+          configure-and-vendor: 'false'
 
       - name: Install R packages (devtools, roxygen2)
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -313,64 +373,6 @@ jobs:
           fi
 
   # ===========================================================================
-  # Change detection (path-based gating)
-  # ===========================================================================
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      r: ${{ steps.filter.outputs.r }}
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Determine changed paths
-        id: filter
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            rust:
-              - '**/*.rs'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - '**/Cargo.toml'
-              - '**/Cargo.lock'
-              - '.cargo/**'
-              - '.github/workflows/**'
-              - 'justfile'
-            r:
-              - 'rpkg/**'
-              - 'minirextendr/**'
-              - 'tests/cross-package/**'
-              - 'miniextendr-api/**'
-              - 'miniextendr-macros/**'
-              - 'miniextendr-engine/**'
-              - 'miniextendr-lint/**'
-              - '**/*.R'
-              - '**/*.r'
-              - '**/configure.ac'
-              - '**/configure'
-              - '**/*.in'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - '**/Cargo.toml'
-              - '**/Cargo.lock'
-              - '.cargo/**'
-              - '.github/workflows/**'
-              - 'justfile'
-            docs:
-              - 'rpkg/man/**'
-              - '**/*.rs'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - '**/Cargo.toml'
-              - '**/Cargo.lock'
-              - 'README*'
-              - 'docs/**'
-
-  # ===========================================================================
   # R Package: R CMD check on Linux
   # ===========================================================================
   r-check-linux:
@@ -443,13 +445,8 @@ jobs:
           path: rpkg/inst/vendor.tar.xz
           key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'miniextendr-*/src/**', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml', 'rpkg/src/rust/**/*.rs') }}
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
-
-      - name: Configure and vendor
-        run: |
-          just configure
-          just vendor
+      - name: Set up cargo-revendor and vendor
+        uses: ./.github/actions/setup-vendor
 
       # NOTE: Cargo tests are disabled due to stack overflow issues on Linux CI.
       # The R package functionality is already tested via R CMD check below.
@@ -603,13 +600,8 @@ jobs:
           shared-key: r-macos-${{ matrix.arch }}
           cache-on-failure: true
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
-
-      - name: Configure and vendor
-        run: |
-          just configure
-          just vendor
+      - name: Set up cargo-revendor and vendor
+        uses: ./.github/actions/setup-vendor
 
       - name: R CMD check
         uses: r-lib/actions/check-r-package@v2
@@ -1107,13 +1099,8 @@ jobs:
           path: rpkg/inst/vendor.tar.xz
           key: vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'miniextendr-*/src/**', 'rpkg/src/rust/Cargo.lock', 'rpkg/src/rust/Cargo.toml', 'rpkg/src/rust/**/*.rs') }}
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
-
-      - name: Configure and vendor
-        run: |
-          just configure
-          just vendor
+      - name: Set up cargo-revendor and vendor
+        uses: ./.github/actions/setup-vendor
 
       - name: Build source tarball
         run: |
@@ -1212,8 +1199,10 @@ jobs:
           shared-key: bootstrap-vendor-test
           cache-on-failure: true
 
-      - name: Install cargo-revendor
-        run: cargo install --path cargo-revendor
+      - name: Set up cargo-revendor (install only)
+        uses: ./.github/actions/setup-vendor
+        with:
+          configure-and-vendor: 'false'
 
       - name: Run bootstrap-vendor regression test
         run: just test-bootstrap-vendor


### PR DESCRIPTION
Closes #850. CI-hygiene: extracts the repeated cargo-revendor install + configure + vendor preamble into one composite action, and reorders the `changes` job ahead of `sync-checks` so declaration order matches the `needs:` edge. **The rust-cache `v2 → v3` bump from the issue is dropped — `Swatinem/rust-cache` has no `v3` tag (latest is `v2.9.1`); `@v3` fails to resolve in Actions** (the first CI run on this branch proved it). No behavioural change to what the jobs run.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- New `.github/actions/setup-vendor` composite action wraps `cargo install --path cargo-revendor` then (optionally) `just configure` + `just vendor`. A `configure-and-vendor` input (default `'true'`) lets install-only consumers reuse the same action.
- Routed through the action:
  - **Full** (install + configure + vendor): `r-check-linux`, `r-check-macos`, `cran-check`.
  - **Install-only** (`configure-and-vendor: 'false'`): `sync-checks` (drives configure/vendor itself, separated by `wrappers-sync-check`), `bootstrap-vendor-test` (vendors via `just test-bootstrap-vendor`).
- Reordered the `changes` job to sit directly before `sync-checks` (pure block move, content unchanged — the large diff churn is the move itself).

## Dropped deliverable: rust-cache v2 → v3
- The issue asked to bump `Swatinem/rust-cache@v2` → `@v3`. There is no `v3`: the action's newest tag is `v2.9.1` (`gh api repos/Swatinem/rust-cache/tags`). `@v3` fails to resolve and aborts the job in ~2s, which is exactly how the first push to this branch failed on `wasm32 check`.
- Reverted to the floating `@v2` major, which is already the latest major and matches the repo's house style for first/third-party actions (`checkout@v6`, `setup-r@v2`, `paths-filter@v4`, `upload-artifact@v7`). If a pinned `@v2.9.1` is preferred, that is a one-line follow-up — flagged on the issue.

## Two deliberate non-changes
- **Commented-out Windows block** keeps its inline preamble. Composite actions cannot inherit a job's `defaults.run.shell`, and the Windows job uses rtools `bash`; routing it would force `shell: bash` (Git bash) and silently change behaviour when Windows CI is re-enabled.
- **`pages.yml`** keeps its inline `cargo install --path cargo-revendor` — that usage is `continue-on-error`, has no `just configure`, and gates `just vendor` behind a cache-miss condition, so it is structurally unlike the R CMD check preamble.

## Test plan
- [x] `yaml.safe_load` parses `ci.yml` and the new `action.yml`.
- [x] `actionlint` exits 0 — no errors on the `uses: ./.github/actions/setup-vendor` references, the `if: inputs.configure-and-vendor` expression, or the reorder.
- [x] `changes` job appears exactly once and now precedes `sync-checks`; job set unchanged (13 jobs).
- [ ] Full CI green on this PR (the real validation — this PR touches `.github/workflows/**`, which is in both path filters, so the R CMD check jobs exercise the action end-to-end).

## Notes
- The composite action requires `just` and a Rust toolchain already on PATH; every calling job installs both before the action step (verified for all five jobs).

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>