### PR TITLE
docs: local path-dep in src/rust/Cargo.toml must be absolute (#864)

### DIFF
--- a/docs/MINIREXTENDR.md
+++ b/docs/MINIREXTENDR.md
@@ -251,6 +251,50 @@ vendor_sync(path = "mypackage")
 miniextendr_available_versions()
 ```
 
+### Wrapping a local Rust crate: use an absolute path
+
+When your R package depends on a Rust crate that lives **outside the package**
+(e.g. an "engine" crate in the same monorepo, or a sibling library on disk),
+the `path = ...` dependency you add to `src/rust/Cargo.toml` **must be
+absolute**, not relative.
+
+`R CMD INSTALL` and `devtools::install()` copy the package into a temporary
+build directory (e.g. `/private/tmp/.../R.INSTALL.../<pkg>/`) *before*
+compiling the Rust staticlib. A relative path resolves against that temporary
+location — which doesn't contain your engine crate — and the build fails:
+
+```toml
+# ❌ breaks: relative path resolves against the temp build dir
+my_engine = { path = "../../../engine" }
+```
+
+```
+error: failed to load manifest for dependency `my_engine`
+  ... No such file or directory
+```
+
+An **absolute** path is read live from its real location, so the temp-copy
+doesn't matter:
+
+```toml
+# ✅ works: absolute path is read from its real location at install time
+my_engine = { path = "/abs/path/to/engine" }
+```
+
+How this interacts with vendoring: `cargo vendor` / the vendor tarball captures
+only the engine crate's **registry** dependencies (its transitive crates.io
+deps). The engine's *own source* is **not** vendored — it is read from the
+`path` at install time. That's why the path has to keep resolving after the
+temp-copy, and why it must be absolute in **source-install mode**.
+
+> **Note:** `use_vendor_lib()` (below) is the supported way to wire a
+> monorepo crate in. It writes a *relative* `dev_path` into
+> `[patch.crates-io]` on purpose — its generated `configure.ac` block rewrites
+> that path to the extracted vendor copy in **tarball/CRAN mode**, so the
+> relative path never reaches the offline build. The absolute-path requirement
+> above applies to a **hand-added** `path = ...` dependency that has no such
+> rewriting machinery. If you hand-roll the dependency, use an absolute path.
+
 ## Diagnostics
 
 ```r

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -139,6 +139,33 @@ just vendor-sync-check  # Check for drift
 just vendor             # Refresh vendored copies (rpkg/vendor/ + inst/vendor.tar.xz)
 ```
 
+### `failed to load manifest for dependency` for a local crate
+
+Symptom: a `path = ...` dependency on a crate outside your package (an "engine"
+crate, a sibling library) builds fine with `cargo build` but fails under
+`R CMD INSTALL` / `devtools::install()`:
+
+```
+error: failed to load manifest for dependency `my_engine`
+  ... No such file or directory
+```
+
+Cause: R copies the package into a temporary build directory before compiling
+the Rust staticlib, so a **relative** path (`../../../engine`) resolves against
+the temp location, which doesn't contain the crate. Fix: use an **absolute**
+path in `src/rust/Cargo.toml`:
+
+```toml
+# ❌ relative — breaks under R's temp-copy
+my_engine = { path = "../../../engine" }
+# ✅ absolute — read live from its real location
+my_engine = { path = "/abs/path/to/engine" }
+```
+
+See [MINIREXTENDR.md](MINIREXTENDR.md#wrapping-a-local-rust-crate-use-an-absolute-path)
+for the full explanation (and how this interacts with `use_vendor_lib()` and
+vendoring).
+
 ### Editing generated files has no effect
 
 Many files in rpkg are generated from `.in` templates. Always edit the template:

--- a/minirextendr/R/vendor-lib.R
+++ b/minirextendr/R/vendor-lib.R
@@ -212,10 +212,29 @@ add_vendor_lib_to_configure_ac <- function(crate, dev_path) {
 #' For CRAN/offline builds, `cargo package` bundles the crate as a tarball
 #' that configure extracts at build time.
 #'
+#' @details
+#' `dev_path` is stored as a **relative** path in `[patch.crates-io]` on
+#' purpose: the generated `configure.ac` block rewrites it to the extracted
+#' vendor copy in tarball/CRAN mode, so the relative path never reaches the
+#' offline build. This is why `use_vendor_lib()` is the supported way to wire
+#' in a monorepo crate.
+#'
+#' If you instead **hand-add** a `path = ...` dependency to
+#' `src/rust/Cargo.toml` (with no such rewriting machinery), it must be an
+#' **absolute** path. `R CMD INSTALL` / `devtools::install()` copy the package
+#' into a temporary build directory before compiling the Rust staticlib, so a
+#' relative path resolves against the temp location and fails with
+#' `failed to load manifest for dependency`. An absolute path is read live from
+#' its real location. (`cargo vendor` captures only the crate's registry deps;
+#' the crate's own source is read from the `path` at install time.)
+#'
 #' @param crate Crate name (e.g., "dvs")
 #' @param version Version spec for Cargo.toml (e.g., "*" or "0.1.0")
 #' @param dev_path Relative path from R package root to the monorepo crate
-#'   (e.g., "../../../dvs")
+#'   (e.g., "../../../dvs"). Stored relative on purpose -- the generated
+#'   `configure.ac` block rewrites it for tarball/CRAN builds. A *hand-added*
+#'   `path = ...` dependency (without that machinery) must be absolute instead;
+#'   see Details.
 #' @param path Path to the R package root
 #' @return Invisibly returns TRUE
 #' @export

--- a/minirextendr/man/use_vendor_lib.Rd
+++ b/minirextendr/man/use_vendor_lib.Rd
@@ -12,7 +12,10 @@ use_vendor_lib(crate, version = "*", dev_path, path = ".")
 \item{version}{Version spec for Cargo.toml (e.g., "*" or "0.1.0")}
 
 \item{dev_path}{Relative path from R package root to the monorepo crate
-(e.g., "../../../dvs")}
+(e.g., "../../../dvs"). Stored relative on purpose -- the generated
+\code{configure.ac} block rewrites it for tarball/CRAN builds. A \emph{hand-added}
+\code{path = ...} dependency (without that machinery) must be absolute instead;
+see Details.}
 
 \item{path}{Path to the R package root}
 }
@@ -24,4 +27,20 @@ Configures your R package to depend on a Rust crate from the same monorepo.
 In dev mode, the crate is resolved via \verb{[patch.crates-io]} path.
 For CRAN/offline builds, \verb{cargo package} bundles the crate as a tarball
 that configure extracts at build time.
+}
+\details{
+\code{dev_path} is stored as a \strong{relative} path in \verb{[patch.crates-io]} on
+purpose: the generated \code{configure.ac} block rewrites it to the extracted
+vendor copy in tarball/CRAN mode, so the relative path never reaches the
+offline build. This is why \code{use_vendor_lib()} is the supported way to wire
+in a monorepo crate.
+
+If you instead \strong{hand-add} a \code{path = ...} dependency to
+\code{src/rust/Cargo.toml} (with no such rewriting machinery), it must be an
+\strong{absolute} path. \verb{R CMD INSTALL} / \code{devtools::install()} copy the package
+into a temporary build directory before compiling the Rust staticlib, so a
+relative path resolves against the temp location and fails with
+\verb{failed to load manifest for dependency}. An absolute path is read live from
+its real location. (\verb{cargo vendor} captures only the crate's registry deps;
+the crate's own source is read from the \code{path} at install time.)
 }


### PR DESCRIPTION
Closes #864.

Documents that a **local `path = ...` dependency** in `src/rust/Cargo.toml`
(wrapping an "engine" crate or sibling library) must use an **absolute** path,
not relative. `R CMD INSTALL` / `devtools::install()` copy the package into a
temporary build dir before compiling the Rust staticlib, so a relative path
resolves against the temp location and fails:

```toml
my_engine = { path = "../../../engine" }   # ❌ failed to load manifest for dependency
my_engine = { path = "/abs/path/to/engine" }  # ✅ read live from its real location
```

`cargo vendor` captures only the engine's *registry* deps; the engine's own
source is read from the `path` at install time — which is why the path must
keep resolving after the temp-copy.

## What changed

- **`docs/MINIREXTENDR.md`** — new "Wrapping a local Rust crate: use an
  absolute path" subsection under Vendoring, with the failing-vs-working
  `Cargo.toml` snippets from the issue and the cargo-vendor interaction. Notes
  the contrast with `use_vendor_lib()` (its relative `dev_path` is intentional
  — rewritten to the vendor copy in tarball mode — so the absolute-path rule
  applies to *hand-added* deps only).
- **`docs/TROUBLESHOOTING.md`** — "failed to load manifest for dependency"
  entry under Vendor / Configure Issues, cross-linked to the above.
- **`minirextendr/R/vendor-lib.R`** — `use_vendor_lib()` gains an `@details`
  block + clarified `@param dev_path` explaining the relative-vs-absolute
  distinction; regenerated `man/use_vendor_lib.Rd`.

## Warning at scaffold/build time

Not implemented here — a naive relative-`path` check in `miniextendr_doctor()`
false-positives on the supported `use_vendor_lib()` flow (which intentionally
writes a relative `dev_path` into `[patch.crates-io]`, rewritten by its
`configure.ac` block in tarball mode). Filed as follow-up **#894** with the
design options. The manual case the issue describes is now fully documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)