### PR TITLE
fix(vendor): fail loudly when a framework crate vendors from git instead of local (#876)

### DIFF
--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -343,6 +343,20 @@ pub fn discover_from_patch_config(manifest_path: &Path) -> Result<Vec<LocalPacka
 
                 let crate_manifest = crate_path.join("Cargo.toml");
                 if !crate_manifest.exists() {
+                    // The `[patch]` entry points at a path with no Cargo.toml,
+                    // so cargo silently doesn't apply the override and the crate
+                    // is vendored from its git/registry source instead. For a
+                    // monorepo framework crate this silently drops in-PR edits
+                    // (the #865/#876 latch-leak failure mode). Warn loudly so the
+                    // misconfiguration is visible; the caller's local-crate
+                    // assertion is what ultimately fails the build.
+                    eprintln!(
+                        "  warning: [patch] entry for `{crate_name}` in {} points at `{}`, \
+                         which has no Cargo.toml — the override will NOT apply and `{crate_name}` \
+                         will be vendored from its git/registry source instead of this path.",
+                        config_path.display(),
+                        crate_path.display(),
+                    );
                     continue; // path doesn't resolve on this machine — skip
                 }
 
@@ -772,6 +786,82 @@ mod tests {
                 .contains("no workspace `Cargo.toml` found above"),
             "unexpected error message: {err}"
         );
+    }
+
+    // endregion
+
+    // region: discover_from_patch_config tests
+
+    /// Build a monorepo-shaped fixture rooted at a TempDir:
+    ///   <root>/miniextendr-api/Cargo.toml         (framework crate source)
+    ///   <root>/rpkg/src/rust/Cargo.toml           (target manifest)
+    ///   <root>/rpkg/src/rust/.cargo/config.toml    (with the given body)
+    /// Returns (TempDir guard, target manifest path).
+    fn patch_config_fixture(config_body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+
+        // Framework crate at the workspace root (the [patch] path target).
+        let api_dir = root.join("miniextendr-api");
+        std::fs::create_dir_all(&api_dir).unwrap();
+        std::fs::write(
+            api_dir.join("Cargo.toml"),
+            "[package]\nname = \"miniextendr-api\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        // Target manifest, nested rpkg-style, with its own .cargo/config.toml.
+        let rust_dir = root.join("rpkg").join("src").join("rust");
+        std::fs::create_dir_all(rust_dir.join(".cargo")).unwrap();
+        let manifest = rust_dir.join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            "[package]\nname = \"rpkg\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(rust_dir.join(".cargo").join("config.toml"), config_body).unwrap();
+
+        (dir, manifest)
+    }
+
+    #[test]
+    fn patch_config_resolves_existing_path() {
+        // A [patch."git+url"] entry whose path resolves to a real Cargo.toml
+        // is returned as a local override.
+        let body = "[patch.\"https://github.com/A2-ai/miniextendr\"]\n\
+                    miniextendr-api = { path = \"../../../miniextendr-api\" }\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let found = discover_from_patch_config(&manifest).unwrap();
+        assert_eq!(found.len(), 1, "the resolvable entry should be discovered");
+        assert_eq!(found[0].name, "miniextendr-api");
+        assert_eq!(found[0].version, "0.1.0");
+    }
+
+    #[test]
+    fn patch_config_skips_missing_path() {
+        // A [patch] entry pointing at a path with NO Cargo.toml is skipped
+        // (and warned about). This is the latch-leak shape (#865/#876): the
+        // override silently doesn't apply, so the framework crate is NOT
+        // reported as a local override and falls back to git vendoring.
+        let body = "[patch.\"https://github.com/A2-ai/miniextendr\"]\n\
+                    miniextendr-api = { path = \"../../../does-not-exist\" }\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let found = discover_from_patch_config(&manifest).unwrap();
+        assert!(
+            found.is_empty(),
+            "an unresolvable [patch] path must NOT be reported as a local override, \
+             so the loud-fail assertion can fire; got {found:?}"
+        );
+    }
+
+    #[test]
+    fn patch_config_no_patch_table_is_empty() {
+        // No [patch] table at all — the dev-tree-without-overrides case. No
+        // local crates discovered; the caller's assertion catches the leak.
+        let body = "[build]\nrustflags = []\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let found = discover_from_patch_config(&manifest).unwrap();
+        assert!(found.is_empty(), "no [patch] table → no local overrides");
     }
 
     // endregion

--- a/cargo-revendor/tests/patch_from_config.rs
+++ b/cargo-revendor/tests/patch_from_config.rs
@@ -375,6 +375,129 @@ no-config-lib = {{ git = "{git_url}" }}
     );
 }
 
+/// **P5** (loud-fail signal, #876) — when the `[patch."<git-url>"]` override IS
+/// present, the patched crate must appear in `--json local_crates`; the
+/// `just vendor` recipe greps exactly this signal to assert framework crates
+/// were vendored from the local workspace, not git@main.
+#[test]
+#[ignore] // invokes cargo vendor
+fn json_local_crates_includes_patched_crate() {
+    let git_upstream = create_local_git_crate(
+        "signal-lib",
+        r#"[package]
+name = "signal-lib"
+version = "0.5.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn signal() {}\npub fn patched() -> &'static str { \"GIT\" }\n",
+    );
+
+    let (_work, manifest) =
+        build_patch_workspace(&git_upstream.url(), "signal-lib", "0.5.0", "LOCAL_SIGNAL");
+    let vendor = manifest.parent().unwrap().join("vendor");
+
+    let output = revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&vendor)
+        .arg("--json")
+        .output()
+        .expect("failed to run cargo-revendor");
+
+    assert!(output.status.success(), "vendor run should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    let locals: Vec<String> = json["local_crates"]
+        .as_array()
+        .expect("local_crates should be an array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        locals.iter().any(|c| c == "signal-lib"),
+        "patched crate must be reported as local; got {locals:?}"
+    );
+}
+
+/// **P6** (loud-fail signal, #876) — when there is NO `[patch]` override (the
+/// latch-leak shape: configure ran in tarball mode and wrote no `[patch]`), the
+/// crate is fetched from git and must NOT appear in `--json local_crates`. This
+/// is the exact condition the `just vendor` recipe turns into a non-zero exit.
+#[test]
+#[ignore] // invokes cargo vendor
+fn json_local_crates_excludes_git_fetched_crate() {
+    let git_upstream = create_local_git_crate(
+        "leak-lib",
+        r#"[package]
+name = "leak-lib"
+version = "0.6.0"
+edition = "2021"
+publish = false
+"#,
+        "pub fn leak() {}\n",
+    );
+    let git_url = git_upstream.url();
+
+    // A project depending on the git source but with NO .cargo/config.toml
+    // [patch] override — so cargo vendors leak-lib straight from git.
+    let work = tempfile::TempDir::new().unwrap();
+    let root = work.path().join("project");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "leak-proj"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+leak-lib = {{ git = "{git_url}" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(root.join("lib.rs"), "pub use leak_lib::leak;\n").unwrap();
+    git_init(&root);
+
+    let vendor = root.join("vendor");
+    let output = revendor_cmd()
+        .arg("revendor")
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .arg("--output")
+        .arg(&vendor)
+        .arg("--json")
+        .output()
+        .expect("failed to run cargo-revendor");
+
+    assert!(output.status.success(), "vendor run should succeed");
+    // leak-lib was vendored (from git), but as an EXTERNAL crate.
+    assert_vendor_has(&vendor, "leak-lib");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    let locals: Vec<String> = json["local_crates"]
+        .as_array()
+        .expect("local_crates should be an array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !locals.iter().any(|c| c == "leak-lib"),
+        "a git-fetched crate must NOT be reported as local — this is the signal \
+         `just vendor` turns into a loud failure (#876); got {locals:?}"
+    );
+}
+
 // Helper: build a workspace with a single `conflict-lib` member (no pkg subdir),
 // used for the `--source-root` test where the source root IS the workspace.
 fn build_lib_workspace(root: &Path, crate_name: &str, version: &str, marker: &str) {

--- a/justfile
+++ b/justfile
@@ -472,15 +472,52 @@ vendor:
     # their edits reflected in vendor/ and inst/vendor.tar.xz, so
     # `vendor-sync-check` passes and the offline tarball ships the PR's code.
     # `--source-root` is no longer needed here (kept as CLI flag for back-compat).
-    cargo revendor \
+    #
+    # `--json` writes a machine-readable summary (incl. `local_crates`) to
+    # STDOUT, which we capture; `-v` progress still streams to STDERR (the
+    # terminal). They coexist. We grep `local_crates` rather than shell out to
+    # `jq` so the assertion has no extra dependency on CI runners.
+    revendor_json="$(cargo revendor \
       --manifest-path rpkg/src/rust/Cargo.toml \
       --output rpkg/vendor \
       --compress rpkg/inst/vendor.tar.xz \
       --blank-md \
       --source-marker \
       --force \
-      -v
+      --json \
+      -v)"
+    # Defense-in-depth (#876): every framework crate MUST have been vendored
+    # from the LOCAL workspace, not fetched from git@main. If configure ran in
+    # tarball mode (inst/vendor.tar.xz already present) it wrote a [source]
+    # replacement but NO [patch."git+url"] override, so cargo-revendor finds
+    # "0 local packages" and silently ships git@main — dropping any in-PR edits
+    # to a framework crate (the #865 latch-leak failure mode). Catch it here, at
+    # the point of damage, instead of hours later in CI.
+    leaked=""
+    for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
+      # `local_crates` is a pretty-printed JSON array, one "name" per line.
+      if ! grep -qE "\"$crate\"" <<<"$revendor_json"; then
+        leaked="$leaked $crate"
+      fi
+    done
+    if [[ -n "$leaked" ]]; then
+      echo "" >&2
+      echo "ERROR: framework crate(s)$leaked were vendored from git, not the local workspace." >&2
+      echo "" >&2
+      echo "cargo-revendor reported these crates as NOT local — they came from the" >&2
+      echo "git URL pinned in Cargo.lock (git@main), so any in-PR edits to them were" >&2
+      echo "silently dropped from rpkg/inst/vendor.tar.xz (#865 latch leak)." >&2
+      echo "" >&2
+      echo "Almost always: configure ran in tarball mode (rpkg/inst/vendor.tar.xz" >&2
+      echo "was present) so it wrote a [source] replacement but no [patch] override." >&2
+      echo "" >&2
+      echo "Fix:  just clean-vendor-leak && just configure && just vendor" >&2
+      echo "" >&2
+      echo "See CLAUDE.md \"The latch leak\" and #876." >&2
+      exit 1
+    fi
     echo ""
+    echo "Vendored framework crates from local workspace: miniextendr-{api,lint,macros}"
     echo "Created rpkg/inst/vendor.tar.xz — DELETE THIS BEFORE RESUMING DEV ITERATION"
     echo "(run 'just clean-vendor-leak' or 'unlink(\"rpkg/inst/vendor.tar.xz\")' in R)"
 
@@ -542,8 +579,13 @@ vendor-verify:
 # bundled instead of a freshly-bootstrapped one. Requires cargo-revendor on PATH
 # and pkgbuild installed in R; skips with a clear message if either is missing.
 # See tests/bootstrap-produces-vendor.sh and #441.
+#
+# Also runs the #876 loud-fail regression: `just vendor` must exit non-zero when
+# a framework crate would be vendored from git instead of the local workspace.
+# See tests/vendor-loud-fail.sh.
 test-bootstrap-vendor:
     bash tests/bootstrap-produces-vendor.sh
+    bash tests/vendor-loud-fail.sh
 
 # Load and test rpkg with devtools
 devtools-test FILTER="": _assert-no-vendor-leak devtools-document

--- a/tests/vendor-loud-fail.sh
+++ b/tests/vendor-loud-fail.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Regression test for #876: `just vendor` must fail LOUDLY when a framework
+# crate would be vendored from git instead of the local workspace.
+#
+# Background: cargo-revendor reads `[patch."<git-url>"]` path overrides from
+# .cargo/config.toml to vendor miniextendr-{api,lint,macros} from the local
+# checkout. When configure runs in tarball mode (inst/vendor.tar.xz present) it
+# writes a `[source]` replacement but NO `[patch]`, so cargo-revendor finds
+# "0 local packages" and silently ships git@main — dropping in-PR framework
+# edits (the #865 latch leak). The `just vendor` recipe now asserts every
+# framework crate appears in `--json local_crates`; this test proves that
+# assertion fires on the leak shape.
+#
+# This test is hermetic: it builds a tiny package whose only dependency is a
+# crate served from a LOCAL bare git repo (file:// URL, no crates.io deps), so
+# `cargo vendor` makes no network calls. It does NOT touch the real rpkg tree.
+#
+# Requirements:
+#   - cargo-revendor on PATH (skips, not fails, if missing)
+#   - git, cargo
+set -euo pipefail
+
+if ! command -v cargo-revendor >/dev/null 2>&1; then
+    echo "SKIP: cargo-revendor not on PATH (install with: cargo install --path cargo-revendor)"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 1. A bare git repo standing in for a framework crate ("miniextendr-api").
+SRC="$WORK/src/miniextendr-api"
+mkdir -p "$SRC/src"
+cat >"$SRC/Cargo.toml" <<'EOF'
+[package]
+name = "miniextendr-api"
+version = "0.1.0"
+edition = "2021"
+publish = false
+EOF
+echo 'pub fn upstream() {}' >"$SRC/src/lib.rs"
+git -C "$SRC" init -q -b main
+git -C "$SRC" -c user.email=t@t.com -c user.name=t add .
+git -C "$SRC" -c user.email=t@t.com -c user.name=t commit -q -m init
+BARE="$WORK/miniextendr-api.git"
+git clone --bare -q "$SRC" "$BARE"
+GIT_URL="file://$BARE"
+
+# --- 2. A package that depends on the framework crate via the bare git URL,
+#         with NO `[patch]` override — the latch-leak shape.
+PKG="$WORK/pkg"
+mkdir -p "$PKG"
+cat >"$PKG/Cargo.toml" <<EOF
+[package]
+name = "leak-pkg"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+miniextendr-api = { git = "$GIT_URL" }
+EOF
+echo 'pub use miniextendr_api::upstream;' >"$PKG/lib.rs"
+git -C "$PKG" init -q
+git -C "$PKG" -c user.email=t@t.com -c user.name=t add .
+git -C "$PKG" -c user.email=t@t.com -c user.name=t commit -q -m init
+
+# --- 3. Vendor with --json and apply the EXACT assertion the recipe uses.
+revendor_json="$(cargo-revendor revendor \
+  --manifest-path "$PKG/Cargo.toml" \
+  --output "$PKG/vendor" \
+  --json)"
+
+leaked=""
+for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
+  if ! grep -qE "\"$crate\"" <<<"$revendor_json"; then
+    leaked="$leaked $crate"
+  fi
+done
+
+# miniextendr-api was fetched from git, so it must be reported as the leak.
+case "$leaked" in
+  *miniextendr-api*)
+    echo "OK: loud-fail assertion correctly flagged git-vendored framework crate(s):$leaked"
+    ;;
+  *)
+    echo "FAIL: a git-vendored framework crate was NOT flagged — the loud-fail" >&2
+    echo "      assertion (#876) would have silently passed on the latch-leak shape." >&2
+    echo "      local_crates JSON was:" >&2
+    echo "$revendor_json" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Problem

`just vendor` (via `cargo-revendor`) **silently** vendored `miniextendr-{api,lint,macros}` from `git@main` instead of the local workspace checkout whenever `.cargo/config.toml` was missing the `[patch."git+url"]` -> sibling-path overrides. That drops any in-PR edits to a framework crate and ships a vendor tarball that doesn't match the PR's source. It was the root cause of a multi-hour CI debugging session (#865 / #877).

The immediate trigger (a CI cache flipping `configure` into tarball mode -> `[source]` replacement, no `[patch]`) was fixed in #877 (merged, `87117330`). This is the **defense-in-depth follow-up (#876)**: make `just vendor` itself fail loudly so the next leak — from any source — is caught at the point of damage.

## Fix

- **`justfile` `vendor:` recipe** — after `cargo revendor`, capture its `--json` stdout (the `-v` progress still streams to stderr; the two coexist) and assert every framework crate appears in `local_crates`. If any was vendored from git, `exit 1` with the latch-leak remedy:
  `just clean-vendor-leak && just configure && just vendor`.
  Greps the JSON array rather than shelling out to `jq` — `jq` isn't guaranteed on every CI runner that runs `just vendor` (the `setup-vendor` action runs on ubuntu/almalinux/macos and installs no `jq`), and grep adds zero dependency.
- **`tests/vendor-loud-fail.sh`** — hermetic regression test wired into `just test-bootstrap-vendor` (the #876 acceptance test path). Builds a tiny package whose only dep is a crate served from a **local bare git repo** (`file://`, no crates.io deps, no network), with **no `[patch]` override** — the exact latch-leak shape — and runs the recipe's assertion to prove it flags the git-vendored framework crate. Skips (exit 0) if `cargo-revendor` isn't on PATH, matching `bootstrap-produces-vendor.sh`.
- **`cargo-revendor`** (optional guard from the issue, implemented):
  - `discover_from_patch_config` now emits a `warning:` when a `[patch."git+url"]` entry's resolved path has **no `Cargo.toml`** (the override silently doesn't apply otherwise).
  - 3 new always-run unit tests (`patch_config_resolves_existing_path`, `patch_config_skips_missing_path`, `patch_config_no_patch_table_is_empty`).
  - 2 new `#[ignore]` (network) integration tests in `patch_from_config.rs` asserting the `--json local_crates` signal includes a patched local crate and excludes a git-fetched one.

### Why `local_crates` (not dir layout)

The issue body suggested discriminating local-vs-git by directory shape (`foo/` vs `foo-0.1.0/`). That's stale: `versioned_dirs` is now the default, so **both** land as versioned dirs. The structured `--json` `local_crates` array is the authoritative signal — it lists exactly the crates `cargo-revendor` vendored from local source.

## Verification

- `cargo fmt --all --manifest-path cargo-revendor/Cargo.toml --check` clean.
- `just revendor-clippy` (`-D warnings`) clean; `just revendor-test` 105 pass / 62 ignored (incl. the 3 new unit tests + 2 new integration tests).
- New integration tests run green with `--ignored` (local `file://` git, no network).
- `tests/vendor-loud-fail.sh` -> `OK: loud-fail assertion correctly flagged git-vendored framework crate(s): miniextendr-api miniextendr-lint miniextendr-macros`.
- **Happy path** end-to-end: `just configure` (dev mode) + `just vendor` -> exit 0, "Local packages to vendor: 3", new success line `Vendored framework crates from local workspace: miniextendr-{api,lint,macros}`.
- **Simulated leak** end-to-end: stripped the `[patch]` block from `.cargo/config.toml`, re-ran `just vendor` -> **exit 1** with:
  > ERROR: framework crate(s) miniextendr-api miniextendr-lint miniextendr-macros were vendored from git, not the local workspace. ... Fix:  just clean-vendor-leak && just configure && just vendor
- Cleanup: restored `.cargo/config.toml`, `just clean-vendor-leak`, reverted transient `Cargo.lock` drift from the vendor run, removed `rpkg/vendor/`. No vendor tarball or stray tracked files left behind (`git status` shows only the 4 intended changes).

Related: #877 (CI trigger fix, merged), #865 (the original failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)