### PR TITLE
refactor(convert): unify scatter_column onto slice-based scatter_native (#831)

### DIFF
--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -144,9 +144,16 @@ pub use crate::dataframe::ColumnSource;
 /// - REALSXP → REALSXP (NA_real_ fill)
 /// - INTSXP  → INTSXP  (NA_integer_ fill)
 /// - LGLSXP  → LGLSXP  (NA_logical fill)
+/// - RAWSXP  → RAWSXP  (`0x00` fill — R raw has no NA)
+/// - CPLXSXP → CPLXSXP (NA complex fill: both parts NA_real_)
 /// - STRSXP  → STRSXP  (NA_character_ fill)
 /// - VECSXP  → VECSXP  (R_NilValue fill)
 /// - anything else → VECSXP (R_NilValue fill)
+///
+/// Contiguous primitive columns (real/integer/logical/raw/complex) scatter as a
+/// flat slice write via [`scatter_native`] — the NA-filled inverse of
+/// [`gather_native`]. String and list columns stay element-by-element because
+/// they are write-barriered arrays of `SEXP` pointers, not flat buffers.
 ///
 /// # Safety
 ///
@@ -162,77 +169,32 @@ pub unsafe fn scatter_column(
     // SAFETY: caller guarantees R main thread; src is valid; n_rows is correct.
     #[allow(unused_unsafe)]
     unsafe {
-        use crate::{SEXPTYPE, SexpExt as _};
+        use crate::{RLogical, Rcomplex, SEXPTYPE, SexpExt as _};
 
-        let stype = src.type_of();
-        let n_present = present_idx.len();
-
-        // The `Rf_allocVector` tags below are the source of truth (#882): there is
-        // no generic `T` in scope here — `stype` is matched at runtime and the
-        // output type must equal the matched input type, so each literal simply
-        // mirrors its own match arm. (The dense/contiguous sibling `gather_native`
-        // *does* take `T: RNativeType` and uses `T::SEXP_TYPE`.)
-        match stype {
-            SEXPTYPE::REALSXP => {
-                let out = crate::sys::Rf_allocVector(SEXPTYPE::REALSXP, n_rows as isize);
-                // Fill with NA_real_ (R's NA for doubles is a specific NaN bit pattern;
-                // f64::NAN has the correct bit pattern since R uses a quiet NaN sentinel).
-                for i in 0..(n_rows as isize) {
-                    out.set_real_elt(i, f64::NAN);
-                }
-                for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        out.set_real_elt(row_i as isize, src.real_elt(pi as isize));
-                    }
-                }
-                out
-            }
-            SEXPTYPE::INTSXP => {
-                let out = crate::sys::Rf_allocVector(SEXPTYPE::INTSXP, n_rows as isize);
-                for i in 0..(n_rows as isize) {
-                    out.set_integer_elt(i, i32::MIN); // NA_integer_
-                }
-                for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        out.set_integer_elt(row_i as isize, src.integer_elt(pi as isize));
-                    }
-                }
-                out
-            }
-            SEXPTYPE::LGLSXP => {
-                let out = crate::sys::Rf_allocVector(SEXPTYPE::LGLSXP, n_rows as isize);
-                for i in 0..(n_rows as isize) {
-                    out.set_logical_elt(i, i32::MIN); // NA_logical
-                }
-                for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        out.set_logical_elt(row_i as isize, src.logical_elt(pi as isize));
-                    }
-                }
-                out
-            }
+        match src.type_of() {
+            SEXPTYPE::REALSXP => scatter_native::<f64>(src, present_idx, n_rows),
+            SEXPTYPE::INTSXP => scatter_native::<i32>(src, present_idx, n_rows),
+            SEXPTYPE::LGLSXP => scatter_native::<RLogical>(src, present_idx, n_rows),
+            SEXPTYPE::RAWSXP => scatter_native::<u8>(src, present_idx, n_rows),
+            SEXPTYPE::CPLXSXP => scatter_native::<Rcomplex>(src, present_idx, n_rows),
             SEXPTYPE::STRSXP => {
                 let out = crate::sys::Rf_allocVector(SEXPTYPE::STRSXP, n_rows as isize);
-                // Fill with NA_character_
+                // Write-barriered CHARSXP-pointer array — fill NA_character_, then
+                // scatter present cells element-by-element.
                 for i in 0..(n_rows as isize) {
                     out.set_string_elt(i, crate::SEXP::na_string());
                 }
                 for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        let charsxp = src.string_elt(pi as isize);
-                        out.set_string_elt(row_i as isize, charsxp);
-                    }
+                    out.set_string_elt(row_i as isize, src.string_elt(pi as isize));
                 }
                 out
             }
             SEXPTYPE::VECSXP => {
                 let out = crate::sys::Rf_allocVector(SEXPTYPE::VECSXP, n_rows as isize);
-                // R_NilValue fill is automatic (Rf_allocVector zero-initialises VECSXP slots).
+                // Write-barriered SEXP-pointer array. R_NilValue fill is automatic
+                // (Rf_allocVector zero-initialises VECSXP slots).
                 for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        let elt = src.vector_elt(pi as isize);
-                        out.set_vector_elt(row_i as isize, elt);
-                    }
+                    out.set_vector_elt(row_i as isize, src.vector_elt(pi as isize));
                 }
                 out
             }
@@ -241,14 +203,49 @@ pub unsafe fn scatter_column(
                 // Cells for absent rows remain R_NilValue.
                 let out = crate::sys::Rf_allocVector(SEXPTYPE::VECSXP, n_rows as isize);
                 for (pi, &row_i) in present_idx.iter().enumerate() {
-                    if pi < n_present {
-                        let elt = src.vector_elt(pi as isize);
-                        out.set_vector_elt(row_i as isize, elt);
-                    }
+                    out.set_vector_elt(row_i as isize, src.vector_elt(pi as isize));
                 }
                 out
             }
         }
+    }
+}
+
+/// Scatter a dense typed column into a fresh SEXP of length `n_rows`, placing the
+/// `j`-th source value at row `present_idx[j]` and the per-type NA sentinel
+/// ([`RNativeType::R_NA`]) at every absent row.
+///
+/// The sparse-placing inverse of [`gather_native`]. Generic over the R element
+/// type: `f64`/`i32`/`RLogical`/`u8`/`Rcomplex` each resolve to the correct
+/// storage via their `RNativeType` impl, so the whole copy is a flat slice write
+/// with no per-element FFI call. Raw (`u8`) has no R NA, so absent positions
+/// become `0x00`.
+///
+/// # Safety
+///
+/// R main thread; `src` must be a `T::SEXP_TYPE` vector with at least
+/// `present_idx.len()` elements, and every index in `present_idx` must be
+/// `< n_rows`. The returned SEXP is unprotected (see [`scatter_column`]). No
+/// allocation occurs between allocating `out` and filling it, so `out` cannot be
+/// reaped mid-scatter.
+#[inline]
+unsafe fn scatter_native<T: RNativeType + Copy>(
+    src: crate::SEXP,
+    present_idx: &[usize],
+    n_rows: usize,
+) -> crate::SEXP {
+    unsafe {
+        use crate::SexpExt as _;
+        let src_vals: &[T] = src.as_slice::<T>();
+        let out = crate::sys::Rf_allocVector(T::SEXP_TYPE, n_rows as isize);
+        let out_vals: &mut [T] = out.as_mut_slice::<T>();
+        // NA-fill the whole output, then place present values. No allocation
+        // between alloc and fill — `out` is GC-safe.
+        out_vals.fill(T::R_NA);
+        for (pi, &row_i) in present_idx.iter().enumerate() {
+            out_vals[row_i] = src_vals[pi];
+        }
+        out
     }
 }
 

--- a/miniextendr-api/src/sexp_types.rs
+++ b/miniextendr-api/src/sexp_types.rs
@@ -7,6 +7,7 @@
 //! Most user code reaches them via [`crate::prelude`].
 
 use crate::SEXP;
+use crate::altrep_traits::NA_REAL;
 use crate::sys::{
     COMPLEX, COMPLEX_ELT, INTEGER, INTEGER_ELT, LOGICAL, LOGICAL_ELT, RAW, RAW_ELT, REAL, REAL_ELT,
     Rf_type2char, Rf_xlength,
@@ -116,6 +117,17 @@ pub trait RNativeType: Sized + Copy + 'static {
     /// The SEXPTYPE for vectors containing this element type.
     const SEXP_TYPE: SEXPTYPE;
 
+    /// The per-type `NA` (missing-value) sentinel used when filling vector slots
+    /// that have no source value (e.g. sparse scatter into a longer column).
+    ///
+    /// - `f64`   → `NA_REAL` (R's canonical NA double bit pattern, *not* a plain `NaN`)
+    /// - `i32`   → `i32::MIN` (`NA_INTEGER`)
+    /// - `RLogical` → `RLogical::NA` (`NA_LOGICAL`)
+    /// - `Rcomplex` → both parts `NA_REAL`
+    /// - `u8` (RAWSXP) → `0` — **R's raw type has no NA**, so absent positions
+    ///   become `0x00` rather than a missing marker.
+    const R_NA: Self;
+
     /// Get mutable pointer to vector data.
     ///
     /// For empty vectors (length 0), returns an aligned dangling pointer rather than
@@ -196,6 +208,7 @@ impl From<bool> for RLogical {
 
 impl RNativeType for i32 {
     const SEXP_TYPE: SEXPTYPE = SEXPTYPE::INTSXP;
+    const R_NA: Self = i32::MIN; // NA_INTEGER
 
     #[inline]
     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {
@@ -216,6 +229,7 @@ impl RNativeType for i32 {
 
 impl RNativeType for f64 {
     const SEXP_TYPE: SEXPTYPE = SEXPTYPE::REALSXP;
+    const R_NA: Self = NA_REAL; // R's canonical NA double bit pattern, not f64::NAN
 
     #[inline]
     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {
@@ -236,6 +250,8 @@ impl RNativeType for f64 {
 
 impl RNativeType for u8 {
     const SEXP_TYPE: SEXPTYPE = SEXPTYPE::RAWSXP;
+    // R's raw vectors have no NA; absent scatter positions become 0x00.
+    const R_NA: Self = 0;
 
     #[inline]
     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {
@@ -256,6 +272,7 @@ impl RNativeType for u8 {
 
 impl RNativeType for RLogical {
     const SEXP_TYPE: SEXPTYPE = SEXPTYPE::LGLSXP;
+    const R_NA: Self = RLogical::NA; // NA_LOGICAL
 
     #[inline]
     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {
@@ -277,6 +294,10 @@ impl RNativeType for RLogical {
 
 impl RNativeType for Rcomplex {
     const SEXP_TYPE: SEXPTYPE = SEXPTYPE::CPLXSXP;
+    const R_NA: Self = Rcomplex {
+        r: NA_REAL,
+        i: NA_REAL,
+    };
 
     #[inline]
     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1811,6 +1811,7 @@ pub fn r_ffi_checked(
 /// ```ignore
 /// impl RNativeType for UserId {
 ///     const SEXP_TYPE: SEXPTYPE = <i32 as RNativeType>::SEXP_TYPE;
+///     const R_NA: Self = UserId(<i32 as RNativeType>::R_NA);
 ///
 ///     unsafe fn dataptr_mut(sexp: SEXP) -> *mut Self {
 ///         <i32 as RNativeType>::dataptr_mut(sexp).cast()
@@ -1876,6 +1877,11 @@ pub fn derive_rnative_type(input: proc_macro::TokenStream) -> proc_macro::TokenS
         impl #impl_generics ::miniextendr_api::RNativeType for #name #ty_generics #where_clause {
             const SEXP_TYPE: ::miniextendr_api::SEXPTYPE =
                 <#inner_ty as ::miniextendr_api::RNativeType>::SEXP_TYPE;
+
+            const R_NA: Self = {
+                let val = <#inner_ty as ::miniextendr_api::RNativeType>::R_NA;
+                #elt_ctor
+            };
 
             #[inline]
             unsafe fn dataptr_mut(sexp: ::miniextendr_api::SEXP) -> *mut Self {


### PR DESCRIPTION
## Summary

Closes #831. Makes `convert::scatter_column` (dense→sparse) symmetric with `gather_column`/`gather_native` (sparse→dense) from PR #816.

### `scatter_native`

New generic `unsafe fn scatter_native<T: RNativeType + Copy>(src, present_idx, n_rows) -> SEXP`, the NA-filled inverse of `gather_native`:

1. `Rf_allocVector(T::SEXP_TYPE, n_rows)`
2. `out_vals.fill(T::R_NA)` — NA-fill the whole out-slice
3. `out_vals[present_idx[j]] = src_vals[j]` for each present index

No per-element FFI; the copy is a flat slice write. `scatter_column`'s primitive arms (`REALSXP`/`INTSXP`/`LGLSXP`/`RAWSXP`/`CPLXSXP`) now delegate to it. **`STRSXP`/`VECSXP` stay element-wise** — they are write-barriered arrays of `SEXP` pointers, not flat buffers, so they must use `SET_STRING_ELT`/`SET_VECTOR_ELT`.

### Per-type NA sentinel

Added `const R_NA: Self` to the `RNativeType` trait (scatter needs an NA fill that gather doesn't), implemented for all five impls from the codebase's canonical R constants:

| type | `R_NA` | source |
|---|---|---|
| `f64` | `NA_REAL` | `altrep_traits::NA_REAL` (R's NA double bit pattern `0x7FF0_0000_0000_07A2`) |
| `i32` | `i32::MIN` | `NA_INTEGER` |
| `RLogical` | `RLogical::NA` | `NA_LOGICAL` |
| `Rcomplex` | `{ r: NA_REAL, i: NA_REAL }` | NA complex |
| `u8` | `0` | **R raw has no NA** — absent raw positions become `0x00` |

The `#[derive(RNativeType)]` newtype macro delegates `R_NA` to the inner type's `R_NA`.

Note: the old `REALSXP` arm filled with `f64::NAN` (a *plain* NaN), not R's canonical `NA_REAL` bit pattern — this refactor corrects that as a side effect.

### Lossless complex/raw

Previously complex (`CPLXSXP`) and raw (`RAWSXP`) columns fell into the `VECSXP` fallback (lossy). They now scatter losslessly through `scatter_native`, matching `gather_column`'s round-trip coverage. Raw-has-no-NA caveat noted above and in code comments.

### GC discipline

Unchanged from `gather_native`: no allocation between `Rf_allocVector` and the fill, so `out` cannot be reaped mid-scatter; the caller roots the result.

## Verification

- `cargo check -p miniextendr-api --locked` — pass
- `cargo check -p miniextendr-api --locked --features macro-coverage,worker-thread` — pass (validates the generated `R_NA` const downstream via `CovPreferNative(pub i32)`)
- `cargo check -p miniextendr-macros --locked` — pass
- `cargo clippy -p miniextendr-api --locked --all-targets` — no issues
- `cargo fmt --all` — clean

**Not run** (drafty PR, needs R + compile-link): R testthat suite, gctorture, `R CMD check`.

## Deferred

Follow-up #902 tracks end-to-end complex/raw scatter round-trip test coverage (a `DataFrameRow` complex/raw fixture driven through the flatten/scatter path), which can't be verified without compiling+linking the R package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)