### PR TITLE
refactor(serde): deduplicate SEXPTYPE name table — delegate to sexptype_name

### DIFF
--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -71,21 +71,17 @@ impl RDeserializer {
 
     fn type_name(&self) -> String {
         let t = self.sexp_type();
-        match t {
-            SEXPTYPE::NILSXP => "NULL".to_string(),
-            SEXPTYPE::LGLSXP => "logical".to_string(),
-            SEXPTYPE::INTSXP => "integer".to_string(),
-            SEXPTYPE::REALSXP => "numeric".to_string(),
-            SEXPTYPE::STRSXP => "character".to_string(),
-            SEXPTYPE::VECSXP => {
-                if self.has_names() {
-                    "named list".to_string()
-                } else {
-                    "list".to_string()
-                }
+        // VECSXP gets special treatment: distinguish named vs unnamed list
+        // for clearer serde error messages. Everything else delegates to the
+        // canonical table in typed_list.
+        if t == SEXPTYPE::VECSXP {
+            if self.has_names() {
+                "named list".to_string()
+            } else {
+                "list".to_string()
             }
-            SEXPTYPE::RAWSXP => "raw".to_string(),
-            _ => format!("SEXPTYPE({})", t as i32),
+        } else {
+            crate::typed_list::sexptype_name(t)
         }
     }
 }


### PR DESCRIPTION
## Summary

Took **Option 1** from #833: have `serde/de.rs` call `crate::typed_list::sexptype_name` instead of maintaining its own inline match arms.

- **Tables matched exactly** — every arm in `serde/de.rs` (`NILSXP`, `LGLSXP`, `INTSXP`, `REALSXP`, `STRSXP`, `RAWSXP`) had identical spellings to the canonical `typed_list::sexptype_name`. This change is **behaviour-preserving**.
- `VECSXP` retains its intentional extension inline: serde distinguishes `"named list"` vs `"list"` for clearer error messages; `sexptype_name` just returns `"list"` for both. The arm is preserved as a special-case `if` before delegating everything else.
- No visibility change needed: `sexptype_name` is already `pub` and re-exported from `miniextendr-api/src/lib.rs`.

**Files changed:**
- `miniextendr-api/src/serde/de.rs` — removed 5 duplicated match arms, replaced with `crate::typed_list::sexptype_name(t)` call.

**Option 2** (`Rf_type2char`) is noted for future consideration — it would provide a single C-level source of truth but changes canonical spellings (e.g. `REALSXP` becomes `"double"` not `"numeric"`) and would require reconciling many error-message/test expectations across the codebase. Out of scope for a low-priority dedup.

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)