### PR TITLE
fix(vendor): resolve framework crates locally + stamp git source — no bare-git dance (#883)

### DIFF
--- a/cargo-revendor/src/main.rs
+++ b/cargo-revendor/src/main.rs
@@ -236,6 +236,22 @@ struct Cli {
     /// or --blank-md are also given.
     #[arg(long, conflicts_with = "external_only")]
     local_only: bool,
+
+    /// Stamp-lock only: rewrite the framework crates' `source =` line in
+    /// Cargo.lock to `git+<url>#<sha>` and exit, without vendoring.
+    ///
+    /// Use after `cargo update` (or `cargo build`) has resolved the lock with
+    /// the dev `[patch."<git-url>"]` override active — which leaves
+    /// miniextendr-{api,lint,macros} as local (no-`source`) entries. This
+    /// reconstructs the canonical tarball-shape attribution that offline
+    /// source-replacement needs, so a lock-only regen (`just update`) keeps
+    /// the committed lock CRAN-installable even on a cross-crate rename (#883).
+    /// No-op (with a warning) when no `[patch."<git-url>"]` table is found.
+    #[arg(
+        long,
+        conflicts_with_all = ["external_only", "local_only", "freeze", "verify", "compress"]
+    )]
+    stamp_lock: bool,
 }
 
 /// Which phase(s) of vendoring to perform.
@@ -404,6 +420,12 @@ fn main() -> Result<()> {
         })
         .collect();
 
+    // Stamp-lock only: don't vendor; just reconstruct the git+url#sha source
+    // attribution for framework crates in an already-resolved lock.
+    if cli.stamp_lock {
+        return run_stamp_lock(&manifest_path, &lockfile, v);
+    }
+
     // Verify-only: don't vendor; just assert existing artifacts are in sync.
     if cli.verify {
         let sync_lockfiles: Vec<std::path::PathBuf> = sync_manifests
@@ -436,6 +458,56 @@ fn main() -> Result<()> {
         }
         Mode::LocalOnly => run_local_only(&cli, &manifest_path, &output, v),
     }
+}
+
+/// Stamp-lock only (`--stamp-lock`): rewrite framework crates' `source =` line
+/// in an already-resolved Cargo.lock to `git+<url>#<sha>`, without vendoring.
+///
+/// The git rev is the live HEAD of the local framework checkout (the same one
+/// the `[patch."<url>"]` table points at); a placeholder is used if HEAD can't
+/// be read. The rev is cosmetic — cargo's `[source."git+<url>"]` replacement
+/// keys on the URL, not the commit — but a real sha keeps the lock honest.
+///
+/// This is the lock-only counterpart of `run_full`'s step 9.5: it lets a
+/// dependency-bump recipe (`just update`) resolve against the local workspace
+/// (patch active, so cross-crate renames work) and still leave the committed
+/// lock in CRAN-installable tarball shape (#883).
+fn run_stamp_lock(
+    manifest_path: &std::path::Path,
+    lockfile: &std::path::Path,
+    v: Verbosity,
+) -> Result<()> {
+    let patch_url_map = metadata::discover_patch_url_map(manifest_path)
+        .context("failed to read [patch] URLs from .cargo/config.toml")?;
+    if patch_url_map.is_empty() {
+        if v.info() {
+            eprintln!(
+                "cargo-revendor --stamp-lock: no [patch.\"<git-url>\"] table found near {} — nothing to stamp",
+                manifest_path.display()
+            );
+        }
+        return Ok(());
+    }
+
+    // Local checkout paths for the patched framework crates (for `git rev-parse`).
+    let candidate_paths: Vec<std::path::PathBuf> =
+        metadata::discover_from_patch_config(manifest_path)
+            .context("failed to read [patch] entries from .cargo/config.toml")?
+            .into_iter()
+            .filter(|p| patch_url_map.contains_key(&p.name))
+            .map(|p| p.path)
+            .collect();
+
+    let rev = vendor::resolve_framework_rev(&candidate_paths, v);
+    let n = vendor::stamp_framework_git_sources(lockfile, &patch_url_map, &rev, v)?;
+    if v.info() {
+        eprintln!(
+            "cargo-revendor --stamp-lock: stamped git source on {n} framework crate(s) in {} (rev {})",
+            lockfile.display(),
+            &rev[..rev.len().min(12)]
+        );
+    }
+    Ok(())
 }
 
 /// Full vendor pass: external deps + local workspace crates (existing behavior).
@@ -682,6 +754,37 @@ fn run_full(
     }
     if v.debug() {
         eprintln!("{}", config_toml);
+    }
+
+    // Step 9.5: Stamp the framework crates' git source into Cargo.lock.
+    //
+    // The lock was resolved with the dev `[patch."<url>"]` path override active
+    // (cargo metadata, step 1b), so a cross-crate feature rename resolves against
+    // the LOCAL workspace instead of git@main (#883) — but that leaves the
+    // framework crates as local (no-`source`) entries. The offline tarball needs
+    // `source = "git+<url>#<sha>"` so cargo's `[source."git+<url>"]` replacement
+    // can redirect them to vendored-sources. Reconstruct that attribution here,
+    // BEFORE copying the lock into vendor/, rather than re-resolving against the
+    // bare git URL (the step that fails on a rename). Skipped under --freeze,
+    // which rewrites the manifest to vendor path deps instead.
+    if !cli.freeze {
+        let patch_url_map = metadata::discover_patch_url_map(manifest_path)
+            .context("failed to read [patch] URLs from .cargo/config.toml")?;
+        if !patch_url_map.is_empty() {
+            let candidate_paths: Vec<std::path::PathBuf> = local_pkgs
+                .iter()
+                .filter(|p| patch_url_map.contains_key(&p.name))
+                .map(|p| p.path.clone())
+                .collect();
+            let rev = vendor::resolve_framework_rev(&candidate_paths, v);
+            let n = vendor::stamp_framework_git_sources(lockfile, &patch_url_map, &rev, v)?;
+            if v.info() && n > 0 {
+                eprintln!(
+                    "  Stamped git source on {n} framework crate(s) in Cargo.lock (rev {})",
+                    &rev[..rev.len().min(12)]
+                );
+            }
+        }
     }
 
     // Step 10: Copy Cargo.lock to vendor/ (checksums retained — no stripping).

--- a/cargo-revendor/src/metadata.rs
+++ b/cargo-revendor/src/metadata.rs
@@ -13,11 +13,23 @@ pub struct LocalPackage {
     pub manifest_path: PathBuf,
 }
 
-/// Load cargo metadata for the given manifest
+/// Load cargo metadata for the given manifest.
+///
+/// Runs `cargo metadata` with the working directory set to the manifest's
+/// parent so that cargo's CWD-relative config discovery picks up that crate's
+/// `.cargo/config.toml`. For an R package in dev/source mode this carries the
+/// `[patch."<git-url>"]` table that redirects the framework crates to the local
+/// workspace checkout — so a cross-crate feature/dep rename (touching both a
+/// framework crate and its consumer) resolves against the PR's sources instead
+/// of git@main (#883). Without the CWD pin cargo would search upward from the
+/// process CWD (the repo root for `just vendor`) and never find the patch.
 pub fn load_metadata(manifest_path: &Path) -> Result<Metadata> {
-    MetadataCommand::new()
-        .manifest_path(manifest_path)
-        .exec()
+    let mut cmd = MetadataCommand::new();
+    cmd.manifest_path(manifest_path);
+    if let Some(dir) = manifest_path.parent() {
+        cmd.current_dir(dir);
+    }
+    cmd.exec()
         .with_context(|| format!("failed to load metadata from {}", manifest_path.display()))
 }
 
@@ -385,6 +397,90 @@ pub fn discover_from_patch_config(manifest_path: &Path) -> Result<Vec<LocalPacka
     }
 
     Ok(results)
+}
+
+/// Map each `[patch."<url>"]` crate to the git URL it is patched from.
+///
+/// This is the provenance the lockfile needs but `discover_from_patch_config`
+/// discards: when cargo resolves with a `[patch."<url>"]` path override active,
+/// the framework crates land in `Cargo.lock` as local (no `source`) entries.
+/// For the offline tarball, those entries must instead carry
+/// `source = "git+<url>#<sha>"` so cargo's `[source."git+<url>"]` replacement
+/// can redirect them to `vendored-sources`. This function recovers the
+/// `crate-name -> <url>` mapping from the same `.cargo/config.toml` walk so the
+/// lockfile can be stamped after resolution. See [`crate::vendor::stamp_framework_git_sources`].
+///
+/// The returned URL is normalized: any leading `git+` scheme prefix is stripped
+/// (cargo accepts `[patch."https://…"]` and `[patch."git+https://…"]`
+/// interchangeably; the lockfile/source-replacement form is `git+<url>`, which
+/// the stamper re-adds). Only entries whose `path` resolves to a readable
+/// `Cargo.toml` are included — an unresolvable patch path means the crate is
+/// vendored from its real git source, which is already lockfile-correct and
+/// must not be stamped.
+pub fn discover_patch_url_map(
+    manifest_path: &Path,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let config_files = cargo_config_search_paths(manifest_path);
+    let mut map: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+
+    for config_path in &config_files {
+        if !config_path.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?;
+        let doc: toml_edit::DocumentMut = content
+            .parse()
+            .with_context(|| format!("failed to parse TOML in {}", config_path.display()))?;
+
+        let config_dir = config_path
+            .parent()
+            .and_then(|p| p.parent())
+            .unwrap_or(config_path.parent().unwrap_or(config_path));
+
+        let Some(patch_tbl) = doc.get("patch").and_then(|v| v.as_table()) else {
+            continue;
+        };
+
+        for (url_key, url_entries) in patch_tbl.iter() {
+            let url = url_key.strip_prefix("git+").unwrap_or(url_key).to_string();
+            let Some(entries) = url_entries.as_table() else {
+                continue;
+            };
+            for (crate_name, crate_spec) in entries.iter() {
+                // First config file closest to the manifest wins.
+                if map.contains_key(crate_name) {
+                    continue;
+                }
+                let path_val = crate_spec
+                    .as_inline_table()
+                    .and_then(|t| t.get("path"))
+                    .and_then(|v| v.as_str())
+                    .or_else(|| {
+                        crate_spec
+                            .as_table()
+                            .and_then(|t| t.get("path"))
+                            .and_then(|v| v.as_str())
+                    });
+                let Some(path_val) = path_val else {
+                    continue; // not a path override
+                };
+                let crate_path = if Path::new(path_val).is_absolute() {
+                    PathBuf::from(path_val)
+                } else {
+                    config_dir.join(path_val)
+                };
+                // Only map entries that resolve to a real local crate — an
+                // unresolvable path is vendored from git (already lock-correct).
+                if !crate_path.join("Cargo.toml").exists() {
+                    continue;
+                }
+                map.insert(crate_name.to_string(), url.clone());
+            }
+        }
+    }
+
+    Ok(map)
 }
 
 /// Return the cargo config search path for a given manifest path, in
@@ -862,6 +958,53 @@ mod tests {
         let (_guard, manifest) = patch_config_fixture(body);
         let found = discover_from_patch_config(&manifest).unwrap();
         assert!(found.is_empty(), "no [patch] table → no local overrides");
+    }
+
+    // endregion
+
+    // region: discover_patch_url_map tests
+
+    #[test]
+    fn patch_url_map_records_url_for_resolvable_entry() {
+        // The resolvable [patch."<url>"] entry is mapped crate -> url.
+        let body = "[patch.\"https://github.com/A2-ai/miniextendr\"]\n\
+                    miniextendr-api = { path = \"../../../miniextendr-api\" }\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let map = discover_patch_url_map(&manifest).unwrap();
+        assert_eq!(
+            map.get("miniextendr-api").map(String::as_str),
+            Some("https://github.com/A2-ai/miniextendr")
+        );
+    }
+
+    #[test]
+    fn patch_url_map_strips_git_plus_prefix() {
+        // cargo accepts [patch."git+https://…"]; the lockfile/source-replacement
+        // form is git+<url>, so the stored url must be the bare URL (the stamper
+        // re-adds git+). Verify the prefix is stripped.
+        let body = "[patch.\"git+https://github.com/A2-ai/miniextendr\"]\n\
+                    miniextendr-api = { path = \"../../../miniextendr-api\" }\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let map = discover_patch_url_map(&manifest).unwrap();
+        assert_eq!(
+            map.get("miniextendr-api").map(String::as_str),
+            Some("https://github.com/A2-ai/miniextendr")
+        );
+    }
+
+    #[test]
+    fn patch_url_map_skips_unresolvable_path() {
+        // An unresolvable [patch] path means the crate is vendored from its real
+        // git source (already lock-correct) — it must NOT be stamped, so it is
+        // absent from the map.
+        let body = "[patch.\"https://github.com/A2-ai/miniextendr\"]\n\
+                    miniextendr-api = { path = \"../../../does-not-exist\" }\n";
+        let (_guard, manifest) = patch_config_fixture(body);
+        let map = discover_patch_url_map(&manifest).unwrap();
+        assert!(
+            map.is_empty(),
+            "unresolvable patch path must not be mapped; got {map:?}"
+        );
     }
 
     // endregion

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -67,6 +67,14 @@ pub fn run_cargo_vendor(
 
     let mut cmd = Command::new("cargo");
     cmd.arg("vendor").arg("--manifest-path").arg(manifest_path);
+    // Pin CWD to the manifest's directory so cargo's config discovery picks up
+    // that crate's `.cargo/config.toml` `[patch."<git-url>"]` table — same
+    // reason as `load_metadata` (#883). cargo vendor re-resolves the dep graph,
+    // so without the patch a cross-crate rename would resolve framework crates
+    // against git@main and fail even though metadata already succeeded locally.
+    if let Some(dir) = manifest_path.parent() {
+        cmd.current_dir(dir);
+    }
     if versioned_dirs {
         cmd.arg("--versioned-dirs");
     }
@@ -612,6 +620,142 @@ pub fn copy_lock_to_vendor(lockfile: &Path, vendor_dir: &Path, v: crate::Verbosi
     }
 
     Ok(())
+}
+
+/// Placeholder commit used when the framework crate's git HEAD can't be read.
+/// Source replacement matches on URL, not commit, so any well-formed 40-hex
+/// sha works for the offline build — this only loses provenance.
+const PLACEHOLDER_GIT_REV: &str = "0000000000000000000000000000000000000000";
+
+/// Read the git HEAD commit of a local checkout, returning it only if it looks
+/// like a full 40-char hex sha.
+fn git_head_rev(dir: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit())).then_some(sha)
+}
+
+/// Resolve the commit sha to stamp as framework-crate provenance in Cargo.lock.
+///
+/// Tries `git rev-parse HEAD` in each candidate checkout (the local framework
+/// crate dirs) in turn; falls back to [`PLACEHOLDER_GIT_REV`] with a warning.
+/// The value is provenance only — cargo's `[source."git+<url>"]` replacement
+/// keys on the URL, never the commit — so a placeholder still builds offline.
+pub fn resolve_framework_rev(candidate_paths: &[PathBuf], v: crate::Verbosity) -> String {
+    for p in candidate_paths {
+        if let Some(sha) = git_head_rev(p) {
+            return sha;
+        }
+    }
+    if v.info() {
+        eprintln!(
+            "  warning: could not read git HEAD for framework provenance; \
+             stamping placeholder rev in Cargo.lock (offline build still works)"
+        );
+    }
+    PLACEHOLDER_GIT_REV.to_string()
+}
+
+/// Stamp `source = "git+<url>#<rev>"` onto the framework crates' `[[package]]`
+/// entries in `lockfile`.
+///
+/// Why this exists: the lock is resolved with the dev `[patch."<url>"]` path
+/// override active (so a cross-crate feature rename resolves against the LOCAL
+/// workspace, not git@main — see #883). That resolution records the framework
+/// crates as local (no `source`) entries. The offline tarball install, however,
+/// needs `source = "git+<url>#<sha>"` so cargo's `[source."git+<url>"]`
+/// replacement can redirect them to `vendored-sources`. We reconstruct that
+/// attribution here rather than re-resolving against the bare git URL (which is
+/// exactly the step that fails on a cross-crate rename).
+///
+/// `patch_url_map` is `crate-name -> <url>` (no `git+` prefix; see
+/// [`crate::metadata::discover_patch_url_map`]). Only packages named in the map
+/// are touched; for those, any existing `source`/`path` is replaced and the new
+/// `source` line is placed immediately after `version` to match cargo's own
+/// canonical key order (and the `grep -A3` lock-shape check). Returns the number
+/// of `[[package]]` entries stamped.
+pub fn stamp_framework_git_sources(
+    lockfile: &Path,
+    patch_url_map: &std::collections::BTreeMap<String, String>,
+    rev: &str,
+    v: crate::Verbosity,
+) -> Result<usize> {
+    if !lockfile.exists() || patch_url_map.is_empty() {
+        return Ok(0);
+    }
+
+    let content = std::fs::read_to_string(lockfile)
+        .with_context(|| format!("failed to read {}", lockfile.display()))?;
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse {}", lockfile.display()))?;
+
+    let Some(packages) = doc
+        .get_mut("package")
+        .and_then(|p| p.as_array_of_tables_mut())
+    else {
+        return Ok(0);
+    };
+
+    let mut stamped = 0usize;
+    for table in packages.iter_mut() {
+        let Some(name) = table.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(url) = patch_url_map.get(name) else {
+            continue;
+        };
+        let source_val = format!("git+{url}#{rev}");
+
+        // Rebuild the table so `source` lands right after `version`, dropping any
+        // pre-existing `source` (we're overwriting it). cargo writes
+        // name/version/source/dependencies in that order; matching it keeps the
+        // lock-shape `grep -A3` and pre-commit hook happy.
+        let entries: Vec<(String, toml_edit::Item)> = table
+            .iter()
+            .filter(|(k, _)| *k != "source")
+            .map(|(k, item)| (k.to_string(), item.clone()))
+            .collect();
+        let existing_keys: Vec<String> = table.iter().map(|(k, _)| k.to_string()).collect();
+        for k in &existing_keys {
+            table.remove(k);
+        }
+        let mut placed = false;
+        for (k, item) in entries {
+            let is_version = k == "version";
+            table.insert(&k, item);
+            if is_version {
+                table.insert("source", toml_edit::value(source_val.clone()));
+                placed = true;
+            }
+        }
+        if !placed {
+            // No `version` key (shouldn't happen in a valid lock) — append source.
+            table.insert("source", toml_edit::value(source_val.clone()));
+        }
+        stamped += 1;
+    }
+
+    if stamped > 0 {
+        std::fs::write(lockfile, doc.to_string())
+            .with_context(|| format!("failed to write {}", lockfile.display()))?;
+        if v.debug() {
+            eprintln!(
+                "  Stamped git source on {stamped} framework crate(s) in {}",
+                lockfile.display()
+            );
+        }
+    }
+
+    Ok(stamped)
 }
 
 /// Find the single subdirectory in a directory (from tar extraction)
@@ -1637,4 +1781,135 @@ path = "../sibling"
         // dependency path is stripped
         assert!(!result.contains("../sibling"));
     }
+
+    // region: stamp_framework_git_sources (#883)
+
+    fn url_map(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn stamp_adds_git_source_after_version() {
+        // A framework crate resolved as a local (no-source) entry gains
+        // `source = "git+<url>#<rev>"` placed immediately after `version`.
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(
+            &lock,
+            r#"version = 4
+
+[[package]]
+name = "miniextendr-api"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#,
+        )
+        .unwrap();
+
+        let map = url_map(&[("miniextendr-api", "https://github.com/A2-ai/miniextendr")]);
+        let n = stamp_framework_git_sources(
+            &lock,
+            &map,
+            "abc1230000000000000000000000000000000000",
+            Verbosity(0),
+        )
+        .unwrap();
+        assert_eq!(n, 1);
+
+        let out = std::fs::read_to_string(&lock).unwrap();
+        // source line present with git+url#rev
+        assert!(out.contains(
+            "source = \"git+https://github.com/A2-ai/miniextendr#abc1230000000000000000000000000000000000\""
+        ));
+        // placed right after version: the `-A 3` lock-shape grep must see it.
+        let api_idx = out.find("name = \"miniextendr-api\"").unwrap();
+        let after = &out[api_idx..];
+        let version_line = after.find("version = ").unwrap();
+        let source_line = after.find("source = ").unwrap();
+        assert!(
+            source_line > version_line && source_line - version_line < 30,
+            "source must immediately follow version; got:\n{after}"
+        );
+        // The registry crate (not in the map) is untouched.
+        assert!(out.contains("source = \"registry+https://github.com/rust-lang/crates.io-index\""));
+    }
+
+    #[test]
+    fn stamp_overwrites_existing_path_source() {
+        // A drifted lock with `source = "path+..."` for a framework crate is
+        // rewritten to the canonical git source (no duplicate source key).
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(
+            &lock,
+            r#"version = 4
+
+[[package]]
+name = "miniextendr-macros"
+version = "0.1.0"
+source = "path+file:///home/dev/miniextendr/miniextendr-macros"
+dependencies = []
+"#,
+        )
+        .unwrap();
+
+        let map = url_map(&[("miniextendr-macros", "https://github.com/A2-ai/miniextendr")]);
+        let n = stamp_framework_git_sources(&lock, &map, &"f".repeat(40), Verbosity(0)).unwrap();
+        assert_eq!(n, 1);
+
+        let out = std::fs::read_to_string(&lock).unwrap();
+        assert!(
+            !out.contains("path+file://"),
+            "path source must be gone:\n{out}"
+        );
+        assert_eq!(
+            out.matches("source = ").count(),
+            1,
+            "exactly one source key (no duplicate):\n{out}"
+        );
+        assert!(out.contains(&format!(
+            "source = \"git+https://github.com/A2-ai/miniextendr#{}\"",
+            "f".repeat(40)
+        )));
+    }
+
+    #[test]
+    fn stamp_noop_when_map_empty_or_no_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        let body = r#"version = 4
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+        std::fs::write(&lock, body).unwrap();
+
+        // Empty map → 0 stamped, file unchanged.
+        assert_eq!(
+            stamp_framework_git_sources(&lock, &url_map(&[]), &"0".repeat(40), Verbosity(0))
+                .unwrap(),
+            0
+        );
+        // Map with a name not in the lock → 0 stamped.
+        let map = url_map(&[("miniextendr-api", "https://github.com/A2-ai/miniextendr")]);
+        assert_eq!(
+            stamp_framework_git_sources(&lock, &map, &"0".repeat(40), Verbosity(0)).unwrap(),
+            0
+        );
+        assert_eq!(std::fs::read_to_string(&lock).unwrap(), body);
+    }
+
+    // endregion
 }

--- a/docs/CARGO_LOCK_SHAPE.md
+++ b/docs/CARGO_LOCK_SHAPE.md
@@ -52,26 +52,34 @@ git URL plus commit hash.
 
 So the regen flow is:
 
-1. Move `.cargo/config.toml` aside (so the patch override is inactive).
-2. Regenerate the lockfile against the bare git URL — entries for
-   miniextendr crates resolve to `source = "git+https://...#<commit>"`.
-3. Restore `.cargo/config.toml`.
-4. Run `cargo revendor` — it recomputes `.cargo-checksum.json` for each
+1. Resolve the lockfile with the dev `[patch."<git-url>"]` override **active**,
+   against the local workspace checkout. This is what makes a coordinated
+   cross-crate change resolve correctly (see below). The framework crates land
+   as local (no-`source`) entries at this point.
+2. Run `cargo revendor` — it **stamps** `source = "git+https://...#<commit>"`
+   back onto those entries (reconstructing the portable attribution that offline
+   source replacement matches), and recomputes `.cargo-checksum.json` for each
    crate after CRAN-trim, so the lock's `checksum =` lines stay valid.
 
-That's exactly what `just vendor` (in this repo) and
-`miniextendr::miniextendr_vendor()` (for scaffolded packages) do.
+That's exactly what `just vendor` / `just update` (in this repo) and
+`miniextendr::miniextendr_vendor()` (for scaffolded packages) do. There is no
+longer a "move `.cargo/config.toml` aside and resolve against bare git" step —
+that was what broke cross-crate renames (#883).
 
-## The cross-crate cargo-surface chicken-and-egg
+## The cross-crate cargo-surface case (solved by #883)
 
-The regen flow above (move `.cargo/config.toml` aside, `cargo generate-lockfile`,
-move back) has one corner case it can't solve: **a PR that changes the cargo
-surface of `miniextendr-{api,macros,lint}` and the rpkg consumer in the same
-commit.** Typical example: renaming a feature like `default-coerce` →
-`coerce-default` everywhere.
+There was one corner case the **bare-git** regen flow (move
+`.cargo/config.toml` aside, `cargo generate-lockfile`, move back) could never
+solve: **a PR that changes the cargo surface of `miniextendr-{api,macros,lint}`
+and the rpkg consumer in the same commit.** Typical example: renaming a feature
+like `default-coerce` → `coerce-default` everywhere.
 
-Symptom — `just vendor`, `Bootstrap Vendor Test`, R CMD check, CRAN-like check
-all fail with:
+With the patch override moved aside, `cargo generate-lockfile` followed the
+bare git URL (`https://github.com/A2-ai/miniextendr`, no rev) to origin's
+default branch (`main`). main still had the *old* feature names; the PR's
+`rpkg/src/rust/Cargo.toml` asked for the *new* names; cargo errored — across
+`just vendor`, the `Bootstrap Vendor Test`, R CMD check, and the CRAN-like
+check:
 
 ```
 error: failed to select a version for `miniextendr-api`.
@@ -80,54 +88,44 @@ but `miniextendr-api` does not have that feature.
  available features: ... default-coerce, default-r6, default-s7, default-strict, ...
 ```
 
-Why: with the patch override moved aside, `cargo generate-lockfile` follows
-the bare git URL (`https://github.com/A2-ai/miniextendr`, no rev) to origin's
-default branch (`main`). main still has the *old* feature names; the PR's
-rpkg/src/rust/Cargo.toml asks for the *new* names; cargo errors. The fix
-would be to make cargo resolve the api crate at the PR's own HEAD instead
-of main — but cargo has no clean mechanism for that.
+### Why cargo can't record a git source from a local resolve
 
-### Why cargo can't fix it cleanly
-
-Cargo's lockfile model fundamentally couples source attribution with
-resolution. To get `source = "git+url#<sha>"` recorded, cargo must
-*resolve* the dep against that git URL — it can't be told to "resolve
-locally but record a git source." Specifically:
+Cargo's lockfile model couples source attribution with resolution. To record
+`source = "git+url#<sha>"`, cargo must *resolve* the dep against that git URL —
+it can't be told to "resolve locally but record a git source." Every lever that
+looks like it might bridge the two is rejected:
 
 | Attempted lever | Cargo's response |
 |---|---|
 | `dep = { path = "...", git = "..." }` | rejected: *"specification is ambiguous. Only one of `git` or `path` is allowed."* |
 | `[patch."url"] dep = { git = "url", rev = "..." }` (same URL) | rejected: *"patches must point to different sources."* |
 | Same-URL patch via different scheme (`https` vs `ssh`) | URLs are normalized; same rejection. |
-| Hand-inject `source = "git+url#<sha>"` into Cargo.lock | cargo strips it on the next `cargo metadata` / `cargo build` — the patch override is authoritative for source attribution. |
+| Hand-inject `source = "git+url#<sha>"` into Cargo.lock | cargo strips it on the next `cargo metadata` / `cargo build` *while the patch is active* — the patch override is authoritative. |
 | `cargo update -p <crate> --precise <sha>` | only works for already-resolved deps; can't bootstrap from the failing resolve. |
 
-The one lever that *does* work is modifying the dep declaration itself to
-include `rev = "<HEAD_SHA>"` — but that means mutating
-`rpkg/src/rust/Cargo.toml` (a tracked file) for the duration of the regen,
-which is its own correctness hazard (trap-restore, SIGKILL window, accidental
-commit). Not worth permanent machinery.
+### How #883 resolves it
 
-### Policy: admin-merge after eyeballing
+Stop pre-resolving against bare git. Keep the `[patch."<git-url>"]` override
+**active** so cargo resolves the framework crates against the *local PR
+checkout* — which has the renamed feature — and let them land as local
+(no-`source`) entries. Then `cargo revendor` **stamps** the `git+<url>#<sha>`
+attribution back on, *after* resolution is done.
 
-Cross-crate cargo-surface changes happen rarely (feature renames, removing
-a public re-export, etc.). When the bootstrap test fails on such a PR:
+This decouples *resolution* (local, sees the PR's surface) from *source
+attribution* (git URL, what offline replacement needs). The hand-inject lever
+above fails only because the patch is still authoritative during a later
+re-resolve; the offline tarball build is **frozen** against `vendored-sources`,
+so nothing re-resolves and the stamped source survives. The stamped sha is the
+framework checkout's live `git HEAD` — cosmetic, since cargo's
+`[source."git+<url>"]` replacement keys on the URL, not the commit.
 
-1. **Read the diff.** Confirm the rename is coordinated — the new feature/symbol
-   exists on miniextendr-api *and* is what rpkg/src/rust/Cargo.toml asks for.
-   Check `git log --stat` for the PR shows changes to both crates.
-2. **Admin-merge.** The CI failure is a transitional state, not a real defect.
-   Once the PR lands on main, the next bootstrap test on any unrelated PR
-   will pass — the rename is now what main has.
-3. **Do not** add temporary `rev` pins to `rpkg/src/rust/Cargo.toml`,
-   modify `just vendor` to inject rev pins, or otherwise build permanent
-   infrastructure to make this single class of PR pass CI. The Bootstrap
-   Vendor Test failing on cross-crate renames is a *correct signal* that
-   deserves human eyeballing, not automated bypass.
+`cargo revendor --stamp-lock` exposes the stamp step on its own (no full
+re-vendor), for the lock-only `just update` recipe.
 
-This was explored as part of PR #710 (`default-* → *-default` rename) and
-PR #735 (the rev-pin workaround, withdrawn). See those PRs for the
-investigation trail.
+> Historically this was handled by **admin-merging the PR red** after eyeballing
+> the diff — the CI failure was treated as a transitional state. PR #710
+> (`default-* → *-default`) was the last PR to need that; PR #735 explored a
+> `rev`-pin workaround (withdrawn). #883 removed the need for both.
 
 ## When does the lock drift?
 
@@ -162,12 +160,13 @@ just vendor
 just update                # this repo
 miniextendr::miniextendr_vendor()  # scaffolded packages
 
-# Manual minimum (what the recipes do under the hood)
-mv rpkg/src/rust/.cargo/config.toml /tmp/cargo-config.toml.bak
-rm rpkg/src/rust/Cargo.lock
-cargo generate-lockfile --manifest-path rpkg/src/rust/Cargo.toml
-mv /tmp/cargo-config.toml.bak rpkg/src/rust/.cargo/config.toml
-# No checksum strip needed — cargo-revendor handles it during `just vendor`
+# Manual minimum (what `just update` does under the hood). Note the [patch]
+# override stays ACTIVE — cargo resolves locally, then cargo-revendor stamps
+# the git source. Run the cargo update from src/rust/ so cargo's CWD-relative
+# config discovery picks up .cargo/config.toml.
+( cd rpkg/src/rust && cargo update )
+cargo revendor --manifest-path rpkg/src/rust/Cargo.toml --stamp-lock
+# No checksum strip needed — checksum lines are retained.
 
 # Verify
 just lock-shape-check

--- a/docs/CRAN_COMPATIBILITY.md
+++ b/docs/CRAN_COMPATIBILITY.md
@@ -107,23 +107,27 @@ artifact for CRAN.
 ## What `just vendor` actually does
 
 ```text
-1. Move src/rust/.cargo/config.toml aside (so the [patch] override is inactive).
-2. Delete and regenerate src/rust/Cargo.lock with cargo against the bare git
-   URL — entries for miniextendr-{api,lint,macros} get
-   `source = "git+https://github.com/A2-ai/miniextendr#<commit>"`.
-3. Restore .cargo/config.toml.
-4. Run `cargo revendor` against the freshly regenerated lockfile, producing
-   rpkg/vendor/ and rpkg/inst/vendor.tar.xz.
-   cargo-revendor recomputes `.cargo-checksum.json` after CRAN-trim: the
-   original `package` hash (matching the lockfile's `checksum = ...` line) is
-   preserved and the `files` map is refreshed to reflect the trimmed files.
-   The committed Cargo.lock can therefore retain its `checksum = ...` lines.
+1. Run `cargo revendor` (the [patch."git+url"] override written by
+   `just configure` stays ACTIVE). cargo-revendor pins cargo's working dir to
+   the manifest dir, so it resolves miniextendr-{api,lint,macros} against the
+   LOCAL workspace checkout — a cross-crate feature/dep rename resolves against
+   the working tree, not git@main (#883). That leaves them as local (no-source)
+   lock entries, so cargo-revendor then STAMPS
+   `source = "git+https://github.com/A2-ai/miniextendr#<commit>"` back on.
+   It also recomputes `.cargo-checksum.json` after CRAN-trim: the original
+   `package` hash (matching the lockfile's `checksum = ...` line) is preserved
+   and the `files` map is refreshed to reflect the trimmed files, so the
+   committed Cargo.lock can retain its `checksum = ...` lines.
+2. Produce rpkg/vendor/ and rpkg/inst/vendor.tar.xz.
 ```
 
-Steps 1–3 ensure the lockfile carries the git source for the workspace crates,
-which cargo's source replacement needs to redirect to vendor at install time.
-Without that, source replacement reports "the source git+... requires a lock
-file to be present first before it can be used against vendored source code".
+The stamped git source is what cargo's source replacement needs to redirect to
+vendor at install time. Without it, source replacement reports "the source
+git+... requires a lock file to be present first before it can be used against
+vendored source code". The stamp is reconstructed *after* a local resolve
+rather than produced by resolving against bare git, which is what used to break
+coordinated cross-crate renames — see
+[Cargo.lock shape](./CARGO_LOCK_SHAPE.md) for the full story.
 
 ## Cargo.lock shape, drift, and why dev iteration may dirty it
 

--- a/justfile
+++ b/justfile
@@ -157,12 +157,15 @@ check-features:
     echo "=== All $passed/$total feature combinations passed ==="
 
 # Update Cargo.lock files across every tracked manifest.
-# rpkg's lock must stay in tarball-shape (no `path+...` sources for
-# miniextendr-{api,lint,macros}). We move .cargo/config.toml aside so the
-# [patch."git+url"] override doesn't bleed into the lock.
-# Checksums are NO LONGER stripped: cargo-revendor now writes valid
-# `.cargo-checksum.json` files that match the registry checksums, so the
-# committed lock can retain `checksum = "..."` lines.
+# rpkg's lock must stay in tarball-shape: framework crates carry
+# `source = "git+url#<sha>"`, no `path+...` sources. We KEEP the dev
+# [patch."git+url"] override active so cargo resolves against the local
+# workspace (a cross-crate feature/dep rename resolves against the working
+# tree, not git@main — #883), then `cargo revendor --stamp-lock` rewrites the
+# resulting local (no-`source`) framework entries back to the canonical
+# git+url#sha shape. No move-aside / bare-git dance.
+# Checksums are NOT stripped: cargo-revendor writes valid `.cargo-checksum.json`
+# files matching the registry checksums, so the lock retains `checksum = "..."`.
 alias cargo-update := update
 [script("bash")]
 update *cargo_flags:
@@ -174,10 +177,11 @@ update *cargo_flags:
     cargo update --manifest-path=tests/cross-package/producer.pkg/src/rust/Cargo.toml {{cargo_flags}}
     cargo update --manifest-path=tests/model_project/src/rust/Cargo.toml {{cargo_flags}}
     rust_dir="{{justfile_directory()}}/rpkg/src/rust"
-    cargo_cfg="$rust_dir/.cargo/config.toml"
-    if [[ -f "$cargo_cfg" ]]; then mv "$cargo_cfg" "$cargo_cfg.tmp_just_update"; fi
-    trap "[[ -f '$cargo_cfg.tmp_just_update' ]] && mv '$cargo_cfg.tmp_just_update' '$cargo_cfg'" EXIT
-    cargo update --manifest-path "$rust_dir/Cargo.toml" {{cargo_flags}}
+    # Run from rust_dir so cargo's CWD-relative config discovery picks up
+    # rust_dir/.cargo/config.toml's [patch] (resolve against the local
+    # workspace, not git@main). Then stamp the canonical git+url#sha back.
+    ( cd "$rust_dir" && cargo update {{cargo_flags}} )
+    cargo revendor --manifest-path "$rust_dir/Cargo.toml" --stamp-lock -v
     just lock-shape-check
 
 # Restore rpkg/src/rust/Cargo.lock from the git index (preserves staged
@@ -434,15 +438,22 @@ configure-fast:
 # (R CMD INSTALL ., devtools::install/test/load) never calls this recipe.
 #
 # Steps:
-#   1. Regenerate Cargo.lock against the bare git URL (no [patch] override),
-#      so the lockfile entries for miniextendr-{api,lint,macros} carry the
-#      `git+https://...#<commit>` source — required by cargo's source
-#      replacement mechanism when the tarball is later installed offline.
-#   2. Run cargo-revendor against the freshly-regenerated lockfile.
-#      cargo-revendor recomputes `.cargo-checksum.json` with real SHA-256s
-#      after CRAN-trim, so the committed Cargo.lock can retain its registry
-#      `checksum = "..."` lines (no post-vendor sed stripping needed).
-#   3. Compress vendor/ to inst/vendor.tar.xz.
+#   1. Run cargo-revendor. With [patch."git+url"] active (written by
+#      `just configure` in dev-monorepo mode), cargo-revendor resolves the
+#      dependency graph against the LOCAL workspace checkout — so a cross-crate
+#      feature/dep rename touching both a framework crate and rpkg resolves
+#      against the working tree, not git@main (#883). cargo-revendor then stamps
+#      the canonical `git+https://...#<commit>` source back into Cargo.lock
+#      (the shape cargo's source-replacement mechanism needs at offline install
+#      time), and recomputes `.cargo-checksum.json` with real SHA-256s after
+#      CRAN-trim, so the committed Cargo.lock keeps its registry checksums.
+#   2. Compress vendor/ to inst/vendor.tar.xz.
+#
+# This recipe assumes `just configure` already ran (the normal `just configure
+# && just vendor` flow), so .cargo/config.toml carries the [patch] override.
+# There is no longer any bare-git pre-resolution dance: removing the [patch]
+# before resolving was exactly the step that made cross-surface rename PRs
+# fail to resolve against git@main and forced the #710 admin-merge (#883).
 #
 # --force re-runs the full vendor even when cargo-revendor's cache thinks the
 # output is current. Cheap insurance against a stale committed tarball when
@@ -450,25 +461,10 @@ configure-fast:
 [script("bash")]
 vendor:
     set -euo pipefail
-    rust_dir="{{justfile_directory()}}/rpkg/src/rust"
-    cargo_cfg="$rust_dir/.cargo/config.toml"
-    # Regenerate lockfile in tarball-shape: temporarily move .cargo aside so
-    # cargo doesn't see the [patch] override and resolves git deps as-is.
-    # Entries for miniextendr-{api,lint,macros} get source = "git+url#<commit>",
-    # which is what cargo's source-replacement mechanism needs at offline
-    # install time.
-    if [[ -f "$cargo_cfg" ]]; then
-      mv "$cargo_cfg" "$cargo_cfg.tmp_just_vendor"
-    fi
-    rm -f "$rust_dir/Cargo.lock"
-    cargo generate-lockfile --manifest-path "$rust_dir/Cargo.toml"
-    if [[ -f "$cargo_cfg.tmp_just_vendor" ]]; then
-      mv "$cargo_cfg.tmp_just_vendor" "$cargo_cfg"
-    fi
     # cargo-revendor auto-reads [patch."git+url"] from .cargo/config.toml
-    # (written by `configure` in dev-monorepo mode) to copy miniextendr-{api,
-    # lint,macros} from this workspace checkout instead of fetching the git URL
-    # pinned in Cargo.lock. PRs that edit a workspace crate alongside rpkg get
+    # (written by `configure` in dev-monorepo mode) to resolve AND copy
+    # miniextendr-{api,lint,macros} from this workspace checkout instead of
+    # fetching the git URL. PRs that edit a workspace crate alongside rpkg get
     # their edits reflected in vendor/ and inst/vendor.tar.xz, so
     # `vendor-sync-check` passes and the offline tarball ships the PR's code.
     # `--source-root` is no longer needed here (kept as CLI flag for back-compat).
@@ -583,9 +579,15 @@ vendor-verify:
 # Also runs the #876 loud-fail regression: `just vendor` must exit non-zero when
 # a framework crate would be vendored from git instead of the local workspace.
 # See tests/vendor-loud-fail.sh.
+#
+# And the #883 cross-surface regression: a PR that adds a framework feature and
+# references it from rpkg in the same commit must vendor without admin-merge —
+# the framework crate resolves against the local workspace, not git@main.
+# See tests/vendor-cross-surface-rename.sh.
 test-bootstrap-vendor:
     bash tests/bootstrap-produces-vendor.sh
     bash tests/vendor-loud-fail.sh
+    bash tests/vendor-cross-surface-rename.sh
 
 # Load and test rpkg with devtools
 devtools-test FILTER="": _assert-no-vendor-leak devtools-document

--- a/minirextendr/R/use-native.R
+++ b/minirextendr/R/use-native.R
@@ -593,7 +593,7 @@ write_wrapper_header <- function(pkg, args) {
 #'
 #' Two output shapes:
 #'   - When `r_shim.h` sits next to `path` (real `src/` install — see
-#'     [write_wrapper_header()]), include it. The shim wraps Rinternals.h
+#'     `write_wrapper_header()`), include it. The shim wraps Rinternals.h
 #'     in `#pragma clang diagnostic push/pop` to suppress clang 21+'s
 #'     `-Wunknown-warning-option` for R's `Boolean.h`. Required because
 #'     `-Wno-unknown-warning-option` in PKG_CFLAGS trips R CMD check

--- a/minirextendr/R/utils.R
+++ b/minirextendr/R/utils.R
@@ -539,28 +539,3 @@ is_miniextendr_package <- function() {
 bullet_created <- function(path, verb = "Created") {
   cli::cli_alert_success("{verb} {.path {path}}")
 }
-
-#' Rename a file, hard-failing on any error
-#'
-#' `file.rename()` returns `FALSE` on failure without throwing — this wrapper
-#' converts any failure into a hard error so callers never silently swallow a
-#' rename that did not happen (important on Windows where renames are
-#' non-atomic and can fail when the target is locked).
-#'
-#' NOTE: `bootstrap.R` carries an identical inline copy of this helper because
-#' it is a standalone script (not a package), not a package function. See #523.
-#'
-#' @param from Source path.
-#' @param to Destination path.
-#' @param context Human-readable context string included in the error message.
-#' @return Invisibly.
-#' @noRd
-safe_rename <- function(from, to, context) {
-  if (!isTRUE(file.rename(from, to))) {
-    cli::cli_abort(c(
-      "Failed to rename {.path {from}} -> {.path {to}}",
-      "x" = context
-    ))
-  }
-  invisible()
-}

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -153,8 +153,11 @@ miniextendr_build <- function(path = ".", install = TRUE) {
 #'
 #' High-level workflow that vendors all crate dependencies and compresses
 #' them into `inst/vendor.tar.xz` for offline CRAN install. Wraps
-#' [vendor_crates_io()] (which delegates to `cargo-revendor`) plus
-#' Cargo.lock checksum stripping and tarball compression.
+#' [vendor_crates_io()] (which delegates to `cargo-revendor`) plus tarball
+#' compression. `cargo-revendor` resolves against the local workspace when a
+#' dev `[patch."<git-url>"]` override is present (so a cross-crate rename
+#' resolves against the working tree, not git@main) and stamps the canonical
+#' `git+url#<sha>` source into `Cargo.lock`; checksum lines are retained.
 #'
 #' Run this before `R CMD build` when preparing a CRAN submission.
 #' Day-to-day development (`R CMD INSTALL .`, `devtools::install/test/load`)
@@ -169,23 +172,7 @@ miniextendr_vendor <- function(path = ".") {
   with_project(path)
   cli::cli_h1("miniextendr vendor workflow")
 
-  # Step 1: regenerate Cargo.lock in tarball-shape.
-  #
-  # In a monorepo dev checkout .cargo/config.toml carries [patch."git+url"]
-  # overrides that redirect miniextendr-{api,lint,macros} to local paths.
-  # cargo records those as `source = "path+file:///..."` in Cargo.lock, which
-  # are invalid at offline install time (the paths don't exist inside the
-  # tarball). Regenerate the lock against the bare git URLs before vendoring.
-  #
-  # Mirrors the same dance in `just vendor` and `bootstrap.R` (PR #526).
-  cli::cli_h2("Step 1: regenerate Cargo.lock in tarball-shape")
-
-  rust_dir      <- usethis::proj_path("src", "rust")
-  cargo_cfg     <- fs::path(rust_dir, ".cargo", "config.toml")
-  cargo_cfg_bak <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
-  cargo_lock    <- fs::path(rust_dir, "Cargo.lock")
-  cargo_toml    <- fs::path(rust_dir, "Cargo.toml")
-
+  cargo_toml <- usethis::proj_path("src", "rust", "Cargo.toml")
   if (!fs::file_exists(cargo_toml)) {
     cli::cli_abort(c(
       "{.path src/rust/Cargo.toml} not found",
@@ -193,43 +180,19 @@ miniextendr_vendor <- function(path = ".") {
     ))
   }
 
-  if (fs::file_exists(cargo_cfg)) {
-    safe_rename(
-      cargo_cfg, cargo_cfg_bak,
-      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
-    )
-  }
-  if (fs::file_exists(cargo_lock)) {
-    fs::file_delete(cargo_lock)
-  }
-
-  cli::cli_alert("Regenerating {.path src/rust/Cargo.lock} without monorepo overrides...")
-  lock_status <- system2("cargo", c(
-    "generate-lockfile",
-    "--manifest-path", cargo_toml
-  ))
-
-  # Restore config regardless of lock_status — restore first, then error.
-  if (fs::file_exists(cargo_cfg_bak)) {
-    safe_rename(
-      cargo_cfg_bak, cargo_cfg,
-      paste0(
-        "cannot restore .cargo/config.toml from backup; ",
-        "manual fix required: rename ", cargo_cfg_bak, " -> ", cargo_cfg
-      )
-    )
-  }
-
-  if (lock_status != 0) {
-    cli::cli_abort(c(
-      "{.code cargo generate-lockfile} failed (exit {lock_status})",
-      "i" = "Check the output above for details"
-    ))
-  }
-  cli::cli_alert_success("Cargo.lock regenerated in tarball-shape")
-
-  # Step 2: cargo revendor + CRAN-trim (delegates to vendor_crates_io)
-  cli::cli_h2("Step 2: vendor all dependencies")
+  # Step 1: cargo revendor + CRAN-trim (delegates to vendor_crates_io).
+  #
+  # cargo-revendor resolves the dependency graph with the dev
+  # [patch."git+url"] override active (it pins cargo's CWD to the manifest
+  # dir, so a monorepo .cargo/config.toml is honoured), then stamps the
+  # framework crates' `source = "git+url#<sha>"` attribution back into
+  # Cargo.lock — the shape offline source-replacement needs. So a cross-crate
+  # feature/dep rename resolves against the local workspace, not git@main
+  # (#883), and there is no bare-git "regenerate the lock first" dance: the
+  # step that disabled the patch was exactly what broke cross-surface renames.
+  # In a standalone package (no [patch] override) cargo resolves the framework
+  # crates from their git URL directly and the natural git source is kept.
+  cli::cli_h2("Step 1: vendor all dependencies")
   vendor_crates_io()
 
   vendor_dir <- usethis::proj_path("vendor")
@@ -242,7 +205,7 @@ miniextendr_vendor <- function(path = ".") {
   # (post PR #408) writes valid .cargo-checksum.json entries with real SHA-256s,
   # so stripping `checksum = "..."` from Cargo.lock is no longer needed and
   # would diverge from the `just vendor` reference output.
-  cli::cli_h2("Step 3: compress vendor tarball")
+  cli::cli_h2("Step 2: compress vendor tarball")
   fs::dir_create(inst_dir)
 
   # Create staging directory for clean compression

--- a/minirextendr/inst/templates/rpkg/bootstrap.R
+++ b/minirextendr/inst/templates/rpkg/bootstrap.R
@@ -1,27 +1,51 @@
 # bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 # Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 # the source directory before R CMD build seals the tarball. Two jobs:
-#   1. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
+#   1. Run ./configure so Makevars and .cargo/config.toml exist before
+#      R CMD build collects them.
+#   2. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
 #      tarball ships with vendored sources for offline install.
-#   2. Run ./configure so Makevars and other generated files exist
-#      before R CMD build collects them.
+#
+# Order matters: configure runs FIRST. In a dev/monorepo checkout (the
+# source dir still has a workspace .git ancestor — pkgbuild's
+# copy-method defaults to "none"), configure detects the monorepo and
+# writes a [patch."<git-url>"] block into src/rust/.cargo/config.toml
+# redirecting miniextendr-{api,lint,macros} to the local workspace.
+# cargo-revendor then resolves the dependency graph against THOSE local
+# sources, so a cross-crate feature/dep rename touching both a framework
+# crate and rpkg resolves against the PR's checkout instead of git@main
+# (#883). cargo-revendor stamps the canonical `source = "git+<url>#<sha>"`
+# attribution back into Cargo.lock itself (the offline source-replacement
+# shape), so there is no longer any bare-git pre-resolution dance here.
+# src/rust/.cargo is .Rbuildignore'd, so the dev [patch] config is never
+# sealed into the tarball — install-time configure rewrites it to the
+# [source] replacement form.
 #
 # Why vendoring lives here, not in configure.ac's auto-vendor block:
-# pkgbuild::build_setup_source uses callr::rscript against the original
-# source dir (Config/build/copy-method defaults to "none"), so when
-# configure runs it walks up to the workspace .git and SOURCE_IS_GIT=true
-# — the .git-walk auto-vendor in configure skips. We do it here, before
-# ./configure is called, so the tarball gets sealed with vendor.tar.xz
-# inside.
+# when configure runs in the source dir it walks up to the workspace .git
+# and SOURCE_IS_GIT=true — the .git-walk auto-vendor in configure skips.
+# We do it here so the tarball gets sealed with vendor.tar.xz inside.
 #
 # configure.ac's self-repair block still handles the complementary
 # install-time case: an end user installs a tarball that arrived
 # without inst/vendor.tar.xz (no .git in the extracted dir, so
-# configure fires auto-vendor there).
+# configure fires auto-vendor there). That path has no [patch] override,
+# so cargo resolves the framework crates straight from the git URL and
+# cargo-revendor leaves the natural git source in place (nothing to stamp).
 #
 # At install time bootstrap.R does NOT run (Config/build/bootstrap is
-# pkgbuild-only). The bundled inst/vendor.tar.xz from step 1 is what
+# pkgbuild-only). The bundled inst/vendor.tar.xz from step 2 is what
 # configure detects to build offline.
+
+if (.Platform$OS.type == "windows") {
+  if (file.exists("configure.ucrt")) {
+    system("sh configure.ucrt")
+  } else if (file.exists("configure.win")) {
+    system("sh configure.win")
+  }
+} else {
+  system2("bash", "./configure")
+}
 
 if (!file.exists("inst/vendor.tar.xz")) {
   cargo_revendor <- Sys.which("cargo-revendor")
@@ -30,71 +54,6 @@ if (!file.exists("inst/vendor.tar.xz")) {
       "bootstrap.R: cargo-revendor not on PATH. Install with:\n",
       "  cargo install --git https://github.com/A2-AI/miniextendr ",
       "cargo-revendor --locked",
-      call. = FALSE
-    )
-  }
-
-  # Regenerate Cargo.lock in tarball-shape before vendoring.
-  #
-  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
-  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
-  # paths.  cargo then records `source = "path+file:///..."` entries in
-  # Cargo.lock.  Those path-source entries are invalid at offline install time
-  # (the workspace paths don't exist inside the tarball), so we must regenerate
-  # the lock against the bare git URLs before invoking cargo-revendor.
-  #
-  # Steps mirror `just vendor`:
-  #   1. Move .cargo/config.toml aside (suppress [patch] override).
-  #   2. Delete Cargo.lock so cargo resolves fresh.
-  #   3. `cargo generate-lockfile` — miniextendr-* entries get
-  #      `source = "git+https://...#<commit>"`, which is what cargo's
-  #      source-replacement mechanism needs during offline install.
-  #   4. Restore .cargo/config.toml.
-  rust_dir <- file.path(getwd(), "src", "rust")
-  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
-  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
-  cargo_lock <- file.path(rust_dir, "Cargo.lock")
-  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
-
-  # file.rename() returns FALSE on failure without throwing — wrap it so any
-  # rename failure is a hard error rather than a silent no-op.
-  safe_rename <- function(from, to, context) {
-    if (!isTRUE(file.rename(from, to))) {
-      stop(
-        "bootstrap.R: failed to rename ", from, " -> ", to,
-        " (", context, ")",
-        call. = FALSE
-      )
-    }
-    invisible()
-  }
-
-  if (file.exists(cargo_cfg)) {
-    safe_rename(
-      cargo_cfg, cargo_cfg_backup,
-      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
-    )
-  }
-  if (file.exists(cargo_lock)) {
-    file.remove(cargo_lock)
-  }
-  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
-  lock_status <- system2("cargo", c(
-    "generate-lockfile",
-    "--manifest-path", cargo_manifest
-  ))
-  if (file.exists(cargo_cfg_backup)) {
-    safe_rename(
-      cargo_cfg_backup, cargo_cfg,
-      paste0(
-        "cannot restore .cargo/config.toml from backup; ",
-        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
-      )
-    )
-  }
-  if (lock_status != 0) {
-    stop(
-      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
       call. = FALSE
     )
   }
@@ -114,14 +73,4 @@ if (!file.exists("inst/vendor.tar.xz")) {
   if (status != 0) {
     stop("bootstrap.R: cargo revendor failed (exit ", status, ")", call. = FALSE)
   }
-}
-
-if (.Platform$OS.type == "windows") {
-  if (file.exists("configure.ucrt")) {
-    system("sh configure.ucrt")
-  } else if (file.exists("configure.win")) {
-    system("sh configure.win")
-  }
-} else {
-  system2("bash", "./configure")
 }

--- a/minirextendr/man/miniextendr_vendor.Rd
+++ b/minirextendr/man/miniextendr_vendor.Rd
@@ -15,8 +15,11 @@ Invisibly returns the path to the created tarball.
 \description{
 High-level workflow that vendors all crate dependencies and compresses
 them into \code{inst/vendor.tar.xz} for offline CRAN install. Wraps
-\code{\link[=vendor_crates_io]{vendor_crates_io()}} (which delegates to \code{cargo-revendor}) plus
-Cargo.lock checksum stripping and tarball compression.
+\code{\link[=vendor_crates_io]{vendor_crates_io()}} (which delegates to \code{cargo-revendor}) plus tarball
+compression. \code{cargo-revendor} resolves against the local workspace when a
+dev \verb{[patch."<git-url>"]} override is present (so a cross-crate rename
+resolves against the working tree, not git@main) and stamps the canonical
+\code{git+url#<sha>} source into \code{Cargo.lock}; checksum lines are retained.
 }
 \details{
 Run this before \verb{R CMD build} when preparing a CRAN submission.

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,34 +1,59 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-05-14 09:21:02
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
-@@ -1,119 +1,11 @@
+--- a/monorepo/rpkg/bootstrap.R	2026-06-08 19:19:32
++++ b/monorepo/rpkg/bootstrap.R	2026-06-08 18:48:01
+@@ -1,40 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 -# the source directory before R CMD build seals the tarball. Two jobs:
--#   1. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
+-#   1. Run ./configure so Makevars and .cargo/config.toml exist before
+-#      R CMD build collects them.
+-#   2. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
 -#      tarball ships with vendored sources for offline install.
--#   2. Run ./configure so Makevars and other generated files exist
--#      before R CMD build collects them.
 +# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE)
 +# Runs ./configure so that Makevars and other generated files exist
 +# before R CMD build creates the source tarball.
  #
+-# Order matters: configure runs FIRST. In a dev/monorepo checkout (the
+-# source dir still has a workspace .git ancestor — pkgbuild's
+-# copy-method defaults to "none"), configure detects the monorepo and
+-# writes a [patch."<git-url>"] block into src/rust/.cargo/config.toml
+-# redirecting miniextendr-{api,lint,macros} to the local workspace.
+-# cargo-revendor then resolves the dependency graph against THOSE local
+-# sources, so a cross-crate feature/dep rename touching both a framework
+-# crate and rpkg resolves against the PR's checkout instead of git@main
+-# (#883). cargo-revendor stamps the canonical `source = "git+<url>#<sha>"`
+-# attribution back into Cargo.lock itself (the offline source-replacement
+-# shape), so there is no longer any bare-git pre-resolution dance here.
+-# src/rust/.cargo is .Rbuildignore'd, so the dev [patch] config is never
+-# sealed into the tarball — install-time configure rewrites it to the
+-# [source] replacement form.
+-#
 -# Why vendoring lives here, not in configure.ac's auto-vendor block:
--# pkgbuild::build_setup_source uses callr::rscript against the original
--# source dir (Config/build/copy-method defaults to "none"), so when
--# configure runs it walks up to the workspace .git and SOURCE_IS_GIT=true
--# — the .git-walk auto-vendor in configure skips. We do it here, before
--# ./configure is called, so the tarball gets sealed with vendor.tar.xz
--# inside.
+-# when configure runs in the source dir it walks up to the workspace .git
+-# and SOURCE_IS_GIT=true — the .git-walk auto-vendor in configure skips.
+-# We do it here so the tarball gets sealed with vendor.tar.xz inside.
 -#
 -# configure.ac's self-repair block still handles the complementary
 -# install-time case: an end user installs a tarball that arrived
 -# without inst/vendor.tar.xz (no .git in the extracted dir, so
--# configure fires auto-vendor there).
+-# configure fires auto-vendor there). That path has no [patch] override,
+-# so cargo resolves the framework crates straight from the git URL and
+-# cargo-revendor leaves the natural git source in place (nothing to stamp).
 -#
 -# At install time bootstrap.R does NOT run (Config/build/bootstrap is
--# pkgbuild-only). The bundled inst/vendor.tar.xz from step 1 is what
+-# pkgbuild-only). The bundled inst/vendor.tar.xz from step 2 is what
 -# configure detects to build offline.
++# Install-mode detection is automatic: if inst/vendor.tar.xz exists
++# (created by `just vendor` from the workspace root, or
++# `minirextendr::miniextendr_vendor()` from this package, before
++# `R CMD build`), configure builds in tarball/offline mode. Otherwise,
++# source/network mode is used.
+ 
+ if (.Platform$OS.type == "windows") {
+@@ -46,31 +17,3 @@
+ } else {
+   system2("bash", "./configure")
+-}
 -
 -if (!file.exists("inst/vendor.tar.xz")) {
 -  cargo_revendor <- Sys.which("cargo-revendor")
@@ -37,71 +62,6 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -      "bootstrap.R: cargo-revendor not on PATH. Install with:\n",
 -      "  cargo install --git https://github.com/A2-AI/miniextendr ",
 -      "cargo-revendor --locked",
--      call. = FALSE
--    )
--  }
--
--  # Regenerate Cargo.lock in tarball-shape before vendoring.
--  #
--  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
--  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
--  # paths.  cargo then records `source = "path+file:///..."` entries in
--  # Cargo.lock.  Those path-source entries are invalid at offline install time
--  # (the workspace paths don't exist inside the tarball), so we must regenerate
--  # the lock against the bare git URLs before invoking cargo-revendor.
--  #
--  # Steps mirror `just vendor`:
--  #   1. Move .cargo/config.toml aside (suppress [patch] override).
--  #   2. Delete Cargo.lock so cargo resolves fresh.
--  #   3. `cargo generate-lockfile` — miniextendr-* entries get
--  #      `source = "git+https://...#<commit>"`, which is what cargo's
--  #      source-replacement mechanism needs during offline install.
--  #   4. Restore .cargo/config.toml.
--  rust_dir <- file.path(getwd(), "src", "rust")
--  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
--  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
--  cargo_lock <- file.path(rust_dir, "Cargo.lock")
--  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
--
--  # file.rename() returns FALSE on failure without throwing — wrap it so any
--  # rename failure is a hard error rather than a silent no-op.
--  safe_rename <- function(from, to, context) {
--    if (!isTRUE(file.rename(from, to))) {
--      stop(
--        "bootstrap.R: failed to rename ", from, " -> ", to,
--        " (", context, ")",
--        call. = FALSE
--      )
--    }
--    invisible()
--  }
--
--  if (file.exists(cargo_cfg)) {
--    safe_rename(
--      cargo_cfg, cargo_cfg_backup,
--      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
--    )
--  }
--  if (file.exists(cargo_lock)) {
--    file.remove(cargo_lock)
--  }
--  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
--  lock_status <- system2("cargo", c(
--    "generate-lockfile",
--    "--manifest-path", cargo_manifest
--  ))
--  if (file.exists(cargo_cfg_backup)) {
--    safe_rename(
--      cargo_cfg_backup, cargo_cfg,
--      paste0(
--        "cannot restore .cargo/config.toml from backup; ",
--        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
--      )
--    )
--  }
--  if (lock_status != 0) {
--    stop(
--      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
 -      call. = FALSE
 -    )
 -  }
@@ -121,17 +81,10 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -  if (status != 0) {
 -    stop("bootstrap.R: cargo revendor failed (exit ", status, ")", call. = FALSE)
 -  }
--}
-+# Install-mode detection is automatic: if inst/vendor.tar.xz exists
-+# (created by `just vendor` from the workspace root, or
-+# `minirextendr::miniextendr_vendor()` from this package, before
-+# `R CMD build`), configure builds in tarball/offline mode. Otherwise,
-+# source/network mode is used.
- 
- if (.Platform$OS.type == "windows") {
+ }
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-06-03 19:45:48
-+++ b/monorepo/rpkg/configure.ac	2026-06-03 19:47:32
+--- a/monorepo/rpkg/configure.ac	2026-06-08 18:48:01
++++ b/monorepo/rpkg/configure.ac	2026-06-08 18:48:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -436,8 +389,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-06-03 19:45:48
-+++ b/rpkg/configure.ac	2026-06-03 19:47:31
+--- a/rpkg/configure.ac	2026-06-08 18:48:01
++++ b/rpkg/configure.ac	2026-06-08 18:48:01
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/bootstrap.R
+++ b/rpkg/bootstrap.R
@@ -1,27 +1,51 @@
 # bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 # Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
 # the source directory before R CMD build seals the tarball. Two jobs:
-#   1. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
+#   1. Run ./configure so Makevars and .cargo/config.toml exist before
+#      R CMD build collects them.
+#   2. Produce inst/vendor.tar.xz via cargo-revendor, so the sealed
 #      tarball ships with vendored sources for offline install.
-#   2. Run ./configure so Makevars and other generated files exist
-#      before R CMD build collects them.
+#
+# Order matters: configure runs FIRST. In a dev/monorepo checkout (the
+# source dir still has a workspace .git ancestor — pkgbuild's
+# copy-method defaults to "none"), configure detects the monorepo and
+# writes a [patch."<git-url>"] block into src/rust/.cargo/config.toml
+# redirecting miniextendr-{api,lint,macros} to the local workspace.
+# cargo-revendor then resolves the dependency graph against THOSE local
+# sources, so a cross-crate feature/dep rename touching both a framework
+# crate and rpkg resolves against the PR's checkout instead of git@main
+# (#883). cargo-revendor stamps the canonical `source = "git+<url>#<sha>"`
+# attribution back into Cargo.lock itself (the offline source-replacement
+# shape), so there is no longer any bare-git pre-resolution dance here.
+# src/rust/.cargo is .Rbuildignore'd, so the dev [patch] config is never
+# sealed into the tarball — install-time configure rewrites it to the
+# [source] replacement form.
 #
 # Why vendoring lives here, not in configure.ac's auto-vendor block:
-# pkgbuild::build_setup_source uses callr::rscript against the original
-# source dir (Config/build/copy-method defaults to "none"), so when
-# configure runs it walks up to the workspace .git and SOURCE_IS_GIT=true
-# — the .git-walk auto-vendor in configure skips. We do it here, before
-# ./configure is called, so the tarball gets sealed with vendor.tar.xz
-# inside.
+# when configure runs in the source dir it walks up to the workspace .git
+# and SOURCE_IS_GIT=true — the .git-walk auto-vendor in configure skips.
+# We do it here so the tarball gets sealed with vendor.tar.xz inside.
 #
 # configure.ac's self-repair block still handles the complementary
 # install-time case: an end user installs a tarball that arrived
 # without inst/vendor.tar.xz (no .git in the extracted dir, so
-# configure fires auto-vendor there).
+# configure fires auto-vendor there). That path has no [patch] override,
+# so cargo resolves the framework crates straight from the git URL and
+# cargo-revendor leaves the natural git source in place (nothing to stamp).
 #
 # At install time bootstrap.R does NOT run (Config/build/bootstrap is
-# pkgbuild-only). The bundled inst/vendor.tar.xz from step 1 is what
+# pkgbuild-only). The bundled inst/vendor.tar.xz from step 2 is what
 # configure detects to build offline.
+
+if (.Platform$OS.type == "windows") {
+  if (file.exists("configure.ucrt")) {
+    system("sh configure.ucrt")
+  } else if (file.exists("configure.win")) {
+    system("sh configure.win")
+  }
+} else {
+  system2("bash", "./configure")
+}
 
 if (!file.exists("inst/vendor.tar.xz")) {
   cargo_revendor <- Sys.which("cargo-revendor")
@@ -30,71 +54,6 @@ if (!file.exists("inst/vendor.tar.xz")) {
       "bootstrap.R: cargo-revendor not on PATH. Install with:\n",
       "  cargo install --git https://github.com/A2-AI/miniextendr ",
       "cargo-revendor --locked",
-      call. = FALSE
-    )
-  }
-
-  # Regenerate Cargo.lock in tarball-shape before vendoring.
-  #
-  # In a dev monorepo checkout, .cargo/config.toml contains [patch."git+url"]
-  # overrides that redirect miniextendr-{api,lint,macros} to local workspace
-  # paths.  cargo then records `source = "path+file:///..."` entries in
-  # Cargo.lock.  Those path-source entries are invalid at offline install time
-  # (the workspace paths don't exist inside the tarball), so we must regenerate
-  # the lock against the bare git URLs before invoking cargo-revendor.
-  #
-  # Steps mirror `just vendor`:
-  #   1. Move .cargo/config.toml aside (suppress [patch] override).
-  #   2. Delete Cargo.lock so cargo resolves fresh.
-  #   3. `cargo generate-lockfile` — miniextendr-* entries get
-  #      `source = "git+https://...#<commit>"`, which is what cargo's
-  #      source-replacement mechanism needs during offline install.
-  #   4. Restore .cargo/config.toml.
-  rust_dir <- file.path(getwd(), "src", "rust")
-  cargo_cfg <- file.path(rust_dir, ".cargo", "config.toml")
-  cargo_cfg_backup <- paste0(cargo_cfg, ".tmp_bootstrap_vendor")
-  cargo_lock <- file.path(rust_dir, "Cargo.lock")
-  cargo_manifest <- file.path(rust_dir, "Cargo.toml")
-
-  # file.rename() returns FALSE on failure without throwing — wrap it so any
-  # rename failure is a hard error rather than a silent no-op.
-  safe_rename <- function(from, to, context) {
-    if (!isTRUE(file.rename(from, to))) {
-      stop(
-        "bootstrap.R: failed to rename ", from, " -> ", to,
-        " (", context, ")",
-        call. = FALSE
-      )
-    }
-    invisible()
-  }
-
-  if (file.exists(cargo_cfg)) {
-    safe_rename(
-      cargo_cfg, cargo_cfg_backup,
-      "cannot move .cargo/config.toml aside; Cargo.lock regeneration aborted"
-    )
-  }
-  if (file.exists(cargo_lock)) {
-    file.remove(cargo_lock)
-  }
-  message("bootstrap.R: regenerating Cargo.lock in tarball-shape")
-  lock_status <- system2("cargo", c(
-    "generate-lockfile",
-    "--manifest-path", cargo_manifest
-  ))
-  if (file.exists(cargo_cfg_backup)) {
-    safe_rename(
-      cargo_cfg_backup, cargo_cfg,
-      paste0(
-        "cannot restore .cargo/config.toml from backup; ",
-        "manual fix required: rename ", cargo_cfg_backup, " -> ", cargo_cfg
-      )
-    )
-  }
-  if (lock_status != 0) {
-    stop(
-      "bootstrap.R: cargo generate-lockfile failed (exit ", lock_status, ")",
       call. = FALSE
     )
   }
@@ -114,14 +73,4 @@ if (!file.exists("inst/vendor.tar.xz")) {
   if (status != 0) {
     stop("bootstrap.R: cargo revendor failed (exit ", status, ")", call. = FALSE)
   }
-}
-
-if (.Platform$OS.type == "windows") {
-  if (file.exists("configure.ucrt")) {
-    system("sh configure.ucrt")
-  } else if (file.exists("configure.win")) {
-    system("sh configure.win")
-  }
-} else {
-  system2("bash", "./configure")
 }

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-api"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#9003e6e19ec11a01e181c38153a71da20c8c983d"
 dependencies = [
  "ahash 0.8.12",
  "aho-corasick",
@@ -2026,6 +2027,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-lint"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#9003e6e19ec11a01e181c38153a71da20c8c983d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2035,6 +2037,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-macros"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#9003e6e19ec11a01e181c38153a71da20c8c983d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/bootstrap-produces-vendor.sh
+++ b/tests/bootstrap-produces-vendor.sh
@@ -31,26 +31,23 @@ fi
 # regenerates it from scratch via bootstrap.R.
 rm -f rpkg/inst/vendor.tar.xz
 
-# Stash the tracked Cargo.lock: bootstrap.R unconditionally deletes it and
-# runs `cargo generate-lockfile` when the latch is absent (see
-# rpkg/bootstrap.R lines ~78-100). Without this stash, a dev whose lockfile
-# pins different transitive checksums than `generate-lockfile` would produce
-# (e.g. workspace tip moved between revendor runs) ends up with a dirty
-# tracked file each time this test runs. The trap restores from the backup.
+# Stash the tracked Cargo.lock: bootstrap.R runs cargo-revendor, which resolves
+# the framework crates against the local workspace (patch active) and stamps the
+# canonical `source = "git+<url>#<sha>"` attribution back in (#883). The stamped
+# <sha> is the workspace's live git HEAD, so a dev whose HEAD has moved since the
+# committed lock was stamped ends up with a dirty tracked file each time this
+# test runs. The trap restores from the backup.
 CARGO_LOCK_BACKUP="/tmp/bootstrap-vendor-test-cargo-lock-$$.bak"
 cp rpkg/src/rust/Cargo.lock "$CARGO_LOCK_BACKUP"
 
 # Trap-clean producer artifacts (latch + configure outputs + built tarball)
 # so the test is idempotent on dev machines and matches the latch-leak
 # hygiene of `just r-cmd-build` (justfile r-cmd-build trap on line ~632).
-# Also restore Cargo.lock from the stash (see above) and clear bootstrap.R's
-# tmp_bootstrap_vendor sidecar in case bootstrap.R fails mid-way before its
-# own restore step runs.
+# Also restore Cargo.lock from the stash (see above).
 # Note: this trap also removes Makevars and .cargo/config.toml, so a
 # `just configure` is needed before the next dev iteration in this checkout.
 trap '
   rm -f rpkg/inst/vendor.tar.xz rpkg/src/Makevars rpkg/src/rust/.cargo/config.toml miniextendr_*.tar.gz
-  rm -f rpkg/src/rust/.cargo/config.toml.tmp_bootstrap_vendor
   rm -rf rpkg/vendor
   if [ -f "$CARGO_LOCK_BACKUP" ]; then
     mv "$CARGO_LOCK_BACKUP" rpkg/src/rust/Cargo.lock

--- a/tests/vendor-cross-surface-rename.sh
+++ b/tests/vendor-cross-surface-rename.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Regression test for #883: a PR that adds/renames a cargo feature on a
+# framework crate (miniextendr-api) AND references it from rpkg in the SAME
+# commit must vendor successfully.
+#
+# The new feature exists only in the local working tree, never on git@main.
+# The old bootstrap.R / `just vendor` pre-resolved Cargo.lock against the bare
+# git URL (origin/main) with the dev [patch] override moved aside — so cargo
+# resolved miniextendr-api at main, which lacks the new feature, and errored:
+#
+#   package `miniextendr` depends on `miniextendr-api` with feature
+#   `mxl883-probe` but `miniextendr-api` does not have that feature.
+#
+# That forced an admin-merge (PR #710 was the last one). After #883, bootstrap.R
+# runs ./configure FIRST (writing the [patch] override) and cargo-revendor
+# resolves against the LOCAL workspace, then stamps the git+url#<sha> source
+# back into Cargo.lock. So this cross-surface rename now vendors with no
+# admin-merge, and the lock stays CRAN-installable (tarball-shape).
+#
+# Requirements: cargo-revendor on PATH (SKIP if absent, like the sibling tests).
+#
+# Asserts:
+#   1. bootstrap.R (configure + cargo-revendor) exits 0 on the cross-rename.
+#   2. src/rust/Cargo.lock is tarball-shape: every framework crate carries
+#      source = "git+https://github.com/A2-ai/miniextendr#<sha>".
+#   3. The vendored miniextendr-api carries the local-only feature — proving the
+#      vendor came from the working tree, not a git@main fetch.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v cargo-revendor >/dev/null 2>&1; then
+    echo "SKIP: cargo-revendor not on PATH (install with: cargo install --git https://github.com/A2-ai/miniextendr cargo-revendor)"
+    exit 0
+fi
+
+API_TOML="miniextendr-api/Cargo.toml"
+RPKG_TOML="rpkg/src/rust/Cargo.toml"
+LOCK="rpkg/src/rust/Cargo.lock"
+
+# Probe feature: a name that exists ONLY in this working tree, never on
+# origin/main. This is what makes the test a faithful #883 reproduction.
+PROBE_API_FEATURE="mxl883-probe"
+PROBE_RPKG_FEATURE="mxl883"
+
+# Stash the tracked files we mutate, plus configure/vendor outputs, and restore
+# everything on exit (success, failure, or interrupt) so the test is idempotent.
+LOCK_BACKUP="/tmp/vendor-cross-rename-cargo-lock-$$.bak"
+cp "$LOCK" "$LOCK_BACKUP"
+trap '
+  git checkout -- "'"$API_TOML"'" "'"$RPKG_TOML"'" 2>/dev/null || true
+  if [ -f "'"$LOCK_BACKUP"'" ]; then mv "'"$LOCK_BACKUP"'" "'"$LOCK"'"; fi
+  rm -f rpkg/inst/vendor.tar.xz rpkg/src/Makevars rpkg/src/rust/.cargo/config.toml
+  rm -f rpkg/src/rust/.cargo/config.toml.tmp_bootstrap_vendor
+  rm -rf rpkg/vendor
+' EXIT
+
+# Inject the cross-crate feature: define it on miniextendr-api, reference it
+# from rpkg. awk insertion is portable across GNU/BSD (sed -i is not).
+inject_after_features() {
+  # $1 = file, $2 = line to insert right after the first [features] header
+  awk -v ins="$2" '
+    /^\[features\]/ && !done { print; print ins; done = 1; next }
+    { print }
+  ' "$1" > "$1.mxl883.tmp" && mv "$1.mxl883.tmp" "$1"
+}
+
+inject_after_features "$API_TOML" "$PROBE_API_FEATURE = []"
+inject_after_features "$RPKG_TOML" "$PROBE_RPKG_FEATURE = [\"miniextendr-api/$PROBE_API_FEATURE\"]"
+
+# Confirm the injection landed (guards against a [features]-less manifest).
+grep -q "^$PROBE_API_FEATURE = \[\]" "$API_TOML" \
+  || { echo "FAIL: could not inject probe feature into $API_TOML" >&2; exit 1; }
+grep -q "miniextendr-api/$PROBE_API_FEATURE" "$RPKG_TOML" \
+  || { echo "FAIL: could not inject probe feature into $RPKG_TOML" >&2; exit 1; }
+
+# Start from a clean latch so bootstrap.R actually runs the vendor branch.
+rm -f rpkg/inst/vendor.tar.xz
+
+# Drive the exact Bootstrap Vendor path: configure (writes the [patch]
+# override) then cargo-revendor (resolves local, stamps git source).
+echo "Running bootstrap.R with cross-surface rename injected..."
+if ! ( cd rpkg && Rscript bootstrap.R ); then
+    echo "FAIL: bootstrap.R errored on a coordinated cross-crate feature rename." >&2
+    echo "      This is the #883 regression: the framework crate must resolve" >&2
+    echo "      against the local workspace, not git@main." >&2
+    exit 1
+fi
+
+# Assert 2: tarball-shape lock (framework crates carry the git source).
+for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
+    if ! grep -A3 "^name = \"$crate\"\$" "$LOCK" \
+            | grep -q '^source = "git+https://github\.com/A2-ai/miniextendr'; then
+        echo "FAIL: $LOCK — $crate is missing the canonical git+url source." >&2
+        echo "      The stamp step did not run; the offline tarball would not install." >&2
+        exit 1
+    fi
+done
+
+# Assert 3: the vendored miniextendr-api carries the local-only feature,
+# proving it came from the working tree (not a git@main fetch). Capture into a
+# variable first — `tar | grep -q` under `set -o pipefail` can SIGPIPE (#551).
+API_VENDORED_TOML="$(tar -xJOf rpkg/inst/vendor.tar.xz vendor/miniextendr-api/Cargo.toml 2>/dev/null || true)"
+if ! grep -q "$PROBE_API_FEATURE" <<<"$API_VENDORED_TOML"; then
+    echo "FAIL: vendored miniextendr-api is missing the local-only feature '$PROBE_API_FEATURE'." >&2
+    echo "      The vendor came from git@main, not the working tree (#876 angle)." >&2
+    exit 1
+fi
+
+echo "OK: cross-surface rename vendored from the local workspace; lock is tarball-shape."


### PR DESCRIPTION
## Problem (#883)

A PR that changes the cargo surface of `miniextendr-{api,macros,lint}` **and**
its rpkg consumer in the same commit — e.g. renaming a feature
`default-coerce` → `coerce-default` everywhere — could not reach green CI.

`just vendor` / `bootstrap.R` / `miniextendr_vendor()` all pre-resolved
`Cargo.lock` against the **bare git URL** (origin/`main`) with the dev
`[patch."git+url"]` override moved aside. cargo then resolved the framework
crates at `main`, which still had the *old* surface, and errored across
**Bootstrap Vendor**, **R CMD check**, and the **CRAN-like check**:

```
error: failed to select a version for `miniextendr-api`.
package `miniextendr` depends on `miniextendr-api` with feature `coerce-default`
but `miniextendr-api` does not have that feature.
```

#710 (`default-*` → `*-default`) was the last PR forced to **admin-merge red**
because of this; #735 explored a `rev`-pin workaround (withdrawn).

## Root cause

cargo-revendor *already* vendors the framework crates from the local workspace
(guarded by the #876 `local_crates` assertion). The only thing still aimed at
`git@main` was the lock **pre-resolution**. And the reason that step existed at
all: cargo's `.cargo/config.toml` discovery is **CWD-relative**, but
cargo-revendor ran from the repo-root CWD, so it never saw
`rpkg/src/rust/.cargo/config.toml`'s `[patch]` table — the recipes compensated
by disabling the patch entirely and resolving against bare git.

## Fix

Keep `[patch."git+url"]` **active** so cargo resolves the framework crates
against the local PR checkout (the cross-rename resolves), then have
cargo-revendor **stamp** `source = "git+url#<sha>"` back into `Cargo.lock`
*after* resolution. This decouples resolution (local, sees the PR surface) from
source attribution (git URL, what offline source-replacement needs). The
offline tarball build is **frozen** against `vendored-sources`, so the stamped
source survives; replacement keys on the URL, not the sha, so the rev is cosmetic.

### Changes

- **cargo-revendor**
  - Pin cargo's CWD to the manifest dir in `load_metadata` + `run_cargo_vendor`
    so the `[patch]` table is honoured (the core bug).
  - `discover_patch_url_map` (crate → git URL, from the same config walk),
    `resolve_framework_rev` (git HEAD of the local checkout, placeholder
    fallback), `stamp_framework_git_sources` (rewrites the `source =` line right
    after `version`, overwriting any drift, idempotent).
  - Stamp in `run_full` (step 9.5) and expose a standalone `--stamp-lock` for
    the lock-only `just update` path.
  - 6 new unit tests.
- **Drop the bare-git dance** in `justfile` (`vendor`, `update`),
  `rpkg/bootstrap.R`, `minirextendr/R/workflow.R`, and the
  `minirextendr/inst/templates/rpkg/bootstrap.R` template. `bootstrap.R` now runs
  `./configure` **first** so the `[patch]` exists at vendor time. Removed the
  orphaned `safe_rename` helper (only the dance used it).
- **docs/CARGO_LOCK_SHAPE.md** + **CRAN_COMPATIBILITY.md**: document the
  local-resolve + stamp flow; demote the admin-merge policy to a historical note.
- **Regenerated `rpkg/src/rust/Cargo.lock`** to canonical `git+url#<sha>` shape
  (it had drifted to the stripped no-source shape that fails the pre-commit
  lock-shape hook).
- **Regression test** `tests/vendor-cross-surface-rename.sh` (wired into
  `just test-bootstrap-vendor`): injects a framework feature that exists only in
  the working tree, references it from rpkg, and asserts bootstrap.R vendors it
  from the local workspace and produces a tarball-shape lock. Would fail on the
  old bare-git flow. Refreshed stale comments in `bootstrap-produces-vendor.sh`.
- Fixed a pre-existing roxygen "could not resolve link" warning in `use-native.R`.

## Verification

- `just revendor-build` / `just revendor-test` (6 new unit tests pass);
  `cargo clippy --manifest-path cargo-revendor/Cargo.toml --all-targets --locked
  -- -D warnings` clean; `cargo doc` clean; `cargo fmt --check` clean.
- `just vendor` resolves the framework crates locally and stamps
  `git+url#<sha>` — `just lock-shape-check` **OK**.
- **Offline + frozen** resolution in tarball mode (`cargo metadata --offline
  --frozen`) succeeds against `vendored-sources` → CRAN-safe.
- `tests/vendor-cross-surface-rename.sh` passes (cross-rename vendors locally,
  tarball-shape lock); the #876 `local_crates` guard still trips on a real leak;
  `just templates-check` clean.

## Acceptance bar (from #883)

- [x] A cross-surface rename PR passes Bootstrap Vendor / R CMD check / CRAN-like
      check **without** admin-merge (covered by the regression test).
- [x] Offline tarball install still builds from `vendored-sources` (CRAN-safe).
- [x] `vendor-sync-check` + the #876 guard still pass.

Follow-up: #886 (`miniextendr_repair_lock()` still strips checksum lines —
pre-#408 behavior).

Closes #883. Unblocks the class of PRs that #710 / #735 hit.
