### PR TITLE
fix(minirextendr): use_miniextendr_description() creates DESCRIPTION if absent (#826)

### DIFF
--- a/minirextendr/R/use-r.R
+++ b/minirextendr/R/use-r.R
@@ -20,7 +20,12 @@ use_miniextendr_package_doc <- function(path = ".") {
   invisible(TRUE)
 }
 
-#' Update DESCRIPTION with miniextendr fields
+#' Configure DESCRIPTION for miniextendr
+#'
+#' Ensures a `DESCRIPTION` exists, then applies the miniextendr config fields.
+#' When `DESCRIPTION` is absent, a minimal one is created by delegating to
+#' [usethis::use_description()] (so `use_miniextendr()` works in a fresh
+#' directory); when it already exists, only the miniextendr fields are updated.
 #'
 #' Adds the required Config/* fields to DESCRIPTION for miniextendr:
 #' - Config/build/bootstrap: TRUE
@@ -37,7 +42,17 @@ use_miniextendr_description <- function(path = ".") {
   desc_path <- usethis::proj_path("DESCRIPTION")
 
   if (!fs::file_exists(desc_path)) {
-    cli::cli_abort("DESCRIPTION file not found. Is this an R package?")
+    # No DESCRIPTION yet: a `use_*` helper should create the thing it names.
+    # Delegate to usethis::use_description(), which derives the package name
+    # from the (already active) project directory and writes a minimal,
+    # well-formed DESCRIPTION. Run it deterministically for scripted use:
+    # check_name = FALSE skips the interactive name check, and usethis.quiet
+    # suppresses bullets so nested scaffolding output stays tidy.
+    cli::cli_alert_info("No {.path DESCRIPTION} found; creating a minimal one")
+    old_quiet <- getOption("usethis.quiet", default = NULL)
+    options(usethis.quiet = TRUE)
+    on.exit(options(usethis.quiet = old_quiet), add = TRUE)
+    usethis::use_description(check_name = FALSE, roxygen = FALSE)
   }
 
   # Set Config fields
@@ -47,9 +62,12 @@ use_miniextendr_description <- function(path = ".") {
     "Config/build/extra-sources" = "src/rust/Cargo.lock"
   )
 
-  # Set License if not already set to something meaningful
+  # Set License if not already set to something meaningful. A freshly created
+  # DESCRIPTION (from usethis::use_description()) carries a placeholder License
+  # like "`use_mit_license()`, `use_gpl3_license()` or friends ..."; treat any
+  # such "use_*_license()" placeholder as unset so we fill in MIT + file LICENSE.
   license <- mx_desc_get_field("License", file = desc_path, default = "")
-  if (!nzchar(license) || license == "use_mit_license()") {
+  if (!nzchar(license) || grepl("use_[a-z0-9]+_license\\(\\)", license)) {
     mx_desc_set(desc_path, "License" = "MIT + file LICENSE")
   }
 

--- a/minirextendr/man/use_miniextendr_description.Rd
+++ b/minirextendr/man/use_miniextendr_description.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/use-r.R
 \name{use_miniextendr_description}
 \alias{use_miniextendr_description}
-\title{Update DESCRIPTION with miniextendr fields}
+\title{Configure DESCRIPTION for miniextendr}
 \usage{
 use_miniextendr_description(path = ".")
 }
@@ -13,14 +13,19 @@ use_miniextendr_description(path = ".")
 Invisibly returns TRUE
 }
 \description{
+Ensures a \code{DESCRIPTION} exists, then applies the miniextendr config fields.
+When \code{DESCRIPTION} is absent, a minimal one is created by delegating to
+\code{\link[usethis:use_description]{usethis::use_description()}} (so \code{use_miniextendr()} works in a fresh
+directory); when it already exists, only the miniextendr fields are updated.
+}
+\details{
 Adds the required Config/* fields to DESCRIPTION for miniextendr:
 \itemize{
 \item Config/build/bootstrap: TRUE
 \item Config/build/never-clean: true
 \item Config/build/extra-sources: src/rust/Cargo.lock
 }
-}
-\details{
+
 Also adds SystemRequirements for Rust.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary

`use_miniextendr_description()` (in `minirextendr/R/use-r.R`) previously **aborted** with `"DESCRIPTION file not found. Is this an R package?"` whenever no `DESCRIPTION` existed. That's surprising for a `use_*` helper — by convention these *create* the thing they name (cf. `usethis::use_description()`). Because `use_miniextendr()` calls this internally, running `use_miniextendr()` in a fresh directory aborted here, forcing the user to hand-create a `DESCRIPTION` first.

This implements **option 1** from the issue: create a minimal `DESCRIPTION` when absent, then apply the miniextendr config fields.

## What changed

- **Create-if-absent** (`minirextendr/R/use-r.R`): when `DESCRIPTION` is missing, delegate to `usethis::use_description()` (which derives the package name from the already-active project set by `with_project()`), then fall through to the existing field-update logic. When a `DESCRIPTION` already exists, behaviour is **unchanged** (update-only).
- **Non-interactive / scripted determinism**: the creation call uses `check_name = FALSE` (skips the interactive name check) and temporarily sets `usethis.quiet = TRUE` to suppress nested usethis bullets. The option is restored via base `on.exit()` (matching the existing `workflow.R` pattern — no `withr` dependency, since `withr` is Suggests-only).
- **License placeholder fix**: `usethis::use_description()` writes a placeholder `License: `use_mit_license()`, `use_gpl3_license()` or friends ...`. The existing License check only matched the literal `"use_mit_license()"`, so a freshly created package would keep an invalid License field. Broadened the check to `grepl("use_[a-z0-9]+_license\\(\\)", license)` so the create path correctly lands `MIT + file LICENSE` (real licenses like `GPL-3` remain untouched).
- Updated the roxygen docs ("creates if absent, updates if present") and regenerated `man/use_miniextendr_description.Rd` cleanly via `roxygen2::roxygenise()`.

## Verification

Light, scoped checks (did **not** run the full minirextendr test suite, which loads the package):

- `parse()` of the edited file — clean.
- `roxygen2::roxygenise("minirextendr")` — exit 0, only the one expected `.Rd` rewritten, no warnings.
- Functional smoke test via `pkgload::load_all()` in throwaway temp dirs:
  - **Fresh dir (no DESCRIPTION)**: creates DESCRIPTION (`Package` derived from dir), applies `Config/build/*`, `SystemRequirements: Rust (>= 1.85)`, `License: MIT + file LICENSE`, and creates `LICENSE`. No abort.
  - **Existing DESCRIPTION** (`License: GPL-3`, `SystemRequirements: libcurl`): real `License` preserved, `Rust (>= 1.85)` appended to `SystemRequirements`, config field added. Update-only path intact.

## Adjacency (not fixed here)

This makes #826 self-consistent for the `use_miniextendr_description()` step. The broader `use_miniextendr()` flow has separate, related scaffolding gaps tracked in #824 / #825 (e.g. NAMESPACE provisioning) — those are intentionally **out of scope** for this PR and not touched. The fix here does not depend on them: it only guarantees the DESCRIPTION step no longer aborts in a fresh directory.

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
