### PR TITLE
feat(webr): draft arm64-native webR dev image (#788)

### DIFF
--- a/Dockerfile.webr-arm64
+++ b/Dockerfile.webr-arm64
@@ -1,0 +1,189 @@
+# syntax=docker/dockerfile:1.7
+#
+# ⚠️ DRAFT — NOT YET VALIDATED ON arm64 HARDWARE. See #788.
+#
+# arm64-native webR dev container, composed from prebuilt parts — no source
+# build of emcc / flang / R→wasm. The blocker that this works around is purely
+# architecture: `Dockerfile.webr`'s base (`ghcr.io/a2-ai/webr-mirror`, a mirror
+# of `ghcr.io/r-wasm/webr`) and its `ghcr.io/r-wasm/flang-wasm` base are
+# **linux/amd64 only**, and `.webr/Dockerfile` hardcodes
+# `--default-host x86_64-unknown-linux-gnu`. Running that under qemu on an
+# arm64 Mac is impractical (the 2026-05-27 attempt exhausted host disk on the
+# datafusion+arrow wasm compile and crashed Docker Desktop).
+#
+# The insight (see #788): building *miniextendr* for wasm needs neither the
+# Fortran→wasm compiler (flang) nor a from-source R→wasm build — those only
+# exist to build R itself to wasm, which a dev image *reuses* rather than
+# rebuilds. miniextendr is Rust + C with no Fortran, and the wasm R is already
+# prebuilt. So:
+#
+#   * the **native arm64 toolchain** (emcc, Rust, host R) comes from
+#     prebuilt arm64 images / installers — no emulated execution, and
+#   * the **portable wasm sysroot** (`/opt/webr/{wasm,R/build,tools,packages,
+#     dist}` — wasm libs + headers + `webr-vars.mk` + the webR JS sources) is
+#     lifted out of the amd64 image with `COPY --from=` — a pure filesystem
+#     copy, no emulated execution of amd64 binaries.
+#
+# ── Q1 (emcc ABI), RESOLVED ──────────────────────────────────────────────────
+# The emcc that links `miniextendr.so` must match the emcc that built the
+# prebuilt wasm R, or the side-module won't load. The wasm R in the mirror was
+# built with Emscripten **4.0.8**. `emscripten/emsdk` publishes per-arch
+# *suffixed* tags (NOT a multi-arch manifest): the bare `:4.0.8` tag is
+# linux/amd64 only, but `:4.0.8-arm64` is a genuine linux/arm64/v8 build of the
+# *same* Emscripten 4.0.8 release (pushed 2025-04-30, digest below). Same emcc
+# version ⇒ same wasm ABI ⇒ no version-skew risk. This is the best-case Q1
+# outcome — no need to drift to a different emcc version.
+#
+# ── Usage (local dev) ────────────────────────────────────────────────────────
+#   just docker-webr-arm64-build         # build natively on an arm64 host
+#   just docker-webr-arm64-shell         # interactive shell, repo at /work
+#   WEBR_ARM64=1 bash tests/webr-smoke.sh   # arm64 end-to-end smoke
+#
+# ── Build args ───────────────────────────────────────────────────────────────
+#   WEBR_AMD64_DONOR — pinned amd64 mirror digest the sysroot is copied from.
+#                      Keep in lockstep with Dockerfile.webr's WEBR_BASE.
+#   EMSDK_ARM64      — arm64 emcc base; pinned to 4.0.8-arm64 by digest.
+#   JUST_VERSION     — `just` release to install. Apt's is too old.
+
+# ── Stage 0: amd64 sysroot donor (filesystem copy only — never executed) ─────
+# Pinned to the SAME digest as Dockerfile.webr's WEBR_BASE so the copied wasm
+# sysroot (incl. the prebuilt wasm R version) stays aligned. Bump both together.
+# `--platform=linux/amd64` forces the amd64 manifest even on an arm64 host; we
+# only `COPY --from=` out of it, so nothing amd64 ever runs under qemu.
+ARG WEBR_AMD64_DONOR=ghcr.io/a2-ai/webr-mirror@sha256:3fbf3dc3537c5b31bca94dd797dc25364693b18d71b1d0975f318fbfd6269d86
+FROM --platform=linux/amd64 ${WEBR_AMD64_DONOR} AS webr-amd64
+
+# ── Stage 1: arm64-native toolchain ──────────────────────────────────────────
+# emscripten/emsdk:4.0.8-arm64 — linux/arm64/v8, Emscripten 4.0.8 (matches the
+# donor's wasm R ABI; see Q1 note above). Base OS is Ubuntu Noble; emcc is on
+# PATH at /emsdk/upstream/emscripten, EMSDK=/emsdk, and Node 22.16.0 ships
+# bundled at /emsdk/node/22.16.0_64bit/bin — so the tier-3 Node smoke needs no
+# separate node install.
+ARG EMSDK_ARM64=emscripten/emsdk:4.0.8-arm64@sha256:9d471ceb4bd9e19f85e6a0924e851971d26bddd19e0bf6aa956b1be865bda6eb
+FROM ${EMSDK_ARM64}
+
+ARG JUST_VERSION=1.36.0
+
+SHELL ["/bin/bash", "-c"]
+
+# OS deps. `autoconf` regenerates rpkg/configure on fresh checkouts; `file` is
+# used by the smoke to confirm the side-module is wasm not ELF; ripgrep/fd/lldb
+# are dev quality-of-life (mirrors Dockerfile.webr). The emsdk base already
+# carries git, curl, make, python3, and node.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        file \
+        ripgrep \
+        fd-find \
+        lldb \
+    && rm -rf /var/lib/apt/lists/*
+
+# `just`. Static-musl tarball, arch-resolved (this image is arm64, but keep the
+# case so a cross-build still works).
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) JUST_TRIPLE=x86_64-unknown-linux-musl ;; \
+         arm64) JUST_TRIPLE=aarch64-unknown-linux-musl ;; \
+         *) echo "unsupported arch: $ARCH"; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_TRIPLE}.tar.gz" \
+       | tar -xz -C /usr/local/bin just
+
+# ── Native arm64 Rust nightly + wasm32-unknown-emscripten + rust-src ─────────
+# nightly is mandatory for `-Z build-std=std,panic_abort` (the wasm side-module
+# rebuilds std against the live emcc ABI + panic=abort — see docs/WEBR.md "Why
+# Rust nightly is mandatory"). `--default-host aarch64-unknown-linux-gnu` is the
+# arm64 counterpart of `.webr/Dockerfile`'s hardcoded x86_64 host — THIS is the
+# line that made the upstream image amd64-only.
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs -o rustup-init.sh; \
+    sh rustup-init.sh -y \
+      --no-modify-path \
+      --profile minimal \
+      --default-toolchain nightly \
+      --default-host aarch64-unknown-linux-gnu \
+      --target wasm32-unknown-emscripten \
+      --component rust-src; \
+    rm rustup-init.sh; \
+    chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
+    rustup --version; cargo --version; rustc --version
+
+# `cargo-limit` (the `cargo lcheck/lclippy/ltest/lbuild` fast-iteration aliases).
+RUN cargo install cargo-limit --locked --version "0.0.13"
+
+# ── Native arm64 host R, version-matched to the wasm R ───────────────────────
+# rig installs prebuilt arm64 R. The version MUST match the donor's wasm R
+# (4.6.0 in the current pin — NOT 4.5.1 as the #788 body assumed; the base was
+# bumped to webR v0.6.0 / R 4.6.0 in #755) for header compatibility with the
+# copied wasm R sysroot. This is intentionally NOT the repo's pinned dev R
+# (rproject.toml r_version) — webR pins what its prebuilt wasm R was built from.
+RUN curl -fsSL https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg \
+    && echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list \
+    && apt-get update \
+    && apt-get install -y r-rig \
+    && rm -rf /var/lib/apt/lists/* \
+    && rig add 4.6.0 \
+    && rig default 4.6.0
+
+# miniextendr's hard R `Imports` (rpkg/DESCRIPTION) in the native arm64 R, plus
+# rwasm. Phase 1 of the smoke (native cdylib wrapper-gen pass) resolves these.
+# The emsdk base is Ubuntu Noble, so the posit PM `__linux__/noble` repo serves
+# matching arm64 CRAN binaries — fast layer.
+RUN Rscript -e 'install.packages(c("cli","lifecycle","R6","S7","vctrs","pak"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest")' \
+    && Rscript -e 'pak::pak("r-wasm/rwasm")'
+
+# ── The portable wasm sysroot, copied out of the amd64 donor ─────────────────
+# These five trees are wasm objects + headers + scripts (webr-vars.mk) + the
+# webR JS sources — NO amd64 host binaries, so they're arch-portable. The
+# arm64-native emcc above links against /opt/webr/wasm + /opt/webr/R/build, and
+# the tier-3 Node smoke rebuilds the bundle out of /opt/webr/src (under
+# /opt/webr) and runs it.
+#
+# NOTE: this also copies the donor's amd64 host R under /opt/webr/host and
+# /opt/R — those amd64 binaries CANNOT run on arm64. The smoke's arm64 path
+# uses the native rig-installed R (on PATH) for BOTH the native pass and the
+# wasm `R CMD INSTALL` (webr-vars.mk drives CC=emcc regardless of which R
+# orchestrates it). See tests/webr-smoke.sh's WEBR_ARM64 branch + the
+# validation checklist in docs/WEBR.md.
+COPY --from=webr-amd64 /opt/webr/wasm     /opt/webr/wasm
+COPY --from=webr-amd64 /opt/webr/R/build  /opt/webr/R/build
+COPY --from=webr-amd64 /opt/webr/tools    /opt/webr/tools
+COPY --from=webr-amd64 /opt/webr/packages /opt/webr/packages
+COPY --from=webr-amd64 /opt/webr/dist     /opt/webr/dist
+# The webR JS sources (esbuild config, Makefile, package-lock.json) live at
+# /opt/webr/src; the tier-3 Node bundle is rebuilt from here. Copied separately
+# so the intent is explicit.
+COPY --from=webr-amd64 /opt/webr/src      /opt/webr/src
+
+ENV WEBR_ROOT="/opt/webr"
+
+# ── Sanity checks — fail the build early if a piece is missing ───────────────
+# NOTE (DRAFT): these verify the image *composed*, NOT that the copied wasm
+# sysroot actually links + loads under the arm64 emcc end-to-end. That is the
+# load-bearing unknown and needs on-arm64-hardware validation (see #788 /
+# docs/WEBR.md checklist).
+RUN set -eux \
+    && rustup target list --installed | grep -q wasm32-unknown-emscripten \
+    && rustup component list --installed | grep -q rust-src \
+    && cargo --version \
+    && emcc --version >/dev/null \
+    && [ "$(emcc --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" = "4.0.8" ] \
+    && R --version >/dev/null \
+    && [ -d /opt/webr/wasm ] && [ -d /opt/webr/R/build ] && [ -d /opt/webr/tools ] \
+    && [ -f /opt/webr/packages/webr-vars.mk ] \
+    && [ -f /opt/webr/src/package-lock.json ] \
+    && Rscript -e 'stopifnot(requireNamespace("rwasm", quietly=TRUE), requireNamespace("S7", quietly=TRUE))' \
+    && just --version >/dev/null \
+    && autoconf --version >/dev/null \
+    && command -v cargo-lcheck >/dev/null \
+    && command -v rg >/dev/null \
+    && command -v fdfind >/dev/null \
+    && command -v file >/dev/null \
+    && command -v node >/dev/null
+
+# `/work` is a plain mount point; bind the repo there at run time. No COPY of
+# source — keeps the image a pure environment artefact.
+WORKDIR /work

--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -18,8 +18,10 @@ base-image mirror (#496), the redundant `-C relocation-model=pic` flag
 dropped (#745), the base-image pin bumped to a tagged webR v0.6.0 / R 4.6.0
 release (#755), and dependency guidance (#752 — see "Dependencies and webR"
 below). Open follow-ups: #495 (cross-crate trait dispatch), #925 (lint for
-eager `importFrom` of compiled deps), #788 (arm64-native dev image), #747
-(drop mirror creds once the GHCR package is public).
+eager `importFrom` of compiled deps), #788 (arm64-native dev image — first cut
+landed as `Dockerfile.webr-arm64`, pending on-hardware validation; see
+"arm64-native dev image" below), #747 (drop mirror creds once the GHCR package
+is public).
 
 ## Target
 
@@ -71,7 +73,10 @@ native (non-WASM) build remains stable-buildable.
 
 Everything lives inside the `Dockerfile.webr` image (inherits
 `ghcr.io/r-wasm/webr` digest-pinned, layers `just`/`autoconf`/`cargo-limit`).
-amd64-only — Apple Silicon runs it under Rosetta, slow but works.
+amd64-only — Apple Silicon runs it under Rosetta, slow but works. For a
+native-arm64 alternative (no Rosetta), see "arm64-native dev image" below
+(`Dockerfile.webr-arm64`, #788 — currently a draft pending on-hardware
+validation).
 
 ```bash
 just docker-webr-build         # one-time image build (~5–10 min cold)
@@ -109,6 +114,82 @@ the container, then prints a testthat pass/fail/skip summary:
 First cold run is **1–2 hours** on Apple Silicon (Rosetta amd64 + cargo
 wasm32 build). Subsequent runs reuse the docker image and most cargo
 artefacts.
+
+## arm64-native dev image (DRAFT — #788)
+
+> **Status: composed but NOT YET VALIDATED on arm64 hardware.** The
+> `Dockerfile.webr-arm64` recipe below is written from prebuilt parts and
+> resolves the one critical unknown (emcc ABI, see below), but it has not been
+> *built or run* on an arm64 box. Treat it as a first cut until the validation
+> checklist at the end of this section is green. Until then, the amd64 path
+> above (Rosetta) is the supported route.
+
+The amd64 image runs on Apple Silicon only under Rosetta — slow, and the
+2026-05-27 attempt at the full datafusion+arrow wasm compile under qemu
+exhausted host disk and crashed Docker Desktop. `Dockerfile.webr-arm64` builds
+**natively on arm64** by composing prebuilt parts, so there is no emulated
+execution and no source build of emcc / flang / R→wasm:
+
+| Piece | Source | Why no source build |
+|---|---|---|
+| emcc | `emscripten/emsdk:4.0.8-arm64` (linux/arm64/v8) | emsdk ships *prebuilt* emcc per host arch |
+| Rust nightly + `wasm32-unknown-emscripten` + `rust-src` | `rustup` `--default-host aarch64-unknown-linux-gnu` | prebuilt arm64 toolchain |
+| host R 4.6.0 | `rig add 4.6.0` | prebuilt arm64 R |
+| wasm R sysroot (`/opt/webr/{wasm,R/build,tools,packages,dist,src}`) | `COPY --from=` the amd64 mirror | wasm objects + headers + scripts are arch-portable; FS copy only |
+
+Neither flang (Fortran→wasm) nor the R→wasm build is needed: miniextendr is
+Rust + C with no Fortran, and the wasm R is already prebuilt — those upstream
+parts exist only to build R itself to wasm, which a dev image reuses.
+
+```bash
+just docker-webr-arm64-build         # build natively on arm64
+just docker-webr-arm64-shell         # interactive shell, repo at /work
+just docker-webr-arm64-smoke         # arm64 end-to-end smoke (WEBR_ARM64=1)
+```
+
+### Why emcc `4.0.8-arm64` specifically (the ABI match)
+
+The emcc that links `miniextendr.so` must match the emcc that built the
+prebuilt wasm R, or the side-module won't load. The mirror's wasm R was built
+with Emscripten **4.0.8**. `emscripten/emsdk` publishes *arch-suffixed* tags,
+**not** a multi-arch manifest: the bare `:4.0.8` tag is linux/amd64 only, but
+`:4.0.8-arm64` is a genuine linux/arm64/v8 build of the **same** 4.0.8 release
+(digest `sha256:9d471ceb4bd9e…`, pushed 2025-04-30). Same emcc version on a
+different host arch ⇒ same wasm ABI ⇒ no version-skew risk. This is the
+best-case answer to #788's open question Q1.
+
+> The #788 issue body assumed host R **4.5.1**; the base image was since bumped
+> to webR v0.6.0 / **R 4.6.0** (#755), so the arm64 image pins `rig add 4.6.0`
+> to stay header-compatible with the copied wasm R. This is deliberately *not*
+> the repo's pinned dev R (`rproject.toml`'s 4.6) — it tracks whatever the
+> prebuilt wasm R was built from.
+
+### Validation checklist (needs on-arm64 hardware)
+
+The dev sandbox has no Docker and can't build/run arm64, so the following are
+**unverified** and must be checked on an Apple Silicon box before #788 is
+closed:
+
+- [ ] **Image builds** — `just docker-webr-arm64-build` completes (donor
+      `COPY --from=` resolves, native toolchain installs, sanity-check layer
+      passes).
+- [ ] **Side-module ABI load** — `just docker-webr-arm64-smoke` Phase 2 links
+      `miniextendr.so` with the arm64 emcc and Phase 3's `library(miniextendr)`
+      loads it in a webR Node session (proves the 4.0.8 arm64↔amd64-built-R ABI
+      really matches, not just by version label).
+- [ ] **Sysroot link/load** — the amd64-built wasm sysroot under `/opt/webr`
+      links and loads cleanly under the arm64-host emcc end-to-end (no missing
+      objects, no header mismatch from the copied tree).
+- [ ] **Native-R orchestration on arm64** — Phase 1 (native cdylib wrapper-gen)
+      and Phase 2's `R CMD INSTALL` both run through the rig-installed arm64 R
+      (`R` on PATH), since the donor's amd64 `/opt/webr/host/R-4.6.0` +
+      `/opt/R/current` binaries can't execute on arm64.
+- [ ] **Node bundle rebuild** — `make /opt/webr/src/dist/webr.mjs` succeeds
+      with the copied `/opt/webr/src` tree and the emsdk image's bundled Node
+      22.16.0.
+- [ ] **Compile weight / disk** — datafusion+arrow wasm compile is now native
+      (no qemu tax) but still heavy; confirm it fits a typical Docker Desktop
+      disk budget.
 
 ## How `CC=emcc` cooperates with our build
 
@@ -310,7 +391,8 @@ is what proves it *loads* in a real webR runtime.
 - Issue #470 — umbrella tracking issue for webR/WASM support.
 - Issue #495 — cross-crate trait dispatch; #752 — dependency guidance
   (this section); #925 — follow-up lint for `importFrom` of compiled deps;
-  #788 — arm64-native dev image.
+  #788 — arm64-native dev image (first cut: `Dockerfile.webr-arm64` + the
+  `docker-webr-arm64-*` just recipes + the `WEBR_ARM64=1` smoke path).
 - Issues #491 / #744 — the base-package variant of the host-R-loads-a-wasm-
   object failure, solved via the install-to-temp-lib pattern (the dependency
   guidance above is the consumer-package-imports variant of the same failure).
@@ -318,8 +400,12 @@ is what proves it *loads* in a real webR runtime.
   of truth for the runtime smoke; `tests/webr-smoke.sh` Phase 3 invokes it).
 - `tests/webr-smoke.sh` — the local end-to-end smoke runner. Mirrors the green
   `webr.yml` tier-2/3 job step-for-step (Phase 2 → `/tmp/wasm-lib`, Phase 3 →
-  `make` the Node bundle, then run `smoke.mjs`). The base image is amd64-only,
-  so it can't be exercised on an arm64 dev box today — tracked in #788.
+  `make` the Node bundle, then run `smoke.mjs`). The default (amd64) image runs
+  under Rosetta on Apple Silicon; `WEBR_ARM64=1` selects the draft
+  `Dockerfile.webr-arm64` native-arm64 path (#788).
+- `Dockerfile.webr-arm64` — draft native-arm64 dev image (#788): amd64 sysroot
+  donor + `emscripten/emsdk:4.0.8-arm64` + native arm64 Rust/R. See
+  "arm64-native dev image" above for the validation checklist.
 - `.webr/` — vendored clone of the webR repo for offline reference.
 - `.webr/Dockerfile` — upstream Rust toolchain install we inherit.
 - `.webr/packages/webr-vars.mk` — the Makevars override webR uses for

--- a/justfile
+++ b/justfile
@@ -1329,3 +1329,44 @@ docker-webr-test: docker-webr-build
 # exits 0 as long as the package itself loads. Stacked on feat/webr-step8.
 docker-webr-smoke *args: docker-webr-build
     bash tests/webr-smoke.sh {{args}}
+
+# ── arm64-native webR dev container (#788) ───────────────────────────────────
+#
+# ⚠️ DRAFT — composed but NOT YET VALIDATED on arm64 hardware (no Docker /
+# arm64 build in the dev sandbox). See Dockerfile.webr-arm64's header + the
+# validation checklist in docs/WEBR.md.
+#
+# `Dockerfile.webr-arm64` builds natively on an arm64 host (Apple Silicon) from
+# prebuilt parts — emscripten/emsdk:4.0.8-arm64 (matches the wasm R's emcc ABI)
+# + native arm64 Rust/R, with the portable wasm sysroot COPY'd out of the amd64
+# mirror. No qemu, no source emcc/flang/R→wasm build. Contrast docker-webr-*
+# above, which runs the amd64 image under Rosetta.
+
+docker_webr_arm64_image := "miniextendr-webr-dev-arm64:latest"
+
+# Build the arm64-native webR dev image. Re-run when Dockerfile.webr-arm64
+# changes. Must run on an arm64 host (the emsdk base + native toolchain are
+# arm64); the donor stage is pinned `--platform=linux/amd64` for the FS copy.
+docker-webr-arm64-build:
+    docker build -f Dockerfile.webr-arm64 -t {{docker_webr_arm64_image}} .
+
+# Interactive shell in the arm64 dev container, repo bind-mounted at /work.
+docker-webr-arm64-shell: docker-webr-arm64-build
+    docker run --rm -it \
+        -v "{{justfile_directory()}}:/work" \
+        -w /work \
+        {{docker_webr_arm64_image}} bash
+
+# Non-interactive: run an arbitrary command inside the arm64 container with the
+# repo mounted.
+docker-webr-arm64-run *cmd: docker-webr-arm64-build
+    docker run --rm \
+        -v "{{justfile_directory()}}:/work" \
+        -w /work \
+        {{docker_webr_arm64_image}} bash -c "{{cmd}}"
+
+# arm64-native end-to-end smoke. Same three-phase flow as docker-webr-smoke but
+# against the arm64 image (WEBR_ARM64=1 selects the native-R orchestration +
+# arm64 image inside tests/webr-smoke.sh).
+docker-webr-arm64-smoke *args: docker-webr-arm64-build
+    WEBR_ARM64=1 bash tests/webr-smoke.sh {{args}}

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -17,23 +17,51 @@
 #   --no-cache        Pass --no-cache to docker build (implies --rebuild-image).
 #   --keep            Don't clean up /tmp/webr-smoke inside the container on exit.
 #   -h, --help        Show this help text and exit.
+#
+# Environment:
+#   WEBR_ARM64=1      arm64-native dev path (#788, ⚠️ DRAFT — unvalidated on
+#                     arm64 hardware). Selects Dockerfile.webr-arm64 + the
+#                     arm64 image, and orchestrates both R passes through the
+#                     native arm64 R on PATH (the donor's amd64 host-R binaries
+#                     under /opt/webr/host + /opt/R can't execute on arm64; the
+#                     wasm sysroot they sit beside is portable and is what emcc
+#                     actually links against). Unset/default = the amd64 path
+#                     (Rosetta under Docker Desktop), unchanged.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MX_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ── arm64 vs amd64 selection (#788) ──────────────────────────────────────────
+# Guarded so the existing amd64 CI / Rosetta path is byte-for-byte unchanged
+# when WEBR_ARM64 is unset.
+WEBR_ARM64="${WEBR_ARM64:-0}"
+
 # ── Constants ───────────────────────────────────────────────────────────────
 
-IMAGE="miniextendr-webr-dev:latest"
 R_VERSION="4.6.0"
 WEBR_ROOT="/opt/webr"
-R_HOST_EXE="${WEBR_ROOT}/host/R-${R_VERSION}/bin/R"
-R_NATIVE_EXE="/opt/R/current/bin/R"
 WASM_TOOLS="${WEBR_ROOT}/tools"
 R_SOURCE="${WEBR_ROOT}/R/build/R-${R_VERSION}"
 WEBR_VARS_MK="${WEBR_ROOT}/packages/webr-vars.mk"
 SMOKE_TMP="/tmp/webr-smoke"
+
+if [[ "$WEBR_ARM64" == "1" ]]; then
+    IMAGE="miniextendr-webr-dev-arm64:latest"
+    DOCKERFILE="${MX_ROOT}/Dockerfile.webr-arm64"
+    # On arm64 the donor's amd64 host-R binaries (/opt/webr/host/R-4.6.0,
+    # /opt/R/current) cannot execute — use the native rig-installed arm64 R on
+    # PATH for BOTH passes. webr-vars.mk still drives CC=emcc for the wasm pass,
+    # so which R orchestrates the install doesn't change the compiler.
+    R_HOST_EXE="R"
+    R_NATIVE_EXE="R"
+else
+    IMAGE="miniextendr-webr-dev:latest"
+    DOCKERFILE="${MX_ROOT}/Dockerfile.webr"
+    R_HOST_EXE="${WEBR_ROOT}/host/R-${R_VERSION}/bin/R"
+    R_NATIVE_EXE="/opt/R/current/bin/R"
+fi
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
@@ -139,14 +167,14 @@ preflight() {
     fi
 
     if [[ $REBUILD_IMAGE -eq 1 ]]; then
-        log "Building docker image ${IMAGE} (--rebuild-image)..."
+        log "Building docker image ${IMAGE} from ${DOCKERFILE##*/} (--rebuild-image)..."
         # shellcheck disable=SC2086
-        docker build $NO_CACHE -f "${MX_ROOT}/Dockerfile.webr" -t "${IMAGE}" "${MX_ROOT}"
+        docker build $NO_CACHE -f "${DOCKERFILE}" -t "${IMAGE}" "${MX_ROOT}"
         ok "Image built."
     else
         if ! docker image inspect "${IMAGE}" &>/dev/null; then
-            log "Image ${IMAGE} not found locally — building..."
-            docker build -f "${MX_ROOT}/Dockerfile.webr" -t "${IMAGE}" "${MX_ROOT}"
+            log "Image ${IMAGE} not found locally — building from ${DOCKERFILE##*/}..."
+            docker build -f "${DOCKERFILE}" -t "${IMAGE}" "${MX_ROOT}"
             ok "Image built."
         else
             ok "Image ${IMAGE} present."
@@ -286,6 +314,11 @@ main() {
     printf "Image:    %s\n" "${IMAGE}"
     printf "Repo:     %s\n" "${MX_ROOT}"
     printf "R:        %s\n" "${R_VERSION}"
+    if [[ "$WEBR_ARM64" == "1" ]]; then
+        printf "Arch:     ${CLR_YELLOW}arm64-native (DRAFT, #788 — unvalidated)${CLR_RESET}\n"
+    else
+        printf "Arch:     amd64 (Rosetta on Apple Silicon)\n"
+    fi
     printf "\n"
 
     preflight


### PR DESCRIPTION
First cut at an **arm64-native webR dev image** for #788, composed from prebuilt parts (no source emcc/flang/R→wasm build). **Drafty on purpose**: I wrote the artifacts and resolved the critical open question (Q1, emcc ABI), but I could not build or run an arm64 Docker image in this environment, so nothing here is hardware-validated yet. Keeping it draft until the checklist below is green on Apple Silicon.

<details>
<summary><h3>AI-written details</h3></summary>

## What this does

`Dockerfile.webr` (→ `ghcr.io/a2-ai/webr-mirror`) and its `flang-wasm` base are **linux/amd64 only**, and `.webr/Dockerfile` hardcodes `--default-host x86_64-unknown-linux-gnu`. So Apple Silicon only had the Rosetta path (slow; the 2026-05-27 qemu attempt exhausted host disk and crashed Docker Desktop).

This composes a native-arm64 image from prebuilt parts — **no** source build of emcc, flang, or R→wasm (none of which miniextendr needs: it's Rust + C with no Fortran, and the wasm R is already prebuilt):

| Piece | Source |
|---|---|
| emcc | `emscripten/emsdk:4.0.8-arm64` (linux/arm64/v8) |
| Rust nightly + `wasm32-unknown-emscripten` + `rust-src` | rustup `--default-host aarch64-unknown-linux-gnu` |
| host R 4.6.0 | `rig add 4.6.0` |
| wasm sysroot `/opt/webr/{wasm,R/build,tools,packages,dist,src}` | `COPY --from=` the amd64 mirror donor (pure FS copy — no emulated execution) |

## Q1 finding (emcc ABI) — RESOLVED, best case

The emcc that links `miniextendr.so` must match the emcc that built the prebuilt wasm R (Emscripten **4.0.8**), or the side-module won't load. `emscripten/emsdk` publishes **arch-suffixed tags, not a multi-arch manifest**:

- bare `:4.0.8` → `linux/amd64` only (confirmed via Docker Hub API)
- `:4.0.8-arm64` → genuine `linux/arm64/v8` build of the **same** 4.0.8 release (digest `sha256:9d471ceb4bd9e…`, pushed 2025-04-30)

Same emcc *version* on a different host arch ⇒ same wasm ABI ⇒ **no version-skew risk**. The arch-suffix convention holds across the whole 4.0.x line. (Sources: Docker Hub `emscripten/emsdk` tag registry; emsdk issues #1211/#1500 confirm the per-arch-tag model.)

**Correction to the issue body**: it assumed host R 4.5.1, but the base was bumped to webR v0.6.0 / **R 4.6.0** in #755 — so the arm64 image pins `rig add 4.6.0` to stay header-compatible with the copied wasm R.

## Changed files

- `Dockerfile.webr-arm64` — the multi-stage image (donor pin = same digest as `Dockerfile.webr`'s `WEBR_BASE`; emcc pinned by digest).
- `justfile` — `docker-webr-arm64-{build,shell,run,smoke}` recipes (mirror the existing `docker-webr-*` style).
- `tests/webr-smoke.sh` — guarded `WEBR_ARM64=1` path: arm64 image + Dockerfile, both R passes orchestrated through the native arm64 R on PATH (donor's amd64 host-R binaries can't execute on arm64). **amd64 path is byte-unchanged when `WEBR_ARM64` is unset.**
- `docs/WEBR.md` — new "arm64-native dev image" section + the validation checklist.

## Needs on-arm64-hardware validation (cannot do here)

- [ ] Image builds (`just docker-webr-arm64-build`) — donor `COPY --from=` resolves, native toolchain installs, sanity layer passes.
- [ ] Side-module ABI load — `just docker-webr-arm64-smoke` Phase 2 links `miniextendr.so` with arm64 emcc and Phase 3 `library(miniextendr)` loads it (proves the 4.0.8 arm64↔amd64-built-R ABI matches in practice, not just by version label).
- [ ] Sysroot link/load — the amd64-built wasm sysroot links + loads cleanly under the arm64-host emcc end-to-end.
- [ ] Native-R orchestration — Phase 1 + Phase 2 both run through the rig arm64 R on PATH.
- [ ] Node bundle rebuild — `make /opt/webr/src/dist/webr.mjs` with the copied `/opt/webr/src` + emsdk's bundled Node 22.16.0.
- [ ] Compile weight / disk — datafusion+arrow wasm compile is now native (no qemu tax) but still heavy.

## Acceptance

`Closes #788` — **but acceptance is NOT met until the checklist above passes on Apple Silicon.** Kept as a draft for that reason.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
