### PR TITLE
build(features): derive clippy_all codegen half from full-codegen aggregate (#677)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,14 +304,19 @@ jobs:
       - name: Clippy (all features)
         id: clippy_all
         continue-on-error: true
-        # NOTE: Can't use `--features full` — the `full` feature in
-        # miniextendr-api omits the forwarding features we want checked
-        # (r6-default/strict-default/coerce-default/worker-default, nonapi, connections) and adds
-        # heavy deps (arrow, datafusion, log) we don't need here. Keep the
-        # explicit list so CI signal matches what rpkg actually enables.
+        # The codegen-selector half is derived from miniextendr-api's
+        # `full-codegen` aggregate (#677) so it can't drift from the Cargo.toml
+        # definition — adding a new `*-default` / nonapi / connections selector
+        # there updates CI automatically. `full-codegen` picks the `r6-default`
+        # side of the r6/s7 mutex; `s7-default` is linted by clippy_default's
+        # rpkg path. We still can't use `--features full` directly: it adds
+        # heavy deps (arrow, datafusion, log) we don't need here. So we pass
+        # `full-codegen` plus a curated integration list (the lighter crates) —
+        # the latter is the only part still hand-maintained, and CI signal
+        # matches what rpkg actually enables.
         run: >-
           cargo clippy --workspace --all-targets --locked
-          --features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,indicatif,strict-default,coerce-default,r6-default,worker-default,jiff,refcount-fast-hash
+          --features full-codegen,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all.log"
         shell: bash
 

--- a/miniextendr-api/Cargo.toml
+++ b/miniextendr-api/Cargo.toml
@@ -124,17 +124,53 @@ growth-debug = []
 ## Enable fast hasher for refcount protect arenas. Uses ahash instead of SipHash
 ## for improved throughput on large collections. Not DOS-resistant.
 refcount-fast-hash = ["dep:ahash"]
-## All additive features (excludes mutually exclusive r6-default/s7-default and nonapi/connections).
-## Use for local development checks: `cargo check -p miniextendr-api --features full`
-full = [
+# region: feature aggregates
+#
+# Two composable aggregates so "all features" is defined in ONE place and CI's
+# `clippy_all` step can derive its codegen-selector half instead of re-curating
+# it (see #677). Adding a new feature only requires updating the matching
+# aggregate below; CI follows automatically.
+#
+# MUTEX CONSTRAINT: `r6-default` and `s7-default` are mutually exclusive — a
+# `compile_error!` in miniextendr-macros fires if both are enabled (#676/#710).
+# This is exactly why `--all-features` can't be used. `full-codegen` therefore
+# picks exactly ONE side of that pair (`r6-default`); to lint the `s7-default`
+# side, run a second invocation swapping the two. (`strict-default` and
+# `coerce-default` are NOT a mutex pair — they're orthogonal, see
+# docs/FEATURE_DEFAULTS.md — so both live in `full-codegen` together.)
+
+## Every optional integration crate (the "dep:" features). Heavy deps like
+## arrow/datafusion/log live here; CI's `clippy_all` enables a curated subset.
+full-integrations = [
     "serde", "serde_json", "num-complex", "uuid", "url", "aho-corasick",
-    "bitflags", "bitvec", "arrow", "datafusion", "toml", "time", "ndarray",
-    "nalgebra", "indexmap", "tinyvec", "bytes", "raw_conversions", "vctrs",
-    "borsh", "ordered-float", "num-bigint", "rust_decimal", "regex",
-    "num-traits", "tabled", "rayon", "sha2", "rand", "rand_distr",
-    "either", "log", "worker-thread", "macro-coverage",
-    "growth-debug",
+    "bitflags", "bitvec", "arrow", "datafusion", "toml", "time", "jiff",
+    "ndarray", "nalgebra", "indexmap", "tinyvec", "bytes", "raw_conversions",
+    "vctrs", "borsh", "ordered-float", "num-bigint", "rust_decimal", "regex",
+    "num-traits", "tabled", "rayon", "sha2", "rand", "rand_distr", "either",
+    "log",
 ]
+
+## Every codegen selector / runtime-surface feature that CI wants linted:
+## the `*-default` forwarding selectors (one mutex side — `r6-default`, NOT
+## `s7-default`), plus `nonapi`, `connections`, `worker-thread` (via
+## `worker-default`), `indicatif`, and `refcount-fast-hash` (the ahash-backed
+## refcount-arena hasher knob). This whole set compiles together — it is
+## the unit CI's `clippy_all` derives.
+full-codegen = [
+    "strict-default", "coerce-default", "r6-default", "worker-default",
+    "nonapi", "connections", "indicatif", "refcount-fast-hash",
+]
+
+## Back-compat kitchen sink: integrations + codegen selectors + debug/audit
+## features. Use for local development checks:
+## `cargo check -p miniextendr-api --features full`.
+## NOTE: now includes the codegen selectors (and hence `r6-default`, `nonapi`,
+## `connections`) via `full-codegen` — `s7-default` is excluded by the mutex.
+full = [
+    "full-integrations", "full-codegen",
+    "macro-coverage", "growth-debug",
+]
+# endregion
 
 [dependencies]
 linkme = { workspace = true }


### PR DESCRIPTION
Two hand-maintained "all features" definitions were drifting: `miniextendr-api/Cargo.toml`'s `full` and `.github/workflows/ci.yml`'s `clippy_all` curated list. A new `*-default` / `nonapi` / `connections` selector added today would silently miss CI coverage until someone remembered to edit `ci.yml` — and indeed `jiff` was already in `clippy_all` but missing from `full`. This splits the definition into composable aggregates so the codegen-selector half is derived from one source of truth.

<details>
<summary>AI-written details</summary>

## The two-drifting-lists problem

1. `miniextendr-api/Cargo.toml` `full = [...]` — kitchen-sink for users.
2. `ci.yml` `clippy_all` — hand-curated list with a `NOTE` explaining why it can't use `--features full` (omits the forwarding selectors CI wants checked; adds heavy deps arrow/datafusion/log CI doesn't need).

Both are maintained by hand and drift. Confirmed live: `jiff` was in `clippy_all` but absent from `full`.

## Aggregate design

`miniextendr-api/Cargo.toml` `[features]` now exposes:

- **`full-integrations`** — every optional integration crate (`serde`, `arrow`, `datafusion`, `ndarray`, `nalgebra`, `jiff`, `log`, …). `jiff` is now included (closing the drift gap above).
- **`full-codegen`** — codegen selectors + runtime-surface features CI wants linted: `strict-default`, `coerce-default`, `r6-default`, `worker-default` (pulls `worker-thread`), `nonapi`, `connections`, `indicatif`.
- **`full = ["full-integrations", "full-codegen", "macro-coverage", "growth-debug"]`** — back-compat kitchen sink. It now also pulls the codegen selectors (so `r6-default`, `nonapi`, `connections` are part of `full` for the first time) — intended, per #677's "users get the kitchen sink".

## Mutex constraint (how `full-codegen` stays compilable)

`r6-default` ⊕ `s7-default` is a hard `compile_error!` in `miniextendr-macros` (#676/#710) — this is precisely why `--all-features` fails CI. `full-codegen` includes exactly **one** side (`r6-default`); `s7-default` is exercised by the rpkg / `clippy_default` path. `strict-default` and `coerce-default` are **not** a mutex pair (orthogonal — `strict` errors on lossy conversions, `coerce` autocasts; both valid together, see `docs/FEATURE_DEFAULTS.md`), so both live in `full-codegen`. The mutex constraint is documented in a comment next to the aggregates.

Verified the mutex still fires: `cargo check -p miniextendr-api --features full-codegen,s7-default` aborts with `features "r6-default" and "s7-default" are mutually exclusive` — proving `full-codegen` alone deliberately avoids it.

## clippy_all rewire

```yaml
cargo clippy --workspace --all-targets --locked
--features full-codegen,rayon,rand,rand_distr,...,borsh,jiff
-- -D warnings
```

The codegen-selector half is now `full-codegen` (can't drift from Cargo.toml). The lighter integration crates remain a curated list (heavy deps arrow/datafusion/log still deliberately skipped — CI doesn't need them). The directly-named feature set is **byte-for-byte identical** to the previous `clippy_all` — no linting coverage was dropped; only the source of the codegen half changed.

## Coverage: derived vs still curated

- **Derived** (auto-follows Cargo.toml): all `*-default` selectors, `nonapi`, `connections`, `worker-thread`, `indicatif`.
- **Still curated** (intentionally — to keep heavy deps out of the clippy job): the integration crate subset. Adding a heavy integration to `full-integrations` won't auto-enter `clippy_all`, by design.

## Verification

- `cargo check -p miniextendr-api --features full-codegen` — compiles (no mutex violation).
- `cargo check -p miniextendr-api --features full` — kitchen sink resolves and compiles.
- `cargo check -p miniextendr-api --features full-codegen,s7-default` — fails with the mutex `compile_error!` (expected; proves the aggregate avoids it).
- `cargo clippy -p miniextendr-api --all-targets --features full-codegen,<curated> -- -D warnings` — clean (the new clippy_all invocation, scoped to the api crate where all selectors land).
- `python3 -c "import yaml; ..."` + `actionlint` — YAML valid; no issues on the clippy steps (only pre-existing SC2086 info warnings elsewhere).
- Confirmed the directly-named clippy_all feature set is unchanged vs `main`.

Related: #676, #710.

Closes #677
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
