### PR TITLE
feat(macros): guided diagnostic for conflicting Prefer* derives (#870)

### DIFF
--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -2150,8 +2150,13 @@ pub fn derive_try_from_list(input: proc_macro::TokenStream) -> proc_macro::Token
 /// Derive `PreferList`: emits an `IntoR` impl selecting list as the type's default
 /// Rust→R conversion (via `IntoList::into_list`).
 ///
-/// A type carries exactly one representation default: stacking two `Prefer*` derives
-/// is a compile error (conflicting `IntoR` impls).
+/// A type carries exactly one representation default: stacking two `Prefer*`
+/// derives is a compile error. Each `Prefer*` derive emits a fixed-name marker
+/// const, so a second one triggers a guided `duplicate definitions with name
+/// __miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers`
+/// error (alongside the raw conflicting-`IntoR`-impl error) — keep one `Prefer*`,
+/// or drop them all and choose a representation per return value at the call site
+/// with an `As*` wrapper (`AsList`, `AsExternalPtr`, `AsDataFrame`, ...).
 ///
 /// # Example
 ///

--- a/miniextendr-macros/src/list_derive.rs
+++ b/miniextendr-macros/src/list_derive.rs
@@ -19,6 +19,11 @@
 //! - `#[derive(PreferDataFrame)]` -- convert via `ColumnSource::into_column_list`
 //! - `#[derive(PreferRNativeType)]` -- convert via `AsRNative` wrapper
 //!
+//! Stacking two of them is a conflict: each derive emits a fixed-name marker const
+//! (`prefer_conflict_marker`), so a second `Prefer*` produces a guided
+//! "duplicate definitions" error pointing at the call-site `As*` wrappers as the
+//! way to choose a representation per return value (see #870).
+//!
 //! ## Field Attributes
 //!
 //! - `#[into_list(ignore)]` -- skip this field during IntoList/TryFromList conversion.
@@ -327,6 +332,38 @@ pub fn derive_try_from_list(input: DeriveInput) -> syn::Result<TokenStream> {
     Ok(expand)
 }
 
+/// Emit a fixed-name conflict marker so that stacking two `Prefer*` derives on a
+/// single type produces a *guided* compile error instead of a cryptic `E0119`
+/// conflicting-`IntoR`-implementation error.
+///
+/// Each `Prefer*` derive declares an inherent associated const with the **same**
+/// self-describing name in an `impl #name` block. A type carries exactly one
+/// representation default, so a second `Prefer*` derive makes rustc report a
+/// `duplicate definitions with name ...` error (E0592) — and the duplicated
+/// identifier itself spells out the fix: pick one type-level default, or choose a
+/// representation per return value at the call site via the `As*` wrappers
+/// (`AsList`, `AsExternalPtr`, `AsDataFrame`, ...).
+///
+/// This fires regardless of derive order and without any cross-derive attribute
+/// inspection — each derive only needs to know its own fixed marker name. (The raw
+/// E0119 on `IntoR` may still co-fire; the duplicate-marker error is the actionable
+/// one because its identifier names both the conflict and the remedy.)
+fn prefer_conflict_marker(input: &DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    quote! {
+        #[allow(non_upper_case_globals, dead_code)]
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// Stacking two `Prefer*` derives on one type is a conflict: a type has
+            /// exactly one `IntoR` default. Keep a single `Prefer*`, or drop them all
+            /// and choose a representation per return value with a call-site `As*`
+            /// wrapper (`AsList`, `AsExternalPtr`, `AsDataFrame`, ...).
+            const __miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers: () = ();
+        }
+    }
+}
+
 /// Derive `PreferList`: emits an `IntoR` impl that converts to R by first calling
 /// `IntoList::into_list`, then `into_sexp`.
 ///
@@ -335,6 +372,7 @@ pub fn derive_try_from_list(input: DeriveInput) -> syn::Result<TokenStream> {
 pub fn derive_prefer_list(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let conflict_marker = prefer_conflict_marker(&input);
 
     let expand = quote! {
         impl #impl_generics ::miniextendr_api::into_r::IntoR for #name #ty_generics #where_clause {
@@ -360,6 +398,8 @@ pub fn derive_prefer_list(input: DeriveInput) -> syn::Result<TokenStream> {
                 ::miniextendr_api::list::IntoList::into_list(self).into_sexp()
             }
         }
+
+        #conflict_marker
     };
 
     Ok(expand)
@@ -373,6 +413,7 @@ pub fn derive_prefer_list(input: DeriveInput) -> syn::Result<TokenStream> {
 pub fn derive_prefer_externalptr(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let conflict_marker = prefer_conflict_marker(&input);
 
     let expand = quote! {
         impl #impl_generics ::miniextendr_api::into_r::IntoR for #name #ty_generics #where_clause {
@@ -398,6 +439,8 @@ pub fn derive_prefer_externalptr(input: DeriveInput) -> syn::Result<TokenStream>
                 ::miniextendr_api::externalptr::ExternalPtr::new(self).into_sexp()
             }
         }
+
+        #conflict_marker
     };
 
     Ok(expand)
@@ -411,6 +454,7 @@ pub fn derive_prefer_externalptr(input: DeriveInput) -> syn::Result<TokenStream>
 pub fn derive_prefer_data_frame(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let conflict_marker = prefer_conflict_marker(&input);
 
     let expand = quote! {
         impl #impl_generics ::miniextendr_api::into_r::IntoR for #name #ty_generics #where_clause {
@@ -436,6 +480,8 @@ pub fn derive_prefer_data_frame(input: DeriveInput) -> syn::Result<TokenStream> 
                 ::miniextendr_api::convert::ColumnSource::into_column_list(self).into_sexp()
             }
         }
+
+        #conflict_marker
     };
 
     Ok(expand)
@@ -450,6 +496,7 @@ pub fn derive_prefer_data_frame(input: DeriveInput) -> syn::Result<TokenStream> 
 pub fn derive_prefer_rnative(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let conflict_marker = prefer_conflict_marker(&input);
 
     let expand = quote! {
         impl #impl_generics ::miniextendr_api::into_r::IntoR for #name #ty_generics #where_clause {
@@ -479,6 +526,8 @@ pub fn derive_prefer_rnative(input: DeriveInput) -> syn::Result<TokenStream> {
                 )
             }
         }
+
+        #conflict_marker
     };
 
     Ok(expand)
@@ -495,6 +544,7 @@ pub fn derive_prefer_rnative(input: DeriveInput) -> syn::Result<TokenStream> {
 pub fn derive_prefer_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let conflict_marker = prefer_conflict_marker(&input);
 
     let expand = quote! {
         impl #impl_generics ::miniextendr_api::into_r::IntoR for #name #ty_generics #where_clause {
@@ -510,6 +560,8 @@ pub fn derive_prefer_vctrs(input: DeriveInput) -> syn::Result<TokenStream> {
                 self.try_into_sexp()
             }
         }
+
+        #conflict_marker
     };
 
     Ok(expand)

--- a/miniextendr-macros/tests/ui/derive_prefer_conflict.rs
+++ b/miniextendr-macros/tests/ui/derive_prefer_conflict.rs
@@ -1,0 +1,15 @@
+//! Test: stacking two `Prefer*` derives on one type is a conflict (#870).
+//!
+//! A type carries exactly one `IntoR` default. Each `Prefer*` derive emits an
+//! inherent associated const with the same self-describing name, so a second
+//! `Prefer*` derive triggers a guided "duplicate definitions" error (E0592)
+//! whose identifier names both the conflict and the remedy: choose a
+//! representation per return value at the call site via the `As*` wrappers.
+//! The raw conflicting-`IntoR`-impl error (E0119) co-fires.
+
+use miniextendr_macros::{IntoList, PreferList, PreferRNativeType, RNativeType};
+
+#[derive(Clone, Copy, IntoList, RNativeType, PreferList, PreferRNativeType)]
+struct Model(i32);
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/derive_prefer_conflict.stderr
+++ b/miniextendr-macros/tests/ui/derive_prefer_conflict.stderr
@@ -1,0 +1,19 @@
+error[E0119]: conflicting implementations of trait `IntoR` for type `Model`
+  --> tests/ui/derive_prefer_conflict.rs:12:58
+   |
+12 | #[derive(Clone, Copy, IntoList, RNativeType, PreferList, PreferRNativeType)]
+   |                                              ----------  ^^^^^^^^^^^^^^^^^ conflicting implementation for `Model`
+   |                                              |
+   |                                              first implementation here
+   |
+   = note: this error originates in the derive macro `PreferRNativeType` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0592]: duplicate definitions with name `__miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers`
+  --> tests/ui/derive_prefer_conflict.rs:12:46
+   |
+12 | #[derive(Clone, Copy, IntoList, RNativeType, PreferList, PreferRNativeType)]
+   |                                              ^^^^^^^^^^  ----------------- other definition for `__miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers`
+   |                                              |
+   |                                              duplicate definitions for `__miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers`
+   |
+   = note: this error originates in the derive macro `PreferList` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Stacking two `Prefer*` derives on one type is a desirable mutual exclusion (a type carries exactly one `IntoR` default), but it previously surfaced only as a cryptic `E0119` conflicting-implementation error on `IntoR`. This makes the conflict self-explanatory and points users at the call-site `As*` wrappers.

<details>
<summary>🤖 Implementation details (AI-written)</summary>

## Mechanism

Each `Prefer*` derive (`PreferList`, `PreferExternalPtr`, `PreferDataFrame`, `PreferRNativeType`, `PreferVctrs`) now emits — in addition to its `impl IntoR` — a fixed-name inherent associated const via a shared `prefer_conflict_marker` helper in `list_derive.rs`:

```rust
impl Model {
    const __miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers: () = ();
}
```

A second `Prefer*` derive declares a second const with the **same** name, so rustc reports a guided `E0592 duplicate definitions with name ...` error whose identifier itself names both the conflict and the remedy. This fires **regardless of derive order** and **without any cross-derive attribute inspection** — each derive only needs to know its own fixed marker name. (Option (a) from the issue / analysis §4.4.)

The raw E0119 on `IntoR` still co-fires, but the duplicate-marker error is the actionable one because its identifier spells out the fix.

## Before vs after

Both fire, but the new E0592 carries the guidance:

```
error[E0119]: conflicting implementations of trait `IntoR` for type `Model`
12 | #[derive(Clone, Copy, IntoList, RNativeType, PreferList, PreferRNativeType)]
   |                                              ----------  ^^^^^^^^^^^^^^^^^ conflicting implementation for `Model`

error[E0592]: duplicate definitions with name `__miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers`
12 | #[derive(Clone, Copy, IntoList, RNativeType, PreferList, PreferRNativeType)]
   |                                              ^^^^^^^^^^  ----------------- other definition for ...
```

Before this PR, only the first (cryptic) E0119 appeared.

## Changes

- `miniextendr-macros/src/list_derive.rs` — `prefer_conflict_marker` helper; wired into all five `derive_prefer_*` functions.
- `miniextendr-macros/src/lib.rs` — updated `PreferList` derive doc to describe the guided diagnostic.
- `miniextendr-macros/tests/ui/derive_prefer_conflict.rs` + `.stderr` — trybuild fixture stacking `PreferList` + `PreferRNativeType` (chosen because both emit a direct `impl IntoR` with no blanket/companion-trait noise, yielding the cleanest two-error snapshot).

## Verification

- `cargo test -p miniextendr-macros` — 324 passed, 73 ignored.
- `cargo check -p miniextendr-macros --features vctrs` and `cargo check -p miniextendr-api --features full` — both compile (single-`Prefer*` macro_coverage fixtures unaffected).
- `cargo fmt --all --check` — clean.

## Caveats

- DX-only, no behaviour change.
- The raw E0119 still co-fires (residual, unavoidable without removing the direct `impl IntoR` emission); the guided E0592 is the prominent/actionable one.
- The const name uses non-upper-case-globals (`#[allow]`'d) so the identifier reads as a sentence.

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
