### PR TITLE
test(api): characterise + cover runtime_shutdown with a job in flight (#734)

### DIFF
--- a/miniextendr-api/tests/worker_shutdown.rs
+++ b/miniextendr-api/tests/worker_shutdown.rs
@@ -48,6 +48,152 @@ fn worker_exits_after_runtime_shutdown() {
     );
 }
 
+/// `miniextendr_runtime_shutdown` while a **pure-Rust** job is in flight.
+///
+/// # What this characterises (issue #734)
+///
+/// #734 asks what happens when shutdown fires mid-job. The honest answer
+/// depends entirely on *which thread* drives the in-flight job, and the
+/// channel topology makes only one shape reachable in production:
+///
+/// - The main→worker channel is `sync_channel::<WorkerMsg>(0)` — a
+///   **rendezvous** channel. A `send` blocks until the worker is actively
+///   in `recv()`.
+/// - While a job runs, the worker is inside `job()`, *not* in `recv()`.
+///   So `shutdown()`'s `tx.send(WorkerMsg::Shutdown)` **blocks** until the
+///   job finishes and the worker loops back to `recv()`.
+/// - `JoinHandle::join()` then completes once the worker breaks out.
+///
+/// **Net behaviour for a pure-Rust job: `shutdown()` blocks until the
+/// in-flight job completes, then joins.** It does NOT abort the job and
+/// does NOT return early — so `R_unload_<pkg>` cannot unmap the DLL while
+/// a pure-Rust worker job is still executing. No use-after-unmap window
+/// for this shape.
+///
+/// # Why the issue's deadlock scenario is unreachable in production
+///
+/// The issue worries about `R_unload_<pkg>` firing mid-`with_r_thread`.
+/// That can't happen on the same thread: R is single-threaded, and
+/// `R_unload_<pkg>` only runs once every `.Call` has returned — i.e. once
+/// every `run_on_worker` on the main thread has already received `Done`
+/// and the worker is back parked on `recv()` (the *idle* case, covered by
+/// `worker_exits_after_runtime_shutdown` above). `dispatch_to_worker`
+/// drives its event loop on the calling thread; the main thread cannot be
+/// blocked in that loop *and* be executing `R_unload_<pkg>` at the same
+/// time.
+///
+/// A genuine deadlock requires `shutdown()` on a *different* thread than
+/// the one driving a `with_r_thread`-blocked job — which in turn requires
+/// `run_on_worker` to have been dispatched from a non-main thread, already
+/// a `debug_assert` violation (#730). So we deliberately do NOT exercise
+/// that path here: it would hang (correctly — the comment in `shutdown()`
+/// explains the no-timeout choice surfaces such hangs rather than masking
+/// them), and a `with_r_thread`-from-shutdown round-trip belongs in an
+/// rpkg testthat fixture with R's top-level handler in place, not a raw
+/// cargo harness (#733).
+///
+/// This test drives the *reachable* shape: a pure-Rust job in flight,
+/// shutdown from a concurrent thread, asserting shutdown waits for the job.
+#[test]
+#[cfg(feature = "worker-thread")]
+fn shutdown_waits_for_in_flight_pure_rust_job() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use miniextendr_api::worker::{is_r_main_thread, run_on_worker};
+
+    // Signals the job sets when it has actually started running on the
+    // worker, and a flag it sets right before it returns.
+    let started = Arc::new(AtomicBool::new(false));
+    let finished = Arc::new(AtomicBool::new(false));
+    // Lets the test thread observe, after the fact, whether shutdown
+    // returned before the job had marked itself finished.
+    let job_done_before_shutdown_returned = Arc::new(AtomicBool::new(false));
+
+    // The job must run via `run_on_worker` dispatched from the R main
+    // thread (the #730 invariant). `dispatch_to_worker` then drives its
+    // event loop on that same thread and blocks until `Done`. So we run
+    // the dispatch on the R-test-main thread and fire `shutdown()` from a
+    // separate observer thread once the job is confirmed running.
+    let started_for_job = Arc::clone(&started);
+    let finished_for_job = Arc::clone(&finished);
+
+    // Spawn the observer that will call shutdown once the job is running.
+    let started_obs = Arc::clone(&started);
+    let finished_obs = Arc::clone(&finished);
+    let done_before = Arc::clone(&job_done_before_shutdown_returned);
+    let observer = std::thread::spawn(move || {
+        // Wait until the job signals it is executing on the worker.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !started_obs.load(Ordering::Acquire) {
+            assert!(
+                Instant::now() < deadline,
+                "in-flight job never started within 5 s"
+            );
+            std::thread::yield_now();
+        }
+
+        // Job is now running on the worker (mid pure-Rust work). Call
+        // shutdown from THIS thread, concurrent with the live job. The
+        // rendezvous `tx.send(Shutdown)` must block until the worker
+        // finishes the job and loops back to `recv()`, then `join()`.
+        let start = Instant::now();
+        miniextendr_api::worker::miniextendr_runtime_shutdown();
+        let elapsed = start.elapsed();
+
+        // Core characterisation: by the time shutdown returned, the job
+        // must have finished — shutdown waited for the in-flight job
+        // rather than racing the DLL unmap against a live worker.
+        done_before.store(finished_obs.load(Ordering::Acquire), Ordering::Release);
+
+        // Generous upper bound: the job sleeps ~300 ms; shutdown should
+        // return shortly after that, well under the deadline. A regression
+        // that wedges shutdown forever fails here instead of hanging CI.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "shutdown did not return within 10 s with a pure-Rust job in flight \
+             (took {elapsed:?}) — possible deadlock regression"
+        );
+    });
+
+    // Drive the dispatch on the R main thread.
+    r_test_utils::with_r_thread(move || {
+        assert!(
+            is_r_main_thread(),
+            "dispatch must happen on the R main thread (#730 invariant)"
+        );
+
+        let r = run_on_worker(move || {
+            // We are now ON the worker thread, inside an in-flight job.
+            started_for_job.store(true, Ordering::Release);
+            // Pure-Rust work only — NO `with_r_thread`. A bounded sleep
+            // stands in for "computation still running" so the observer
+            // thread has time to fire shutdown while we're live.
+            std::thread::sleep(Duration::from_millis(300));
+            finished_for_job.store(true, Ordering::Release);
+            99i32
+        });
+
+        // The job completes normally even though shutdown was racing it:
+        // shutdown's rendezvous `send` only lands once we return here and
+        // the worker loops back to `recv()`.
+        assert_eq!(r, Ok(99), "in-flight job result lost across shutdown race");
+    });
+
+    observer.join().expect("observer thread panicked");
+
+    assert!(
+        finished.load(Ordering::Acquire),
+        "in-flight job never marked finished"
+    );
+    assert!(
+        job_done_before_shutdown_returned.load(Ordering::Acquire),
+        "shutdown returned BEFORE the in-flight pure-Rust job finished — \
+         this is the #277 / #734 use-after-unmap window: the DLL could be \
+         unmapped while the worker is still executing job code"
+    );
+}
+
 #[test]
 #[cfg(not(feature = "worker-thread"))]
 fn shutdown_is_noop_without_worker_thread_feature() {


### PR DESCRIPTION
Follow-up to #731 (overlaps #277). #731 covered shutdown when the worker is idle (parked on `recv()`) and the blocking-`join()` invariant. This adds coverage + a precise characterisation for shutdown **while a job is in flight**, which was the open gap.

<details>
<summary><h3>AI-written details</h3></summary>

## What I characterised

The behaviour depends entirely on *which thread* drives the in-flight job, and the channel topology makes only one shape reachable in production:

- The main→worker channel is `sync_channel::<WorkerMsg>(0)` — a **capacity-0 rendezvous** channel. A `send` blocks until the worker is actively in `recv()`.
- While a job runs, the worker is inside `job()`, **not** in `recv()`. So `shutdown()`'s `tx.send(WorkerMsg::Shutdown)` **blocks** until the job finishes and the worker loops back to `recv()`. `JoinHandle::join()` then completes.

**Net behaviour for a pure-Rust job: `shutdown()` blocks until the in-flight job completes, then joins.** It does NOT abort the job and does NOT return early — so `R_unload_<pkg>` cannot unmap the DLL while a pure-Rust worker job is still executing. No use-after-unmap window for this shape.

### Why the issue's deadlock scenario is unreachable in production

The issue worries about `R_unload_<pkg>` firing mid-`with_r_thread`. That cannot happen on the same thread: R is single-threaded, and `R_unload_<pkg>` only runs once every `.Call` has returned — i.e. once every main-thread `run_on_worker` has already received `Done` and the worker is back parked on `recv()` (the *idle* case, already covered by `worker_exits_after_runtime_shutdown`). `dispatch_to_worker` drives its event loop on the calling thread; the main thread cannot be blocked in that loop **and** be executing `R_unload_<pkg>` simultaneously.

A genuine deadlock requires `shutdown()` on a *different* thread than the one driving a `with_r_thread`-blocked job — which in turn requires `run_on_worker` to have been dispatched from a non-main thread, already a `debug_assert` violation (#730). I deliberately did NOT exercise that path: it would hang (correctly — the no-timeout choice in `shutdown()` surfaces such hangs rather than masking them), and a `with_r_thread`-under-shutdown round-trip belongs in an rpkg testthat fixture with R's top-level handler in place, not a raw cargo harness (per #733).

## What changed

- `miniextendr-api/tests/worker_shutdown.rs`: new `shutdown_waits_for_in_flight_pure_rust_job` (feature-gated on `worker-thread`). Dispatches a pure-Rust job (bounded sleep, no `with_r_thread`) from the R main thread, fires `miniextendr_runtime_shutdown()` from a concurrent observer thread once the job is confirmed running, and asserts (a) the job's result survives (`Ok(99)`), (b) shutdown returned only *after* the job marked itself finished — i.e. shutdown waited for the live job, no DLL-unmap race. Bounded with generous deadlines so a regression that wedges shutdown fails loudly instead of hanging CI.
- **Home rationale**: `worker_shutdown.rs` already owns the shutdown semantics and is its own integration binary, so taking the worker down here cannot disrupt other test binaries that need a live worker.

## No bug found

The reachable in-flight shape (pure-Rust job) is **correct**: shutdown waits. The issue's hypothesised deadlock is only reachable through an already-asserted-against misuse (#730), so no fix and no new follow-up issue — the existing #730 / #733 framing covers it.

## Test plan

- [x] `cargo test -p miniextendr-api --test worker_shutdown --features worker-thread,nonapi` — both tests pass (new test ~0.38s, confirming the ~300 ms sleep + shutdown-waits ordering).
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (default features) clean — imports moved inside the feature-gated test so the no-`worker-thread` build has no unused-import warnings.
- [x] `cargo clippy -p miniextendr-api --tests --features worker-thread,nonapi -- -D warnings` clean.
- [x] `cargo fmt --all` clean.

_Drafted by Claude (claude-opus-4-8 [1m]). Reviewed by the author._

</details>

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)
