### PR TITLE
fix(minirextendr): bootstrap fresh-package wrappers before auto-vendor (#822)

### DIFF
--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -107,6 +107,26 @@ miniextendr_configure <- function(path = ".") {
 #' the wrappers and `NAMESPACE` are already in their final form, so a repeat
 #' `document()` would be a fixpoint and no further install is needed.
 #'
+#' @section Fresh-package bootstrap:
+#' A brand-new package has no generated `R/<pkg>-wrappers.R` yet. The wrappers
+#' are produced by the cdylib pass during a *source-mode* install
+#' ([`./configure`][miniextendr_configure] with no `inst/vendor.tar.xz`).
+#' A plain `devtools::install(build = TRUE)` cannot bootstrap them: its
+#' `R CMD build` step runs `bootstrap.R`, which auto-vendors into
+#' `inst/vendor.tar.xz`, and that latch flips `./configure` into offline
+#' *tarball* mode — which ships pre-generated wrappers and skips wrapper
+#' generation. With no wrappers to ship, the install either fails loudly
+#' ("tarball is missing pre-generated wrappers") or, worse, leaves the
+#' namespace empty.
+#'
+#' When `miniextendr_build()` detects that the wrappers file is absent, it
+#' first runs an in-place source-mode bootstrap (clear any stale latch ->
+#' configure -> `devtools::install(build = FALSE)` -> `devtools::document()`)
+#' so the wrappers exist before the normal build path runs. The bootstrap
+#' never creates `inst/vendor.tar.xz`, so it does not leak the tarball-mode
+#' latch into subsequent dev iteration. Once wrappers are present, the normal
+#' build path runs unchanged.
+#'
 #' @param path Path to the R package root, or `NULL` to use the active project.
 #' @param install Whether to run the `R CMD INSTALL` steps. If `FALSE`, only
 #'   runs autoconf + configure + roxygen2 (no compile, no reinstall).
@@ -126,10 +146,24 @@ miniextendr_build <- function(path = ".", install = TRUE) {
   miniextendr_configure()
 
   if (install) {
-    cli::cli_h2("Step 3: install (compile Rust + generate R wrappers)")
     if (!has_devtools) {
+      cli::cli_h2("Step 3: install (compile Rust + generate R wrappers)")
       cli::cli_warn("devtools not installed, skipping install step")
     } else {
+      # Fresh-package bootstrap (#822). On a brand-new package the generated
+      # R/<pkg>-wrappers.R does not exist yet. The normal devtools::install()
+      # below uses build = TRUE, whose R CMD build step runs bootstrap.R, which
+      # auto-vendors inst/vendor.tar.xz and flips ./configure into tarball mode
+      # — a mode that SKIPS wrapper generation. So the very build that should
+      # have created the wrappers can't, and library() exposes nothing. Detect
+      # this and generate the wrappers first via an in-place source-mode install
+      # (build = FALSE), which never touches inst/vendor.tar.xz.
+      if (!wrappers_file_exists(pkg_path)) {
+        cli::cli_h2("Step 3a: bootstrap wrappers (fresh package, source mode)")
+        bootstrap_fresh_wrappers(pkg_path)
+      }
+
+      cli::cli_h2("Step 3: install (compile Rust + generate R wrappers)")
       install_pkg(pkg_path)
       cli::cli_alert_success("Installed package")
     }
@@ -205,6 +239,125 @@ namespace_digest <- function(namespace_path) {
     return(NA_character_)
   }
   paste(readLines(namespace_path, warn = FALSE), collapse = "\n")
+}
+
+#' Does the package's generated R wrapper file exist yet?
+#'
+#' The cdylib pass writes `R/<pkg>-wrappers.R`; its presence is the signal
+#' that the package has been bootstrapped at least once. A fresh scaffold
+#' has the Rust sources but no wrappers file.
+#'
+#' @param pkg_path Absolute path to the package root.
+#' @return `TRUE` if any `R/*-wrappers.R` file exists.
+#' @noRd
+wrappers_file_exists <- function(pkg_path) {
+  r_dir <- fs::path(pkg_path, "R")
+  if (!fs::dir_exists(r_dir)) {
+    return(FALSE)
+  }
+  length(fs::dir_ls(r_dir, glob = "*-wrappers.R", fail = FALSE)) > 0
+}
+
+#' Bootstrap a fresh package's R wrappers via a source-mode install
+#'
+#' On a brand-new package there is no generated `R/<pkg>-wrappers.R`. The
+#' wrappers are emitted by the cdylib pass during a *source-mode*
+#' `R CMD INSTALL` (no `inst/vendor.tar.xz` latch). A plain
+#' `devtools::install(build = TRUE)` can't bootstrap them because its
+#' `R CMD build` step runs `bootstrap.R`, which auto-vendors the tarball and
+#' flips `./configure` into wrapper-skipping tarball mode.
+#'
+#' This helper reproduces the proven manual workaround in-process: clear any
+#' stale latch so configure stays in source mode, re-run `./configure`, then
+#' do an in-place `devtools::install(build = FALSE)` to generate the wrappers,
+#' run `devtools::document()` so the NAMESPACE picks up the new exports, and
+#' install once more so the namespace-aware install lands. It never creates
+#' `inst/vendor.tar.xz`, so the tarball-mode latch does not leak into later
+#' dev iteration.
+#'
+#' @param pkg_path Absolute path to the package root.
+#' @return Invisibly `TRUE`.
+#' @noRd
+bootstrap_fresh_wrappers <- function(pkg_path) {
+  cli::cli_alert_info(c(
+    "No generated {.path R/*-wrappers.R} found — bootstrapping wrappers ",
+    "via a source-mode install before the full build."
+  ))
+
+  # Clear any stale tarball-mode latch so ./configure resolves in source mode
+  # (where the cdylib wrapper-gen pass runs). The bootstrap install is always
+  # source-mode; leaving a latch behind would skip wrapper generation again.
+  clear_install_mode_latch(pkg_path)
+
+  # Re-configure in source mode now that the latch is gone, so the
+  # tarball-mode .cargo/config.toml (if any) is replaced.
+  miniextendr_configure(pkg_path)
+
+  # Generate wrappers via an in-place install. build = FALSE skips R CMD build
+  # (and therefore bootstrap.R's auto-vendor), keeping configure in source mode.
+  tryCatch(
+    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
+    error = function(e) {
+      cli::cli_abort(c(
+        "Bootstrap install (source mode) failed",
+        "i" = conditionMessage(e)
+      ))
+    }
+  )
+
+  if (!wrappers_file_exists(pkg_path)) {
+    cli::cli_abort(c(
+      "Bootstrap install completed but no {.path R/*-wrappers.R} was generated.",
+      "i" = paste(
+        "Expected the cdylib wrapper-gen pass to write it. Check that",
+        "{.code #[miniextendr]} functions are reachable from {.file src/rust/lib.rs}."
+      )
+    ))
+  }
+
+  # document() so NAMESPACE exports the freshly-generated wrappers, then
+  # install once more so the installed package's namespace matches.
+  devtools::document(pkg_path)
+  tryCatch(
+    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
+    error = function(e) {
+      cli::cli_abort(c(
+        "Bootstrap re-install (after document) failed",
+        "i" = conditionMessage(e)
+      ))
+    }
+  )
+
+  cli::cli_alert_success("Bootstrapped R wrappers (source mode)")
+  invisible(TRUE)
+}
+
+#' Remove the install-mode latch and its source-mode-incompatible siblings
+#'
+#' `inst/vendor.tar.xz` is the single signal that flips `./configure` into
+#' offline tarball mode. The unpacked `vendor/` directory and the
+#' tarball-mode `src/rust/.cargo/config.toml` are downstream artifacts of the
+#' same mode. Clearing all three guarantees the next `./configure` resolves in
+#' source mode. Safe and idempotent — no-op if nothing is present.
+#'
+#' @param pkg_path Absolute path to the package root.
+#' @return Invisibly `TRUE`.
+#' @noRd
+clear_install_mode_latch <- function(pkg_path) {
+  latch <- fs::path(pkg_path, "inst", "vendor.tar.xz")
+  if (fs::file_exists(latch)) {
+    fs::file_delete(latch)
+    cli::cli_alert_info("Cleared stale {.path inst/vendor.tar.xz} latch.")
+  }
+  vendor_dir <- fs::path(pkg_path, "vendor")
+  if (fs::dir_exists(vendor_dir)) {
+    fs::dir_delete(vendor_dir)
+  }
+  cargo_dir <- fs::path(pkg_path, "src", "rust", ".cargo")
+  if (fs::dir_exists(cargo_dir)) {
+    fs::dir_delete(cargo_dir)
+  }
+  invisible(TRUE)
 }
 
 #' Prepare vendor tarball for CRAN submission

--- a/minirextendr/inst/templates/rpkg/lib.rs
+++ b/minirextendr/inst/templates/rpkg/lib.rs
@@ -14,12 +14,17 @@ miniextendr_api::miniextendr_init!();
 //    updates NAMESPACE + man/ with roxygen2 — all in one step.
 //
 //    Do NOT install with a bare `devtools::install()` / `R CMD INSTALL .` /
-//    `devtools::document()`: the package's bootstrap step vendors dependencies
-//    into inst/vendor.tar.xz, which flips ./configure into offline "tarball"
-//    mode. Tarball mode ships pre-generated wrappers and SKIPS wrapper
-//    generation, so on a fresh build those paths produce an empty namespace
-//    (library() exposes no functions). miniextendr_build() sets
-//    MINIEXTENDR_FORCE_WRAPPER_GEN so wrappers are regenerated regardless.
+//    `devtools::document()`: the package's bootstrap step (R CMD build's
+//    bootstrap.R) vendors dependencies into inst/vendor.tar.xz, which flips
+//    ./configure into offline "tarball" mode. Tarball mode ships pre-generated
+//    wrappers and SKIPS wrapper generation, so on a fresh build those paths
+//    produce an empty namespace (library() exposes no functions).
+//
+//    miniextendr_build() handles this: on a fresh package (no
+//    R/<pkg>-wrappers.R yet) it first generates the wrappers via an in-place
+//    source-mode install (which never auto-vendors), and on later builds sets
+//    MINIEXTENDR_FORCE_WRAPPER_GEN to force regeneration if a tarball latch is
+//    present.
 
 /// A simple function that adds two numbers
 ///

--- a/minirextendr/man/miniextendr_build.Rd
+++ b/minirextendr/man/miniextendr_build.Rd
@@ -42,3 +42,25 @@ the wrappers and \code{NAMESPACE} are already in their final form, so a repeat
 \code{document()} would be a fixpoint and no further install is needed.
 }
 
+\section{Fresh-package bootstrap}{
+
+A brand-new package has no generated \verb{R/<pkg>-wrappers.R} yet. The wrappers
+are produced by the cdylib pass during a \emph{source-mode} install
+(\code{\link[=miniextendr_configure]{./configure}} with no \code{inst/vendor.tar.xz}).
+A plain \code{devtools::install(build = TRUE)} cannot bootstrap them: its
+\verb{R CMD build} step runs \code{bootstrap.R}, which auto-vendors into
+\code{inst/vendor.tar.xz}, and that latch flips \code{./configure} into offline
+\emph{tarball} mode — which ships pre-generated wrappers and skips wrapper
+generation. With no wrappers to ship, the install either fails loudly
+("tarball is missing pre-generated wrappers") or, worse, leaves the
+namespace empty.
+
+When \code{miniextendr_build()} detects that the wrappers file is absent, it
+first runs an in-place source-mode bootstrap (clear any stale latch ->
+configure -> \code{devtools::install(build = FALSE)} -> \code{devtools::document()})
+so the wrappers exist before the normal build path runs. The bootstrap
+never creates \code{inst/vendor.tar.xz}, so it does not leak the tarball-mode
+latch into subsequent dev iteration. Once wrappers are present, the normal
+build path runs unchanged.
+}
+

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -506,13 +506,17 @@ test_that("monorepo scaffolding builds and functions work end-to-end", {
 # -----------------------------------------------------------------------------
 
 # Standalone counterpart to the monorepo round-trip above, and the in-suite home
-# for the #757 / #775 regression (it lived as a standalone bash script + bespoke
-# CI job before; see #805). create_miniextendr_package() + miniextendr_build()
-# scaffold a package that sits outside any .git ancestor, so configure
-# auto-vendors and flips into *tarball mode* mid-install. Tarball mode skips the
-# cdylib wrapper-gen pass unless MINIEXTENDR_FORCE_WRAPPER_GEN is set, which
-# miniextendr_build() does (#757). Before that fix the install produced a
-# wrappers-less, empty-namespace package and library() exposed nothing.
+# for the #757 / #775 / #822 regression (it lived as a standalone bash script +
+# bespoke CI job before; see #805). create_miniextendr_package() +
+# miniextendr_build() scaffold a package that sits outside any .git ancestor, so
+# a build = TRUE install's R CMD build step auto-vendors and would flip into
+# *tarball mode* — which skips the cdylib wrapper-gen pass. On a brand-new
+# package (no R/<pkg>-wrappers.R yet) that means the wrappers can never be
+# generated and library() exposes nothing (#822). miniextendr_build() now
+# detects the absent wrappers file and bootstraps them first via an in-place
+# source-mode install (build = FALSE), which never auto-vendors; the
+# MINIEXTENDR_FORCE_WRAPPER_GEN override still guards the wrappers-present case
+# against a leaked tarball latch (#757).
 #
 # Unlike the monorepo tests, create_miniextendr_package() takes no local_path, so
 # it scaffolds against miniextendr `main` and this test is network-dependent
@@ -543,11 +547,11 @@ test_that("standalone scaffolding builds in tarball mode and exposes functions",
       miniextendr_build(pkg_path, install = TRUE)
     )
 
-    # Wrapper-gen ran and emitted the scaffolded exports (the #757 symptom is an
-    # absent wrappers file).
+    # Wrapper-gen ran and emitted the scaffolded exports (the #757 / #822 symptom
+    # is an absent wrappers file).
     wrappers <- file.path(pkg_path, "R", paste0(pkg_name, "-wrappers.R"))
     expect_true(file.exists(wrappers),
-                info = "tarball-mode build skipped wrapper-gen (#757 regression)")
+                info = "fresh-package build skipped wrapper-gen (#757/#822 regression)")
     wrappers_src <- paste(readLines(wrappers, warn = FALSE), collapse = "\n")
     expect_match(wrappers_src, "add", fixed = TRUE)
     expect_match(wrappers_src, "hello", fixed = TRUE)

--- a/minirextendr/tests/testthat/test-workflow-bootstrap.R
+++ b/minirextendr/tests/testthat/test-workflow-bootstrap.R
@@ -1,0 +1,65 @@
+# Tests for miniextendr_build()'s fresh-package bootstrap helpers (#822).
+# These exercise the pure-R guards without invoking a compile/build.
+
+make_pkg_root <- function() {
+  tmp <- tempfile("workflow-bootstrap-")
+  dir.create(tmp)
+  writeLines(
+    "Package: testpkg\nTitle: Test\nVersion: 0.1.0\n",
+    file.path(tmp, "DESCRIPTION")
+  )
+  writeLines("", file.path(tmp, "NAMESPACE"))
+  dir.create(file.path(tmp, "R"))
+  tmp
+}
+
+test_that("wrappers_file_exists detects a generated *-wrappers.R", {
+  tmp <- make_pkg_root()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  # Fresh package: no wrappers file yet.
+  expect_false(minirextendr:::wrappers_file_exists(tmp))
+
+  # Once a *-wrappers.R lands, it is detected regardless of the package stem.
+  writeLines("# generated", file.path(tmp, "R", "testpkg-wrappers.R"))
+  expect_true(minirextendr:::wrappers_file_exists(tmp))
+})
+
+test_that("wrappers_file_exists is FALSE when the R/ directory is missing", {
+  tmp <- tempfile("workflow-bootstrap-nodir-")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  expect_false(minirextendr:::wrappers_file_exists(tmp))
+})
+
+test_that("clear_install_mode_latch removes tarball, vendor/, and .cargo/", {
+  tmp <- make_pkg_root()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  inst_dir <- file.path(tmp, "inst")
+  dir.create(inst_dir)
+  tarball <- file.path(inst_dir, "vendor.tar.xz")
+  writeLines("fake tarball", tarball)
+
+  vendor_dir <- file.path(tmp, "vendor")
+  dir.create(vendor_dir)
+  writeLines("x", file.path(vendor_dir, "marker"))
+
+  cargo_dir <- file.path(tmp, "src", "rust", ".cargo")
+  dir.create(cargo_dir, recursive = TRUE)
+  writeLines("[build]", file.path(cargo_dir, "config.toml"))
+
+  expect_true(minirextendr:::clear_install_mode_latch(tmp))
+
+  expect_false(file.exists(tarball))
+  expect_false(dir.exists(vendor_dir))
+  expect_false(dir.exists(cargo_dir))
+})
+
+test_that("clear_install_mode_latch is a no-op when nothing is present", {
+  tmp <- make_pkg_root()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  expect_true(minirextendr:::clear_install_mode_latch(tmp))
+})


### PR DESCRIPTION
## Problem

On a brand-new package, `minirextendr::miniextendr_build()` could not generate `R/<pkg>-wrappers.R`, so the installed package exposed an empty namespace.

The chain:
1. `miniextendr_build()` calls `devtools::install(pkg_path)` — which defaults to `build = TRUE`.
2. `build = TRUE` runs `R CMD build`, whose `bootstrap.R` (run in a staging dir with no `.git` ancestor) auto-vendors `inst/vendor.tar.xz` into the package.
3. The tarball latch flips `./configure` into offline **tarball mode**, and `Makevars.in` skips the cdylib wrapper-gen pass in that mode.
4. A fresh package has no wrappers to ship → empty namespace (or a loud "tarball is missing pre-generated wrappers" error, depending on whether `MINIEXTENDR_FORCE_WRAPPER_GEN` propagates).

### Root cause

`Makevars.in` *does* honor `MINIEXTENDR_FORCE_WRAPPER_GEN`, but `miniextendr_build()` sets it via `Sys.setenv()` in the **R session**, and `devtools::install(build = TRUE)` runs the actual `R CMD INSTALL` two subprocess hops away (`R CMD build` → `R CMD INSTALL <built-tarball>`). The in-session env override does not reliably survive into that nested install, and the auto-vendor in `bootstrap.R` has already sealed the tarball-mode latch into the build artifact regardless. So the build that should have created the wrappers can't.

## Fix (issue option 2)

Detect a fresh package (no `R/*-wrappers.R`) and bootstrap the wrappers first via an in-place **source-mode** install that never auto-vendors, mirroring the proven manual workaround:

```
clear any stale latch -> ./configure (source mode) ->
devtools::install(build = FALSE) -> devtools::document() ->
devtools::install(build = FALSE)
```

Once wrappers are present, the normal `build = TRUE` path runs unchanged — and the existing `MINIEXTENDR_FORCE_WRAPPER_GEN` override still guards the wrappers-present case against a leaked tarball latch.

### Single-pass guarantee

A single `miniextendr_build()` on a brand-new package now ends with `library(pkg)` exposing the exported wrappers: the bootstrap generates them in source mode, `document()` exports them, the re-install lands the namespace, and the normal build proceeds on a package that now has wrappers.

### Latch-leak safety

The bootstrap path is `build = FALSE` throughout, so it never invokes `R CMD build`/`bootstrap.R` and never creates `inst/vendor.tar.xz`. `clear_install_mode_latch()` removes the tarball **and** its `vendor/` + `src/rust/.cargo/` siblings before configuring, so a pre-existing latch can't keep configure in tarball mode and nothing leaks into later dev iteration.

### Not #860

Distinct from #860 (install → document ordering). This is the auto-vendor → tarball-latch → wrapper-skip chain.

## Changes

- `minirextendr/R/workflow.R`: fresh-package guard in `miniextendr_build()`; new internal helpers `wrappers_file_exists()`, `bootstrap_fresh_wrappers()`, `clear_install_mode_latch()`; new `@section Fresh-package bootstrap` doc.
- `minirextendr/inst/templates/rpkg/lib.rs`: corrected the misleading comment that claimed the force flag regenerates wrappers "regardless" on a fresh build. (Template-only file; not in the `templates-sources` sync manifest, so no `templates-approve` needed. No `configure.ac`/`Makevars.in` churn.)
- `minirextendr/man/miniextendr_build.Rd`: regenerated (roxygen2 8.0.0, matches `RoxygenNote`).
- Tests: new `test-workflow-bootstrap.R` (pure-R guards, runs in CI without compiling); updated the #757/#822 standalone e2e comments in `test-templates.R`.

## Verification

- R parse-check on all edited files; new unit tests pass via `devtools::load_all` + `test_file`.
- `roxygen2::roxygenise()` rewrote only `miniextendr_build.Rd`, no warnings, no spurious churn.
- Did **not** run a full scaffold + cargo + `R CMD build`/`INSTALL` repro (heavy/network; the existing `skip_e2e()` standalone test covers it).

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
