### PR TITLE
refactor(api): derive arrow TryFromSexp tags from RNativeType; document SEXPTYPE source-of-truth sites (#882)

### DIFF
--- a/miniextendr-api/src/allocator.rs
+++ b/miniextendr-api/src/allocator.rs
@@ -233,6 +233,9 @@ unsafe fn alloc_main_thread(layout: Layout) -> SendableDataPtr {
     // If this happens inside run_on_worker, R_UnwindProtect will catch it.
     // Outside of that context, Rust destructors may be skipped.
     // Use _unchecked since we're guaranteed to be on R main thread via with_r_thread_or_inline.
+    // RAWSXP literal is the source of truth (#882): this is an opaque R-managed
+    // byte arena used as a `*mut u8` allocation, not a typed vector — there is no
+    // `T: RNativeType` element to derive the tag from.
     let sexp = unsafe { crate::sys::Rf_allocVector_unchecked(SEXPTYPE::RAWSXP, total_isize) };
     if sexp.is_null() {
         return sendable_data_ptr_null();

--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -152,6 +152,11 @@ pub unsafe fn scatter_column(
         let stype = src.type_of();
         let n_present = present_idx.len();
 
+        // The `Rf_allocVector` tags below are the source of truth (#882): there is
+        // no generic `T` in scope here — `stype` is matched at runtime and the
+        // output type must equal the matched input type, so each literal simply
+        // mirrors its own match arm. (The dense/contiguous sibling `gather_native`
+        // *does* take `T: RNativeType` and uses `T::SEXP_TYPE`.)
         match stype {
             SEXPTYPE::REALSXP => {
                 let out = crate::sys::Rf_allocVector(SEXPTYPE::REALSXP, n_rows as isize);

--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -1,5 +1,11 @@
 //! Coerced scalar conversions (multi-source numeric) and large integer scalars.
 //!
+//! **The `SEXPTYPE` literals here are the source of truth (#882).** They are
+//! *runtime* match arms on `sexp.type_of()`, deliberately accepting several
+//! source types and coercing into one target Rust type — there is no single `T`
+//! whose `T::SEXP_TYPE` they could be folded into (the whole point is the 1:N
+//! input fan-in). Leave them.
+//!
 //! These types accept multiple R source types (INTSXP, REALSXP, RAWSXP, LGLSXP)
 //! and coerce to the target Rust type via [`TryCoerce`].
 //!

--- a/miniextendr-api/src/from_r/logical.rs
+++ b/miniextendr-api/src/from_r/logical.rs
@@ -1,5 +1,11 @@
 //! Logical type conversions (Rboolean, bool, Option variants).
 //!
+//! **`LGLSXP` literals here are the source of truth (#882).** `bool`/`Rboolean`
+//! are deliberately *not* `RNativeType` — R logical vectors are stored as `i32`
+//! (that's `RLogical`), and these impls translate the three-state TRUE/FALSE/NA
+//! `LGLSXP` payload into a two-state Rust `bool`. There is no `T::SEXP_TYPE` to
+//! derive the tag from for `bool`; the literal is the boundary, leave it.
+//!
 //! Handles the three R logical states (TRUE, FALSE, NA) and maps them to Rust:
 //!
 //! | Rust Type | NA Handling |

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -1,5 +1,12 @@
 //! NA-aware vector conversions (`Vec<Option<T>>`, `Box<[Option<T>]>`).
 //!
+//! **The `SEXPTYPE` literals here are the source of truth (#882).** The macro
+//! that generates the native-type impls is passed the tag as `$sexptype` from the
+//! caller (where the concrete element type *is* known); the hand-written logical
+//! impls use `LGLSXP` because `bool`/`Rboolean` are not `RNativeType` (R logicals
+//! are `i32`), and the string/raw impls use `STRSXP`/`RAWSXP` literals because
+//! those element types have no `RNativeType` collapse — leave them.
+//!
 //! Maps R's NA values to `None` and non-NA values to `Some(v)`.
 //! Covers native types (i32, f64, u8), logical (bool, Rboolean, RLogical),
 //! string (`Option<String>`), complex (`Option<Rcomplex>`), and coerced

--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -488,10 +488,13 @@ impl TryFromSexp for Float64Array {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        // Derive the expected tag from the element type instead of hardwiring it,
+        // so it can't drift from the `sexp_to_arrow_buffer::<f64>` / `f64::elt`
+        // calls below that read the same buffer (#882, follow-up to #881).
         let actual = sexp.type_of();
-        if actual != SEXPTYPE::REALSXP {
+        if actual != <f64 as RNativeType>::SEXP_TYPE {
             return Err(SexpTypeError {
-                expected: SEXPTYPE::REALSXP,
+                expected: <f64 as RNativeType>::SEXP_TYPE,
                 actual,
             }
             .into());
@@ -532,10 +535,11 @@ impl TryFromSexp for Int32Array {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        // Tag derived from the element type (`i32`) — see Float64Array above (#882).
         let actual = sexp.type_of();
-        if actual != SEXPTYPE::INTSXP {
+        if actual != <i32 as RNativeType>::SEXP_TYPE {
             return Err(SexpTypeError {
-                expected: SEXPTYPE::INTSXP,
+                expected: <i32 as RNativeType>::SEXP_TYPE,
                 actual,
             }
             .into());
@@ -575,10 +579,11 @@ impl TryFromSexp for UInt8Array {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        // Tag derived from the element type (`u8`) — see Float64Array above (#882).
         let actual = sexp.type_of();
-        if actual != SEXPTYPE::RAWSXP {
+        if actual != <u8 as RNativeType>::SEXP_TYPE {
             return Err(SexpTypeError {
-                expected: SEXPTYPE::RAWSXP,
+                expected: <u8 as RNativeType>::SEXP_TYPE,
                 actual,
             }
             .into());
@@ -612,6 +617,9 @@ impl TryFromSexp for BooleanArray {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        // Literal is the source of truth here (#882): Arrow's BooleanArray is
+        // bit-packed and built element-by-element via `logical_elt`, so there is
+        // no `RLogical`-typed buffer path alongside this guard to desync from.
         let actual = sexp.type_of();
         if actual != SEXPTYPE::LGLSXP {
             return Err(SexpTypeError {
@@ -1266,6 +1274,9 @@ impl IntoR for StringArray {
     fn into_sexp(self) -> SEXP {
         let n = Array::len(&self);
         unsafe {
+            // STRSXP literal is the source of truth (#882): R strings are
+            // write-barriered CHARSXP-pointer arrays, not a `RNativeType` element
+            // type, so there is no `alloc_r_vector::<T>` collapse here.
             let sexp = sys::Rf_allocVector(SEXPTYPE::STRSXP, n as R_xlen_t);
             let guard = crate::gc_protect::OwnedProtect::new(sexp);
             for i in 0..n {

--- a/miniextendr-api/src/optionals/bitflags_impl.rs
+++ b/miniextendr-api/src/optionals/bitflags_impl.rs
@@ -2,6 +2,10 @@
 //!
 //! Provides conversions between R integers and bitflags types.
 //!
+//! **`INTSXP` literal is the source of truth (#882).** A `bitflags` type is a
+//! user newtype over its backing integer, not a `RNativeType`, so `INTSXP` is
+//! the R↔Rust mapping here rather than a redundant copy of a `T::SEXP_TYPE`.
+//!
 //! # Features
 //!
 //! Enable this module with the `bitflags` feature:

--- a/miniextendr-api/src/optionals/bitvec_impl.rs
+++ b/miniextendr-api/src/optionals/bitvec_impl.rs
@@ -2,6 +2,10 @@
 //!
 //! Provides conversions between R logical vectors and `BitVec` types.
 //!
+//! **`LGLSXP` literal is the source of truth (#882).** `BitVec` packs bits, so
+//! there is no `RNativeType` element to derive the tag from; the `LGLSXP` literal
+//! is the mapping to R logicals, not a redundant copy of a `T::SEXP_TYPE`.
+//!
 //! # Features
 //!
 //! Enable this module with the `bitvec` feature:

--- a/miniextendr-api/src/optionals/datetime_realsxp.rs
+++ b/miniextendr-api/src/optionals/datetime_realsxp.rs
@@ -1,5 +1,11 @@
 //! Macro for the REALSXP-backed date/time conversion matrix.
 //!
+//! **`REALSXP` literal is the source of truth (#882).** Datetime newtypes are
+//! *defined* to ride on R's `REALSXP` (`f64` days/seconds + a class attribute);
+//! they are not `RNativeType` themselves, so there is no generic `T::SEXP_TYPE`
+//! to fold this into. The literal is the R↔Rust mapping, not a redundant copy
+//! of one — leave it in place.
+//!
 //! Generates all 8 `TryFromSexp` + `IntoR` impls (scalar / `Option<T>` / `Vec<T>` /
 //! `Vec<Option<T>>`, both directions) for types that:
 //! - are backed by a single REALSXP `f64` value,

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -2,6 +2,11 @@
 //!
 //! Provides conversions between R date/time types and `jiff` types.
 //!
+//! **`REALSXP`/`STRSXP` literals are the source of truth (#882).** `jiff` types
+//! map onto R `POSIXct`/`Date`/`difftime` (`REALSXP` + class/`tzone` attributes)
+//! by definition; they are not `RNativeType`, so the literals *are* the mapping,
+//! not a redundant restatement of a `T::SEXP_TYPE` — leave them.
+//!
 //! | R Type | Rust Type | Notes |
 //! |--------|-----------|-------|
 //! | `POSIXct` (UTC) | `jiff::Timestamp` | Seconds since epoch, ns precision |

--- a/miniextendr-api/src/optionals/serde_impl.rs
+++ b/miniextendr-api/src/optionals/serde_impl.rs
@@ -3,6 +3,11 @@
 //! Provides adapter traits for serializing Rust types to JSON and deserializing
 //! from JSON strings in R.
 //!
+//! **`SEXPTYPE` literals here are chosen by the *runtime* JSON value (#882),**
+//! not a compile-time Rust type — a `serde_json::Value` decides at runtime whether
+//! it becomes `LGLSXP`/`INTSXP`/`REALSXP`/`STRSXP`/`VECSXP`. There is no `T` to
+//! derive the tag from, so the literals are load-bearing — leave them.
+//!
 //! | Rust Trait | Adapter Trait | Use Case |
 //! |------------|---------------|----------|
 //! | `serde::Serialize` | `RSerialize` | Convert Rust → JSON string |

--- a/miniextendr-api/src/optionals/toml_impl.rs
+++ b/miniextendr-api/src/optionals/toml_impl.rs
@@ -2,6 +2,11 @@
 //!
 //! Provides conversions between TOML values and R types.
 //!
+//! **`SEXPTYPE` literals here are chosen by the *runtime* TOML value (#882),**
+//! not a compile-time Rust type — a `toml::Value` decides at runtime whether it
+//! becomes `INTSXP`/`REALSXP`/`LGLSXP`/`STRSXP`/`VECSXP`. There is no `T` to
+//! derive the tag from, so the literals are load-bearing — leave them.
+//!
 //! # Features
 //!
 //! Enable this module with the `toml` feature:

--- a/miniextendr-api/src/raw_conversions.rs
+++ b/miniextendr-api/src/raw_conversions.rs
@@ -399,6 +399,11 @@ fn align_slice<T: Pod>(bytes: &[u8]) -> Result<Vec<T>, RawError> {
 // endregion
 
 // region: IntoR implementations
+//
+// `RAWSXP` literals throughout this region are the source of truth (#882): the
+// generic `T: Pod` is the *value being byte-serialized* (a `u32`, a struct, …),
+// not an R element type, and the destination is always a byte buffer. `T` is not
+// `RNativeType`, so there is no `T::SEXP_TYPE` to fold these into — leave them.
 
 impl<T: Pod> IntoR for Raw<T> {
     type Error = std::convert::Infallible;


### PR DESCRIPTION
Audit follow-up to #867 / #881. The recurring smell from #881 was code that hand-derives an R-type fact the Rust type system already determines, then has to keep a `SEXPTYPE` literal in sync with it by hand. This pass walks the rest of `miniextendr-api` for the same class. It is a judgement audit, not a mechanical sweep: a blanket rewrite would have broken the datetime/bitflags/logical/runtime-typed sites whose literal *is* the mapping.

<details>
<summary>AI-generated summary of the audit (site → known-type? → migrated / left-with-reason)</summary>

## Migrated (a known element type determines the tag)

| Site | Known type | Change |
|---|---|---|
| `optionals/arrow_impl.rs` `Float64Array::try_from_sexp` | `f64` (`RNativeType`) | `SEXPTYPE::REALSXP` → `<f64 as RNativeType>::SEXP_TYPE` |
| `optionals/arrow_impl.rs` `Int32Array::try_from_sexp` | `i32` (`RNativeType`) | `SEXPTYPE::INTSXP` → `<i32 as RNativeType>::SEXP_TYPE` |
| `optionals/arrow_impl.rs` `UInt8Array::try_from_sexp` | `u8` (`RNativeType`) | `SEXPTYPE::RAWSXP` → `<u8 as RNativeType>::SEXP_TYPE` |

These three guards each call `sexp_to_arrow_buffer::<T>` / `T::elt` on the same buffer a few lines below; tying the guard's expected tag to the same `T::SEXP_TYPE` makes a size/tag desync unrepresentable — exactly what #881 did for the value-buffer recovery.

The `Rf_allocVector` fallbacks the issue flagged are **already** migrated: arrow's `Float64Array`/`Int32Array`/`UInt8Array`/`BooleanArray` `into_sexp` already use `alloc_r_vector::<f64|i32|u8|RLogical>()` (i.e. `T::SEXP_TYPE`), and `convert.rs::gather_native` already takes `T: RNativeType`.

## Left in place (literal is the genuine source of truth — comment added)

| Site | Why it stays |
|---|---|
| `arrow_impl.rs` `BooleanArray` / `StringArray` (`LGLSXP`/`STRSXP`) | bit-packed / write-barriered CHARSXP arrays; no `RNativeType`-typed buffer path alongside to desync from |
| `convert.rs::scatter_column` (`REALSXP`/`INTSXP`/`LGLSXP`/`STRSXP`/`VECSXP`) | runtime match arms on `src.type_of()`; each literal mirrors its own arm, no generic `T` |
| `from_r/coerced_scalars.rs` | runtime 1:N fan-in (accept INTSXP/REALSXP/RAWSXP/LGLSXP → one Rust type) |
| `from_r/logical.rs`, `from_r/na_vectors.rs` (`LGLSXP`) | `bool`/`Rboolean` are deliberately **not** `RNativeType` (R logicals are `i32`) |
| `optionals/datetime_realsxp.rs`, `jiff_impl.rs` (`REALSXP`) | datetime newtypes ride on REALSXP by definition; not `RNativeType` |
| `optionals/bitflags_impl.rs` (`INTSXP`), `bitvec_impl.rs` (`LGLSXP`) | user newtype over an int / packed bits; not `RNativeType` |
| `raw_conversions.rs`, `allocator.rs` (`RAWSXP`) | `T: Pod` byte serialization / opaque `*mut u8` arena — destination is always a byte buffer |
| `optionals/serde_impl.rs`, `toml_impl.rs` | tag chosen by the **runtime** JSON/TOML value, not a compile-time type |

Each of these now carries a one-line "literal is the source of truth (#882)" note so the next reader's audit is a no-op.

## Secondary (codegen) — noted, deferred

`miniextendr-macros/src/vctrs_derive.rs::base_to_sexptype` maps a user-supplied base-type *string* to a tag — there is no `T: RNativeType` at codegen time, so it's the legitimate mapping table (leave).

`miniextendr-macros/src/altrep.rs:203/237` emits a hardcoded `expected: SEXPTYPE::INTSXP` in the `#ref_ident`/`#mut_ident` `TryFromSexp` error path, but the `is_altrep` check there fires for any ALTREP element type (real/string/…), so the diagnostic tag is inaccurate for non-integer ALTREP derives. This is a diagnostic-quality nit, not a correctness bug (the actual gate is `is_altrep` + `altrep_data1_as`), and fixing it touches proc-macro output (needs `force-document` + regenerated wrappers). Deferred to follow-up #890 rather than dragged into this drafty PR.

</details>

## Verification

`cargo check -p miniextendr-api --features "arrow,jiff,bitflags,bitvec,serde,toml"` — clean, no warnings.

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
