### PR TITLE
test(connections): silence benign 'incomplete final line' readLines warnings (#873)

### DIFF
--- a/rpkg/tests/testthat/test-connections.R
+++ b/rpkg/tests/testthat/test-connections.R
@@ -11,7 +11,7 @@ skip_if_missing_feature("connections")
 test_that("string_input_connection reads multi-line content", {
   con <- string_input_connection("line1\nline2\nline3")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_length(lines, 3)
   expect_equal(lines, c("line1", "line2", "line3"))
 })
@@ -19,7 +19,7 @@ test_that("string_input_connection reads multi-line content", {
 test_that("string_input_connection reads single line", {
   con <- string_input_connection("hello")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_length(lines, 1)
   expect_equal(lines, "hello")
 })
@@ -27,7 +27,7 @@ test_that("string_input_connection reads single line", {
 test_that("string_input_connection reads empty string", {
   con <- string_input_connection("")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_length(lines, 0)
 })
 
@@ -38,14 +38,14 @@ test_that("string_input_connection reads empty string", {
 test_that("counter_connection generates sequential integers", {
   con <- counter_connection(1L, 5L)
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, as.character(1:5))
 })
 
 test_that("counter_connection with single value", {
   con <- counter_connection(42L, 42L)
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, "42")
 })
 
@@ -58,7 +58,7 @@ test_that("memory_connection write then read roundtrip", {
   on.exit(close(con))
   writeLines("Hello, World!", con)
   seek(con, 0)
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, "Hello, World!")
 })
 
@@ -67,7 +67,7 @@ test_that("memory_connection write multiple lines", {
   on.exit(close(con))
   writeLines(c("foo", "bar", "baz"), con)
   seek(con, 0)
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, c("foo", "bar", "baz"))
 })
 
@@ -78,14 +78,14 @@ test_that("memory_connection write multiple lines", {
 test_that("uppercase_connection transforms to uppercase", {
   con <- uppercase_connection("hello world")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, "HELLO WORLD")
 })
 
 test_that("uppercase_connection preserves non-alpha characters", {
   con <- uppercase_connection("abc 123 !@#")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, "ABC 123 !@#")
 })
 
@@ -96,7 +96,7 @@ test_that("uppercase_connection preserves non-alpha characters", {
 test_that("rot13_connection encodes text", {
   con <- rot13_connection("hello")
   on.exit(close(con))
-  lines <- readLines(con)
+  lines <- readLines(con, warn = FALSE)
   expect_equal(lines, "uryyb")
 })
 
@@ -104,11 +104,11 @@ test_that("rot13 double-application returns original", {
   # ROT13 is its own inverse
   con1 <- rot13_connection("hello world")
   on.exit(close(con1), add = TRUE)
-  encoded <- readLines(con1)
+  encoded <- readLines(con1, warn = FALSE)
 
   con2 <- rot13_connection(encoded)
   on.exit(close(con2), add = TRUE)
-  decoded <- readLines(con2)
+  decoded <- readLines(con2, warn = FALSE)
 
   expect_equal(decoded, "hello world")
 })


### PR DESCRIPTION
## Root cause

Rust-backed in-memory connections (`string_input_connection`, `uppercase_connection`, `rot13_connection`, etc.) are built from literal strings with no trailing newline (`"hello"`, `"hello world"`, `"abc 123 !@#"`, …). `base::readLines()` emits a benign `incomplete final line found` warning for any source whose last line isn't `\n`-terminated. This is correct R behaviour — not a bug in the connection layer.

## Fix

Pass `warn = FALSE` to all 12 `readLines(con*)` calls in `test-connections.R` (lines 14, 22, 30, 41, 48, 61, 70, 81, 88, 99, 107, 111). This is the idiomatic silencer for the specific "incomplete final line" notice: it does not suppress other warnings and does not change line semantics. Applied uniformly to all 12 calls (only 7 warned today, but all read from the same in-memory-connection abstraction where the notice is always benign).

`suppressWarnings()` was explicitly rejected — it would hide unrelated warnings. Adding trailing `\n` to input strings was also rejected — it would change `expect_length`/`expect_equal` semantics.

## Verification

- Before: `WARN 7` (all from `test-connections.R`), `FAIL 0`, `PASS 6330`
- After: `WARN 0`, `FAIL 0`, `PASS 6330` (SKIP 19, unchanged)
- No `WARNING: 'test-connections.R:` lines in `/tmp/conn-test.log`
- `cargo fmt --all -- --check` exits 0 (no Rust files changed)
- `git log origin/main..HEAD` shows exactly one commit

Closes #873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)