### PR TITLE
docs(webr): complete dependency-import constraint guidance (#752)

### DIFF
--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -15,10 +15,11 @@ Tracking: umbrella #470. Shipped: tier 1/2/3 CI (#480 / #491 / #492),
 cross-package wasm stubs (#493), side-module `RUSTFLAGS`
 (`-Zdefault-visibility=hidden`, #494), `link_to_r()` wasm gating (#482), webR
 base-image mirror (#496), the redundant `-C relocation-model=pic` flag
-dropped (#745), and the base-image pin bumped to a tagged webR v0.6.0 / R 4.6.0
-release (#755). Open follow-ups: #495 (cross-crate trait dispatch), #752
-(dependency guidance — see "Dependencies and webR" below), #788 (arm64-native
-dev image), #747 (drop mirror creds once the GHCR package is public).
+dropped (#745), the base-image pin bumped to a tagged webR v0.6.0 / R 4.6.0
+release (#755), and dependency guidance (#752 — see "Dependencies and webR"
+below). Open follow-ups: #495 (cross-crate trait dispatch), #925 (lint for
+eager `importFrom` of compiled deps), #788 (arm64-native dev image), #747
+(drop mirror creds once the GHCR package is public).
 
 ## Target
 
@@ -237,9 +238,23 @@ unable to load shared object '.../somePkg.so': invalid ELF header
 ```
 
 This is the same host-R-loads-a-wasm-object failure that bites webR's own
-base packages (handled by installing to an empty temp library; see tier 2 /
-#491), but here it's triggered by *your package's own declared imports*, so
-the framework can't paper over it for you.
+base packages — handled by installing to an empty temp library, the
+`install-to-temp-lib` pattern; see tier 2 / #491 / #744. The difference is
+the *trigger*: #491/#744 are about webR's own base-package `.so`s, whereas
+this failure is driven by *your package's own declared imports*, so the
+framework can't paper over it for you.
+
+### Why `--no-byte-compile` alone doesn't save you
+
+Both the wasm-install scripts and CI pass `--no-byte-compile` (see
+`tests/webr-smoke.sh` and `.github/workflows/webr.yml`, mirroring rwasm's
+flag set). That suppresses the *byte-compile* half of the cascade, but the
+lazy-load step that materialises the namespace still runs `loadNamespace()`
+for everything in your `Imports`/`Depends` namespace-load graph. Skipping
+byte-compilation does **not** prune your declared imports, so an
+`importFrom` of a compiled package still reaches for its `.so`. The only
+robust fix is to keep the compiled dependency out of the namespace-load graph
+entirely — see the guidance below.
 
 **Guidance:**
 
@@ -252,9 +267,11 @@ the framework can't paper over it for you.
   graph, so the wasm install's lazy-load never reaches for their `.so`.
 
 This mirrors what the astra downstream did (moved its Shiny stack to
-`Suggests` + `::`). Tracked in #752; a future `minirextendr_doctor()` /
-`miniextendr_check_static()` lint may flag eager `importFrom` of
-known-compiled packages.
+`Suggests` + `::`). Documented under #752; a future `minirextendr_doctor()` /
+`miniextendr_check_static()` lint that flags eager `importFrom` of
+known-compiled packages when a webR target is configured is tracked
+separately in #925 (the "is it compiled?" / "is webR the target?" detection
+needs design — see that issue).
 
 ## CI
 
@@ -291,8 +308,12 @@ is what proves it *loads* in a real webR runtime.
 ## See also
 
 - Issue #470 — umbrella tracking issue for webR/WASM support.
-- Issue #495 — cross-crate trait dispatch; #752 — dependency guidance;
+- Issue #495 — cross-crate trait dispatch; #752 — dependency guidance
+  (this section); #925 — follow-up lint for `importFrom` of compiled deps;
   #788 — arm64-native dev image.
+- Issues #491 / #744 — the base-package variant of the host-R-loads-a-wasm-
+  object failure, solved via the install-to-temp-lib pattern (the dependency
+  guidance above is the consumer-package-imports variant of the same failure).
 - `tests/webr-node-smoke/smoke.mjs` — the CI tier-3 Node runner (single source
   of truth for the runtime smoke; `tests/webr-smoke.sh` Phase 3 invokes it).
 - `tests/webr-smoke.sh` — the local end-to-end smoke runner. Mirrors the green


### PR DESCRIPTION
## Summary

Completes the webR dependency-import guidance for #752. The "Dependencies and webR" section already landed in `f562cdba`, but it was missing two items the issue explicitly asked for. This PR finishes the job and closes the issue.

The constraint: a miniextendr package whose `NAMESPACE` eagerly imports a **compiled** package (`importFrom(somePkg, …)` / `import(somePkg)` where `somePkg` ships a `.so`) forces `loadNamespace(somePkg)` during the wasm `R CMD INSTALL` lazy-load step. The host R then tries to `dyn.load` the wasm-built `somePkg.so` and dies with `invalid ELF header`. The fix (validated by the astra downstream): demote compiled deps to `Suggests` and call via `pkg::fn()`.

## What changed

- **`docs/WEBR.md` — "Dependencies and webR"**: added the **#744** cross-reference (the section only cited #491; #491/#744 are the paired base-package variant of the same host-R-loads-a-wasm-object failure, solved via install-to-temp-lib) and clarified that this section is the *consumer-package-imports* variant of that same failure.
- **`docs/WEBR.md` — new "Why `--no-byte-compile` alone doesn't save you" subsection**: tier-2 and the smoke scripts already pass `--no-byte-compile` (`.github/workflows/webr.yml`, `tests/webr-smoke.sh`), but the lazy-load step still runs `loadNamespace()` over the declared imports — skipping byte-compilation does **not** prune a compiled `importFrom`. Documents both halves of the cascade together to avoid confusion.
- **`docs/WEBR.md` — tracking + "See also"**: moved #752 from "Open follow-ups" to shipped; added explicit #491/#744 and #470 (umbrella) cross-references; pointed the deferred optional lint at follow-up **#925**.

The section already covered the core deliverables (the namespace-load constraint, the `Suggests` + `::` pattern with a `check_installed()`/`requireNamespace()` guard, and the pure-R-safe vs compiled-defer distinction) — this PR rounds it out to fully match the issue spec.

## The optional lint — deferred (#925)

The issue's optional `minirextendr_doctor()` / `miniextendr_check_static()` lint is **deferred** to **#925**. It needs non-trivial design: detecting whether a dependency is "compiled" without `loadNamespace`-ing it (the very failure we guard against), and detecting that a webR target is configured (no clean in-source signal — the wasm path is detected at *configure* time via `CC=emcc`, invisible to a static R-side doctor). The follow-up carries the full design sketch (curated deny-list as the smallest viable start, `webr = TRUE` gating).

## Verification

Docs-only change (no R/Rust touched, no compile needed). Re-read the section against the issue's failure chain: `importFrom` compiled pkg → `loadNamespace` during lazy-load → host R `dyn.load` of wasm `.so` → `invalid ELF header`. Confirmed nothing under `site/` is staged (gitignored, regenerated by CI on push to `main`).

## Refs

- Closes #752
- Follow-up lint: #925
- Umbrella: #470
- Base-package variant of the same failure: #491 / #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
