### PR TITLE
test(minirextendr): wire standalone round-trip e2e into on-demand CI (#775)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   pull_request:
+    # `labeled` lets the on-demand round-trip e2e job (r-roundtrip-e2e) be
+    # triggered by applying the `run-e2e` label to a PR. The default activity
+    # types (opened/synchronize/reopened) cover everything else; adding
+    # labeled/unlabeled is additive — no existing job keys on the label.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
     tags: ["v*"]
@@ -1213,6 +1218,87 @@ jobs:
         run: just test-bootstrap-vendor
 
   # ===========================================================================
+  # Standalone round-trip e2e (on-demand: nightly cron + label + dispatch)
+  # ===========================================================================
+  # Exercises the full standalone (non-monorepo) flow that the per-PR suite
+  # cannot afford: create_miniextendr_package() -> miniextendr_build() (auto-
+  # vendor flips to tarball mode mid-install) -> wrapper-gen -> install ->
+  # library() exposes the functions. This is the #757/#775 regression target:
+  # any change that makes a build entry point bypass MINIEXTENDR_FORCE_WRAPPER_GEN
+  # (or alters the tarball-mode skip) re-introduces the empty-namespace bug.
+  #
+  # The assertions live in the gated testthat round-trip at
+  # minirextendr/tests/testthat/test-templates.R:521 — CI runs the suite, it does
+  # NOT reimplement the checks in shell (per #805). MINIEXTENDR_RUN_E2E=1 lifts
+  # skip_e2e()'s skip_on_ci() so the otherwise-skipped e2e tests actually run.
+  #
+  # On-demand only — NOT in ci-success.needs, so it never gates a PR and adds no
+  # minutes to normal runs. Triggers: weekly cron (Sat 06:00 UTC), the `run-e2e`
+  # PR label, or `gh workflow run ci.yml --ref <branch>`. Heavy: cold-compiles
+  # Rust + autoconf + network-fetches/vendors miniextendr `main`.
+  r-roundtrip-e2e:
+    name: Standalone round-trip e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      contains(github.event.pull_request.labels.*.name, 'run-e2e')
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: minirextendr
+          extra-packages: any::testthat, any::devtools, any::withr, any::roxygen2
+          needs: check
+
+      - name: Install autoconf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rpkg/src/rust -> target
+          shared-key: roundtrip-e2e
+          cache-on-failure: true
+
+      # cargo-revendor on PATH so the standalone build's auto-vendor (tarball
+      # mode) can seal inst/vendor.tar.xz mid-install.
+      - name: Set up cargo-revendor (install only)
+        uses: ./.github/actions/setup-vendor
+        with:
+          configure-and-vendor: 'false'
+
+      - name: Run standalone round-trip e2e
+        run: just minirextendr-roundtrip
+
+  # ===========================================================================
   # Summary job (for branch protection)
   # ===========================================================================
   ci-success:
@@ -1231,6 +1317,7 @@ jobs:
       - minirextendr
       - cran-check
       - bootstrap-vendor-test
+      # - r-roundtrip-e2e # non-gating: on-demand only (cron / run-e2e label / dispatch), see #775
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/justfile
+++ b/justfile
@@ -797,6 +797,25 @@ minirextendr-rcmdcheck:
     export MINIEXTENDR_LOCAL_PATH="$(pwd)"
     Rscript -e "rcmdcheck::rcmdcheck('minirextendr', args = c('--no-manual'), error_on = 'warning')"
 
+# Standalone round-trip regression (heavy; maintainer/nightly only).
+#
+# Drives the gated testthat e2e tests in minirextendr/tests/testthat/test-templates.R
+# — including the #757/#775 standalone build → wrapper-gen → library() round-trip
+# at :521 — by flipping the MINIEXTENDR_RUN_E2E bypass so skip_e2e() does NOT
+# skip_on_ci(). MINIEXTENDR_LOCAL_PATH points the scaffolder at this checkout.
+#
+# Cold-compiles a Rust crate, runs autoconf, and (for the standalone test)
+# network-fetches + vendors miniextendr `main` via cargo-revendor — minutes per
+# run, network-dependent. NOT part of the per-PR suite; runs in the nightly /
+# label-gated CI job `r-roundtrip-e2e` (see .github/workflows/ci.yml). Requires
+# cargo, autoconf, R, and cargo-revendor on PATH; individual tests self-skip with
+# a clear reason if a tool is missing. See #775 / #805.
+[script("bash")]
+minirextendr-roundtrip:
+    export MINIEXTENDR_LOCAL_PATH="$(pwd)"
+    export MINIEXTENDR_RUN_E2E=1
+    Rscript -e 'testthat::set_max_fails(Inf); devtools::test("minirextendr", filter = "templates")'
+
 # Full development cycle for minirextendr: document, test, check
 minirextendr-dev: minirextendr-document minirextendr-test minirextendr-check
 

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -66,9 +66,25 @@ install_to_templib <- function(pkg_path, tmp) {
   lib_path
 }
 
-# Standard e2e skip guards
+# Standard e2e skip guards.
+#
+# These tests cold-compile a Rust crate, run autoconf, and (for the standalone
+# round-trip) network-fetch + vendor miniextendr — minutes per run. They're
+# skipped on CI by default so the per-PR `minirextendr` job stays fast.
+#
+# Opt-in bypass: set MINIEXTENDR_RUN_E2E=1 to run them on CI anyway (used by the
+# nightly/label-gated round-trip job — see .github/workflows/ci.yml
+# `r-roundtrip-e2e`). The bypass only lifts the skip_on_ci() gate; the
+# tool-availability + local-repo guards below still apply, so a misconfigured
+# runner skips with a clear reason instead of erroring. Local runs (where
+# skip_on_ci() is already a no-op) are unaffected by the flag. See #775 / #805:
+# before this, skip_on_ci() ran first and the round-trip was unreachable in CI.
 skip_e2e <- function() {
-  skip_on_ci()
+  # as.logical("1") is NA in R, so accept the common truthy spellings explicitly.
+  run_e2e <- tolower(Sys.getenv("MINIEXTENDR_RUN_E2E", "")) %in% c("1", "true", "yes")
+  if (!run_e2e) {
+    skip_on_ci()
+  }
   skip_if_not(nzchar(Sys.which("autoconf")), "autoconf not available")
   skip_if_not(nzchar(Sys.which("cargo")), "Rust toolchain not available")
   skip_if_not(nzchar(Sys.which("R")), "R not available")


### PR DESCRIPTION
## Summary

Closes #775. The standalone `miniextendr_build()` → wrapper-gen → `library()` round-trip **already exists** as a `test_that()` at `minirextendr/tests/testthat/test-templates.R:521` (landed in #803), but it was **unreachable in CI**: `skip_e2e()` calls `skip_on_ci()` first, so the test never ran even though the `minirextendr` job already exports `MINIEXTENDR_LOCAL_PATH`. That is precisely the gap #775 wants closed — coverage existed in-suite but couldn't fire (the #805 finding). This PR makes it runnable on demand without adding minutes to every PR.

<details>
<summary>🤖 Implementation details (AI-written)</summary>

### (a) Skip-bypass flag — `minirextendr/tests/testthat/test-templates.R`
`skip_e2e()` now consults `MINIEXTENDR_RUN_E2E`. When set (`1`/`true`/`yes`), it does **not** call `skip_on_ci()`; the tool-availability (`autoconf`/`cargo`/`R`) and `skip_if_no_local_repo()` guards still apply, so a misconfigured runner self-skips with a clear reason instead of erroring. Default per-PR CI behaviour and local runs are byte-for-byte unchanged. (Note: `as.logical("1")` is `NA` in R, so the truthy spellings are matched explicitly.)

### (b) Maintainer entry point — `justfile`
`just minirextendr-roundtrip` sets `MINIEXTENDR_RUN_E2E=1` + `MINIEXTENDR_LOCAL_PATH="$(pwd)"` and runs the gated testthat suite (`filter = "templates"`). It **reuses the :521 assertions** rather than reimplementing them in shell — per #805's principle that CI runs the suite, it doesn't fork the checks.

### (c) Nightly / label-gated CI — `.github/workflows/ci.yml`
New **non-gating** `r-roundtrip-e2e` job, modeled on `bootstrap-vendor-test` (R + rv + Rust + sccache + `setup-vendor` for cargo-revendor) and `r-check-macos` (on-demand `if:`). It runs only on the weekly cron (`Sat 06:00 UTC`), the `run-e2e` PR label, or `workflow_dispatch`. It is **not** added to `ci-success.needs`, so it never gates a PR and adds no time to normal runs. `labeled`/`unlabeled` added to `pull_request` types so the label actually triggers — same pattern already used by the existing `heap-check` label.

### Regression target
Any future change that makes a build entry point bypass `MINIEXTENDR_FORCE_WRAPPER_GEN` (or alters the tarball-mode wrapper-gen skip, #757) re-introduces the empty-namespace bug — now caught nightly / on-label instead of silently.

### Adjacency
- #803 added the `test_that` at :521 (assertions reused here, not duplicated).
- #822 / draft PR #910 add `test-workflow-bootstrap.R` + bootstrap helpers off the same `main`; this branches off `main` **without** #910 — no overlap.
- Model harness: `just test-bootstrap-vendor`, review doc `reviews/2026-05-29-build-wrapper-gen-tarball.md`.

### Verified
- R-parsed the edited `test-templates.R` (`Rscript -e 'parse(...)'`).
- `just --evaluate` parses; `just --show minirextendr-roundtrip` renders correctly.
- YAML structure validated: 4 triggers, PR types include `labeled`/`unlabeled`, weekly cron present, `r-roundtrip-e2e` gated on `workflow_dispatch || schedule || run-e2e`, and confirmed **absent** from `ci-success.needs`.
- Did **not** run the full round-trip (cargo cold-compile + autoconf + network vendor of miniextendr `main` — minutes; drafty by nature).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
