### PR TITLE
test(into_r_as): exercise StorageCoerceError::MissingValue NA path (#762)

### DIFF
--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -402,6 +402,15 @@ impl IntoRAs<f64> for i16 {
 impl IntoRAs<f64> for i32 {
     #[inline]
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
+        // i32::MIN is R's NA_integer_ sentinel. A blind `self as f64` would
+        // turn it into the finite value -2147483648.0, silently destroying the
+        // missing-value semantics. Detect it and surface MissingValue instead.
+        if self == crate::altrep_traits::NA_INTEGER {
+            return Err(StorageCoerceError::MissingValue {
+                to: "f64",
+                index: None,
+            });
+        }
         Ok((self as f64).into_sexp())
     }
 }
@@ -734,10 +743,44 @@ macro_rules! impl_vec_into_r_as_f64_infallible {
 
 impl_vec_into_r_as_f64_infallible!(i8);
 impl_vec_into_r_as_f64_infallible!(i16);
-impl_vec_into_r_as_f64_infallible!(i32);
 impl_vec_into_r_as_f64_infallible!(u8);
 impl_vec_into_r_as_f64_infallible!(u16);
 impl_vec_into_r_as_f64_infallible!(u32);
+
+// i32 -> f64: widening is value-preserving EXCEPT for i32::MIN, which is R's
+// NA_integer_ sentinel. Casting it would yield the finite -2147483648.0 and
+// silently drop the missing-value semantics, so detect it and error instead.
+impl IntoRAs<f64> for Vec<i32> {
+    fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
+        let mut result = Vec::with_capacity(self.len());
+        for (i, val) in self.into_iter().enumerate() {
+            if val == crate::altrep_traits::NA_INTEGER {
+                return Err(StorageCoerceError::MissingValue {
+                    to: "f64",
+                    index: Some(i),
+                });
+            }
+            result.push(val as f64);
+        }
+        Ok(result.into_sexp())
+    }
+}
+
+impl IntoRAs<f64> for &[i32] {
+    fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
+        let mut result = Vec::with_capacity(self.len());
+        for (i, &val) in self.iter().enumerate() {
+            if val == crate::altrep_traits::NA_INTEGER {
+                return Err(StorageCoerceError::MissingValue {
+                    to: "f64",
+                    index: Some(i),
+                });
+            }
+            result.push(val as f64);
+        }
+        Ok(result.into_sexp())
+    }
+}
 
 // Large integers - check precision
 impl_vec_into_r_as!(f64, "f64"; i64, "i64");

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -1115,6 +1115,60 @@ fn into_r_as_scalar_i64_to_i32_too_large_errors() {
     });
 }
 
+/// Vec<i32> IntoRAs<f64> — NA_integer_ (i32::MIN) sentinel must surface
+/// MissingValue rather than silently widening to the finite -2147483648.0.
+/// Parallels `into_r_as_vec_f64_nan_to_i32_errors` on the NonFinite path.
+#[test]
+fn into_r_as_vec_i32_na_to_f64_missing_value_errors() {
+    use miniextendr_api::into_r_as::StorageCoerceError;
+    r_test_utils::with_r_thread(|| {
+        let v = vec![1i32, NA_INTEGER, 3];
+        let result = IntoRAs::<f64>::into_r_as(v);
+        assert!(
+            matches!(
+                result,
+                Err(StorageCoerceError::MissingValue {
+                    to: "f64",
+                    index: Some(1)
+                })
+            ),
+            "NA_integer_ in Vec<i32> must error as MissingValue at index 1, got {result:?}"
+        );
+    });
+}
+
+/// All-valid Vec<i32> IntoRAs<f64> still widens successfully — guards against
+/// the NA check rejecting ordinary negative values.
+#[test]
+fn into_r_as_vec_i32_to_f64_all_valid() {
+    r_test_utils::with_r_thread(|| {
+        let v = vec![-5i32, 0, 7];
+        let sexp = IntoRAs::<f64>::into_r_as(v).unwrap();
+        assert_eq!(sexp.type_of(), SEXPTYPE::REALSXP);
+        let data: &[f64] = unsafe { sexp.as_slice() };
+        assert_eq!(data, &[-5.0, 0.0, 7.0]);
+    });
+}
+
+/// Scalar i32 IntoRAs<f64> — i32::MIN (NA_integer_) must surface MissingValue.
+#[test]
+fn into_r_as_scalar_i32_na_to_f64_missing_value_errors() {
+    use miniextendr_api::into_r_as::StorageCoerceError;
+    r_test_utils::with_r_thread(|| {
+        let result = IntoRAs::<f64>::into_r_as(i32::MIN);
+        assert!(
+            matches!(
+                result,
+                Err(StorageCoerceError::MissingValue {
+                    to: "f64",
+                    index: None
+                })
+            ),
+            "scalar i32::MIN must error as MissingValue, got {result:?}"
+        );
+    });
+}
+
 // endregion
 
 // region: NA_real_ bit-exact identity — verified via Vec<Option<f64>> roundtrip


### PR DESCRIPTION
## What this does

`miniextendr-api/src/into_r_as.rs` sat at 5–11% region coverage and the `StorageCoerceError::MissingValue` variant was **declared but never constructed** — present in the enum, `Display`, and `at_index`, yet no `IntoRAs` impl ever returned it. The `i32 → f64` paths (scalar and `Vec`/slice) blindly cast `i32::MIN` (R's `NA_integer_` sentinel) to the finite `-2147483648.0`, silently destroying missing-value semantics.

So this isn't *just* a test gap: the path the issue describes ("the implementation should detect the NA sentinel and return `StorageCoerceError::MissingValue`") **did not exist**. This PR implements that behavior, then covers it.

## Uncovered path

`StorageCoerceError::MissingValue` (`into_r_as.rs:98`) — reachable from neither `IntoRAs::<f64>` for `Vec<i32>` (was the infallible-widening macro) nor scalar `i32` (was a blind `self as f64`).

## Changes

- **`src/into_r_as.rs`** — `i32 IntoRAs<f64>` (scalar) now returns `MissingValue { index: None }` for `NA_INTEGER`. Pulled `i32` out of `impl_vec_into_r_as_f64_infallible!` and added dedicated `Vec<i32>` / `&[i32]` impls returning `MissingValue { index: Some(i) }` at the offending element.
- **`tests/conversion_coverage.rs`** — modeled on the parallel `NonFinite` test `into_r_as_vec_f64_nan_to_i32_errors`:
  - `into_r_as_vec_i32_na_to_f64_missing_value_errors` — `vec![1, NA_INTEGER, 3]` → `Err(MissingValue { to: "f64", index: Some(1) })`
  - `into_r_as_scalar_i32_na_to_f64_missing_value_errors` — `i32::MIN` → `Err(MissingValue { to: "f64", index: None })`
  - `into_r_as_vec_i32_to_f64_all_valid` — guard: `vec![-5, 0, 7]` still widens so ordinary negatives aren't rejected
  - All assert the **exact** `StorageCoerceError::MissingValue` variant via `matches!`.

## Verification

- `cargo fmt --all` — clean.
- `cargo test -p miniextendr-api --test conversion_coverage into_r_as` — **10 passed, 0 failed** (3 new + the all-valid guard + 6 pre-existing).

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
