### PR TITLE
fix(cargo-revendor): --blank-md skips include_str! .md source inputs (#828)

### DIFF
--- a/cargo-revendor/src/strip.rs
+++ b/cargo-revendor/src/strip.rs
@@ -389,6 +389,65 @@ fn scan_referenced_top_dirs(crate_dir: &Path) -> Vec<String> {
     top_dirs.into_iter().collect()
 }
 
+/// Collect the absolute, canonicalized paths of every `.md` file under
+/// `crate_dir` that is pulled into Rust source via `include_str!` /
+/// `include_bytes!` / `include!`.
+///
+/// Such files are *source inputs*, not documentation: blanking them turns
+/// `format!(include_str!("tpl.md"), name = …)` into `format!("", name = …)`,
+/// which is a hard compile error (see #828). The caller uses the returned set
+/// to skip those files during `--blank-md`.
+///
+/// Each macro-argument string literal is resolved relative to the referencing
+/// `.rs` file (matching rustc's `include_str!` semantics) and canonicalized;
+/// only paths that resolve to a real file under the crate root with a `.md`
+/// extension are returned. Composed paths (`concat!(...)`) that don't resolve
+/// to a literal file are ignored — they don't name a single `.md` to protect.
+pub(crate) fn referenced_md_files(
+    crate_dir: &Path,
+) -> std::collections::BTreeSet<std::path::PathBuf> {
+    let mut protected: std::collections::BTreeSet<std::path::PathBuf> =
+        std::collections::BTreeSet::new();
+    let crate_root = match crate_dir.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return protected,
+    };
+
+    for entry in walkdir::WalkDir::new(crate_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        for literal in extract_include_arg_literals(&content) {
+            if !literal.ends_with(".md") {
+                continue;
+            }
+            // Resolve relative to the referencing .rs file (rustc semantics),
+            // canonicalize, and confirm it stays within the crate root.
+            let resolved = parent.join(&literal);
+            if let Ok(canon) = resolved.canonicalize()
+                && canon.starts_with(&crate_root)
+            {
+                protected.insert(canon);
+            }
+        }
+    }
+    protected
+}
+
 /// Pull every string literal that appears inside the argument list of an
 /// `include_str!`, `include_bytes!`, or `include!` macro invocation. Argument
 /// spans are matched with balanced-paren tracking so nested macro calls
@@ -945,6 +1004,58 @@ default = []
         );
         assert!(paths.iter().any(|p| p == "../benches/"));
         assert!(paths.iter().any(|p| p == ".rs"));
+    }
+
+    #[test]
+    fn referenced_md_files_resolves_relative_to_rs_file() {
+        // derive_builder_core shape: src/x.rs does include_str!("doc_tpl/y.md").
+        // referenced_md_files must return the canonical path of doc_tpl/y.md
+        // (so --blank-md can skip it) but NOT an unrelated docs/README.md (#828).
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("tplcrate");
+        std::fs::create_dir_all(crate_dir.join("src/doc_tpl")).unwrap();
+        std::fs::write(
+            crate_dir.join("src/lib.rs"),
+            r#"const X: &str = include_str!("doc_tpl/builder.md");"#,
+        )
+        .unwrap();
+        let referenced = crate_dir.join("src/doc_tpl/builder.md");
+        std::fs::write(&referenced, "template body").unwrap();
+        // An unreferenced .md that should NOT be protected.
+        std::fs::write(crate_dir.join("README.md"), "# docs").unwrap();
+
+        let protected = referenced_md_files(&crate_dir);
+        let canon_referenced = referenced.canonicalize().unwrap();
+        assert!(
+            protected.contains(&canon_referenced),
+            "include_str! .md must be protected, got: {protected:?}"
+        );
+        let canon_readme = crate_dir.join("README.md").canonicalize().unwrap();
+        assert!(
+            !protected.contains(&canon_readme),
+            "unreferenced README.md must NOT be protected"
+        );
+    }
+
+    #[test]
+    fn referenced_md_files_ignores_non_md_includes() {
+        // include_str! of a .rs or .txt file must not appear in the .md set.
+        let dir = TempDir::new().unwrap();
+        let crate_dir = dir.path().join("c");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(
+            crate_dir.join("src/lib.rs"),
+            r#"const A: &str = include_str!("data.txt"); const B: &str = include_str!("gen.rs");"#,
+        )
+        .unwrap();
+        std::fs::write(crate_dir.join("src/data.txt"), "x").unwrap();
+        std::fs::write(crate_dir.join("src/gen.rs"), "// gen").unwrap();
+
+        let protected = referenced_md_files(&crate_dir);
+        assert!(
+            protected.is_empty(),
+            "no .md referenced, got: {protected:?}"
+        );
     }
 
     #[test]

--- a/cargo-revendor/src/vendor.rs
+++ b/cargo-revendor/src/vendor.rs
@@ -1333,6 +1333,52 @@ pub fn regenerate_lockfile(
     Ok(())
 }
 
+/// Blank every `.md` file under `vendor_dir`, **except** those pulled into
+/// Rust source via `include_str!`/`include_bytes!`/`include!`.
+///
+/// Some crates use `.md` files as `format!` templates or doc-comment bodies
+/// (e.g. `derive_builder_core`'s `src/doc_tpl/builder_struct.md`). Blanking
+/// such a file turns `format!(include_str!("x.md"), name = …)` into
+/// `format!("", name = …)` — a hard compile error that breaks every
+/// vendored/tarball build whose dependency graph contains it (#828). Those
+/// files are left byte-for-byte intact, so the caller's subsequent
+/// `recompute_checksums` (which hashes actual disk contents) yields the
+/// correct, unchanged SHA-256 for them — no special checksum handling needed.
+///
+/// Returns the number of `.md` files left intact because they're
+/// source-referenced.
+fn blank_md_files(vendor_dir: &Path) -> Result<usize> {
+    // Build a per-crate set of source-referenced .md files (canonicalized).
+    let mut protected: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+    for entry in std::fs::read_dir(vendor_dir)
+        .with_context(|| format!("failed to read vendor dir {}", vendor_dir.display()))?
+    {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            protected.extend(crate::strip::referenced_md_files(&entry.path()));
+        }
+    }
+
+    let mut skipped = 0usize;
+    for entry in walkdir::WalkDir::new(vendor_dir) {
+        let entry = entry?;
+        if entry.file_type().is_file()
+            && let Some(ext) = entry.path().extension()
+            && ext == "md"
+        {
+            // Canonicalize to match the canonical paths recorded in `protected`.
+            if let Ok(canon) = entry.path().canonicalize()
+                && protected.contains(&canon)
+            {
+                skipped += 1;
+                continue;
+            }
+            std::fs::write(entry.path(), "")?;
+        }
+    }
+    Ok(skipped)
+}
+
 /// Compress vendor/ into a .tar.xz tarball
 pub fn compress_vendor(
     vendor_dir: &Path,
@@ -1345,17 +1391,9 @@ pub fn compress_vendor(
     }
 
     if blank_md {
-        for entry in walkdir::WalkDir::new(vendor_dir) {
-            let entry = entry?;
-            if entry.file_type().is_file()
-                && let Some(ext) = entry.path().extension()
-                && ext == "md"
-            {
-                std::fs::write(entry.path(), "")?;
-            }
-        }
+        let skipped = blank_md_files(vendor_dir)?;
         if v.debug() {
-            eprintln!("  Blanked .md files in vendor/");
+            eprintln!("  Blanked .md files in vendor/ ({skipped} source-referenced kept intact)");
         }
 
         // Blanking .md invalidates the per-file SHA-256s in
@@ -1662,6 +1700,91 @@ external = { git = "https://example.com/ext" }
             Verbosity(0),
         )
         .unwrap();
+    }
+
+    // endregion
+
+    // region: blank_md (#828)
+
+    /// `--blank-md` must blank documentation `.md` (crate-root README, etc.)
+    /// but leave `.md` files that Rust source pulls in via `include_str!`
+    /// intact — blanking those produces a `format!("", …)` compile error and
+    /// breaks every vendored build whose deps include such a crate (#828).
+    ///
+    /// The intact file's checksum must also stay correct: because we don't
+    /// touch it, the post-blank `recompute_checksums` (hashing actual disk
+    /// contents) yields its unchanged SHA-256 automatically.
+    #[test]
+    fn blank_md_skips_include_str_referenced_files() {
+        use sha2::Digest;
+
+        let dir = tempfile::tempdir().unwrap();
+        let vendor = dir.path().join("vendor");
+        let crate_dir = vendor.join("tplcrate-0.1.0");
+        std::fs::create_dir_all(crate_dir.join("src/doc_tpl")).unwrap();
+
+        // Rust source that pulls a .md template into source via include_str!
+        // inside a format! call — the exact derive_builder_core shape.
+        std::fs::write(
+            crate_dir.join("src/lib.rs"),
+            r#"pub fn doc(name: &str) -> String {
+    format!(include_str!("doc_tpl/builder_struct.md"), struct_name = name)
+}
+"#,
+        )
+        .unwrap();
+        let tpl_body = "Builder for {struct_name}.\n";
+        std::fs::write(crate_dir.join("src/doc_tpl/builder_struct.md"), tpl_body).unwrap();
+
+        // A crate-root README that SHOULD be blanked (pure docs).
+        std::fs::write(crate_dir.join("README.md"), "# tplcrate\n\nDocs.\n").unwrap();
+
+        // Minimal .cargo-checksum.json with a package hash, so the recompute
+        // path is exercised end-to-end.
+        let pkg = "deadbeef1234deadbeef1234deadbeef1234deadbeef1234deadbeef1234dead";
+        std::fs::write(
+            crate_dir.join(".cargo-checksum.json"),
+            serde_json::json!({ "package": pkg, "files": {} }).to_string(),
+        )
+        .unwrap();
+
+        // Run the blank step (no tar).
+        let skipped = blank_md_files(&vendor).unwrap();
+        assert_eq!(skipped, 1, "exactly one source-referenced .md kept intact");
+
+        // The include_str! template must be byte-for-byte intact.
+        let tpl_after =
+            std::fs::read_to_string(crate_dir.join("src/doc_tpl/builder_struct.md")).unwrap();
+        assert_eq!(tpl_after, tpl_body, "include_str! .md must not be blanked");
+
+        // The crate-root README must be blanked.
+        let readme_after = std::fs::read_to_string(crate_dir.join("README.md")).unwrap();
+        assert_eq!(readme_after, "", "crate-root README must be blanked");
+
+        // Now recompute checksums (the production sequence) and confirm the
+        // intact template's recorded SHA-256 matches its real content, while
+        // the blanked README's recorded SHA-256 matches the empty string.
+        crate::checksum::recompute_checksums(&vendor).unwrap();
+        let raw = std::fs::read_to_string(crate_dir.join(".cargo-checksum.json")).unwrap();
+        let cksum: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let files = cksum["files"].as_object().unwrap();
+
+        let tpl_hash = format!("{:x}", sha2::Sha256::digest(tpl_body.as_bytes()));
+        assert_eq!(
+            files["src/doc_tpl/builder_struct.md"].as_str().unwrap(),
+            tpl_hash,
+            "checksum of intact template must match its real (unchanged) content"
+        );
+
+        let empty_hash = format!("{:x}", sha2::Sha256::digest(b""));
+        assert_eq!(
+            files["README.md"].as_str().unwrap(),
+            empty_hash,
+            "checksum of blanked README must match the empty string"
+        );
+
+        // package field preserved.
+        assert_eq!(cksum["package"].as_str().unwrap(), pkg);
     }
 
     // endregion


### PR DESCRIPTION
## Problem

`cargo-revendor --blank-md` blanked **every** `.md` file in the vendor tree, including `.md` files that crates pull into Rust *source* via `include_str!` / `include_bytes!`. The canonical case is `derive_builder_core-0.20.2`:

```rust
// src/doc_tpl/builder_struct.md is a format! template
format!(include_str!("doc_tpl/builder_method.md"), struct_name = …)
```

Blanking turns that into `format!("", struct_name = …)` — a hard compile error on current Rust (`named argument is not used by name`). Result: any miniextendr package whose dependency graph contains such a crate fails the **vendored/tarball** build (`R CMD build` / `R CMD check` / `install_github`). Dev-mode (non-vendored) installs are unaffected, which is why it hides until check/release time. `--blank-md` is on by default in the scaffolded `bootstrap.R`, so every downstream package was exposed.

## Fix — option 1 (include_str scan), the most robust

I chose **option 1** over the simpler "never blank under `src/`" fallback because the framework already ships the exact scanner machinery (built for preserving `tests/`/`benches/` dirs referenced by `include_str!`), so option 1 is just as cheap here and is precise — it protects referenced `.md` wherever they live (including outside `src/`) and still blanks unreferenced docs under `src/`.

- New `strip::referenced_md_files(crate_dir)` walks each crate's `.rs` files, extracts `include_str!`/`include_bytes!`/`include!` string-literal arguments (reusing the existing `extract_include_arg_literals`), resolves each relative to the referencing `.rs` file (matching rustc semantics), canonicalizes, and returns the set of referenced `.md` paths under the crate root.
- The blank step in `compress_vendor` (extracted into a testable `blank_md_files()`) builds the per-crate protected set and **skips** those files, blanking only true documentation `.md` (crate-root README/CHANGELOG/etc.).

## Checksum consistency

Protected files are left **byte-for-byte intact**, so the existing post-blank `recompute_checksums` (which hashes *actual disk contents*) produces their correct, unchanged SHA-256 automatically. No special-casing was needed in `checksum.rs` — the recompute is already content-driven, and the regression test asserts this end-to-end (intact template's recorded hash == real content; blanked README's recorded hash == empty string; `package` field preserved).

## Regression tests

- `strip::referenced_md_files_resolves_relative_to_rs_file` — `include_str!("doc_tpl/builder.md")` is protected; an unreferenced `README.md` is not.
- `strip::referenced_md_files_ignores_non_md_includes` — `.txt`/`.rs` includes don't pollute the `.md` set.
- `vendor::blank_md_skips_include_str_referenced_files` — drives `blank_md_files` + `recompute_checksums` on a `derive_builder_core`-shaped fixture: template stays intact with correct checksum, crate-root README is blanked.

## Verification

- `just revendor-build` — clean.
- `just revendor-test` — 105 unit tests + integration suites, 0 failures (102 → 105 with the new tests).
- `cargo fmt --check` + `cargo clippy --all-targets` — clean.

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
