### PR TITLE
fix(hooks): clear message + git-checkout hint on lockfile git-source stripping (#680)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,6 +23,7 @@ if [ -n "$staged_wrappers" ] && [ -z "$staged_namespace" ]; then
     echo "  Run: just devtools-document" >&2
     echo "  Then stage the updated NAMESPACE and man/ pages." >&2
     echo "  Staged wrapper files:" >&2
+    # shellcheck disable=SC2086  # intentional word-split: one file per %s line
     printf '    %s\n' $staged_wrappers >&2
     exit 1
 fi
@@ -40,18 +41,35 @@ fi
 #      `source` line STRIPPED entirely
 # We inspect the staged blob (not the diff) so the assertion is structural and
 # doesn't depend on whether the lockfile's prior shape was already broken.
+#
+# NOTE (#680): the earlier diff-based form —
+#   lock_content=$(git diff --cached … | grep '^+' | grep -v '^+++')
+# — exited the whole hook *silently* under `set -euo pipefail` when the staged
+# diff had only deletions (cargo stripped the `source = "git+…"` lines): the
+# leading `grep '^+'` found nothing, returned 1, pipefail propagated it, and the
+# command-substitution aborted the script with no message. The staged-blob form
+# below is immune: every grep here is either the condition of an `if`/`if !`
+# (where `set -e`/pipefail are suppressed for the tested pipeline) or guarded
+# with `|| true`. Keep it that way — never re-introduce a bare grep pipeline in
+# a command-substitution under pipefail.
 staged_lock=$(echo "$STAGED" | grep -F 'rpkg/src/rust/Cargo.lock' || true)
 if [ -n "$staged_lock" ]; then
-    staged_blob=$(git show ":rpkg/src/rust/Cargo.lock")
+    # The lockfile is staged ACM (line 10 filters out deletions), so the index
+    # blob always exists; guard with `|| true` anyway so a future filter change
+    # can't turn a `git show` failure into a silent `set -e` abort.
+    staged_blob=$(git show ":rpkg/src/rust/Cargo.lock" || true)
     for crate in miniextendr-api miniextendr-lint miniextendr-macros; do
         if ! echo "$staged_blob" | grep -A 3 "^name = \"$crate\"\$" \
                 | grep -q '^source = "git+https://github\.com/A2-ai/miniextendr'; then
             echo "pre-commit: rpkg/src/rust/Cargo.lock — $crate is missing the canonical" >&2
             echo "  source = \"git+https://github.com/A2-ai/miniextendr#<sha>\" line." >&2
+            echo "  This commit would strip the git+url sources the tarball build needs." >&2
             echo "  Likely cause: local 'just check / clippy / build / test' stripped it" >&2
             echo "  under '--config \"patch.'…'.path=…\"'." >&2
-            echo "  Run: just cargo-lock-restore    # restore from HEAD" >&2
-            echo "    or just vendor                # regenerate canonical shape" >&2
+            echo "  Restore the canonical shape, then re-stage Cargo.lock:" >&2
+            echo "    just cargo-lock-restore                        # restore from HEAD" >&2
+            echo "    git checkout -- rpkg/src/rust/Cargo.lock       # discard the staged change" >&2
+            echo "    just vendor                                    # regenerate canonical shape" >&2
             exit 1
         fi
     done


### PR DESCRIPTION
## Root cause

`.githooks/pre-commit`'s Cargo.lock check *used to be* diff-based:

```bash
lock_content=$(git diff --cached -- rpkg/src/rust/Cargo.lock | grep '^+' | grep -v '^+++')
if echo "$lock_content" | grep -qE '^\+source = "path\+'; then ...
```

Under `set -euo pipefail`, a **deletion-only** staged diff — cargo strips the
`source = "git+…"` lines when `[patch.crates-io]` path overrides win — makes the
leading `grep '^+'` find nothing and exit 1. `pipefail` propagates the 1, the
command-substitution aborts, and the whole hook exits **silently, with no
message**. The commit is rejected and the user has no idea why. This was hit
during PR #675's rescue (cargo had stripped 3 `source = "git+…"` lines).

## STILL_VALID

The *literal* buggy pipeline was **already removed by PR #709** (commit
`ab6f9442`, ~13 days ago), which switched to **structural staged-blob
inspection** (`git show ":rpkg/src/rust/Cargo.lock"` + `if ! grep | grep -q`).
That form is immune to the silent exit: every grep is now either the condition
of an `if`/`if !` (where `set -e`/pipefail are suppressed for the tested
pipeline) or guarded with `|| true`. So the silent-exit bug itself is fixed.

This PR closes out the issue's **remaining actionable asks** that #709 didn't
cover, and hardens against regression.

## What changed (`.githooks/pre-commit`)

- **Document the pipefail trap**: a `NOTE (#680)` comment records the old
  diff-based form, exactly why it exited silently, and why the staged-blob form
  is safe — so the bad shape is never re-introduced.
- **Recovery hint the issue asked for**: the missing-canonical-source message
  now lists `git checkout -- rpkg/src/rust/Cargo.lock` (discard the staged
  change) alongside `just cargo-lock-restore` and `just vendor`, and explains
  that the commit *would strip the git+url sources the tarball build needs*.
- **Belt-and-suspenders on `git show`**: guarded with `|| true` so a future
  `--diff-filter` change can't turn a `git show` failure into a silent
  `set -e` abort.
- **shellcheck**: quieted a pre-existing SC2086 on the wrapper-list `printf`
  (intentional word-split, documented with a disable directive).

## `.githooks/` sweep

`.githooks/` contains only `pre-commit`. Also audited the sibling
`just lock-shape-check` recipe (same lock-shape logic) and the broader
`justfile` for the vulnerable shape (bare `grep` as the first stage of a piped
command-substitution under `pipefail`):

- `lock-shape-check` uses the safe `if ! grep -A 3 … | grep -q …` form — immune.
- The only other `grep`-in-substitution in `justfile` (line ~246) is already
  `|| true`-guarded.

No other instances of the latent bug found.

## Verification

- `bash -n .githooks/pre-commit` — passes.
- `shellcheck .githooks/pre-commit` — clean (after the SC2086 directive).
- **End-to-end simulation** in a throwaway git repo wired to the new hook:
  - **Deletion-only diff (#680 repro)**: cargo strips the 3 `source = "git+…"`
    lines → hook **rejects with the clear message + `git checkout --` hint**,
    exit 1, *not* a silent exit. ✅
  - **Legitimate dep bump that keeps git sources**: **accepted**, no false
    rejection (false-rejection guard verified — rejection is scoped to the
    git-source-stripping shape, not any Cargo.lock change). ✅
  - **`path+` drift** (the other drift mode): **rejected** with the canonical
    message. ✅

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
