### PR TITLE
feat(api): r!() and r_str!() macros for evaluating R code from Rust (#687)

### DIFF
--- a/miniextendr-api/src/expression.rs
+++ b/miniextendr-api/src/expression.rs
@@ -27,7 +27,10 @@
 
 use crate::gc_protect::{OwnedProtect, ProtectScope};
 use crate::sexp_ext::PairListExt;
-use crate::sys::{self, R_BaseEnv, R_EmptyEnv, R_GlobalEnv, R_tryEvalSilent, Rf_install};
+use crate::sys::{
+    self, ParseStatus, R_BaseEnv, R_EmptyEnv, R_GlobalEnv, R_ParseVector, R_tryEvalSilent,
+    Rf_install,
+};
 use crate::{SEXP, SexpExt};
 use std::ffi::{CStr, CString};
 
@@ -421,6 +424,117 @@ pub unsafe fn dollar_extract(target: SEXP, name: &str) -> Result<SEXP, String> {
         let name_sexp = OwnedProtect::new(SEXP::scalar_string_from_str(name));
         RCall::new("$").arg(target).arg(name_sexp.get()).eval_base()
     }
+}
+// endregion
+
+// region: r_eval_str (runtime string parse + eval)
+
+/// Parse a string of R source and evaluate it in `env`.
+///
+/// This is the runtime workhorse behind the [`r_str!`](crate::r_str) and
+/// [`r!`](crate::r) macros. It performs the full
+/// `R_ParseVector` → check status → `Rf_eval` ladder with correct GC
+/// protection on every intermediate SEXP, so callers never have to hand-roll
+/// `OwnedProtect` around the parse tree.
+///
+/// Only the **last** top-level expression's value is returned (matching R's
+/// `eval(parse(text = ...))` semantics): each parsed expression is evaluated in
+/// order so that side effects (assignments, `library()`, …) take effect, and
+/// the value of the final one is returned. An empty / whitespace-only string
+/// yields `R_NilValue`.
+///
+/// # Safety
+///
+/// - Must be called from (or routed to) the R main thread. The parse and eval
+///   FFI calls go through the checked `#[r_ffi_checked]` variants, which
+///   serialize onto the R thread via `with_r_thread`, so calling from a
+///   worker thread is sound — but the returned SEXP must not outlive the R
+///   session.
+/// - `env` must be a valid ENVSXP.
+///
+/// # Returns
+///
+/// - `Ok(SEXP)` with the value of the last expression (**unprotected** — the
+///   caller should protect it if further allocations will occur before use).
+/// - `Err(String)` if parsing fails (syntax error / incomplete input) or if
+///   evaluation raises an R error. The error is captured via
+///   `R_tryEvalSilent` + `geterrmessage()`, so it never longjmps through Rust
+///   frames.
+///
+/// # Example
+///
+/// ```ignore
+/// use miniextendr_api::expression::r_eval_str;
+/// use miniextendr_api::sys::R_GlobalEnv;
+///
+/// unsafe {
+///     let three = r_eval_str("1L + 2L", R_GlobalEnv)?;
+///     // three is an INTSXP holding 3
+/// }
+/// ```
+pub unsafe fn r_eval_str(code: &str, env: SEXP) -> Result<SEXP, String> {
+    unsafe {
+        // 1. Wrap the source in a length-1 STRSXP. scalar_string_from_str
+        //    allocates a CHARSXP + STRSXP; protect it across the parse, which
+        //    allocates again.
+        let code_sexp = OwnedProtect::new(SEXP::scalar_string_from_str(code));
+
+        // 2. Parse. R_ParseVector returns an EXPRSXP (a vector of expressions).
+        //    Protect it across the subsequent VECTOR_ELT / Rf_eval allocations.
+        let mut status = ParseStatus::PARSE_NULL;
+        let parsed = R_ParseVector(code_sexp.get(), -1, &mut status, sys::R_NilValue);
+
+        match status {
+            ParseStatus::PARSE_OK => {}
+            ParseStatus::PARSE_INCOMPLETE => {
+                return Err(format!(
+                    "incomplete R expression (unbalanced delimiter?): {code}"
+                ));
+            }
+            ParseStatus::PARSE_ERROR => {
+                return Err(format!("R syntax error while parsing: {code}"));
+            }
+            ParseStatus::PARSE_EOF => {
+                return Err(format!("unexpected end of input while parsing: {code}"));
+            }
+            ParseStatus::PARSE_NULL => {
+                return Err(format!("R_ParseVector returned PARSE_NULL for: {code}"));
+            }
+        }
+
+        let parsed = OwnedProtect::new(parsed);
+
+        // 3. Evaluate each parsed expression in order; return the value of the
+        //    last one. An empty EXPRSXP (blank source) yields R_NilValue.
+        let n = parsed.get().xlength();
+        let mut result = sys::R_NilValue;
+        for i in 0..n {
+            // VECTOR_ELT borrows from `parsed` (still protected). The element
+            // is part of the protected EXPRSXP, so it stays reachable.
+            let expr = parsed.get().vector_elt(i);
+
+            let mut error_occurred: std::os::raw::c_int = 0;
+            result = R_tryEvalSilent(expr, env, &mut error_occurred);
+            if error_occurred != 0 {
+                return Err(get_r_error_message());
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+/// Parse and evaluate a string of R source in `R_GlobalEnv`.
+///
+/// Convenience wrapper over [`r_eval_str`] for the common case. See that
+/// function for safety and return semantics.
+///
+/// # Safety
+///
+/// Same as [`r_eval_str`].
+#[inline]
+pub unsafe fn r_eval_str_global(code: &str) -> Result<SEXP, String> {
+    unsafe { r_eval_str(code, R_GlobalEnv) }
 }
 // endregion
 

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -502,6 +502,128 @@ macro_rules! report_growth {
     () => {};
 }
 
+/// Parse and evaluate **runtime** R source from Rust.
+///
+/// `r_str!` is sugar around [`expression::r_eval_str`]. It is the right tool
+/// when the R code is genuinely dynamic — built with `format!`, derived from
+/// user input, or otherwise not known at compile time. For code you can write
+/// literally, prefer [`r!`](crate::r), which gives a cheap compile-time
+/// sanity check on the token stream.
+///
+/// The argument is any expression evaluating to something `AsRef<str>`
+/// (`&str`, `String`, `&String`, …). It is parsed with `R_ParseVector` and
+/// evaluated with `Rf_eval`, with every intermediate SEXP protected and the
+/// parse status checked, so a syntax error becomes an `Err`, never a segfault
+/// or silent wrong answer.
+///
+/// # Forms
+///
+/// - `r_str!(code)` — evaluate in `R_GlobalEnv`.
+/// - `r_str!(code, env = e)` — evaluate in the environment SEXP `e`.
+///
+/// Both forms evaluate to `Result<SEXP, String>`; the `SEXP` is **unprotected**
+/// (protect it before further allocations).
+///
+/// # Safety
+///
+/// Expands to an `unsafe` block. Must be reached from (or routed to) the R
+/// main thread — the underlying FFI is `#[r_ffi_checked]`, so calls from a
+/// worker thread are serialized onto the R thread.
+///
+/// # Example
+///
+/// ```ignore
+/// let obj = "mtcars";
+/// let code = format!("summary({obj})");
+/// let summary = r_str!(&code)?;          // in R_GlobalEnv
+/// let three = r_str!("1L + 2L")?;
+/// let in_env = r_str!("x + 1", env = my_env)?;
+/// ```
+#[macro_export]
+macro_rules! r_str {
+    ($code:expr $(,)?) => {
+        unsafe {
+            $crate::expression::r_eval_str(
+                ::core::convert::AsRef::<str>::as_ref(&$code),
+                $crate::sys::R_GlobalEnv,
+            )
+        }
+    };
+    ($code:expr, env = $env:expr $(,)?) => {
+        unsafe {
+            $crate::expression::r_eval_str(::core::convert::AsRef::<str>::as_ref(&$code), $env)
+        }
+    };
+}
+
+/// Evaluate R code written as **Rust tokens**, validated at compile time.
+///
+/// `r!` takes a single R expression as a token stream, `stringify!`s it into a
+/// static R source string at build time, and evaluates it via
+/// [`expression::r_eval_str`] (the same protect-safe parse + eval path as
+/// [`r_str!`](crate::r_str)).
+///
+/// # What you get today
+///
+/// Because the argument is a Rust token tree, the Rust front-end already
+/// rejects **unbalanced delimiters** (`r!(f(1, 2)` won't compile) and
+/// lexically invalid tokens before R ever sees the string — a cheap
+/// compile-time guard over the pure-runtime [`r_str!`](crate::r_str). The
+/// source is lowered to a `&'static str` (`stringify!`), so there is no
+/// `format!` allocation at the call site.
+///
+/// # What is deferred
+///
+/// True build-time R-grammar validation (embedding R's parser / invoking
+/// `R_ParseVector` from `build.rs`) and direct `Rf_lang*` call-tree lowering
+/// (skipping the runtime parser entirely) are tracked as a follow-up — see the
+/// issue referenced in the crate docs. Until then `r!` parses its static
+/// string at first evaluation, exactly like `r_str!`.
+///
+/// # Forms
+///
+/// - `r!(R tokens…)` — evaluate in `R_GlobalEnv`.
+/// - `r!(env: e; R tokens…)` — evaluate in the environment SEXP `e`. The
+///   leading `env: <expr> ;` is consumed as Rust, the rest is R source. (The
+///   `;` separator is used instead of a trailing `, env =` because R source is
+///   a free token stream — a trailing keyword can't be reliably split off it.)
+///
+/// Both evaluate to `Result<SEXP, String>`; the `SEXP` is **unprotected**.
+///
+/// For genuinely dynamic code, use [`r_str!`](crate::r_str) instead.
+///
+/// # Note on `stringify!` spacing
+///
+/// `stringify!` normalises whitespace (`a+b` and `a + b` both stringify to
+/// `a + b`) but preserves token order and literal contents, which is all R's
+/// parser needs. String literals keep their quotes.
+///
+/// # Safety
+///
+/// Expands to an `unsafe` block; see [`r_str!`](crate::r_str).
+///
+/// # Example
+///
+/// ```ignore
+/// let three = r!(1L + 2L)?;
+/// let rows = r!(getFromNamespace(".theoph_rows", "dataframeflows")())?;
+/// let in_env = r!(env: my_env; x + 1)?;
+/// ```
+#[macro_export]
+macro_rules! r {
+    (env: $env:expr; $($code:tt)+) => {
+        unsafe { $crate::expression::r_eval_str(::core::stringify!($($code)+), $env) }
+    };
+    ($($code:tt)+) => {
+        unsafe {
+            $crate::expression::r_eval_str(
+                ::core::stringify!($($code)+),
+                $crate::sys::R_GlobalEnv,
+            )
+        }
+    };
+}
+
 // `indicatif` progress integration (R console)
 #[cfg(feature = "indicatif")]
 pub mod progress;
@@ -556,7 +678,7 @@ pub mod encoding;
 
 // Expression evaluation helpers (RSymbol, RCall, REnv)
 pub mod expression;
-pub use expression::{RCall, REnv, RSymbol};
+pub use expression::{RCall, REnv, RSymbol, r_eval_str, r_eval_str_global};
 
 // S4 slot access and class checking helpers
 pub mod s4_helpers;

--- a/miniextendr-api/src/prelude.rs
+++ b/miniextendr-api/src/prelude.rs
@@ -74,6 +74,14 @@ pub use crate::{Sendable, with_r_thread};
 pub use crate::{r_print, r_println, r_warning};
 // endregion
 
+// region: R evaluation
+//
+// `r!` / `r_str!` evaluate R source from Rust; `r_eval_str` is the underlying
+// protect-safe parse + eval function they expand to.
+pub use crate::expression::r_eval_str;
+pub use crate::{r, r_str};
+// endregion
+
 // region: Safe R-value surface
 //
 // `SEXP` is the central newtype; `SexpExt` is the ergonomic extension trait

--- a/miniextendr-api/src/sys.rs
+++ b/miniextendr-api/src/sys.rs
@@ -938,6 +938,44 @@ unsafe extern "C-unwind" {
         error_occurred: *mut ::std::os::raw::c_int,
     ) -> SEXP;
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
+
+    /// Parse R source text into an EXPRSXP (a list of parsed expressions).
+    ///
+    /// `text` is a STRSXP holding the source, `n` is the number of expressions
+    /// to parse (`-1` for all), `status` receives the [`ParseStatus`] outcome,
+    /// and `srcfile` is a srcref/`R_NilValue`. Allocates; protect the result.
+    ///
+    /// Prefer the safe [`crate::expression::r_eval_str`] wrapper, which does the
+    /// STRSXP construction, status check, and protection bookkeeping for you.
+    #[doc(alias = "ParseVector")]
+    pub fn R_ParseVector(
+        text: SEXP,
+        n: ::std::os::raw::c_int,
+        status: *mut ParseStatus,
+        srcfile: SEXP,
+    ) -> SEXP;
+}
+
+/// Outcome of [`R_ParseVector`] (from `R_ext/Parse.h`).
+///
+/// `PARSE_NULL` is never returned by `R_ParseVector`; the meaningful success
+/// value is [`ParseStatus::PARSE_OK`]. The remaining variants indicate parse
+/// failures (`PARSE_ERROR`), incomplete input (`PARSE_INCOMPLETE`), or
+/// end-of-input (`PARSE_EOF`).
+#[allow(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseStatus {
+    /// Never returned by `R_ParseVector`; the default-initialized sentinel.
+    PARSE_NULL,
+    /// Parse succeeded.
+    PARSE_OK,
+    /// Input ended mid-expression (e.g. an unbalanced delimiter).
+    PARSE_INCOMPLETE,
+    /// A syntax error was encountered.
+    PARSE_ERROR,
+    /// End of input reached with no further expressions.
+    PARSE_EOF,
 }
 
 // region: Connections API (R_ext/Connections.h)

--- a/miniextendr-api/tests/r_eval.rs
+++ b/miniextendr-api/tests/r_eval.rs
@@ -1,0 +1,114 @@
+//! Integration tests for the `r!` / `r_str!` eval macros and the underlying
+//! `r_eval_str` parse + eval helper (issue #687).
+//!
+//! These exercise the real R runtime: parse a string of R source, evaluate it
+//! with full GC protection, and verify the parse-error path returns `Err`
+//! rather than segfaulting or silently producing a wrong value.
+
+mod r_test_utils;
+
+use miniextendr_api::expression::r_eval_str;
+use miniextendr_api::sys::R_GlobalEnv;
+use miniextendr_api::{SexpExt, r, r_str};
+
+#[test]
+fn r_eval_suite() {
+    r_test_utils::with_r_thread(|| {
+        test_r_str_arithmetic();
+        test_r_macro_arithmetic();
+        test_assignment_and_lookup();
+        test_env_form();
+        test_empty_source();
+        test_parse_error_is_err();
+        test_eval_error_is_err();
+        test_dynamic_format_string();
+    });
+}
+
+/// `r_str!("1L + 2L")` → INTSXP 3.
+fn test_r_str_arithmetic() {
+    let result = r_str!("1L + 2L").expect("1L + 2L should evaluate");
+    assert_eq!(result.as_integer(), Some(3), "expected INTSXP 3");
+}
+
+/// `r!(1L + 2L)` (token form) lowers to the same static string and yields 3.
+fn test_r_macro_arithmetic() {
+    let result = r!(1L + 2L).expect("r!(1L + 2L) should evaluate");
+    assert_eq!(result.as_integer(), Some(3), "expected INTSXP 3");
+
+    // A more elaborate single-expression call tree (the issue's motivating
+    // shape): nested calls + string args, all in one token stream.
+    let nchars = r!(nchar("hello")).expect("nchar(\"hello\") should evaluate");
+    assert_eq!(nchars.as_integer(), Some(5));
+}
+
+/// Symbol / environment case: assign into the global env, then read it back.
+/// Verifies that side-effecting statements take effect and the *last*
+/// expression's value is what comes back.
+fn test_assignment_and_lookup() {
+    // Assignment is not a valid Rust `expr`, so it must go through the token
+    // stream (`r!`) or the string form (`r_str!`).
+    let assigned = r!(.mx687_x <- 41L + 1L).expect("assignment should evaluate");
+    // `<-` returns its value invisibly; we get 42 back.
+    assert_eq!(assigned.as_integer(), Some(42));
+
+    let looked_up = r_str!(".mx687_x").expect("lookup should evaluate");
+    assert_eq!(looked_up.as_integer(), Some(42));
+}
+
+/// Explicit environment form: evaluate in a fresh child environment and confirm
+/// the binding lands there, not in the global env.
+fn test_env_form() {
+    // Build a new environment and bind it in R, then evaluate against it.
+    let env = r_str!("new.env()").expect("new.env() should evaluate");
+    // env is unprotected; protect it across the next eval (which allocates).
+    let _guard = unsafe { miniextendr_api::OwnedProtect::new(env) };
+
+    let v = r!(env: env; local_val <- 7L; local_val * 6L).expect("env eval should work");
+    assert_eq!(v.as_integer(), Some(42));
+
+    // The binding must NOT have leaked into the global env.
+    let exists = r_str!("exists(\"local_val\", envir = globalenv(), inherits = FALSE)")
+        .expect("exists() should evaluate");
+    assert_eq!(exists.as_logical(), Some(false));
+}
+
+/// Blank source yields `R_NilValue`.
+fn test_empty_source() {
+    let nil = r_str!("   ").expect("whitespace-only source should be Ok(NULL)");
+    assert!(nil.is_nil(), "blank source should evaluate to NULL");
+}
+
+/// A genuine R syntax error must return `Err`, not crash or wrong-answer.
+fn test_parse_error_is_err() {
+    // Unbalanced paren — a classic parse failure.
+    let err = unsafe { r_eval_str("1 + (2", R_GlobalEnv) };
+    assert!(err.is_err(), "unbalanced paren must be an Err, got {err:?}");
+
+    // Outright garbage tokens.
+    let err2 = unsafe { r_eval_str("if if if", R_GlobalEnv) };
+    assert!(err2.is_err(), "garbage must be an Err, got {err2:?}");
+}
+
+/// A runtime R error (valid syntax, failing eval) is captured as `Err`.
+fn test_eval_error_is_err() {
+    let err = r_str!("stop(\"boom from R\")");
+    assert!(err.is_err(), "stop() should surface as Err");
+    let msg = err.unwrap_err();
+    assert!(
+        msg.contains("boom from R"),
+        "error message should carry R's message, got: {msg}"
+    );
+
+    // Calling an undefined function is also an eval-time error.
+    let err2 = r_str!("this_function_does_not_exist_687()");
+    assert!(err2.is_err(), "undefined function should surface as Err");
+}
+
+/// The runtime-string use case from the issue: `format!`-built source.
+fn test_dynamic_format_string() {
+    let obj = "c(1L, 2L, 3L, 4L)";
+    let code = format!("sum({obj})");
+    let total = r_str!(&code).expect("dynamic sum should evaluate");
+    assert_eq!(total.as_integer(), Some(10));
+}


### PR DESCRIPTION
Implements the tractable core of #687: ergonomic macros for evaluating R code from Rust, replacing the hand-rolled `Rf_install` + `Rf_lang*` + `Rf_eval` + `OwnedProtect` ladders that are verbose and protect-error-prone today.

## The two macros

- **`r_str!(code [, env = e])`** — runtime string. Sugar over the new public `expression::r_eval_str(code, env) -> Result<SEXP, String>`. For genuinely dynamic R code (`format!`-built, user input). No compile-time check.
- **`r!(R tokens [, env: e; ...])`** — takes R syntax as a Rust token stream, `stringify!`s it to a `&'static str` at build time, and reuses the same `r_eval_str` path. `stringify!` faithfully preserves R tokens including `<-`, nested calls, string literals, and `;` statement separators (verified). Equivalent to `r!(getFromNamespace(".theoph_rows", "dataframeflows")())`.

Both evaluate to `Result<SEXP, String>`; the `SEXP` is **unprotected** (caller protects), matching `RCall::eval`.

## What `r!` does today vs. what's deferred

`r!` is the **static-string-lowering** variant. The compile-time benefit it delivers now is what the Rust front-end already enforces on the token stream: **unbalanced delimiters / lexically invalid tokens fail at `cargo check`**. The R source is parsed at first eval (same path as `r_str!`).

Deferred to **#938** (the genuinely novel parts): true build-time R-grammar validation (embedded R grammar / `R_ParseVector` from `build.rs`, requires promoting `r!` to a proc macro) and direct `Rf_lang*` call-tree lowering (no runtime parser cost). API sketch from the issue carried into #938.

## Protect-safety approach

This feature exists to prevent the exact protect bug it would otherwise be easy to write. `r_eval_str` protects every intermediate across every allocation:

- The length-1 STRSXP source is held in an `OwnedProtect` across `R_ParseVector` (which allocates).
- The parsed `EXPRSXP` is held in an `OwnedProtect` across the `VECTOR_ELT` / `Rf_eval` loop.
- Parse status is checked (`PARSE_OK` / `INCOMPLETE` / `ERROR` / `EOF` / `NULL`) — failures return `Err`, never a longjmp or silent wrong answer.
- Eval goes through `R_tryEvalSilent` + `geterrmessage()`, so R errors are captured as `Err(String)` rather than longjmping through Rust frames.
- Each top-level expression is evaluated in order (side effects apply); the last value is returned. Intermediate unprotected results are fine — only the final one is used, with no allocation between it and the return.

## FFI / MXL

- `R_ParseVector` + `ParseStatus` declared in the **checked** `#[r_ffi_checked]` extern block, so it routes through `with_r_thread` — calling `r_eval_str` from the worker thread is sound (serialized onto the R main thread).
- No `Rf_error` (MXL300 clean), no `_unchecked` FFI (MXL301 clean); `cargo check` ran the `build.rs` lint pass with no MXL diagnostics.

## Verification

- `cargo fmt --all` — clean.
- `cargo check -p miniextendr-api -p miniextendr-macros --tests` — clean, no warnings.
- `cargo test -p miniextendr-api --test r_eval` — **passed** (cold-compiled + linked R). The suite covers: `r_str!("1L + 2L")` → `3`, `r!(1L + 2L)` + `r!(nchar("hello"))`, assignment + lookup, the explicit-env form (binding does not leak to global), empty source → `NULL`, the **parse-error path** (unbalanced paren + garbage → `Err`), the **eval-error path** (`stop()` + undefined function → `Err` carrying R's message), and a dynamic `format!` string.

Pure Rust-facing macros (not `#[miniextendr]`), so no wrapper/NAMESPACE/wasm_registry regeneration needed.

Refs #687 (the full `r!` compile-time-validation + `Rf_lang*`-lowering vision is deferred to #938)
Refs #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)
