### PR TITLE
docs(build): scope the codegen-units=1 comment to the native linkme path (inert on wasm)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Cargo.toml.tmpl
+++ b/minirextendr/inst/templates/monorepo/rpkg/Cargo.toml.tmpl
@@ -22,11 +22,10 @@ miniextendr-api = { git = "https://github.com/A2-ai/miniextendr" }
 [build-dependencies]
 miniextendr-lint = { git = "https://github.com/A2-ai/miniextendr" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 

--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -23,9 +23,9 @@ IS_WASM_INSTALL       = @IS_WASM_INSTALL@
 CARGO_BUILD_STD_FLAG  = @CARGO_BUILD_STD_FLAG@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/minirextendr/inst/templates/rpkg/Cargo.toml.tmpl
+++ b/minirextendr/inst/templates/rpkg/Cargo.toml.tmpl
@@ -22,11 +22,10 @@ miniextendr-api = { git = "https://github.com/A2-ai/miniextendr" }
 [build-dependencies]
 miniextendr-lint = { git = "https://github.com/A2-ai/miniextendr" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -23,9 +23,9 @@ IS_WASM_INSTALL       = @IS_WASM_INSTALL@
 CARGO_BUILD_STD_FLAG  = @CARGO_BUILD_STD_FLAG@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -83,8 +83,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -  }
  }
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-06-08 23:59:01
-+++ b/monorepo/rpkg/configure.ac	2026-06-08 23:59:15
+--- a/monorepo/rpkg/configure.ac	2026-06-10 01:05:07
++++ b/monorepo/rpkg/configure.ac	2026-06-10 01:05:07
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -389,8 +389,8 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
  
  AC_OUTPUT
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-06-08 23:59:01
-+++ b/rpkg/configure.ac	2026-06-08 23:59:08
+--- a/rpkg/configure.ac	2026-06-10 01:05:07
++++ b/rpkg/configure.ac	2026-06-10 01:05:07
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -23,9 +23,9 @@ IS_WASM_INSTALL       = @IS_WASM_INSTALL@
 CARGO_BUILD_STD_FLAG  = @CARGO_BUILD_STD_FLAG@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/rpkg/src/rust/Cargo.toml
+++ b/rpkg/src/rust/Cargo.toml
@@ -78,11 +78,10 @@ log = { version = "0.4", optional = true }
 [build-dependencies]
 miniextendr-lint = { git = "https://github.com/A2-ai/miniextendr" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 

--- a/tests/cross-package/consumer.pkg/src/Makevars.in
+++ b/tests/cross-package/consumer.pkg/src/Makevars.in
@@ -20,9 +20,9 @@ TAR_FORCE_LOCAL       = @TAR_FORCE_LOCAL@
 NATIVE_PKG_CPPFLAGS   = @NATIVE_PKG_CPPFLAGS@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/tests/cross-package/consumer.pkg/src/rust/Cargo.toml
+++ b/tests/cross-package/consumer.pkg/src/rust/Cargo.toml
@@ -32,11 +32,10 @@ miniextendr-api = { path = "../../../../../miniextendr-api" }
 miniextendr-macros = { path = "../../../../../miniextendr-macros" }
 miniextendr-lint = { path = "../../../../../miniextendr-lint" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 

--- a/tests/cross-package/producer.pkg/src/Makevars.in
+++ b/tests/cross-package/producer.pkg/src/Makevars.in
@@ -20,9 +20,9 @@ TAR_FORCE_LOCAL       = @TAR_FORCE_LOCAL@
 NATIVE_PKG_CPPFLAGS   = @NATIVE_PKG_CPPFLAGS@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/tests/cross-package/producer.pkg/src/rust/Cargo.toml
+++ b/tests/cross-package/producer.pkg/src/rust/Cargo.toml
@@ -32,11 +32,10 @@ miniextendr-api = { path = "../../../../../miniextendr-api" }
 miniextendr-macros = { path = "../../../../../miniextendr-macros" }
 miniextendr-lint = { path = "../../../../../miniextendr-lint" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 

--- a/tests/model_project/src/Makevars.in
+++ b/tests/model_project/src/Makevars.in
@@ -20,9 +20,9 @@ TAR_FORCE_LOCAL       = @TAR_FORCE_LOCAL@
 NATIVE_PKG_CPPFLAGS   = @NATIVE_PKG_CPPFLAGS@
 
 CARGO_AR = $(CARGO_LIBDIR)/lib$(CARGO_STATICLIB_NAME).a
-# codegen-units = 1 in Cargo.toml ensures the user crate compiles into a single .o
-# inside the staticlib archive. The linker pulls it in (via R_init_<pkg>), which
-# brings all linkme distributed_slice entries along — no force_load needed.
+# codegen-units = 1 in Cargo.toml forces the user crate into a single .o (NATIVE path).
+# On wasm32-*, registration goes via wasm_registry.rs (ordinary symbol refs), not linkme,
+# so the setting is inert there.
 PKG_LIBS = $(CARGO_AR)
 PKG_CPPFLAGS = $(NATIVE_PKG_CPPFLAGS)
 

--- a/tests/model_project/src/rust/Cargo.toml
+++ b/tests/model_project/src/rust/Cargo.toml
@@ -26,11 +26,10 @@ itertools = "0.14"
 [build-dependencies]
 miniextendr-lint = { git = "https://github.com/A2-ai/miniextendr" }
 
-# codegen-units = 1 ensures the entire user crate compiles into a single .o file
-# inside the staticlib archive. This is required for linkme's distributed_slice:
-# the linker only pulls archive members that resolve undefined symbols, so with
-# multiple .o files, distributed_slice entries in unreferenced .o files get dropped.
-# With a single .o, pulling in R_init_<pkg> brings everything along.
+# codegen-units = 1 forces the user crate into a single .o so the linker can't drop
+# unreferenced linkme #[distributed_slice] archive members (NATIVE registration path).
+# Inert on wasm32-*, which registers via the generated wasm_registry.rs (ordinary
+# symbol references), not linkme.
 [profile.dev]
 codegen-units = 1
 


### PR DESCRIPTION
Scopes the `codegen-units = 1` comment to the **native** linkme registration path. Doc-comment only, no behaviour change.

## Summary
- Updated the `codegen-units = 1` comment in all `Cargo.toml` and `Makevars.in` files to clarify it only defends against linkme `#[distributed_slice]` archive-member drops on **native** targets.
- On `wasm32-*`, registration goes through the generated `wasm_registry.rs` (ordinary symbol references, not linkme), so the setting is inert there. The previous wording read as a blanket necessity, which could lead someone to assume it's load-bearing for webR.

## Files updated
- `rpkg/src/rust/Cargo.toml`, `rpkg/src/Makevars.in`
- `tests/cross-package/producer.pkg/src/rust/Cargo.toml` + `src/Makevars.in`
- `tests/cross-package/consumer.pkg/src/rust/Cargo.toml` + `src/Makevars.in`
- `tests/model_project/src/rust/Cargo.toml` + `src/Makevars.in`
- `minirextendr/inst/templates/rpkg/Cargo.toml.tmpl` + `Makevars.in`
- `minirextendr/inst/templates/monorepo/rpkg/Cargo.toml.tmpl` + `Makevars.in`
- `patches/templates.patch` (regenerated by `just templates-approve`)

## Templates sync
`Makevars.in` is manifest-tracked (`rpkg/src/Makevars.in` is the source of truth); `Cargo.toml.tmpl` template copies are not manifest-tracked and were edited directly. `just templates-approve` regenerated `patches/templates.patch`; `just templates-check` passes clean. A repo-wide grep confirmed no remaining copies of the old wording outside `rv/` (installed-library snapshots, not tracked).

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
