### PR TITLE
ci: harden `Install rv` recipe against transient API/CDN failures (#738)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1175,9 +1175,16 @@ jobs:
           use-public-rspm: true
 
       - name: Install rv (for .Rprofile activate.R)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RV_VERSION=$(curl -sSL https://api.github.com/repos/A2-ai/rv/releases/latest | sed -n 's/.*"tag_name": "\(v[^"]*\)".*/\1/p')
-          curl -sSL "https://github.com/A2-ai/rv/releases/download/${RV_VERSION}/rv-${RV_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/rv.tar.gz
+          set -euo pipefail
+          RV_VERSION=$(gh api repos/A2-ai/rv/releases/latest --jq .tag_name)
+          : "${RV_VERSION:?empty rv version}"
+          curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --location \
+               --silent --show-error --fail \
+               "https://github.com/A2-ai/rv/releases/download/${RV_VERSION}/rv-${RV_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+               -o /tmp/rv.tar.gz
           # Tarball ships a flat `rv` binary at the top level — no subdir.
           tar -xzf /tmp/rv.tar.gz -C /tmp
           sudo install -m 0755 /tmp/rv /usr/local/bin/rv


### PR DESCRIPTION
## Problem

The `Install rv (for .Rprofile activate.R)` step in `.github/workflows/ci.yml` (Bootstrap Vendor Test job) read `releases/latest` with `curl -sSL | sed` and had no error checking. A transient GitHub API / release-CDN hiccup silently produced a non-gzip download and `tar` choked downstream.

### Failure chain (as filed in #738)

1. `curl -sSL` (no `--fail`) swallows HTTP/rate-limit errors → JSON error body or empty output.
2. `sed -n '…/p'` → empty `RV_VERSION=""` on no-match.
3. The next `curl -sSL` downloads `.../download//rv--x86_64-unknown-linux-gnu.tar.gz` → 404 HTML written to `/tmp/rv.tar.gz`.
4. `tar -xzf` → `gzip: stdin: not in gzip format` → exit 2.

No `set -euo pipefail`, no `[ -n "$RV_VERSION" ]` guard, no `curl --fail`, no API retry. This broke main's Bootstrap Vendor Test on `1d3d5051` despite healthy assets — the proximate cause was almost certainly an unauthenticated-API rate-limit miss on `releases/latest`.

## Hardened pattern applied

```yaml
- name: Install rv (for .Rprofile activate.R)
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    set -euo pipefail
    RV_VERSION=$(gh api repos/A2-ai/rv/releases/latest --jq .tag_name)
    : "${RV_VERSION:?empty rv version}"
    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --location \
         --silent --show-error --fail \
         "https://github.com/A2-ai/rv/releases/download/${RV_VERSION}/rv-${RV_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
         -o /tmp/rv.tar.gz
    tar -xzf /tmp/rv.tar.gz -C /tmp
    sudo install -m 0755 /tmp/rv /usr/local/bin/rv
    rv --version
```

- `set -euo pipefail` aborts on first failure instead of carrying empty/garbage state forward.
- `gh api … --jq .tag_name` uses the authenticated token (no anonymous rate-limit) and proper JSON parsing — no fragile `sed` on the API response body.
- `: "${RV_VERSION:?…}"` fails loudly if version extraction somehow still produces empty.
- `curl --fail --retry 5 --retry-connrefused` turns HTTP errors into curl exits and retries transient network problems.
- Added `GITHUB_TOKEN` env for the authenticated `gh api` call.

## Blocks / files swept

| File | Blocks hardened |
|---|---|
| `.github/workflows/ci.yml` | 1 (Bootstrap Vendor Test — only `Install rv` block in the repo) |

The issue referenced `r-tests.yml` and "others", but a full sweep (`grep -rn 'Install rv\|rv/releases\|releases/latest' .github/workflows/` plus broader `A2-ai/rv` / `rv.tar.gz` / `/usr/local/bin/rv` searches) found only this single block. `r-tests.yml` no longer exists — those jobs were consolidated into `ci.yml`. The `pages.yml` / `mirror-webr.yml` `rv` hits are unrelated false positives ("preserve", "Copying").

## Per-block deviations

- **Target triple preserved**: kept the original `x86_64-unknown-linux-gnu` (Linux amd64 runner) — not blindly forced. No non-amd64 / macOS `Install rv` blocks exist.
- **No pinned versions**: the block uses `latest`, so version intent is preserved (no swap).

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK.
- `actionlint .github/workflows/ci.yml` → no issues in the edited block (1177–1191); only pre-existing, unrelated SC2086 infos elsewhere.
- Re-grep for fragile `curl -sSL … releases/latest | sed` → none remain.
- Spot-read of the edited block confirmed.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
