### PR TITLE
docs: remove stale fn-level unsafe(main_thread) references (#740)

### DIFF
--- a/docs/EXPRESSION_EVAL.md
+++ b/docs/EXPRESSION_EVAL.md
@@ -110,7 +110,7 @@ All functions in this module require:
 - Being called from the **R main thread** (they use R API calls)
 - `unsafe` blocks (they call into C)
 
-In `#[miniextendr]` functions, use these inside `unsafe(main_thread)` blocks or within ALTREP callbacks (which already run on the main thread).
+Standalone `#[miniextendr]` functions already run on the main thread (they are the default), so these calls are safe there; they are also safe within ALTREP callbacks, which run on the main thread too.
 
 ## Use Cases
 

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -623,7 +623,7 @@ Debug-only SEXP thread assertions:
 fn assert_main_thread() { ... }
 ```
 
-**Implication:** Release builds could have SEXP-access thread safety violations that go undetected. Use `#[miniextendr(unsafe(main_thread))]` for explicit main-thread-only functions.
+**Implication:** Release builds could have SEXP-access thread safety violations that go undetected. Standalone `#[miniextendr]` functions taking `SEXP`/`RArray` parameters run on the main thread by default (they are `!Send`), so they avoid this class of violation without any explicit attribute.
 
 **Runtime thread checks (always active):** The checked FFI wrappers (`Rf_error`, `Rprintf`, etc.) check `is_r_main_thread()` at runtime in all build modes and panic with a clear message like "Rf_error called from non-main thread".
 

--- a/docs/MINIEXTENDR_ATTRIBUTE.md
+++ b/docs/MINIEXTENDR_ATTRIBUTE.md
@@ -62,15 +62,16 @@ pub fn set_option(key: String, value: i32) { /* ... */ }
 |-----------|--------|
 | `worker` | Run on worker thread (default if `worker-default` feature) |
 | `no_worker` | Run on main R thread |
-| `unsafe(main_thread)` | Main thread, no worker overhead (for SEXP params) |
 
-Functions taking `SEXP` parameters automatically run on main thread.
+Functions taking `SEXP` parameters automatically run on the main thread — they
+are `!Send`, so the generated wrapper can only execute there. No attribute is
+needed.
 
 ```rust
 #[miniextendr(no_worker)]
 pub fn fast_add(x: i32, y: i32) -> i32 { x + y }
 
-#[miniextendr(unsafe(main_thread))]
+#[miniextendr]
 pub fn inspect_sexp(x: miniextendr_api::sys::SEXP) -> i32 { /* ... */ }
 ```
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -157,9 +157,9 @@ This means:
 
 For `#[miniextendr]` functions, this works naturally -- by default your function runs on the
 main thread, so progress bar output works directly. If using the `worker-thread` feature,
-operations that need R console access should use `unsafe(main_thread)` or run the progress
-bar update on the main thread. In practice, since indicatif batches draws, the simplest
-approach is to create the progress bar and call `pb.inc()` from your function directly.
+operations that need R console access should run the progress bar update on the main thread.
+In practice, since indicatif batches draws, the simplest approach is to create the progress
+bar and call `pb.inc()` from your function directly.
 
 See [THREADS.md](THREADS.md) for details on the worker thread model.
 

--- a/docs/RARRAY.md
+++ b/docs/RARRAY.md
@@ -44,13 +44,13 @@ Supported element types (`T`) are those implementing `RNativeType`:
 ```rust
 use miniextendr_api::rarray::RMatrix;
 
-// RMatrix parameters require main_thread (RArray is !Send)
-#[miniextendr(unsafe(main_thread))]
+// RMatrix parameters run on the main thread automatically (RArray is !Send)
+#[miniextendr]
 pub fn matrix_sum(m: RMatrix<f64>) -> f64 {
     unsafe { m.as_slice().iter().sum() }
 }
 
-#[miniextendr(unsafe(main_thread))]
+#[miniextendr]
 pub fn column_means(m: RMatrix<f64>) -> Vec<f64> {
     let nrow = unsafe { m.nrow() };
     let ncol = unsafe { m.ncol() };
@@ -80,11 +80,12 @@ column_means(m)
 other threads because the underlying R APIs (`DATAPTR_RO`, etc.) must be called on
 the R main thread.
 
-Functions that accept `RArray`, `RMatrix`, or `RVector` parameters must use
-`#[miniextendr(unsafe(main_thread))]`:
+Functions that accept `RArray`, `RMatrix`, or `RVector` parameters run on the
+main thread automatically — these types are `!Send`, so the generated wrapper
+can only execute there. No attribute is required:
 
 ```rust
-#[miniextendr(unsafe(main_thread))]
+#[miniextendr]
 pub fn process(m: RMatrix<f64>) -> f64 {
     // Runs on main thread -- RMatrix access is safe
     unsafe { m.as_slice().iter().sum() }
@@ -94,7 +95,7 @@ pub fn process(m: RMatrix<f64>) -> f64 {
 To use the data in worker threads or parallel code, copy it first with `to_vec()`:
 
 ```rust
-#[miniextendr(unsafe(main_thread))]
+#[miniextendr]
 pub fn parallel_process(m: RMatrix<f64>) -> f64 {
     // Copy on main thread -- Vec<f64> is Send
     let data: Vec<f64> = unsafe { m.to_vec() };
@@ -259,7 +260,7 @@ is not available -- use `to_vec_coerced()` instead.
 | `bool` | `LGLSXP` (RLogical) | Logical conversion |
 
 ```rust
-#[miniextendr(unsafe(main_thread))]
+#[miniextendr]
 pub fn process_bool_matrix(m: RMatrix<bool>) -> Vec<bool> {
     unsafe { m.to_vec_coerced() }
 }
@@ -347,6 +348,6 @@ for row in 0..nrow {
 ## See Also
 
 - [Type Conversions](TYPE_CONVERSIONS.md) -- `TryFromSexp`/`IntoR` system
-- [`#[miniextendr]` Attribute](MINIEXTENDR_ATTRIBUTE.md) -- `unsafe(main_thread)` and other options
+- [`#[miniextendr]` Attribute](MINIEXTENDR_ATTRIBUTE.md) -- threading and other options
 - [Rayon Integration](RAYON.md) -- `with_r_matrix` and `new_r_matrix` for parallel matrix construction
 - [GC Protection](GC_PROTECT.md) -- Protecting allocated arrays from garbage collection

--- a/docs/archive/DOCS_META.md
+++ b/docs/archive/DOCS_META.md
@@ -614,7 +614,6 @@ Generates:
 #[miniextendr]                    // Basic usage
 #[miniextendr(invisible)]         // Force invisible return
 #[miniextendr(visible)]           // Force visible return
-#[miniextendr(unsafe(main_thread))] // Force main thread execution
 #[miniextendr(check_interrupt)]   // Check Ctrl+C before running
 ```
 
@@ -624,7 +623,6 @@ Generates:
 |-----------|----------|
 | Returns `SEXP` | Main thread |
 | Takes `Dots` (`...`) | Main thread |
-| `#[miniextendr(unsafe(main_thread))]` | Main thread |
 | `extern "C-unwind"` ABI | Main thread (direct C wrapper) |
 | Everything else | Worker thread |
 

--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -46,7 +46,7 @@
 //!
 //! Use `try_from_sexp_unchecked` when you're certain you're on the main thread:
 //! - Inside ALTREP callbacks
-//! - Inside `#[miniextendr(unsafe(main_thread))]` functions
+//! - Inside standalone `#[miniextendr]` functions (they run on the main thread)
 //! - Inside `extern "C-unwind"` functions called directly by R
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -526,8 +526,8 @@ impl_try_from_sexp_scalar_native!(crate::Rcomplex, CPLXSXP);
 ///
 /// # Safety
 ///
-/// SEXP handles are only valid on R's main thread. Use with
-/// `#[miniextendr(unsafe(main_thread))]` functions.
+/// SEXP handles are only valid on R's main thread. Standalone `#[miniextendr]`
+/// functions taking a `SEXP` parameter run on the main thread automatically.
 impl TryFromSexp for SEXP {
     type Error = SexpError;
 

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -38,7 +38,7 @@
 //!
 //! Use `into_sexp_unchecked` when you're certain you're on the main thread:
 //! - Inside ALTREP callbacks
-//! - Inside `#[miniextendr(unsafe(main_thread))]` functions
+//! - Inside standalone `#[miniextendr]` functions (they run on the main thread)
 //! - Inside `extern "C-unwind"` functions called directly by R
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/miniextendr-api/src/optionals/ndarray_impl.rs
+++ b/miniextendr-api/src/optionals/ndarray_impl.rs
@@ -1441,7 +1441,7 @@ use crate::rarray::{RArray, RArray3D, RMatrix, RVector};
 /// use miniextendr_api::rarray::RVector;
 /// use ndarray::ArrayView1;
 ///
-/// #[miniextendr(unsafe(main_thread))]
+/// #[miniextendr]
 /// fn vector_sum(v: RVector<f64>) -> f64 {
 ///     let view: ArrayView1<f64> = (&v).into();
 ///     view.sum()
@@ -1467,7 +1467,7 @@ impl<'a, T: RNativeType> From<&'a RVector<T>> for ArrayView1<'a, T> {
 /// use miniextendr_api::rarray::RMatrix;
 /// use ndarray::ArrayView2;
 ///
-/// #[miniextendr(unsafe(main_thread))]
+/// #[miniextendr]
 /// fn matrix_trace(m: RMatrix<f64>) -> f64 {
 ///     let view: ArrayView2<f64> = (&m).into();
 ///     view.diag().sum()
@@ -1521,7 +1521,7 @@ impl<'a, T: RNativeType, const NDIM: usize> From<&'a RArray<T, NDIM>> for ArrayV
 /// use miniextendr_api::rarray::RVector;
 /// use ndarray::Array1;
 ///
-/// #[miniextendr(unsafe(main_thread))]
+/// #[miniextendr]
 /// fn double_vector(v: RVector<f64>) -> Array1<f64> {
 ///     let arr: Array1<f64> = (&v).into();
 ///     arr * 2.0

--- a/miniextendr-api/src/rarray.rs
+++ b/miniextendr-api/src/rarray.rs
@@ -29,8 +29,9 @@
 //! from other threads. This is because the underlying R APIs (`DATAPTR_RO`, etc.)
 //! must be called on the R main thread.
 //!
-//! For functions that use `RArray`/`RMatrix` parameters, you must use
-//! `#[miniextendr(unsafe(main_thread))]` to ensure execution on the main thread.
+//! Functions that use `RArray`/`RMatrix` parameters run on the main thread
+//! automatically — these types are `!Send`, so the generated wrapper can only
+//! execute there. No attribute is required.
 //!
 //! For worker-thread usability, use [`to_vec()`][RArray::to_vec] to copy data
 //! on the main thread, then pass the owned `Vec` to worker threads.
@@ -76,8 +77,8 @@
 //! ```ignore
 //! use miniextendr_api::rarray::{RMatrix, RArray};
 //!
-//! // Must run on main thread due to RMatrix parameter
-//! #[miniextendr(unsafe(main_thread))]
+//! // Runs on the main thread due to the RMatrix parameter (RArray is !Send)
+//! #[miniextendr]
 //! fn matrix_sum(m: RMatrix<f64>) -> f64 {
 //!     unsafe { m.as_slice().iter().sum() }
 //! }
@@ -303,7 +304,7 @@ impl<T: RNativeType, const NDIM: usize> RArray<T, NDIM> {
     /// ```ignore
     /// use miniextendr_api::rarray::RMatrix;
     ///
-    /// #[miniextendr(unsafe(main_thread))]
+    /// #[miniextendr]
     /// fn process_matrix(m: RMatrix<f64>) -> f64 {
     ///     // Copy data - Vec<f64> is Send and can be used in worker threads
     ///     let data: Vec<f64> = unsafe { m.to_vec() };


### PR DESCRIPTION
Removes stale `unsafe(main_thread)` references from standalone-`#[miniextendr]`-function examples and prose. The fn-level option was deliberately removed in #245 (it was dead — codegen suppressed it with `let _ = (...)`), so these docs hand users a syntax that no longer parses.

<details>
<summary><h3>AI-written details</h3></summary>

## Why

For standalone `#[miniextendr]` functions, main-thread execution is now the **emergent default**: a fn taking `SEXP` / `RArray` / `RMatrix` arguments is `!Send`, so its generated C wrapper can only run on the main thread. There is **no replacement attribute** at the fn level — `unsafe(main_thread)` simply no longer exists there. (It remains valid on **impl methods** and **trait methods**, where the parser still accepts it.)

## Discrimination applied

Each hit was classified **standalone-fn vs impl-method/trait-method** by reading the surrounding code. Discriminator: is the `#[miniextendr...]` attribute on a free `pub fn`, or on a method inside an `impl` / trait block? Only **standalone-fn** occurrences were stripped.

- All edited occurrences sit on free functions (e.g. `fn matrix_sum(m: RMatrix<f64>)`, `fn vector_sum(v: RVector<f64>)`) or in fn-level prose / option tables.
- The still-valid **impl-option** references in macro source (`miniextendr-macros/src/miniextendr_impl.rs:1475,2449`, `miniextendr_impl_trait.rs:131`) were **left untouched** — they parse the live impl-method option.

## What changed

**Docs (`docs/*.md`):**
- `docs/MINIEXTENDR_ATTRIBUTE.md` — removed the `unsafe(main_thread)` option-table row + reworded the example (`#[miniextendr(unsafe(main_thread))]` → `#[miniextendr]`).
- `docs/RARRAY.md` — 5 standalone-fn example attributes stripped, the "must use `#[miniextendr(unsafe(main_thread))]`" prose reworded to "run on the main thread automatically", and the See-Also link text fixed.
- `docs/EXPRESSION_EVAL.md`, `docs/PROGRESS.md`, `docs/GAPS.md` — prose reworded so it reads correctly without the attribute (no dangling "use these inside blocks").
- `docs/archive/DOCS_META.md` — archived file, but the two edits were clean (an attribute-list example + an execution-strategy table row), so done here too.

**Rustdoc (all `ignore` blocks / prose — not doctests):**
- `miniextendr-api/src/rarray.rs` — module prose + 2 examples.
- `miniextendr-api/src/optionals/ndarray_impl.rs` — 3 standalone-fn examples.
- `miniextendr-api/src/from_r.rs`, `miniextendr-api/src/into_r.rs` — `_unchecked`-usage prose lists, reworded to refer to standalone `#[miniextendr]` functions.

Explanatory comments ("runs on main thread due to `RMatrix` param") were kept — still true.

## Verification

- `grep -rn 'unsafe(main_thread)' docs/ miniextendr-api/src/` → **no matches** remain in scope.
- Impl-method / trait-method references in macro source confirmed still present and untouched.
- Nothing under `site/` staged (that dir is gitignored / CI-regenerated from `docs/`).
- No compile needed — all edited sites are `ignore` blocks or prose.

## Caveats

- Macro-source impl-option references intentionally left in place (they back the still-valid impl/trait-method option).

</details>

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
