### PR TITLE
fix(justfile): delete broken templates-check-ci recipe (#874)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1018,27 +1018,6 @@ templates-check:
 
     diff -ruN "$tmp" "$tmp2"
 
-# CI-friendly: only prints diff when failing
-[script("bash")]
-templates-check-ci:
-    set -euo pipefail
-
-    test -f "{{patch_file}}"
-
-    tmp="$(mktemp -d)"
-    trap 'rm -rf "$tmp"' EXIT
-
-    just _templates-upstream-populate "$tmp"
-
-    if [[ -s "{{patch_file}}" ]]; then
-      patch -d "$tmp" -p1 --forward --batch < "{{patch_file}}" >/dev/null
-    fi
-
-    if ! diff -ruN "$tmp" "{{local_root}}" >/dev/null; then
-      diff -ruN "$tmp" "{{local_root}}"
-      exit 1
-    fi
-
 # Check that shared recipe bodies in the two template justfiles stay in sync.
 # Recipes that are identical modulo {{rpkg}}/ path prefix are listed in the script.
 templates-recipes-check:


### PR DESCRIPTION
## Summary

- Deletes the `templates-check-ci` recipe from `justfile` (lines 1021–1040 + its comment).
- No other files needed changes — the recipe had zero references outside its own definition.

## Why this is safe

`templates-check-ci` was structurally broken and could never pass:
- It diffed the manifest snapshot (populated by `_templates-upstream-populate`, which only touches `templates-sources` manifest entries) against the **entire** `minirextendr/inst/templates/` directory.
- Standalone scaffolding files (`README.md`, `monorepo/Cargo.toml.tmpl`, `.gitignore`, etc.) are deliberately excluded from the manifest, so the whole-tree diff always reported them as "Only in templates" → always `exit 1`.

CI uses the scoped `just templates-check` (`.github/workflows/ci.yml:234`), which compares only manifest files on both sides and passes correctly. `templates-check-ci` was a dead local-only recipe whose name implied it was the CI gate — it wasn't.

Shared helpers (`_templates-upstream-populate`, `templates-approve`, `templates-check`, `templates-recipes-check`, `templates-sources`) are all untouched.

## Verification

```
$ just --list | grep -i templates
    templates-approve              # (Builds an upstream snapshot from templates-sources before diffing.)
    templates-check                # - exits nonzero if the patch no longer applies cleanly
    templates-recipes-check        # Recipes that are identical modulo {{rpkg}}/ path prefix are listed in the script.
    templates-sources
```

`templates-check-ci` is gone; the real gates remain.

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)