### PR TITLE
perf(optionals): read logical R columns via as_slice instead of per-element logical_elt

### DIFF
--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -620,15 +620,14 @@ impl TryFromSexp for BooleanArray {
             }
             .into());
         }
-        let len = sexp.len();
-        let mut builder = arrow_array::builder::BooleanBuilder::with_capacity(len);
+        let slice: &[crate::RLogical] = unsafe { sexp.as_slice() };
+        let mut builder = arrow_array::builder::BooleanBuilder::with_capacity(slice.len());
 
-        for i in 0..len {
-            let val = sexp.logical_elt(i as R_xlen_t);
-            if val == crate::altrep_traits::NA_LOGICAL {
+        for &val in slice {
+            if val.is_na() {
                 builder.append_null();
             } else {
-                builder.append_value(val != 0);
+                builder.append_value(val.to_i32() != 0);
             }
         }
 

--- a/miniextendr-api/src/optionals/bitvec_impl.rs
+++ b/miniextendr-api/src/optionals/bitvec_impl.rs
@@ -46,7 +46,6 @@
 pub use bitvec::order::{Lsb0, Msb0};
 pub use bitvec::vec::BitVec;
 
-use crate::altrep_traits::NA_LOGICAL;
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::impl_option_try_from_sexp;
 use crate::into_r::IntoR;
@@ -72,18 +71,17 @@ impl TryFromSexp for RBitVec {
             .into());
         }
 
-        let len = sexp.len();
-        let mut bits = RBitVec::with_capacity(len);
+        let slice: &[crate::RLogical] = unsafe { sexp.as_slice() };
+        let mut bits = RBitVec::with_capacity(slice.len());
 
-        for i in 0..len {
-            let val = sexp.logical_elt(i as crate::R_xlen_t);
-            if val == NA_LOGICAL {
+        for (i, &val) in slice.iter().enumerate() {
+            if val.is_na() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for RBitVec",
                     i
                 )));
             }
-            bits.push(val != 0);
+            bits.push(val.to_i32() != 0);
         }
 
         Ok(bits)
@@ -150,18 +148,17 @@ impl TryFromSexp for BitVec<u8, Msb0> {
             .into());
         }
 
-        let len = sexp.len();
-        let mut bits = BitVec::<u8, Msb0>::with_capacity(len);
+        let slice: &[crate::RLogical] = unsafe { sexp.as_slice() };
+        let mut bits = BitVec::<u8, Msb0>::with_capacity(slice.len());
 
-        for i in 0..len {
-            let val = sexp.logical_elt(i as crate::R_xlen_t);
-            if val == NA_LOGICAL {
+        for (i, &val) in slice.iter().enumerate() {
+            if val.is_na() {
                 return Err(SexpError::InvalidValue(format!(
                     "NA at index {} not allowed for BitVec",
                     i
                 )));
             }
-            bits.push(val != 0);
+            bits.push(val.to_i32() != 0);
         }
 
         Ok(bits)


### PR DESCRIPTION
## Summary

- **`optionals/bitvec_impl.rs` (both sites):** `RBitVec` (`Lsb0`) and `BitVec<u8, Msb0>` `TryFromSexp` impls now call `sexp.as_slice::<RLogical>()` and iterate the slice, replacing the `for i in 0..len { sexp.logical_elt(i) }` index loop. Dropped now-unused `NA_LOGICAL` import.
- **`optionals/arrow_impl.rs` (~line 623):** `BooleanArray` `TryFromSexp` impl converted the same way.

NA semantics are identical: `val.is_na()` (`RLogical::is_na()` checks `self.0 == i32::MIN`) replaces `== NA_LOGICAL`/`crate::altrep_traits::NA_LOGICAL`. The NA branch behaviour (bitvec: early-return `InvalidValue`; arrow: `append_null`) is unchanged.

**Out of scope (untouched):**
- `serde/de.rs` and `serde/dataframe_de.rs` — streaming-visitor model, element-wise by design.
- `StringArray` and all string/list columns — write-barriered, no flat slice available.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)