### PR TITLE
docs: correct stale "commit the site" guidance (CLAUDE.md / AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ GitHub Actions auto-deploys on push to `main` when `site/**`, `docs/**`, or `*/s
 
 `site/content/manual/` is **auto-generated from `docs/`** by `scripts/docs-to-site.sh` (1:1 conversion, not curated summaries). Edit `docs/*.md` only — never edit `site/content/manual/*.md` directly. The generator derives frontmatter (title + description) from each doc's `# Heading` and first paragraph. `site/content/_index.md` and anything outside `manual/` are hand-authored and must be edited directly.
 
-**After editing `docs/`, regenerate and commit both together**: `just site-docs && git add docs/ site/content/manual/ site/data/plans.json`. CI runs `docs-to-site.sh` itself before each deploy, so the live site is always correct — but the in-repo `site/content/manual/` drifts out of sync if you skip the regenerate step, making subsequent diffs noisy and masking unrelated site edits.
+**The generated manual (`site/content/manual/*.md`, except the hand-authored `_index.md`) and the Zola build output (`site/public/`) are gitignored** since #593 — so edit `docs/*.md` and commit only that; there is **nothing to commit on the site side**. CI runs `docs-to-site.sh` and rebuilds the site from `docs/` before each deploy, so the live site is always correct. To preview locally, run `just site-docs` (+ `just site-build`); don't `git add` the output.
 
 ### Site scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,9 +382,13 @@ unexpected drift. See `minirextendr/CLAUDE.md` for templates-specific quirks.
 
 ### Site / docs sync
 
-`site/content/manual/` is generated from `docs/` by `scripts/docs-to-site.sh`.
-After editing `docs/`, run `just site-docs` and commit both. See
-`site/CLAUDE.md` for the full pipeline.
+`site/content/manual/*.md` is generated from `docs/` by `scripts/docs-to-site.sh`
+— and is **gitignored** (along with the `site/public/` Zola build) since #593.
+So edit `docs/*.md` only; there is **nothing to commit on the site side**. The
+Pages workflow (`.github/workflows/pages.yml`) regenerates the manual and rebuilds
+the site from `docs/` on every push to `main`, so the live site stays current
+automatically. To preview locally, run `just site-docs` (+ `just site-build`) —
+but don't `git add` the output. See `site/CLAUDE.md` for the full pipeline.
 
 ## Common issues
 


### PR DESCRIPTION
<!-- TODO(@CGMossa): replace with your framing -->
The agent-facing docs still tell you to `git add` the generated site, which has been wrong since #593. Surfaced while working #880.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `CLAUDE.md` (*Sync checks → Site / docs sync*) and `AGENTS.md` (site section) both said "after editing `docs/`, run `just site-docs` and commit both". Since #593, `site/content/manual/*.md` (except `_index.md`) and `site/public/` are gitignored, and `pages.yml` rebuilds the site from `docs/` on every push to `main`. There is nothing to commit on the site side.
- `AGENTS.md` also referenced `site/data/plans.json` in the `git add` line; that file no longer exists (plans moved to GitHub issues).
- Both now say: edit `docs/*.md` only, preview locally with `just site-docs` / `just site-build`, do not `git add` the generated output.

## Notes
- Verified against the repo: `git check-ignore` confirms `site/content/manual/arrow.md` and `site/public/` are ignored, while `site/content/manual/_index.md` and `site/data/issues.json` are tracked.
- Docs-only; no code paths touched.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>