### PR TITLE
fix(minirextendr): add inst/vendor.tar.xz to scaffolded .gitignore templates

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/gitignore
+++ b/minirextendr/inst/templates/monorepo/rpkg/gitignore
@@ -20,7 +20,8 @@ ra-target/
 src/rust/ra_target/
 src/rust/target/
 
-# Vendor compression stamp file
+# Vendor tarball — generated at build/release time; never tracked.
+inst/vendor.tar.xz
 inst/.vendor.tar.xz.cksum
 
 # Intermediary files from configure.ac

--- a/minirextendr/inst/templates/rpkg/gitignore
+++ b/minirextendr/inst/templates/rpkg/gitignore
@@ -20,7 +20,8 @@ ra-target/
 src/rust/ra_target/
 src/rust/target/
 
-# Vendor compression stamp file
+# Vendor tarball — generated at build/release time; never tracked.
+inst/vendor.tar.xz
 inst/.vendor.tar.xz.cksum
 
 # Intermediary files from configure.ac


### PR DESCRIPTION
## Summary

- Adds `inst/vendor.tar.xz` to both `minirextendr/inst/templates/rpkg/gitignore` and `minirextendr/inst/templates/monorepo/rpkg/gitignore`
- The entry is placed immediately before the existing `inst/.vendor.tar.xz.cksum` line, matching the ordering in the dev-master `rpkg/.gitignore`
- The comment is updated from "Vendor compression stamp file" to "Vendor tarball — generated at build/release time; never tracked." to describe both lines

## Why

The scaffolded `.gitignore` ignored `inst/.vendor.tar.xz.cksum` and `vendor/` but not `inst/vendor.tar.xz` itself. The first build writes a ~9 MB tarball that would then be committed — the exact binary-bloat / merge-conflict / stale-after-rebase problem that `rpkg/.gitignore` solved on 2026-04-18 (when it was gitignored at the repo level). The template never received the same treatment.

## Files changed

- `minirextendr/inst/templates/rpkg/gitignore` — one new `inst/vendor.tar.xz` line + comment update
- `minirextendr/inst/templates/monorepo/rpkg/gitignore` — same

## Templates-sync check

`gitignore` is **not** in the `templates-sources` manifest in `justfile` (the manifest only covers build-system files like `configure.ac`, `Makevars.in`, `build.rs`, etc., not the gitignore). Therefore a direct edit to the template requires no `templates-approve`. `just templates-check` passes cleanly both before and after this change.

## Overlap with #897 / #862

PR #897 (open draft, branch from same `main`) adds `config.status` and `config.log` to these same two template gitignore files. That PR's changes are orthogonal — different lines, no conflict. Both patches are one-line additions to the same files; whoever merges second will get a trivial non-conflicting merge.

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)