### PR TITLE
refactor(macros): emit integer ALTREP trait impls directly (Path A spike, #711)

### DIFF
--- a/analysis/altrep-path-a-procmacro-2026-06-09.md
+++ b/analysis/altrep-path-a-procmacro-2026-06-09.md
@@ -1,0 +1,134 @@
+# ALTREP Path (a): declarative macros → proc-macro direct emit (#711)
+
+Spike date: 2026-06-09. Tracks Path (a) from #682 (follow-up to the Path (b)
+consolidation landed in PR #713).
+
+## Goal
+
+Make `#[derive(AltrepInteger)]` (+ Real/Logical/Raw/String/Complex/List) parse
+the `#[altrep(dataptr|serialize|subset|…)]` attributes and **emit the underlying
+trait impls directly**, removing the `impl_alt<family>_from_data!`
+declarative-macro indirection. The declarative macros stay public (hand-rolled
+`optionals/{arrow,nalgebra,ndarray}_impl.rs` call sites depend on them); the
+proc-macro just stops *delegating* to them.
+
+## What this spike actually did
+
+Migrated **one family — integer** — as a feasibility proof. The other 6
+families still delegate to their declarative macros (`emit_direct: false`).
+
+### The 6-arm option matrix → proc-macro emit
+
+Every `impl_alt<family>_from_data!` arm expands to exactly four items. The
+mapping the proc-macro now reproduces directly:
+
+| Arm | `impl Altrep` | `impl AltVec` | `impl Alt<Family>` | `impl InferBase` |
+|---|---|---|---|---|
+| `($ty)` | `__impl_altrep_base!(ty, RUnwind)` | `__impl_altvec_integer_dataptr!` (materializing) | `__impl_altinteger_methods!` | `impl_inferbase_integer!` |
+| `($ty, dataptr)` | `__impl_altrep_base!(ty, RUnwind)` | `__impl_altvec_dataptr!(ty, i32)` | ″ | ″ |
+| `($ty, serialize)` | `__impl_altrep_base!(ty, RUnwind, with_serialize)` | materializing | ″ | ″ |
+| `($ty, subset)` | `__impl_altrep_base!(ty, RUnwind)` | `__impl_altvec_extract_subset!` | ″ | ″ |
+| `($ty, dataptr, serialize)` | `…RUnwind, with_serialize` | `__impl_altvec_dataptr!(ty, i32)` | ″ | ″ |
+| `($ty, subset, serialize)` | `…RUnwind, with_serialize` | `__impl_altvec_extract_subset!` | ″ | ″ |
+
+So the option matrix reduces to three orthogonal booleans driving small,
+independent emit decisions:
+
+- `has_serialize` → flips the base macro to the `with_serialize` arm.
+- `has_dataptr` vs `has_subset` vs neither → selects the `AltVec` impl.
+- (family is fixed per derive entry point → `methods_macro` + `inferbase_macro`).
+
+`validate_options` already rejects `dataptr + subset` and `subset` on
+unsupported families at the derive call site, so the proc-macro never has to
+emit an illegal combination.
+
+### Implementation shape (the shared emit helper the other 6 families reuse)
+
+The emit lives in `AltrepAttrs::generate_lowlevel_direct` in
+`miniextendr-macros/src/altrep_derive.rs`. It is **fully family-generic** — it
+reads everything family-specific off the existing `AltrepFamilyConfig`:
+
+- `dataptr_macro: Option<(&str, Option<TokenStream>)>` — the typed dataptr macro
+  + element type (already present).
+- `methods_macro`, `inferbase_macro`, `default_guard` — already present.
+- `materializing_dataptr_macro: &str` — **new** field naming the per-family
+  materializing dataptr macro (`__impl_altvec_<family>_dataptr`) used on the
+  default/serialize arms.
+- `emit_direct: bool` — **new** per-family switch. `generate_lowlevel` early-
+  returns into `generate_lowlevel_direct` when set.
+
+To migrate a remaining family, flip `emit_direct: true` and set
+`materializing_dataptr_macro` on its `AltrepFamilyConfig` — no new emit code.
+The helper already handles every arm for every atomic family. Complex/raw/real/
+logical are structurally identical to integer; only the string and list
+families need extra attention (see below).
+
+### Folding the two prior code paths into one
+
+Pre-#711 the derive had two paths:
+
+1. **Simple path** (default `RUnwind` guard, no `subset`) → delegate to
+   `impl_alt<family>_from_data!`.
+2. **Expanded path** (non-default guard OR `subset`) → emit the `__impl_*`
+   macros directly.
+
+The expanded path's `AltVec` choice for the *no-dataptr/no-subset* case was a
+**bare `impl AltVec {}`** (non-materializing) — different from the simple
+path's materializing macro. This was an accident of the split, only reachable
+with a non-default guard. The direct path preserves that exact behavior
+(branch on `has_non_default_guard()`) so the migration is a pure de-indirection
+with zero semantic drift. No production fixture uses a non-default guard on any
+ALTREP derive, so this branch is exercised only by the proc-macro unit tests.
+(A future cleanup could make non-default-guard + no-options materialize like
+everything else — arguably a latent bug fix — but that is out of scope for a
+behaviour-preserving spike.)
+
+## Byte-equivalence argument
+
+The emitted trait surface is byte-equivalent to delegating to
+`impl_altinteger_from_data!` for every default-guard arm:
+
+- `__impl_altrep_base!(ty)` ≡ `__impl_altrep_base!(ty, RUnwind)` (the no-guard
+  arm forwards to the `RUnwind` arm), and `__impl_altrep_base!(ty,
+  with_serialize)` ≡ `__impl_altrep_base!(ty, RUnwind, with_serialize)`.
+- the `AltVec` / methods / inferbase macros are emitted with identical
+  arguments.
+
+Empirical confirmation: `git status` shows `rpkg/R/miniextendr-wrappers.R`,
+`rpkg/NAMESPACE`, and `rpkg/src/rust/wasm_registry.rs` **all unchanged** after
+the migration. Those artifacts are generated from the emitted trait surface; if
+the surface had drifted, they would have changed. `cargo check -p
+miniextendr-api -p miniextendr-macros` passes and the full
+`cargo test -p miniextendr-macros` suite (324 tests, incl. trybuild UI tests)
+is green.
+
+## Estimated effort / risk per remaining family
+
+Per the issue, the heavy work is the first family; the rest reuse
+`generate_lowlevel_direct`.
+
+| Family | Effort | Risk | Notes |
+|---|---|---|---|
+| **real** | trivial | low | structurally identical to integer; flip `emit_direct`, set `materializing_dataptr_macro`. |
+| **logical** | trivial | low | same; logical `elt` quirk lives in `__impl_altlogical_methods`, not the emit path. |
+| **raw** | trivial | low | same; raw has no `sum/min/max`, irrelevant to emit. |
+| **complex** | trivial | low | same; element type is `::miniextendr_api::Rcomplex`. |
+| **string** | small | medium | `dataptr_macro = None`, `string_dataptr = true`. The default/dataptr arms both route through `__impl_altvec_string_dataptr!` (no typed contiguous pointer). `generate_lowlevel_direct` needs a string branch: when `string_dataptr`, the `has_dataptr` and default arms both emit `__impl_altvec_string_dataptr!`. Modest extra branch; raw `Rf_protect`/`Rf_unprotect` discipline already lives inside the macro, untouched. |
+| **list** | small–medium | medium | List has its **own** derive entry (`derive_altrep_list`) that does not use `AltrepFamilyConfig` at all and already emits `impl Altrep`/`AltVec`/`AltList`/`InferBase` inline for the serialize case. Migrating list means either folding it into the generic helper (it rejects `dataptr`/`subset`, so only the default + `serialize` arms exist) or leaving it as-is (it is already mostly "direct"). Lowest value of the seven. |
+
+Cross-cutting risk for the whole migration: **gctorture sweep**. The integer
+spike changed no emitted bytes, so the existing gctorture coverage still
+applies. Once a family's emit genuinely diverges (it should not, if done as a
+pure de-indirection), run the `gctorture(TRUE)` harness over the ALTREP
+fixtures per `docs/GCTORTURE_TESTING.md`.
+
+## Recommendation
+
+**Proceed with the migration via the follow-up issue.** The spike proves the
+approach is clean, the emitted surface is byte-equivalent, and the shared
+`generate_lowlevel_direct` helper makes the remaining 5 atomic families nearly
+mechanical. The declarative macros stay public for the `optionals/*` hand-rolled
+call sites, exactly as #711 requires. The only families needing real thought
+are string (extra `string_dataptr` branch) and list (separate entry point, low
+value). This is the right de-indirection; #711 should be closed by the
+follow-up that finishes the remaining families.

--- a/miniextendr-macros/src/altrep_derive.rs
+++ b/miniextendr-macros/src/altrep_derive.rs
@@ -90,6 +90,26 @@ struct AltrepFamilyConfig<'a> {
     /// String family uses `RUnwind` because elt/dataptr call R APIs (Rf_mkCharLenCE).
     /// All families now default to `RUnwind`.
     default_guard: &'a str,
+    /// Emit the underlying `__impl_*` trait-impl macros directly instead of
+    /// delegating to the family's `impl_alt<family>_from_data!` declarative
+    /// macro (Path (a) from #682 / #711).
+    ///
+    /// When `true`, [`AltrepAttrs::generate_lowlevel`] routes through
+    /// [`AltrepAttrs::generate_lowlevel_direct`], which reproduces the exact
+    /// declarative-macro arm expansions from the proc-macro. The emitted trait
+    /// surface is byte-equivalent to the delegated path; only the indirection
+    /// is removed. Currently set only for the integer family (the migration
+    /// spike); the remaining families still delegate.
+    ///
+    /// `materializing_dataptr_macro` carries the per-family materializing
+    /// dataptr macro name (e.g. `"__impl_altvec_integer_dataptr"`) used on the
+    /// default/serialize arms; only consulted when `emit_direct` is `true`.
+    emit_direct: bool,
+    /// Family-specific materializing dataptr macro (e.g.
+    /// `"__impl_altvec_integer_dataptr"`). Only meaningful when `emit_direct`
+    /// is `true`; the default/serialize arms use it to install the trivial
+    /// `AltrepDataptr` + materializing `AltVec`.
+    materializing_dataptr_macro: &'a str,
 }
 
 /// Parsed `#[altrep(...)]` attributes controlling ALTREP derive code generation.
@@ -342,6 +362,117 @@ impl AltrepAttrs {
     /// # Errors
     ///
     /// Returns `Err` if option validation fails (e.g., `subset` on an unsupported family).
+    /// Path (a) emit: reproduce the `impl_alt<family>_from_data!` arm
+    /// expansions directly from the proc-macro, with no declarative-macro hop.
+    ///
+    /// This is the #682/#711 migration. The emitted trait surface is
+    /// byte-equivalent to delegating to `impl_alt<family>_from_data!` — the four
+    /// items every arm produces are:
+    ///
+    /// 1. `__impl_altrep_base!(Ty, <guard>[, with_serialize])` — `impl Altrep`.
+    /// 2. an `AltVec` impl, one of:
+    ///    - materializing (`materializing_dataptr_macro`) — default/serialize arms,
+    ///    - direct dataptr (`__impl_altvec_dataptr!(Ty, <elem>)`) — `dataptr` arm,
+    ///    - subset (`__impl_altvec_extract_subset!`) — `subset` arm,
+    /// 3. `methods_macro!(Ty)` — the family `Alt<Family>` impl,
+    /// 4. `inferbase_macro!(Ty)` — `impl InferBase`.
+    ///
+    /// Folding the declarative macro's "simple path" and the proc-macro's prior
+    /// "expanded path" into one: the guard is honoured uniformly (the declarative
+    /// macro only handled the default `RUnwind` guard; non-default guards used the
+    /// old expanded path) and option combinations are validated at the derive
+    /// call site rather than 7 hops deep in macro expansion.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if option validation fails (delegated to the caller, which
+    /// has already run `validate_options`).
+    fn generate_lowlevel_direct(
+        &self,
+        name: &syn::Ident,
+        generics: &syn::Generics,
+        family: &AltrepFamilyConfig,
+    ) -> syn::Result<TokenStream> {
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+        let AltrepFamilyConfig {
+            ref dataptr_macro,
+            methods_macro,
+            inferbase_macro,
+            default_guard,
+            materializing_dataptr_macro,
+            ..
+        } = *family;
+
+        let has_serialize = self.lowlevel_options.iter().any(|o| o == "serialize");
+        let has_dataptr = self.lowlevel_options.iter().any(|o| o == "dataptr");
+        let has_subset = self.lowlevel_options.iter().any(|o| o == "subset");
+
+        let guard = self
+            .guard
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| syn::Ident::new(default_guard, proc_macro2::Span::call_site()));
+
+        // 1. Altrep base. The declarative macro's default/dataptr/subset arms use
+        //    `__impl_altrep_base!($ty)` (default RUnwind guard); the `*serialize`
+        //    arms use `__impl_altrep_base!($ty, with_serialize)`. We additionally
+        //    thread an explicit guard so non-default guards no longer need a
+        //    separate code path.
+        let base_impl = if has_serialize {
+            quote! { ::miniextendr_api::__impl_altrep_base!(#name #ty_generics, #guard, with_serialize); }
+        } else {
+            quote! { ::miniextendr_api::__impl_altrep_base!(#name #ty_generics, #guard); }
+        };
+
+        // 2. AltVec impl. Mirrors the per-arm choice in `impl_alt<family>_from_data!`:
+        //    - `dataptr` arm -> direct `__impl_altvec_dataptr!($ty, $elem)`,
+        //    - `subset` arm  -> `__impl_altvec_extract_subset!`,
+        //    - default / serialize arms -> the family materializing dataptr macro
+        //      (e.g. `__impl_altvec_integer_dataptr!`), which installs a trivial
+        //      `AltrepDataptr` returning `None` then delegates to
+        //      `__impl_altvec_dataptr!`.
+        let vec_impl = if has_dataptr {
+            let (macro_name, elem_ty) = dataptr_macro
+                .as_ref()
+                .expect("emit_direct family must define a typed dataptr macro");
+            let dp_macro = syn::Ident::new(macro_name, proc_macro2::Span::call_site());
+            let elem = elem_ty
+                .as_ref()
+                .expect("emit_direct dataptr macro must carry an element type");
+            quote! { ::miniextendr_api::#dp_macro!(#name #ty_generics, #elem); }
+        } else if has_subset {
+            quote! { ::miniextendr_api::__impl_altvec_extract_subset!(#name #ty_generics); }
+        } else if self.has_non_default_guard() {
+            // Behaviour-preservation: the pre-#711 expanded path (the only path
+            // that handled non-default guards) emitted a *bare* `impl AltVec`
+            // for the no-dataptr/no-subset case — NOT the materializing macro.
+            // Match that exactly so this migration is a pure de-indirection
+            // with no semantic drift. (No production fixture uses a non-default
+            // guard on an integer ALTREP, so this branch is exercised only by
+            // the proc-macro unit tests.)
+            quote! { impl #impl_generics ::miniextendr_api::altrep_traits::AltVec for #name #ty_generics #where_clause {} }
+        } else {
+            let mat_macro =
+                syn::Ident::new(materializing_dataptr_macro, proc_macro2::Span::call_site());
+            quote! { ::miniextendr_api::#mat_macro!(#name #ty_generics); }
+        };
+
+        // 3. Family method impl (`impl Alt<Family>`).
+        let methods_ident = syn::Ident::new(methods_macro, proc_macro2::Span::call_site());
+        let methods_impl = quote! { ::miniextendr_api::#methods_ident!(#name #ty_generics); };
+
+        // 4. InferBase.
+        let inferbase_ident = syn::Ident::new(inferbase_macro, proc_macro2::Span::call_site());
+        let inferbase_impl = quote! { ::miniextendr_api::#inferbase_ident!(#name #ty_generics); };
+
+        Ok(quote! {
+            #base_impl
+            #vec_impl
+            #methods_impl
+            #inferbase_impl
+        })
+    }
+
     fn generate_lowlevel(
         &self,
         name: &syn::Ident,
@@ -357,6 +488,10 @@ impl AltrepAttrs {
             methods_macro,
             inferbase_macro,
             default_guard,
+            emit_direct,
+            // Consumed only by `generate_lowlevel_direct` (which re-reads it
+            // from `family`); the early-return below means it is unused here.
+            materializing_dataptr_macro: _,
         } = *family;
         let altvec_dataptr_macro = dataptr_macro;
         let altvec_string_dataptr = string_dataptr;
@@ -366,6 +501,13 @@ impl AltrepAttrs {
         }
 
         self.validate_options(macro_base, altvec_subset)?;
+
+        // Path (a) from #682 / #711: emit the underlying trait-impl macros
+        // directly, bypassing the `impl_alt<family>_from_data!` declarative
+        // macro entirely. Currently only the integer family is migrated.
+        if emit_direct {
+            return self.generate_lowlevel_direct(name, generics, family);
+        }
 
         let has_serialize = self.lowlevel_options.iter().any(|o| o == "serialize");
         let has_dataptr = self.lowlevel_options.iter().any(|o| o == "dataptr");
@@ -566,6 +708,12 @@ pub fn derive_altrep_integer(input: syn::DeriveInput) -> syn::Result<TokenStream
             methods_macro: "__impl_altinteger_methods",
             inferbase_macro: "impl_inferbase_integer",
             default_guard: "RUnwind",
+            // Migration spike (#711 / Path (a) of #682): the integer family
+            // emits its trait impls directly, bypassing the declarative
+            // `impl_altinteger_from_data!` macro. Remaining families still
+            // delegate (`emit_direct: false`) pending the follow-up issue.
+            emit_direct: true,
+            materializing_dataptr_macro: "__impl_altvec_integer_dataptr",
         },
     )
 }
@@ -599,6 +747,8 @@ pub fn derive_altrep_real(input: syn::DeriveInput) -> syn::Result<TokenStream> {
             methods_macro: "__impl_altreal_methods",
             inferbase_macro: "impl_inferbase_real",
             default_guard: "RUnwind",
+            emit_direct: false,
+            materializing_dataptr_macro: "__impl_altvec_real_dataptr",
         },
     )
 }
@@ -632,6 +782,8 @@ pub fn derive_altrep_logical(input: syn::DeriveInput) -> syn::Result<TokenStream
             methods_macro: "__impl_altlogical_methods",
             inferbase_macro: "impl_inferbase_logical",
             default_guard: "RUnwind",
+            emit_direct: false,
+            materializing_dataptr_macro: "__impl_altvec_logical_dataptr",
         },
     )
 }
@@ -665,6 +817,8 @@ pub fn derive_altrep_raw(input: syn::DeriveInput) -> syn::Result<TokenStream> {
             methods_macro: "__impl_altraw_methods",
             inferbase_macro: "impl_inferbase_raw",
             default_guard: "RUnwind",
+            emit_direct: false,
+            materializing_dataptr_macro: "__impl_altvec_raw_dataptr",
         },
     )
 }
@@ -702,6 +856,11 @@ pub fn derive_altrep_string(input: syn::DeriveInput) -> syn::Result<TokenStream>
             // String elt calls Rf_mkCharLenCE; dataptr calls Rf_allocVector + SET_STRING_ELT.
             // These R API calls can longjmp — must use RUnwind.
             default_guard: "RUnwind",
+            emit_direct: false,
+            // String has no typed contiguous dataptr; its default/dataptr arms
+            // both route through `__impl_altvec_string_dataptr!`. Inert until
+            // string is migrated (`emit_direct: false`).
+            materializing_dataptr_macro: "__impl_altvec_string_dataptr",
         },
     )
 }
@@ -742,6 +901,8 @@ pub fn derive_altrep_complex(input: syn::DeriveInput) -> syn::Result<TokenStream
             methods_macro: "__impl_altcomplex_methods",
             inferbase_macro: "impl_inferbase_complex",
             default_guard: "RUnwind",
+            emit_direct: false,
+            materializing_dataptr_macro: "__impl_altvec_complex_dataptr",
         },
     )
 }

--- a/miniextendr-macros/src/tests.rs
+++ b/miniextendr-macros/src/tests.rs
@@ -327,8 +327,16 @@ fn test_derive_altrep_integer_basic() {
     assert!(output_str.contains("AltIntegerData"));
     assert!(output_str.contains("fn elt"));
 
-    // Should call impl_altinteger_from_data!
-    assert!(output_str.contains("impl_altinteger_from_data"));
+    // Path (a) / #711: the integer family emits the underlying trait-impl
+    // macros directly — it no longer delegates to impl_altinteger_from_data!.
+    assert!(
+        !output_str.contains("impl_altinteger_from_data"),
+        "migrated integer family must not delegate to the declarative macro"
+    );
+    assert!(output_str.contains("__impl_altrep_base"));
+    assert!(output_str.contains("__impl_altvec_integer_dataptr"));
+    assert!(output_str.contains("__impl_altinteger_methods"));
+    assert!(output_str.contains("impl_inferbase_integer"));
 
     // Registration: TypedExternal
     assert!(
@@ -857,8 +865,13 @@ fn test_derive_altrep_integer_r_unwind_guard() {
     let output = crate::altrep_derive::derive_altrep_integer(input).unwrap();
     let output_str = output.to_string();
 
-    // RUnwind is the default guard — should use the high-level macro
-    assert!(output_str.contains("impl_altinteger_from_data"));
+    // RUnwind is the default guard. Pre-#711 this used the high-level
+    // impl_altinteger_from_data! macro; the integer family now emits the
+    // underlying __impl_* macros directly (with the default RUnwind guard).
+    assert!(!output_str.contains("impl_altinteger_from_data"));
+    assert!(output_str.contains("__impl_altrep_base"));
+    assert!(output_str.contains("__impl_altvec_integer_dataptr"));
+    assert!(output_str.contains("RUnwind"));
 }
 
 #[test]


### PR DESCRIPTION
Feasibility spike for Path (a) from #682 (tracked by #711): make the
`#[derive(Altrep*)]` proc-macros emit the underlying ALTREP trait impls
directly, removing the `impl_alt<family>_from_data!` declarative-macro
indirection. This PR migrates **one family — integer** — as the proof, with a
fully family-generic helper the remaining six families reuse. The user-facing
derive surface is unchanged.

<details>
<summary>AI-written details (Claude Opus 4.8, 1M context)</summary>

## STILL_VALID

Confirmed. `miniextendr-api/src/altrep_impl/macros.rs` still houses the 22
declarative macros with the canonical 6-arm shape per family, and
`miniextendr-macros/src/altrep_derive.rs` still delegates the simple path to
`impl_alt<family>_from_data!` (and the expanded path to the individual
`__impl_*` macros). The indirection #711 describes exists exactly as written.

## What changed (the spike)

Migrated the **integer** family to direct emit. `derive_altrep_integer`'s
`AltrepFamilyConfig` now sets `emit_direct: true`, routing through a new
`AltrepAttrs::generate_lowlevel_direct` that reproduces the exact 6-arm
expansions from the proc-macro:

- `($ty)` / `($ty, serialize)` -> `__impl_altrep_base!` (`with_serialize` on the
  serialize arm) + materializing `__impl_altvec_integer_dataptr!` + methods +
  inferbase.
- `($ty, dataptr)` / `($ty, dataptr, serialize)` -> direct
  `__impl_altvec_dataptr!(Ty, i32)`.
- `($ty, subset)` / `($ty, subset, serialize)` -> `__impl_altvec_extract_subset!`.

The helper is family-generic: it reads everything family-specific off
`AltrepFamilyConfig` (incl. two new fields, `emit_direct` and
`materializing_dataptr_macro`). Migrating a remaining family is a one-line
`emit_direct: true` flip — no new emit code (see the follow-up issue for the
per-family table; string and list need a small extra branch).

### Before / after (integer, default arm)

Before — derive emits:
```rust
::miniextendr_api::impl_altinteger_from_data!(MyType);
```
which expands (one declarative hop) to `__impl_altrep_base!` +
`__impl_altvec_integer_dataptr!` + `__impl_altinteger_methods!` +
`impl_inferbase_integer!`.

After — derive emits those four directly:
```rust
::miniextendr_api::__impl_altrep_base!(MyType, RUnwind);
::miniextendr_api::__impl_altvec_integer_dataptr!(MyType);
::miniextendr_api::__impl_altinteger_methods!(MyType);
::miniextendr_api::impl_inferbase_integer!(MyType);
```

## Byte-equivalence argument

The emitted trait surface is byte-equivalent to delegating:

- `__impl_altrep_base!(Ty)` ≡ `__impl_altrep_base!(Ty, RUnwind)` (no-guard arm
  forwards to the RUnwind arm); likewise the `with_serialize` arm.
- AltVec / methods / inferbase emit identical arguments.
- The pre-#711 expanded path's *bare* `impl AltVec {}` for the non-default-guard
  + no-options case is preserved exactly (branch on `has_non_default_guard()`),
  so there is zero semantic drift. No production fixture uses a non-default
  guard on an integer ALTREP — that branch is exercised only by unit tests.

Empirical confirmation: `rpkg/R/miniextendr-wrappers.R`, `rpkg/NAMESPACE`, and
`rpkg/src/rust/wasm_registry.rs` are **all unchanged** — those are generated
from the emitted trait surface, so if it had drifted they would have moved.

## Verification

- `cargo fmt --all` — clean.
- `cargo check -p miniextendr-api -p miniextendr-macros` — pass (sandbox-disabled).
- `cargo test -p miniextendr-macros` — 324 passed, 73 ignored, 0 failed, incl.
  the trybuild UI test for the `dataptr + subset` rejection.
- Updated two integer-family unit tests in `tests.rs` that asserted the old
  delegation (`impl_altinteger_from_data` present) to assert the new direct
  output (`__impl_altrep_base` / `__impl_altvec_integer_dataptr` /
  `__impl_altinteger_methods` / `impl_inferbase_integer`).
- Generated artifacts (wrappers / NAMESPACE / wasm registry / Cargo.lock) —
  confirmed unchanged.

Not run: `R CMD check` / gctorture (drafty spike; emitted bytes did not move, so
existing coverage applies). Flagged for the follow-up.

## Files

- `miniextendr-macros/src/altrep_derive.rs` — new `generate_lowlevel_direct`,
  two new `AltrepFamilyConfig` fields, integer flipped to `emit_direct: true`.
- `miniextendr-macros/src/tests.rs` — two integer-family assertions updated.
- `analysis/altrep-path-a-procmacro-2026-06-09.md` — design writeup +
  per-family effort/risk table.

## Follow-up

Remaining six families (real/logical/raw/string/complex/list): #933.

</details>

Refs #711, #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)
