### PR TITLE
fix(templates): add config.status and config.log to rpkg gitignore templates

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/gitignore
+++ b/minirextendr/inst/templates/monorepo/rpkg/gitignore
@@ -1,4 +1,6 @@
 configure~
+config.log
+config.status
 autom4te.cache
 .cargo/config.toml
 src/Makevars

--- a/minirextendr/inst/templates/rpkg/gitignore
+++ b/minirextendr/inst/templates/rpkg/gitignore
@@ -1,4 +1,6 @@
 configure~
+config.log
+config.status
 autom4te.cache
 .cargo/config.toml
 src/Makevars


### PR DESCRIPTION
## Summary

Scaffolded packages (`minirextendr::use_miniextendr_package()`) would commit `config.status` and `config.log` — both contain machine-specific absolute paths — because neither template `.gitignore` excluded them.

- Added `config.log` and `config.status` to `minirextendr/inst/templates/rpkg/gitignore`
- Added `config.log` and `config.status` to `minirextendr/inst/templates/monorepo/rpkg/gitignore`

The entries are placed immediately after `configure~` (the existing configure-output entry), matching the ordering in `rpkg/.gitignore` (the master source).

## Templates-sync finding

The `gitignore` template files are **not** listed in the `templates-sources` manifest in `justfile` (only build infrastructure files like `configure.ac`, `Makevars.in`, `stub.c`, etc. are tracked there). Direct edits to these files are correct — no `just templates-approve` needed. `just templates-check` passes with exit 0.

`rpkg/.gitignore` (the dev package — the source of truth) already had both entries (lines 3–4). The templates simply hadn't been updated to match.

Closes #862

## Test plan

- [ ] `just templates-check` passes (confirmed locally: exit 0)
- [ ] Scaffolded package via `minirextendr::use_miniextendr_package()` no longer stages `config.log` / `config.status` after `bash ./configure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)