### PR TITLE
fix(minirextendr): run_with_logging() env restore drops names for single var (#804)

### DIFF
--- a/minirextendr/R/system.R
+++ b/minirextendr/R/system.R
@@ -39,7 +39,11 @@ run_with_logging <- function(command, args = character(),
   # Run command via system2 with env vars and working directory
   run_fn <- function() {
     if (length(env) > 0) {
-      old_env <- Sys.getenv(names(env), unset = NA)
+      # names = TRUE forces a named result regardless of length(env).
+      # Sys.getenv() auto-names only for length > 1, so a single-variable env
+      # would otherwise lose its name and the on.exit() restore below would
+      # call Sys.setenv("value") with no name -> "all arguments must be named".
+      old_env <- Sys.getenv(names(env), unset = NA, names = TRUE)
       do.call(Sys.setenv, as.list(env))
       on.exit({
         # Restore: unset vars that were previously unset, restore others

--- a/minirextendr/tests/testthat/test-system.R
+++ b/minirextendr/tests/testthat/test-system.R
@@ -50,3 +50,84 @@ test_that("run_with_logging reports success for a zero-exit command", {
   expect_true(result$success)
   expect_null(result$status)
 })
+
+# An *empty* R script: a metacharacter-free, zero-exit no-op used by the
+# env-restore tests below. We only care that run_with_logging() runs *some*
+# command (so the env-apply/on.exit-restore path executes), not its output.
+# Returns the path; caller is responsible for unlink() via its own on.exit.
+make_empty_rscript <- function() {
+  empty <- file.path(tempdir(), "minirextendr-empty-env-9f3c.R")
+  file.create(empty)
+  empty
+}
+
+test_that("run_with_logging restores a single already-set env var (#804)", {
+  rscript <- find_rscript()
+  skip_if_not(nzchar(rscript), "Rscript not found")
+
+  empty <- make_empty_rscript()
+  on.exit(unlink(empty), add = TRUE)
+
+  # Pre-set a sentinel value and arrange to restore the prior state ourselves
+  # (base Sys.setenv/Sys.unsetenv; withr is only needed for the empty-script
+  # defer above, which is part of the test scaffolding, not the code path).
+  var <- "MINIREXTENDR_TEST_ENV_804"
+  prior <- Sys.getenv(var, unset = NA)
+  Sys.setenv(MINIREXTENDR_TEST_ENV_804 = "sentinel")
+  on.exit(
+    if (is.na(prior)) Sys.unsetenv(var) else do.call(Sys.setenv, stats::setNames(list(prior), var)),
+    add = TRUE
+  )
+
+  # Single-variable env: this is the case that tripped "all arguments must be
+  # named" before names = TRUE was added to the Sys.getenv() capture.
+  expect_no_error(
+    minirextendr:::run_with_logging(
+      rscript, empty,
+      log_prefix = "test-env-single",
+      env = c(MINIREXTENDR_TEST_ENV_804 = "temp")
+    )
+  )
+
+  # The sentinel value must be restored once run_with_logging() returns.
+  expect_identical(Sys.getenv(var, unset = NA), "sentinel")
+})
+
+test_that("run_with_logging restores multiple env vars and unsets previously-unset ones", {
+  rscript <- find_rscript()
+  skip_if_not(nzchar(rscript), "Rscript not found")
+
+  empty <- make_empty_rscript()
+  on.exit(unlink(empty), add = TRUE)
+
+  set_var <- "MINIREXTENDR_TEST_ENV_804_A"   # already set -> restore to sentinel
+  unset_var <- "MINIREXTENDR_TEST_ENV_804_B" # previously unset -> must end unset
+
+  prior_set <- Sys.getenv(set_var, unset = NA)
+  prior_unset <- Sys.getenv(unset_var, unset = NA)
+  Sys.setenv(MINIREXTENDR_TEST_ENV_804_A = "sentinel-a")
+  Sys.unsetenv(unset_var)
+  on.exit(
+    {
+      if (is.na(prior_set)) Sys.unsetenv(set_var) else do.call(Sys.setenv, stats::setNames(list(prior_set), set_var))
+      if (is.na(prior_unset)) Sys.unsetenv(unset_var) else do.call(Sys.setenv, stats::setNames(list(prior_unset), unset_var))
+    },
+    add = TRUE
+  )
+
+  expect_no_error(
+    minirextendr:::run_with_logging(
+      rscript, empty,
+      log_prefix = "test-env-multi",
+      env = c(
+        MINIREXTENDR_TEST_ENV_804_A = "temp-a",
+        MINIREXTENDR_TEST_ENV_804_B = "temp-b"
+      )
+    )
+  )
+
+  # The set var is restored to its sentinel; the previously-unset var is unset
+  # again (Sys.getenv returns "" for an unset name without `names`/`unset`).
+  expect_identical(Sys.getenv(set_var, unset = NA), "sentinel-a")
+  expect_identical(Sys.getenv(unset_var, unset = NA), NA_character_)
+})


### PR DESCRIPTION
Splitting a latent defect out of #799.

## The latent bug
`run_with_logging()` (`minirextendr/R/system.R`) temporarily applies caller-supplied env vars and restores them in `on.exit()`. It captured the prior values with:

```r
old_env <- Sys.getenv(names(env), unset = NA)
```

`Sys.getenv()` only auto-names its result when given **more than one** name. So for a single-variable `env`, `old_env` is unnamed, and the restore path

```r
do.call(Sys.setenv, as.list(old_env[!is.na(old_env)]))
```

calls `Sys.setenv("value")` with no name -> `all arguments must be named`.

Latent today: production callers pass `env = character()` or multi-var sets, so the one-var path is never exercised. Surfaced incidentally while debugging the #799 `R CMD check` failure (an earlier draft passed a single-var env and tripped this).

## The fix (one line)
Add `names = TRUE` so the capture is named regardless of `length(env)`:

```r
old_env <- Sys.getenv(names(env), unset = NA, names = TRUE)
```

## Regression tests
Two new tests in `tests/testthat/test-system.R`:
- **Single already-set var**: pre-set a sentinel, call `run_with_logging(..., env = c(VAR = "temp"))`, assert no error and the sentinel is restored afterward. This is the exact case that errored before the fix.
- **Multi-var path**: one already-set var (restored to its sentinel) plus one previously-unset var (must end unset again).

Both use base `Sys.setenv` / `Sys.unsetenv` with test-local `on.exit()` cleanup — no `withr` dependency (it's Suggests-only in minirextendr).

## Verification
- `Rscript -e 'parse(...)'` on both edited files: parses clean.
- `just minirextendr-test system`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 11 ]` (4 new env-restore assertions among them).

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
