### PR TITLE
test(serde): gate JSON-using tests behind serde_json (#692 already implemented)

### DIFF
--- a/miniextendr-api/tests/from_r.rs
+++ b/miniextendr-api/tests/from_r.rs
@@ -305,7 +305,7 @@ fn test_na_logical_bare_scalar_rejected() {
 // region: Feature-gated tests for macro-based conversions
 
 /// Helper to create a VECSXP (R list) from SEXPs
-#[cfg(any(feature = "serde", feature = "aho-corasick"))]
+#[cfg(any(feature = "serde_json", feature = "aho-corasick"))]
 unsafe fn make_list(elements: &[SEXP], guard: &mut ProtectCount) -> SEXP {
     use miniextendr_api::prelude::SexpExt;
     let len = elements.len() as R_xlen_t;
@@ -393,7 +393,7 @@ fn aho_corasick_vec_option_from_list() {
 
 // region: serde (JSON) feature tests
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn json_value_option_from_nil() {
     use miniextendr_api::serde_impl::JsonValue;
@@ -405,7 +405,7 @@ fn json_value_option_from_nil() {
     });
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn json_value_option_from_sexp() {
     use miniextendr_api::serde_impl::JsonValue;
@@ -424,7 +424,7 @@ fn json_value_option_from_sexp() {
     });
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn json_value_vec_from_list() {
     use miniextendr_api::serde_impl::JsonValue;
@@ -445,7 +445,7 @@ fn json_value_vec_from_list() {
     });
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn json_value_vec_option_from_list() {
     use miniextendr_api::serde_impl::JsonValue;
@@ -613,7 +613,7 @@ fn aho_corasick_unchecked_vec() {
     });
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn json_value_unchecked_vec_option() {
     use miniextendr_api::serde_impl::JsonValue;

--- a/miniextendr-api/tests/serde_streaming.rs
+++ b/miniextendr-api/tests/serde_streaming.rs
@@ -124,6 +124,9 @@ fn iter_to_dataframe_empty_yields_empty_dataframe() {
 
 // region: strict-schema rejection + NA-pad for missing fields
 
+// Uses `serde_json::Value` to push heterogeneous shapes, so it requires the
+// `serde_json` feature (the rest of this file only needs `serde`).
+#[cfg(feature = "serde_json")]
 #[test]
 fn dataframe_builder_strict_rejects_new_fields() {
     r_test_utils::with_r_thread(|| {


### PR DESCRIPTION
While picking up #692 (growing-schema mode for the streaming serde DataFrame builder), I found the feature is **already implemented and merged** — PR #726 ("feat(serde): DataFrameBuilder pre-declared + growing schema modes (#693 #692)", commit `de564c5a`) landed `SerdeRowBuilder::grow_schema()` and `absorb_new_fields()` exactly as #692 sketched. So this PR is not a re-implementation; it's a small build-fix for a latent compile break I tripped over while verifying that code.

<details>
<summary>AI-generated details</summary>

## #692 is already done (no action needed on the feature)

The type was renamed `DataFrameBuilder` → `SerdeRowBuilder` during the unified-DataFrame façade refactor (#783/#806), so the name in the issue is stale. The implementation in `miniextendr-api/src/serde/columnar.rs` matches the issue's per-push sketch:

- `SerdeRowBuilder::<T>::grow_schema()` — opt-in builder method (`grow: bool`), default mode unchanged.
- `absorb_new_fields()` — Union-mode `SchemaAccumulator` discovery, diffs against `schema.field_map`, allocates a fresh `ColumnBuffer`, back-fills `self.nrow` NA via `push_na()`, then appends to `columns` / `field_map`.
- Unit tests tagged `(#692)`: `grow_schema_back_fills_na_on_new_field`, `grow_schema_combined_with_with_schema`, `grow_schema_noop_when_no_new_fields`, plus `with_schema_rejects_unknown_field` for the strict (non-growing) rejection path.

All four pass on current `main` under `--features serde_json`.

## The actual fix in this PR

`cargo check -p miniextendr-api --features serde --tests` **failed to compile** before this PR. Several tests gated `#[cfg(feature = "serde")]` use `serde_impl::JsonValue` / `serde_json::Value`, which only exist under the `serde_json` feature (`serde_json = ["serde", "dep:serde_json"]`).

Why CI never caught it:
- `clippy_all` always enables `serde` **and** `serde_json` together.
- `clippy_default` (no features) gates the whole `serde_streaming.rs` file out via `#![cfg(feature = "serde")]`.

So the break only surfaces with `serde` on but `serde_json` off — the natural flag for the streaming/builder work.

Changes (test-only, no runtime code touched):
- `tests/from_r.rs`: 5 `JsonValue` tests re-gated `serde` → `serde_json`; `make_list` helper's gate updated to `any(serde_json, aho-corasick)` (all its callers are JSON or aho-corasick tests, so under `serde`-only it was dead code).
- `tests/serde_streaming.rs`: the `serde_json::Value` test re-gated to `serde_json`; the file stays `#![cfg(feature = "serde")]` for the rest.

## Verification

- `cargo fmt --all` — clean.
- `cargo check -p miniextendr-api --features serde --tests` — compiles warning-free (was a hard error before).
- `cargo check -p miniextendr-api --features serde_json --tests` — clean.
- `cargo test -p miniextendr-api --features serde_json --lib -- grow_schema with_schema_rejects` — 4 passed.
- `cargo test -p miniextendr-api --features serde_json --test serde_streaming` — 15 passed.

No SEXP-storage path added (test cfg-gating only) → gctorture / no-arg-fixture convention is n/a.

Refs #692 (feature already merged via #726). I intentionally avoided an auto-closing keyword — the issue's disposition is for the maintainer to decide.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
