### PR TITLE
build(miniextendr-api): demote refcount-fast-hash from default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
         # explicit list so CI signal matches what rpkg actually enables.
         run: >-
           cargo clippy --workspace --all-targets --locked
-          --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,indicatif,strict-default,coerce-default,r6-default,worker-default,jiff
+          --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,indicatif,strict-default,coerce-default,r6-default,worker-default,jiff,refcount-fast-hash
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all.log"
         shell: bash
 

--- a/miniextendr-api/Cargo.toml
+++ b/miniextendr-api/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/miniextendr-api"
 rust-version = "1.85"
 
 [features]
-default = ["doc-lint", "refcount-fast-hash"]
+default = ["doc-lint"]
 ## Enable non-API R functions. These may break with R updates and cause
 ## `R CMD check` warnings. See NONAPI.md for details.
 nonapi = []

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -207,7 +207,7 @@
 //! | `doc-lint` | Warn on roxygen doc comment mismatches (enabled by default) |
 //! | `macro-coverage` | Expose macro coverage test module for `cargo expand` auditing |
 //! | `growth-debug` | Track and report collection growth events (zero-cost when off) |
-//! | `refcount-fast-hash` | Use ahash for refcount arenas (enabled by default, not DOS-resistant) |
+//! | `refcount-fast-hash` | Use ahash for refcount arenas (opt-in, not DOS-resistant) |
 // Re-export linkme for use by generated code (distributed_slice entries)
 #[doc(hidden)]
 pub use linkme;


### PR DESCRIPTION
## Default-feature debt

`miniextendr-api` shipped `default = ["doc-lint", "refcount-fast-hash"]`. The `refcount-fast-hash` feature adds an ahash-backed `FastHashMap` / `FastHashMapArena` variant of `refcount_protect::Arena`, pulling `ahash` (and its transitives) into the dependency graph for **every default user**.

But `refcount_protect` has **no production callers**. Grepping the workspace, the only references are:

- The module's own implementation (`miniextendr-api/src/refcount_protect.rs`).
- `rpkg/src/rust/refcount_protect_tests.rs` — which uses the BTreeMap-based `RefCountedArena`, *not* any fast-hash type.
- Opt-in-only consumers: `miniextendr-bench`'s own `refcount-fast-hash` forwarding feature + the feature-gated `fast_hash_benches` module, and `miniextendr-cli`'s `bench` command (passes the feature explicitly to `cargo bench`).

Production code goes through `gc_protect::OwnedProtect` / `ProtectScope` / `protect_pool::ProtectPool` — `refcount_protect` is the third (unused) pillar (see #510, which proposes consolidating `ProtectPool` + `Arena`). So every default user paid for `ahash` they never exercised.

## The change

```diff
- default = ["doc-lint", "refcount-fast-hash"]
+ default = ["doc-lint"]
```

The `std::collections::HashMap` backing already exists unconditionally (`HashMapArena = Arena<HashMap<usize, Entry>>`); the feature only *adds* `FastHashMap` / `FastHashMapArena`. The module compiles identically with and without the flag — this is purely a default-graph change, no fallback to write. Users who want the ahash variant opt in with `features = ["refcount-fast-hash"]`.

Also updated the lib.rs feature-table doc line (`enabled by default` → `opt-in`).

## Dependency-graph delta

`cargo tree -p miniextendr-api -e no-dev` (production graph, dev-deps excluded):

| | crates |
|---|---|
| with `refcount-fast-hash` (old default) | 18 |
| default after demotion | 11 |

7 crates leave the default production graph: **`ahash`, `zerocopy`, `version_check` (build-dep), `getrandom`, `once_cell`, `cfg-if`, `libc`**.

`cargo tree -p miniextendr-api -i ahash`:
- default after demotion → `error: package ID specification 'ahash' did not match any packages`
- `--features refcount-fast-hash` → `ahash v0.8.12 └── miniextendr-api`

(`ahash` remains in the root `Cargo.lock` because `miniextendr-bench` still declares the optional forwarding feature — the workspace lockfile records all reachable deps. No lockfile churn: root `Cargo.lock` and `rpkg/src/rust/Cargo.lock` are both unchanged.)

## CI / clippy coverage

Before this PR, the ahash path was linted via `clippy_default` (which runs default features). After demotion it would no longer be. The curated `clippy_all` list did **not** include `refcount-fast-hash`, so post-demotion **neither** clippy job would exercise the opt-in path — a silent coverage drop.

Fix: appended `refcount-fast-hash` to the explicit `clippy_all` feature list in `.github/workflows/ci.yml`, so the ahash `FastHashMap*` path stays linted as an opt-in.

## Sanity checks (from the issue)

1. **No by-default reliance** — confirmed. The flag is still in `default` on `main`; the only references are opt-in (bench feature, CLI bench command, feature-gated bench module) plus doc lines. The one production-side test uses `RefCountedArena` (BTreeMap), not a fast-hash type.
2. **Graph delta** — 18 → 11 production crates (above). A size build was not run (heavy release link); the dependency-graph delta stands in for it.
3. **clippy_all** — did not pass the flag; now does (above).

## Verification

- `cargo check -p miniextendr-api` (default, no ahash) → pass (exit 0).
- `cargo check -p miniextendr-api --features refcount-fast-hash` (ahash compiled in) → pass (exit 0).
- `cargo tree` before/after for the dependency delta (above).

Refs #510.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
