### PR TITLE
docs: enum-as-instance vs by-value, and their mutual exclusivity (E0119)

### DIFF
--- a/docs/CLASS_SYSTEMS.md
+++ b/docs/CLASS_SYSTEMS.md
@@ -936,6 +936,62 @@ All functions require the R main thread and operate on raw SEXP values.
 
 ---
 
+## Enums: value vs instance
+
+A fieldless enum can be exposed to R in **two mutually-exclusive** ways. Pick one.
+
+**By value** — the enum crosses the boundary as an R character or factor and is
+reconstructed on each call; there is no persistent R object holding a Rust
+instance:
+
+- `#[derive(MatchArg)]` → R character scalar validated with `match.arg`.
+- `#[derive(RFactor)]` → R `factor` with integer codes and level labels.
+
+This is the right choice for a closed set of options passed as arguments. See
+[ENUMS_AND_FACTORS.md](ENUMS_AND_FACTORS.md).
+
+**By reference** — the enum is wrapped exactly like a struct: `#[derive(ExternalPtr)]`
+plus a class-system `impl` block. R holds an opaque pointer to a boxed instance,
+and the impl block's methods become R6/S3/S4/S7/env methods. The variants are
+internal state, invisible to R:
+
+```rust
+#[derive(Clone, Copy, ExternalPtr)]
+pub enum DType { F32, F64 }
+
+#[miniextendr(r6)]
+impl DType {
+    pub fn new_f32() -> Self { DType::F32 }
+    pub fn is_float(&self) -> bool { matches!(self, DType::F32 | DType::F64) }
+    pub fn size_bytes(&self) -> i32 { match self { DType::F32 => 4, DType::F64 => 8 } }
+}
+```
+
+Use this when the enum needs methods or object identity.
+
+### You cannot have both
+
+Deriving both `ExternalPtr` and `MatchArg`/`RFactor` on one type is a hard
+compile error:
+
+```
+error[E0119]: conflicting implementations of trait `IntoR` for type `DType`
+   = note: conflicting implementation in crate `miniextendr_api`:
+           - impl<T> IntoR for T where T: IntoExternalPtr;
+   = note: this error originates in the derive macro `MatchArg`
+```
+
+`ExternalPtr` supplies a blanket `impl<T> IntoR for T where T: IntoExternalPtr`,
+while `MatchArg`/`RFactor` generate their own `impl IntoR` (and a conflicting
+`TryFromSexp`). A type is therefore *either* a by-value enum *or* a by-reference
+instance — never both.
+
+If you want both a friendly string API *and* methods, keep the enum by-value and
+put the behaviour on a separate wrapper struct (or expose free functions that
+take the by-value enum).
+
+---
+
 ## Recommendations
 
 1. **Start with Env** for simple cases

--- a/docs/ENUMS_AND_FACTORS.md
+++ b/docs/ENUMS_AND_FACTORS.md
@@ -9,6 +9,13 @@ miniextendr provides two complementary systems for enum-like types:
 | `RFactor` | Factor (integer + levels) | No | - | Categorical data for `table()`, `lm()`, etc. |
 | `MatchArg` | Character scalar | Yes | First choice | Parameter validation (`match.arg()` style) |
 
+Both systems pass the enum **by value** (as a factor/string). If instead you want
+the enum to be a methods-bearing **instance** — an `ExternalPtr` wrapped with a
+class-system `impl` block — see
+[CLASS_SYSTEMS.md § Enums: value vs instance](CLASS_SYSTEMS.md#enums-value-vs-instance).
+Note the two are **mutually exclusive**: deriving `ExternalPtr` alongside
+`MatchArg`/`RFactor` is a compile error (`E0119`, conflicting `IntoR`).
+
 ## RFactor: enum as R Factor
 
 Maps a Rust enum to an R factor with levels. Each variant becomes a level.


### PR DESCRIPTION
_TODO (author): replace this line with your framing paragraph, in your own voice, before merge._

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add an "Enums: value vs instance" section to `CLASS_SYSTEMS.md`: a fieldless enum can be wrapped as an `ExternalPtr`-backed instance via a class-system `impl` block (wrapped exactly like a struct), which was previously undocumented (the doc did not mention enums at all).
- Document that the by-value path (`MatchArg`/`RFactor`) and the by-reference path (`ExternalPtr` + impl) are mutually exclusive: deriving both is `E0119` (`ExternalPtr`'s blanket `impl<T> IntoR for T where T: IntoExternalPtr` vs the `impl IntoR` that `MatchArg`/`RFactor` generate). Includes the workaround (keep the enum by-value, put methods on a separate wrapper struct or free functions).
- Add a cross-link from `ENUMS_AND_FACTORS.md` to the new section, noting the exclusivity.
- Refs #830.

## Test plan
- [ ] Docs-only; confirm the new section renders and the cross-link anchor resolves.
- [ ] Maintainer: regenerate `site/content/manual/` via `just site-docs` (deferred from this branch).

## Notes
- Verified against miniextendr `1d1448f` / rustc 1.95.0 by a probe: enum + `#[miniextendr(r6)] impl` compiles to an R6 class; adding `MatchArg` to the same enum fails with `E0119`.
- The `site/` regen is intentionally left out (generated artifact + maintainer build step).

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
