### PR TITLE
docs(convert): document Collect* exemption from As* naming convention (#871)

### DIFF
--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -58,6 +58,21 @@
 //! | Type should *always* convert one way | `Prefer*` derive |
 //! | Override conversion for one function | `As*` wrapper or `return` attribute |
 //! | Type has multiple valid representations | Don't use `Prefer*`; use `As*` or `return` |
+//!
+//! ## A note on the `Collect*` adapters (naming-convention boundary)
+//!
+//! This module also exposes [`Collect`], [`CollectStrings`], [`CollectNA`], and
+//! [`CollectNAInt`]. These are representation-forcing `IntoR` wrappers in the same
+//! spirit as the `As*` family, but they deliberately **do not** carry the `As*`
+//! prefix. The distinction is structural: the `As*` wrappers wrap a *finished value*
+//! `T` and re-route its conversion (`AsList<T>`, `AsExternalPtr<T>`, `AsRNative<T>`),
+//! whereas the `Collect*` wrappers wrap an *iterator* `I: ExactSizeIterator` and
+//! materialize it directly into a freshly allocated R vector. The `As*`-of-`T` shape
+//! ("convert this value *as* a list / pointer / native scalar") does not describe what
+//! these do — `Collect` names the operation (drain an iterator into an R vector),
+//! which is the more accurate verb. This divergence is intentional and tracked; see
+//! the conversion control-surface analysis (`analysis/conversion-control-surface-2026-06-07.md`,
+//! §3.4 / §4.5) and issue #871.
 
 use crate::RNativeType;
 use crate::externalptr::{ExternalPtr, IntoExternalPtr};
@@ -1060,6 +1075,15 @@ where
 // endregion
 
 // region: Collect — zero-allocation iterator-to-R-vector adapters
+//
+// Naming-convention exemption: the four `Collect*` types below are
+// representation-forcing `IntoR` wrappers, like the `As*` family above, but they
+// intentionally diverge from the `As*` prefix. `As*` wraps a finished value `T`
+// and re-routes its conversion; `Collect*` wraps an *iterator*
+// (`I: ExactSizeIterator`) and drains it straight into a freshly allocated R
+// vector. The `As*`-of-`T` shape does not describe an iterator adapter, so
+// `Collect` (the verb for the operation) is the accurate name. See the module-level
+// docs, `analysis/conversion-control-surface-2026-06-07.md` (§3.4 / §4.5), and #871.
 
 /// Write an `ExactSizeIterator` of native R types directly into an R vector.
 ///
@@ -1068,6 +1092,13 @@ where
 ///
 /// Requires `ExactSizeIterator` because R vectors must know their length
 /// at allocation time.
+///
+/// # Naming
+///
+/// `Collect` is in the representation-forcing wrapper family but does not take the
+/// `As*` prefix used by [`AsList`] / [`AsExternalPtr`] / [`AsRNative`]: those wrap a
+/// finished value `T`, whereas `Collect` wraps an *iterator* and materializes it into
+/// an R vector. The divergence is intentional — see the module docs and #871.
 ///
 /// # Example
 ///
@@ -1122,7 +1153,8 @@ where
 /// Write an `ExactSizeIterator` of `String` directly into an R character vector.
 ///
 /// Strings require per-element CHARSXP allocation (no bulk `copy_from_slice`),
-/// so this is a separate type from [`Collect`].
+/// so this is a separate type from [`Collect`]. Like [`Collect`], it is an
+/// iterator adapter and is exempt from the `As*` naming convention (see #871).
 ///
 /// # Example
 ///
@@ -1161,6 +1193,9 @@ where
 /// Write an `ExactSizeIterator` of `Option<T>` directly into an R vector with NA support.
 ///
 /// `None` values become `NA` in R. Works for `f64` and `i32`.
+///
+/// Like [`Collect`], this is an iterator adapter and is exempt from the `As*`
+/// naming convention (see #871).
 ///
 /// # Example
 ///
@@ -1212,6 +1247,9 @@ where
 }
 
 /// Write an `ExactSizeIterator` of `Option<i32>` directly into an R integer vector with NA.
+///
+/// Like [`Collect`], this is an iterator adapter and is exempt from the `As*`
+/// naming convention (see #871).
 pub struct CollectNAInt<I>(pub I);
 
 impl<I> IntoR for CollectNAInt<I>


### PR DESCRIPTION
Follow-up from #869. The `Collect` / `CollectStrings` / `CollectNA` / `CollectNAInt` iterator-adapter wrappers in `convert.rs` are representation-forcing `IntoR` wrappers in the same family as `AsList` / `AsExternalPtr` / `AsRNative`, but don't carry the `As*` prefix. Per the analysis (`analysis/conversion-control-surface-2026-06-07.md` §3.4 / §4.5), this PR **documents the exemption** rather than renaming.

<details>
<summary>AI-generated details (decision, blast radius, what changed)</summary>

### Decision: document-exemption (not rename)

The `As*` wrappers wrap a *finished value* `T` and re-route its conversion (`AsList<T>`, `AsExternalPtr<T>`, `AsRNative<T>`). The `Collect*` wrappers wrap an *iterator* (`I: ExactSizeIterator`) and drain it directly into a freshly allocated R vector. The `As*`-of-`T` shape does not describe an iterator adapter — `Collect` (the verb for the operation) is the more accurate name. §4.5 of the analysis explicitly offers this as a valid resolution.

### Blast-radius evidence (favouring document over rename)

Real type-name references (excluding unrelated `// Collect …` comments and `.collect()` calls):
- `miniextendr-api/src/convert.rs` — definitions + doc examples
- `miniextendr-api/src/lib.rs` — `pub use` re-export
- `rpkg/src/rust/collect_tests.rs` — **vendored** fixture, 8 functions using all four types

A rename would spread into the committed vendored `rpkg/src/rust/` sources (which mirror the workspace) for no API-clarity gain, and would obscure the "drain an iterator into an R vector" semantic. `wasm_registry.rs` references the `test_collect_*` C symbols, not the `Collect` type, so those would be unaffected — but the vendored fixture sprawl alone makes document the lower-risk, more defensible path.

### What changed

- Added a "convention boundary" note in the `convert` module-level docs, right after the `As*` / `Prefer*` / `return` overview, explaining why `Collect*` is exempt.
- Added a region-level comment and a short rustdoc `# Naming` rationale on `Collect`, plus one-line exemption notes on `CollectStrings` / `CollectNA` / `CollectNAInt`.
- All notes cite `analysis/conversion-control-surface-2026-06-07.md` (§3.4 / §4.5) and #871.

No behaviour change; docs only.

### Verification

- `cargo check -p miniextendr-api --features "arrow,serde" --locked` — clean.
- `cargo doc -p miniextendr-api --features "arrow,serde" --no-deps` — no new warnings; the new intra-doc links (`[Collect]`, `[AsList]`, etc.) all resolve (remaining warnings are pre-existing and unrelated to `Collect*`).
- `cargo fmt --all` — clean.

No vendor tarball regeneration needed (docs-only, no public rename); CI regenerates it anyway.

</details>

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)
