### PR TITLE
fix(optionals): triage 174 lossy `as` casts — checked conversions + From + documented (#629)

### DIFF
--- a/miniextendr-api/src/optionals/arrow_impl.rs
+++ b/miniextendr-api/src/optionals/arrow_impl.rs
@@ -780,7 +780,12 @@ impl TryFromSexp for Date32Array {
             if is_na_real(v) {
                 builder.append_null();
             } else {
-                builder.append_value(v as i32); // f64 days → i32 days
+                // Arrow Date32 stores i32 days; R Date is an f64 day count.
+                // Truncation is intentional (fractional days are dropped) and
+                // the cast saturates for out-of-range values (no UB).
+                #[allow(clippy::cast_possible_truncation)]
+                let days = v as i32; // f64 days → i32 days
+                builder.append_value(days);
             }
         }
 
@@ -826,7 +831,12 @@ pub fn posixct_to_timestamp(sexp: SEXP) -> Result<TimestampSecondArray, SexpErro
         if is_na_real(v) {
             builder.append_null();
         } else {
-            builder.append_value(v as i64); // f64 seconds → i64 seconds
+            // Arrow stores i64 seconds; R POSIXct is f64 seconds. Fractional
+            // seconds are intentionally truncated (documented above); the cast
+            // saturates for out-of-range values (no UB).
+            #[allow(clippy::cast_possible_truncation)]
+            let secs = v as i64; // f64 seconds → i64 seconds
+            builder.append_value(secs);
         }
     }
 
@@ -907,7 +917,8 @@ impl IntoR for Date32Array {
                 *slot = if self.is_null(i) {
                     NA_REAL
                 } else {
-                    self.value(i) as f64
+                    // Date32 value is i32 days; widening to f64 is lossless.
+                    f64::from(self.value(i))
                 };
             }
 
@@ -1410,7 +1421,7 @@ fn arrow_array_to_sexp(array: &ArrayRef) -> SEXP {
         DataType::Float32 => {
             // Widen f32 → f64 for R
             let arr = array.as_primitive::<arrow_array::types::Float32Type>();
-            let widened: Float64Array = arr.iter().map(|v| v.map(|x| x as f64)).collect();
+            let widened: Float64Array = arr.iter().map(|v| v.map(f64::from)).collect();
             widened.into_sexp()
         }
         DataType::Int32 => array.as_primitive::<Int32Type>().clone().into_sexp(),
@@ -1422,12 +1433,12 @@ fn arrow_array_to_sexp(array: &ArrayRef) -> SEXP {
         }
         DataType::Int16 => {
             let arr = array.as_primitive::<arrow_array::types::Int16Type>();
-            let widened: Int32Array = arr.iter().map(|v| v.map(|x| x as i32)).collect();
+            let widened: Int32Array = arr.iter().map(|v| v.map(i32::from)).collect();
             widened.into_sexp()
         }
         DataType::Int8 => {
             let arr = array.as_primitive::<arrow_array::types::Int8Type>();
-            let widened: Int32Array = arr.iter().map(|v| v.map(|x| x as i32)).collect();
+            let widened: Int32Array = arr.iter().map(|v| v.map(i32::from)).collect();
             widened.into_sexp()
         }
         DataType::UInt8 => array.as_primitive::<UInt8Type>().clone().into_sexp(),

--- a/miniextendr-api/src/optionals/bytes_impl.rs
+++ b/miniextendr-api/src/optionals/bytes_impl.rs
@@ -124,7 +124,10 @@ pub trait RBuf {
     /// Gets a signed byte from the buffer.
     /// Returns `None` if no bytes remain.
     fn get_i8(&self) -> Option<i32> {
-        self.get_u8().map(|v| v as i8 as i32)
+        // `v as i8` deliberately reinterprets the unsigned byte as signed
+        // (e.g. 0xFF → -1); `i32::from` then widens losslessly.
+        #[allow(clippy::cast_possible_truncation)]
+        self.get_u8().map(|v| i32::from(v as i8))
     }
 
     /// Gets a big-endian u16 from the buffer.

--- a/miniextendr-api/src/optionals/indexmap_impl.rs
+++ b/miniextendr-api/src/optionals/indexmap_impl.rs
@@ -217,7 +217,9 @@ pub trait RIndexMapOps<T> {
 
 impl<T> RIndexMapOps<T> for IndexMap<String, T> {
     fn len(&self) -> i32 {
-        IndexMap::len(self) as i32
+        // R lengths are 32-bit `int`. A map with more than `i32::MAX` entries
+        // can't be represented exactly; saturate rather than silently wrap.
+        i32::try_from(IndexMap::len(self)).unwrap_or(i32::MAX)
     }
 
     fn is_empty(&self) -> bool {
@@ -239,14 +241,20 @@ impl<T> RIndexMapOps<T> for IndexMap<String, T> {
         if index < 0 {
             return None;
         }
-        IndexMap::get_index(self, index as usize).map(|(k, v)| (k.clone(), v.clone()))
+        // SAFETY: `index >= 0` checked above, so the sign cast cannot lose data.
+        #[allow(clippy::cast_sign_loss)]
+        let index = index as usize;
+        IndexMap::get_index(self, index).map(|(k, v)| (k.clone(), v.clone()))
     }
 
     fn get_key_at(&self, index: i32) -> Option<String> {
         if index < 0 {
             return None;
         }
-        IndexMap::get_index(self, index as usize).map(|(k, _)| k.clone())
+        // SAFETY: `index >= 0` checked above, so the sign cast cannot lose data.
+        #[allow(clippy::cast_sign_loss)]
+        let index = index as usize;
+        IndexMap::get_index(self, index).map(|(k, _)| k.clone())
     }
 
     fn first(&self) -> Option<(String, T)>
@@ -265,7 +273,9 @@ impl<T> RIndexMapOps<T> for IndexMap<String, T> {
 
     fn get_index_of(&self, key: &str) -> i32 {
         IndexMap::get_index_of(self, key)
-            .map(|i| i as i32)
+            // R `int` index; saturate at `i32::MAX` for maps too large to index
+            // exactly (rather than silently wrapping into a bogus index).
+            .map(|i| i32::try_from(i).unwrap_or(i32::MAX))
             .unwrap_or(-1)
     }
 }

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -55,6 +55,24 @@ fn unix_epoch_date() -> Date {
     jiff::civil::date(1970, 1, 1)
 }
 
+/// Split a POSIXct `f64` (seconds since epoch) into a jiff `Timestamp`.
+///
+/// Uses a floor-based split so negative timestamps round toward -∞:
+/// `whole = floor(secs)`, `fract = secs - whole ∈ [0, 1)`.
+///
+/// The two `as` casts here are deliberate and bounded:
+/// - `whole = secs.floor() as i64`: a float-to-int cast in Rust saturates at
+///   `i64::MIN`/`i64::MAX` (no UB). Any out-of-range value is then rejected by
+///   `Timestamp::new`, which validates the second/nanosecond range.
+/// - `nanos = (fract * 1e9) as i32`: `fract ∈ [0, 1)` so the product is in
+///   `[0, 1e9) < i32::MAX`; the cast can never truncate.
+#[allow(clippy::cast_possible_truncation)]
+fn posix_secs_to_timestamp(secs: f64) -> Result<Timestamp, jiff::Error> {
+    let whole = secs.floor() as i64;
+    let nanos = ((secs - secs.floor()) * 1_000_000_000.0) as i32;
+    Timestamp::new(whole, nanos)
+}
+
 // region: Timestamp <-> POSIXct (UTC)
 //
 // Floor-based split: whole = floor(secs), fract in [0, 1) — correct for negative
@@ -64,12 +82,10 @@ impl_realsxp_datetime!(
     Timestamp,
     "POSIXct",
     |secs: f64| {
-        let whole = secs.floor() as i64;
-        let nanos = ((secs - secs.floor()) * 1_000_000_000.0) as i32;
-        Timestamp::new(whole, nanos)
+        posix_secs_to_timestamp(secs)
             .map_err(|e| SexpError::InvalidValue(format!("jiff Timestamp out of range: {e}")))
     },
-    |ts: Timestamp| ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0),
+    |ts: Timestamp| ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0),
     |sexp: SEXP| set_posixct_utc(sexp)
 );
 
@@ -83,6 +99,9 @@ impl_realsxp_datetime!(
     Date,
     "Date",
     |days: f64| {
+        // `days.trunc() as i64` saturates on overflow (no UB); out-of-range
+        // values are then rejected by `try_days` below.
+        #[allow(clippy::cast_possible_truncation)]
         let days_i64 = days.trunc() as i64;
         let span = Span::new()
             .try_days(days_i64)
@@ -93,7 +112,7 @@ impl_realsxp_datetime!(
     },
     |d: Date| {
         let span = d.since(unix_epoch_date()).unwrap_or_default();
-        span.get_days() as f64
+        f64::from(span.get_days())
     },
     |sexp: SEXP| sexp.set_class(date_class_sexp())
 );
@@ -152,10 +171,7 @@ impl TryFromSexp for Zoned {
                 .map_err(|e| SexpError::InvalidValue(format!("unknown IANA tz {tz_name:?}: {e}")))?
         };
 
-        let whole = secs.floor() as i64;
-        let fract = secs - secs.floor();
-        let nanos = (fract * 1_000_000_000.0) as i32;
-        let ts = Timestamp::new(whole, nanos)
+        let ts = posix_secs_to_timestamp(secs)
             .map_err(|e| SexpError::InvalidValue(format!("jiff Timestamp out of range: {e}")))?;
         Ok(ts.to_zoned(tz))
     }
@@ -176,7 +192,7 @@ impl IntoR for Zoned {
             let ts = self.timestamp();
             vec.set_real_elt(
                 0,
-                ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0),
+                ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0),
             );
             let iana = self.time_zone().iana_name().unwrap_or("UTC");
             set_posixct_tz(vec, iana);
@@ -288,10 +304,7 @@ impl TryFromSexp for Vec<Zoned> {
                     i
                 )));
             }
-            let whole = secs.floor() as i64;
-            let fract = secs - secs.floor();
-            let nanos = (fract * 1_000_000_000.0) as i32;
-            let ts = Timestamp::new(whole, nanos).map_err(|e| {
+            let ts = posix_secs_to_timestamp(secs).map_err(|e| {
                 SexpError::InvalidValue(format!("jiff Timestamp out of range at index {i}: {e}"))
             })?;
             result.push(ts.to_zoned(tz.clone()));
@@ -342,7 +355,8 @@ impl IntoR for Vec<Zoned> {
             Rf_protect(vec);
             for (slot, z) in dst.iter_mut().zip(self) {
                 let ts = z.timestamp();
-                *slot = ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0);
+                *slot =
+                    ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0);
             }
             set_posixct_tz(vec, &first_iana);
             Rf_unprotect(1);
@@ -393,10 +407,7 @@ impl TryFromSexp for Vec<Option<Zoned>> {
             if secs.is_nan() {
                 result.push(None);
             } else {
-                let whole = secs.floor() as i64;
-                let fract = secs - secs.floor();
-                let nanos = (fract * 1_000_000_000.0) as i32;
-                let ts = Timestamp::new(whole, nanos).map_err(|e| {
+                let ts = posix_secs_to_timestamp(secs).map_err(|e| {
                     SexpError::InvalidValue(format!(
                         "jiff Timestamp out of range at index {i}: {e}"
                     ))
@@ -431,7 +442,8 @@ impl IntoR for Vec<Option<Zoned>> {
                 *slot = match opt {
                     Some(z) => {
                         let ts = z.timestamp();
-                        ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0)
+                        ts.as_second() as f64
+                            + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0)
                     }
                     None => f64::NAN,
                 };
@@ -473,7 +485,12 @@ impl_realsxp_datetime!(
     SignedDuration,
     "difftime",
     |secs: f64| {
+        // `whole` saturates on overflow (no UB); `frac_nanos` is bounded to
+        // `(-1e9, 1e9)` because `secs - secs.trunc() ∈ (-1, 1)`, so neither
+        // cast can lose meaningful data.
+        #[allow(clippy::cast_possible_truncation)]
         let whole = secs.trunc() as i64;
+        #[allow(clippy::cast_possible_truncation)]
         let frac_nanos = ((secs - secs.trunc()) * 1_000_000_000.0) as i32;
         Ok::<SignedDuration, SexpError>(SignedDuration::new(whole, frac_nanos))
     },
@@ -517,7 +534,13 @@ impl RSignedDuration for SignedDuration {
     }
     fn as_milliseconds(&self) -> i64 {
         // as_millis() returns i128; clamp to i64 range (saturating, not truncating).
-        self.as_millis().clamp(i64::MIN as i128, i64::MAX as i128) as i64
+        // SAFETY (lint): after clamping into `[i64::MIN, i64::MAX]` the value is
+        // by construction representable as `i64`, so the narrowing cannot truncate.
+        #[allow(clippy::cast_possible_truncation)]
+        let ms = self
+            .as_millis()
+            .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64;
+        ms
     }
     fn whole_seconds(&self) -> i64 {
         self.as_secs()
@@ -881,7 +904,7 @@ impl AltrepLen for JiffTimestampVec {
 impl AltRealData for JiffTimestampVec {
     fn elt(&self, i: usize) -> f64 {
         let ts = &self.data[i];
-        ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0)
+        ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0)
     }
 }
 
@@ -944,7 +967,7 @@ impl AltrepLen for JiffZonedVec {
 impl AltRealData for JiffZonedVec {
     fn elt(&self, i: usize) -> f64 {
         let ts = self.data[i].timestamp();
-        ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0)
+        ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0)
     }
 }
 
@@ -1012,10 +1035,7 @@ impl crate::from_r::TryFromSexp for JiffZonedVec {
                     "NA at index {i} not allowed for JiffZonedVec"
                 )));
             }
-            let whole = secs.floor() as i64;
-            let fract = secs - secs.floor();
-            let nanos = (fract * 1_000_000_000.0) as i32;
-            let ts = Timestamp::new(whole, nanos).map_err(|e| {
+            let ts = posix_secs_to_timestamp(secs).map_err(|e| {
                 crate::from_r::SexpError::InvalidValue(format!(
                     "jiff Timestamp out of range at index {i}: {e}"
                 ))
@@ -1064,8 +1084,10 @@ pub mod vctrs_support {
     /// `milliseconds`, `microseconds`, `nanoseconds` — all as integer (`INTSXP`).
     pub fn span_vec_to_rcrd(spans: &[Span]) -> SEXP {
         let n = spans.len();
-        // get_years → i16; get_months/weeks/days/hours → i32
-        // get_minutes/seconds/ms/us/ns → i64 (truncate to i32; in practice always fits)
+        // get_years → i16; get_months/weeks/days/hours → i32 (lossless)
+        // get_minutes/seconds/ms/us/ns → i64; these are emitted to R's INTSXP
+        // columns, so saturate at i32::MAX rather than silently wrapping for an
+        // (in practice never observed) unbalanced span with a >2^31 field.
         //
         // GC-SAFETY: all guards are held alive until after List::from_raw_values
         // returns. from_raw_values calls Rf_allocVector(VECSXP, …) which can
@@ -1075,11 +1097,31 @@ pub mod vctrs_support {
         let g_weeks = unsafe { alloc_int_col(n, |i| spans[i].get_weeks()) };
         let g_days = unsafe { alloc_int_col(n, |i| spans[i].get_days()) };
         let g_hours = unsafe { alloc_int_col(n, |i| spans[i].get_hours()) };
-        let g_minutes = unsafe { alloc_int_col(n, |i| spans[i].get_minutes() as i32) };
-        let g_seconds = unsafe { alloc_int_col(n, |i| spans[i].get_seconds() as i32) };
-        let g_milliseconds = unsafe { alloc_int_col(n, |i| spans[i].get_milliseconds() as i32) };
-        let g_microseconds = unsafe { alloc_int_col(n, |i| spans[i].get_microseconds() as i32) };
-        let g_nanoseconds = unsafe { alloc_int_col(n, |i| spans[i].get_nanoseconds() as i32) };
+        let g_minutes = unsafe {
+            alloc_int_col(n, |i| {
+                i32::try_from(spans[i].get_minutes()).unwrap_or(i32::MAX)
+            })
+        };
+        let g_seconds = unsafe {
+            alloc_int_col(n, |i| {
+                i32::try_from(spans[i].get_seconds()).unwrap_or(i32::MAX)
+            })
+        };
+        let g_milliseconds = unsafe {
+            alloc_int_col(n, |i| {
+                i32::try_from(spans[i].get_milliseconds()).unwrap_or(i32::MAX)
+            })
+        };
+        let g_microseconds = unsafe {
+            alloc_int_col(n, |i| {
+                i32::try_from(spans[i].get_microseconds()).unwrap_or(i32::MAX)
+            })
+        };
+        let g_nanoseconds = unsafe {
+            alloc_int_col(n, |i| {
+                i32::try_from(spans[i].get_nanoseconds()).unwrap_or(i32::MAX)
+            })
+        };
 
         let list = List::from_raw_values(vec![
             g_years.get(),
@@ -1129,7 +1171,8 @@ pub mod vctrs_support {
 
         for (i, z) in zones.iter().enumerate() {
             let ts = z.timestamp();
-            ts_dst[i] = ts.as_second() as f64 + (ts.subsec_nanosecond() as f64 / 1_000_000_000.0);
+            ts_dst[i] =
+                ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0);
             let iana = z.time_zone().iana_name().unwrap_or("UTC");
             tz_col.set_string_elt(i as crate::R_xlen_t, SEXP::charsxp(iana));
         }

--- a/miniextendr-api/src/optionals/ndarray_impl.rs
+++ b/miniextendr-api/src/optionals/ndarray_impl.rs
@@ -1182,7 +1182,10 @@ fn get_array_dims(sexp: SEXP) -> Option<Vec<usize>> {
             if d < 0 {
                 return None;
             }
-            dims.push(d as usize);
+            // SAFETY: `d >= 0` checked above, so the sign cast cannot lose data.
+            #[allow(clippy::cast_sign_loss)]
+            let d = d as usize;
+            dims.push(d);
         }
         Some(dims)
     }
@@ -1919,29 +1922,31 @@ impl RNdArrayOps for Array1<i32> {
     }
 
     fn sum(&self) -> f64 {
-        self.iter().map(|&x| x as f64).sum()
+        self.iter().map(|&x| f64::from(x)).sum()
     }
 
     fn mean(&self) -> f64 {
         if Array1::is_empty(self) {
             f64::NAN
         } else {
-            self.iter().map(|&x| x as f64).sum::<f64>() / Array1::len(self) as f64
+            self.iter().map(|&x| f64::from(x)).sum::<f64>() / Array1::len(self) as f64
         }
     }
 
     fn min(&self) -> f64 {
-        self.iter().map(|&x| x as f64).fold(f64::INFINITY, f64::min)
+        self.iter()
+            .map(|&x| f64::from(x))
+            .fold(f64::INFINITY, f64::min)
     }
 
     fn max(&self) -> f64 {
         self.iter()
-            .map(|&x| x as f64)
+            .map(|&x| f64::from(x))
             .fold(f64::NEG_INFINITY, f64::max)
     }
 
     fn product(&self) -> f64 {
-        self.iter().map(|&x| x as f64).product()
+        self.iter().map(|&x| f64::from(x)).product()
     }
 
     fn var(&self) -> f64 {
@@ -1949,8 +1954,11 @@ impl RNdArrayOps for Array1<i32> {
         if n == 0.0 {
             return f64::NAN;
         }
-        let mean = self.iter().map(|&x| x as f64).sum::<f64>() / n;
-        self.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n
+        let mean = self.iter().map(|&x| f64::from(x)).sum::<f64>() / n;
+        self.iter()
+            .map(|&x| (f64::from(x) - mean).powi(2))
+            .sum::<f64>()
+            / n
     }
 
     fn std(&self) -> f64 {
@@ -1979,29 +1987,31 @@ impl RNdArrayOps for Array2<i32> {
     }
 
     fn sum(&self) -> f64 {
-        self.iter().map(|&x| x as f64).sum()
+        self.iter().map(|&x| f64::from(x)).sum()
     }
 
     fn mean(&self) -> f64 {
         if Array2::is_empty(self) {
             f64::NAN
         } else {
-            self.iter().map(|&x| x as f64).sum::<f64>() / Array2::len(self) as f64
+            self.iter().map(|&x| f64::from(x)).sum::<f64>() / Array2::len(self) as f64
         }
     }
 
     fn min(&self) -> f64 {
-        self.iter().map(|&x| x as f64).fold(f64::INFINITY, f64::min)
+        self.iter()
+            .map(|&x| f64::from(x))
+            .fold(f64::INFINITY, f64::min)
     }
 
     fn max(&self) -> f64 {
         self.iter()
-            .map(|&x| x as f64)
+            .map(|&x| f64::from(x))
             .fold(f64::NEG_INFINITY, f64::max)
     }
 
     fn product(&self) -> f64 {
-        self.iter().map(|&x| x as f64).product()
+        self.iter().map(|&x| f64::from(x)).product()
     }
 
     fn var(&self) -> f64 {
@@ -2009,8 +2019,11 @@ impl RNdArrayOps for Array2<i32> {
         if n == 0.0 {
             return f64::NAN;
         }
-        let mean = self.iter().map(|&x| x as f64).sum::<f64>() / n;
-        self.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n
+        let mean = self.iter().map(|&x| f64::from(x)).sum::<f64>() / n;
+        self.iter()
+            .map(|&x| (f64::from(x) - mean).powi(2))
+            .sum::<f64>()
+            / n
     }
 
     fn std(&self) -> f64 {
@@ -2039,29 +2052,31 @@ impl RNdArrayOps for ArrayD<i32> {
     }
 
     fn sum(&self) -> f64 {
-        self.iter().map(|&x| x as f64).sum()
+        self.iter().map(|&x| f64::from(x)).sum()
     }
 
     fn mean(&self) -> f64 {
         if ArrayD::is_empty(self) {
             f64::NAN
         } else {
-            self.iter().map(|&x| x as f64).sum::<f64>() / ArrayD::len(self) as f64
+            self.iter().map(|&x| f64::from(x)).sum::<f64>() / ArrayD::len(self) as f64
         }
     }
 
     fn min(&self) -> f64 {
-        self.iter().map(|&x| x as f64).fold(f64::INFINITY, f64::min)
+        self.iter()
+            .map(|&x| f64::from(x))
+            .fold(f64::INFINITY, f64::min)
     }
 
     fn max(&self) -> f64 {
         self.iter()
-            .map(|&x| x as f64)
+            .map(|&x| f64::from(x))
             .fold(f64::NEG_INFINITY, f64::max)
     }
 
     fn product(&self) -> f64 {
-        self.iter().map(|&x| x as f64).product()
+        self.iter().map(|&x| f64::from(x)).product()
     }
 
     fn var(&self) -> f64 {
@@ -2069,8 +2084,11 @@ impl RNdArrayOps for ArrayD<i32> {
         if n == 0.0 {
             return f64::NAN;
         }
-        let mean = self.iter().map(|&x| x as f64).sum::<f64>() / n;
-        self.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n
+        let mean = self.iter().map(|&x| f64::from(x)).sum::<f64>() / n;
+        self.iter()
+            .map(|&x| (f64::from(x) - mean).powi(2))
+            .sum::<f64>()
+            / n
     }
 
     fn std(&self) -> f64 {
@@ -2142,6 +2160,10 @@ pub trait RNdSlice {
 impl RNdSlice for Array1<f64> {
     type Elem = f64;
 
+    // SAFETY (lint): R indices arrive as `i32`; `get` guards `< 0` and
+    // `slice_1d` clamps with `.max(0)` before the `as usize` cast, so the
+    // sign cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get(&self, index: i32) -> Option<f64> {
         if index < 0 {
             return None;
@@ -2157,6 +2179,7 @@ impl RNdSlice for Array1<f64> {
         self.view().last().copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn slice_1d(&self, start: i32, end: i32) -> Vec<f64> {
         let start = start.max(0) as usize;
         let end = (end.max(0) as usize).min(self.len());
@@ -2170,6 +2193,10 @@ impl RNdSlice for Array1<f64> {
 impl RNdSlice for Array1<i32> {
     type Elem = i32;
 
+    // SAFETY (lint): R indices arrive as `i32`; `get` guards `< 0` and
+    // `slice_1d` clamps with `.max(0)` before the `as usize` cast, so the
+    // sign cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get(&self, index: i32) -> Option<i32> {
         if index < 0 {
             return None;
@@ -2185,6 +2212,7 @@ impl RNdSlice for Array1<i32> {
         self.view().last().copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn slice_1d(&self, start: i32, end: i32) -> Vec<i32> {
         let start = start.max(0) as usize;
         let end = (end.max(0) as usize).min(self.len());
@@ -2245,6 +2273,10 @@ pub trait RNdSlice2D {
 impl RNdSlice2D for Array2<f64> {
     type Elem = f64;
 
+    // SAFETY (lint): R indices arrive as `i32`; each method below guards
+    // `< 0` (returning `None`/empty) before the `as usize` cast, so the sign
+    // cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get_2d(&self, row: i32, col: i32) -> Option<f64> {
         if row < 0 || col < 0 {
             return None;
@@ -2252,6 +2284,7 @@ impl RNdSlice2D for Array2<f64> {
         self.get((row as usize, col as usize)).copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn row(&self, row: i32) -> Vec<f64> {
         let (nrows, _) = self.dim();
         if row < 0 || row as usize >= nrows {
@@ -2261,6 +2294,7 @@ impl RNdSlice2D for Array2<f64> {
         self.view().row(row as usize).to_vec()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn col(&self, col: i32) -> Vec<f64> {
         let (_, ncols) = self.dim();
         if col < 0 || col as usize >= ncols {
@@ -2287,6 +2321,10 @@ impl RNdSlice2D for Array2<f64> {
 impl RNdSlice2D for Array2<i32> {
     type Elem = i32;
 
+    // SAFETY (lint): R indices arrive as `i32`; each method below guards
+    // `< 0` (returning `None`/empty) before the `as usize` cast, so the sign
+    // cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get_2d(&self, row: i32, col: i32) -> Option<i32> {
         if row < 0 || col < 0 {
             return None;
@@ -2294,6 +2332,7 @@ impl RNdSlice2D for Array2<i32> {
         self.get((row as usize, col as usize)).copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn row(&self, row: i32) -> Vec<i32> {
         let (nrows, _) = self.dim();
         if row < 0 || row as usize >= nrows {
@@ -2303,6 +2342,7 @@ impl RNdSlice2D for Array2<i32> {
         self.view().row(row as usize).to_vec()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn col(&self, col: i32) -> Vec<i32> {
         let (_, ncols) = self.dim();
         if col < 0 || col as usize >= ncols {
@@ -2407,6 +2447,10 @@ pub trait RNdIndex {
 impl RNdIndex for ArrayD<f64> {
     type Elem = f64;
 
+    // SAFETY (lint): R indices arrive as `i32`; every method below guards
+    // `< 0` (or clamps via `.max(0)`) before the `as usize` cast, so the sign
+    // cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get_nd(&self, indices: Vec<i32>) -> Option<f64> {
         if indices.len() != self.ndim() {
             return None;
@@ -2419,6 +2463,7 @@ impl RNdIndex for ArrayD<f64> {
         self.get(IxDyn(&idx)).copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn slice_nd(&self, start: Vec<i32>, end: Vec<i32>) -> Option<Vec<f64>> {
         let ndim = self.ndim();
         if start.len() != ndim || end.len() != ndim {
@@ -2497,6 +2542,7 @@ impl RNdIndex for ArrayD<f64> {
         self.iter().copied().collect()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn axis_slice(&self, axis: i32, index: i32) -> Vec<f64> {
         let ndim = self.ndim();
         if axis < 0 || axis as usize >= ndim {
@@ -2541,6 +2587,7 @@ impl RNdIndex for ArrayD<f64> {
         result
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn reshape(&self, new_shape: Vec<i32>) -> Option<Vec<f64>> {
         let new_len: usize = new_shape.iter().map(|&d| d.max(0) as usize).product();
         if new_len != self.len() {
@@ -2554,6 +2601,10 @@ impl RNdIndex for ArrayD<f64> {
 impl RNdIndex for ArrayD<i32> {
     type Elem = i32;
 
+    // SAFETY (lint): R indices arrive as `i32`; every method below guards
+    // `< 0` (or clamps via `.max(0)`) before the `as usize` cast, so the sign
+    // cast cannot lose data.
+    #[allow(clippy::cast_sign_loss)]
     fn get_nd(&self, indices: Vec<i32>) -> Option<i32> {
         if indices.len() != self.ndim() {
             return None;
@@ -2565,6 +2616,7 @@ impl RNdIndex for ArrayD<i32> {
         self.get(IxDyn(&idx)).copied()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn slice_nd(&self, start: Vec<i32>, end: Vec<i32>) -> Option<Vec<i32>> {
         let ndim = self.ndim();
         if start.len() != ndim || end.len() != ndim {
@@ -2637,6 +2689,7 @@ impl RNdIndex for ArrayD<i32> {
         self.iter().copied().collect()
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn axis_slice(&self, axis: i32, index: i32) -> Vec<i32> {
         let ndim = self.ndim();
         if axis < 0 || axis as usize >= ndim {
@@ -2678,6 +2731,7 @@ impl RNdIndex for ArrayD<i32> {
         result
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn reshape(&self, new_shape: Vec<i32>) -> Option<Vec<i32>> {
         let new_len: usize = new_shape.iter().map(|&d| d.max(0) as usize).product();
         if new_len != self.len() {

--- a/miniextendr-api/src/optionals/num_bigint_impl.rs
+++ b/miniextendr-api/src/optionals/num_bigint_impl.rs
@@ -68,9 +68,13 @@ impl TryCoerce<BigInt> for f64 {
         if self.fract() != 0.0 {
             return Err(CoerceError::PrecisionLoss);
         }
-        // Convert via i64 if in range, otherwise use string for larger values
+        // Convert via i64 if in range, otherwise use string for larger values.
         if self >= i64::MIN as f64 && self <= i64::MAX as f64 {
-            Ok(BigInt::from(self as i64))
+            // SAFETY (lint): the range guard above means `self` is in i64
+            // range, so the cast cannot truncate.
+            #[allow(clippy::cast_possible_truncation)]
+            let n = self as i64;
+            Ok(BigInt::from(n))
         } else {
             // For very large values, convert via string representation
             let s = format!("{:.0}", self);
@@ -99,7 +103,11 @@ impl TryCoerce<BigUint> for f64 {
         }
         // Convert via u64 if in range, otherwise use string for larger values
         if self <= u64::MAX as f64 {
-            Ok(BigUint::from(self as u64))
+            // SAFETY (lint): non-negative (checked above) and `<= u64::MAX`,
+            // so the cast cannot lose the sign or truncate.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let n = self as u64;
+            Ok(BigUint::from(n))
         } else {
             let s = format!("{:.0}", self);
             BigUint::from_str(&s).map_err(|_| CoerceError::Overflow)
@@ -723,7 +731,7 @@ impl RBigIntBitOps for BigInt {
     fn count_ones(&self) -> i64 {
         // Count ones in absolute value
         let (_, digits) = self.to_u32_digits();
-        digits.iter().map(|d| d.count_ones() as i64).sum()
+        digits.iter().map(|d| i64::from(d.count_ones())).sum()
     }
 
     fn trailing_zeros(&self) -> Option<i64> {
@@ -736,7 +744,7 @@ impl RBigIntBitOps for BigInt {
             if *digit == 0 {
                 count += 32;
             } else {
-                count += digit.trailing_zeros() as i64;
+                count += i64::from(digit.trailing_zeros());
                 break;
             }
         }
@@ -825,7 +833,7 @@ impl RBigUintBitOps for BigUint {
     fn count_ones(&self) -> i64 {
         self.to_u32_digits()
             .iter()
-            .map(|d| d.count_ones() as i64)
+            .map(|d| i64::from(d.count_ones()))
             .sum()
     }
 
@@ -840,7 +848,7 @@ impl RBigUintBitOps for BigUint {
             if *digit == 0 {
                 count += 32;
             } else {
-                count += digit.trailing_zeros() as i64;
+                count += i64::from(digit.trailing_zeros());
                 break;
             }
         }

--- a/miniextendr-api/src/optionals/ordered_float_impl.rs
+++ b/miniextendr-api/src/optionals/ordered_float_impl.rs
@@ -54,12 +54,15 @@ impl TryCoerce<OrderedFloat<f32>> for f64 {
             }));
         }
         // Check for overflow beyond f32 range
-        if self.abs() > f32::MAX as f64 {
+        if self.abs() > f64::from(f32::MAX) {
             return Err(CoerceError::Overflow);
         }
+        // Deliberate narrowing; the round-trip check below rejects any value
+        // that loses precision in the f64 → f32 conversion.
+        #[allow(clippy::cast_possible_truncation)]
         let f32_val = self as f32;
         // Check for precision loss by round-tripping
-        if (f32_val as f64 - self).abs() > f64::EPSILON * self.abs().max(1.0) {
+        if (f64::from(f32_val) - self).abs() > f64::EPSILON * self.abs().max(1.0) {
             return Err(CoerceError::PrecisionLoss);
         }
         Ok(OrderedFloat(f32_val))
@@ -70,7 +73,7 @@ impl TryCoerce<OrderedFloat<f32>> for f64 {
 impl Coerce<OrderedFloat<f64>> for i32 {
     #[inline(always)]
     fn coerce(self) -> OrderedFloat<f64> {
-        OrderedFloat(self as f64)
+        OrderedFloat(f64::from(self))
     }
 }
 
@@ -78,7 +81,11 @@ impl Coerce<OrderedFloat<f64>> for i32 {
 impl TryCoerce<OrderedFloat<f32>> for i32 {
     type Error = CoerceError;
 
+    // Both casts are deliberate round-trip precision probes: `self as f32`
+    // may lose precision for large i32, and `f32_val as i32` reverses it; if
+    // the round trip disagrees we return `PrecisionLoss`.
     #[inline]
+    #[allow(clippy::cast_possible_truncation)]
     fn try_coerce(self) -> Result<OrderedFloat<f32>, CoerceError> {
         let f32_val = self as f32;
         // Check for precision loss by round-tripping
@@ -101,7 +108,7 @@ impl Coerce<f64> for OrderedFloat<f64> {
 impl Coerce<f64> for OrderedFloat<f32> {
     #[inline(always)]
     fn coerce(self) -> f64 {
-        self.0 as f64
+        f64::from(self.0)
     }
 }
 
@@ -112,6 +119,9 @@ fn parse_f64(sexp: SEXP) -> Result<f64, SexpError> {
 
 fn parse_f32(sexp: SEXP) -> Result<f32, SexpError> {
     let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
+    // R stores doubles; narrowing to the requested f32 storage is intentional
+    // and lossy by design (use `OrderedFloat<f64>` to preserve full precision).
+    #[allow(clippy::cast_possible_truncation)]
     Ok(value as f32)
 }
 
@@ -145,6 +155,8 @@ impl TryFromSexp for Option<OrderedFloat<f32>> {
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
         let value: Option<f64> = TryFromSexp::try_from_sexp(sexp)?;
+        // Intentional, by-design narrowing into f32 storage (see `parse_f32`).
+        #[allow(clippy::cast_possible_truncation)]
         Ok(value.map(|v| OrderedFloat(v as f32)))
     }
 }
@@ -181,7 +193,10 @@ impl TryFromSexp for Vec<OrderedFloat<f32>> {
         }
 
         let slice: &[f64] = unsafe { sexp.as_slice::<f64>() };
-        Ok(slice.iter().map(|v| OrderedFloat(*v as f32)).collect())
+        // Intentional, by-design narrowing into f32 storage (see `parse_f32`).
+        #[allow(clippy::cast_possible_truncation)]
+        let out = slice.iter().map(|v| OrderedFloat(*v as f32)).collect();
+        Ok(out)
     }
 }
 
@@ -199,20 +214,23 @@ impl TryFromSexp for Vec<Option<OrderedFloat<f32>>> {
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
         let values: Vec<Option<f64>> = TryFromSexp::try_from_sexp(sexp)?;
-        Ok(values
+        // Intentional, by-design narrowing into f32 storage (see `parse_f32`).
+        #[allow(clippy::cast_possible_truncation)]
+        let out = values
             .into_iter()
             .map(|v| v.map(|val| OrderedFloat(val as f32)))
-            .collect())
+            .collect();
+        Ok(out)
     }
 }
 
 into_r_infallible!(OrderedFloat<f64>, |this| this.0.into_sexp());
-into_r_infallible!(OrderedFloat<f32>, |this| (this.0 as f64).into_sexp());
+into_r_infallible!(OrderedFloat<f32>, |this| f64::from(this.0).into_sexp());
 into_r_infallible!(Option<OrderedFloat<f64>>, |this| this
     .map(|v| v.0)
     .into_sexp());
 into_r_infallible!(Option<OrderedFloat<f32>>, |this| this
-    .map(|v| v.0 as f64)
+    .map(|v| f64::from(v.0))
     .into_sexp());
 into_r_infallible!(Vec<OrderedFloat<f64>>, |this| this
     .into_iter()
@@ -221,7 +239,7 @@ into_r_infallible!(Vec<OrderedFloat<f64>>, |this| this
     .into_sexp());
 into_r_infallible!(Vec<OrderedFloat<f32>>, |this| this
     .into_iter()
-    .map(|v| v.0 as f64)
+    .map(|v| f64::from(v.0))
     .collect::<Vec<_>>()
     .into_sexp());
 into_r_infallible!(Vec<Option<OrderedFloat<f64>>>, |this| this
@@ -231,7 +249,7 @@ into_r_infallible!(Vec<Option<OrderedFloat<f64>>>, |this| this
     .into_sexp());
 into_r_infallible!(Vec<Option<OrderedFloat<f32>>>, |this| this
     .into_iter()
-    .map(|v| v.map(|val| val.0 as f64))
+    .map(|v| v.map(|val| f64::from(val.0)))
     .collect::<Vec<_>>()
     .into_sexp());
 // endregion

--- a/miniextendr-api/src/optionals/rand_impl.rs
+++ b/miniextendr-api/src/optionals/rand_impl.rs
@@ -138,7 +138,11 @@ impl TryRng for RRng {
         let u = unsafe { crate::sys::unif_rand() };
         // u * 2^32, but we need to be careful with floating point
         // Using the standard conversion: floor(u * (MAX + 1))
-        Ok((u * (u32::MAX as f64 + 1.0)) as u32)
+        // SAFETY (lint): `u ∈ [0, 1)` so the product is in `[0, 2^32)`; the cast
+        // is the intended floor-to-u32 of a non-negative, in-range value.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let scaled = (u * (f64::from(u32::MAX) + 1.0)) as u32;
+        Ok(scaled)
     }
 
     /// Generate a random u64 using R's RNG.
@@ -147,8 +151,8 @@ impl TryRng for RRng {
     #[inline]
     fn try_next_u64(&mut self) -> Result<u64, Infallible> {
         // Combine two u32 values — call try_next_u32 (infallible) directly
-        let high = self.try_next_u32()? as u64;
-        let low = self.try_next_u32()? as u64;
+        let high = u64::from(self.try_next_u32()?);
+        let low = u64::from(self.try_next_u32()?);
         Ok((high << 32) | low)
     }
 
@@ -237,7 +241,12 @@ impl RDistributions for RRng {
 
     #[inline]
     fn uniform_index(&mut self, n: usize) -> usize {
-        unsafe { crate::sys::R_unif_index(n as f64) as usize }
+        // SAFETY (lint): `R_unif_index` returns a non-negative f64 in `[0, n)`;
+        // the `as usize` cast floors it back into range. `n as f64` may lose
+        // precision only for n > 2^53, which exceeds any realistic R length.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let idx = unsafe { crate::sys::R_unif_index(n as f64) as usize };
+        idx
     }
 
     #[inline]

--- a/miniextendr-api/src/optionals/rayon_bridge.rs
+++ b/miniextendr-api/src/optionals/rayon_bridge.rs
@@ -250,13 +250,18 @@ where
     T: RNativeType + Send + Sync,
     F: Fn(&mut [T], usize) + Send + Sync,
 {
-    // Validate length fits in R_xlen_t
+    // Validate length fits in R_xlen_t.
+    // SAFETY (lint): on a 64-bit target `usize == u64`, so `i64::MAX as usize`
+    // is the exact `R_xlen_t` ceiling and cannot truncate.
     #[cfg(target_pointer_width = "64")]
-    assert!(
-        len <= i64::MAX as usize,
-        "with_r_vec: length {} exceeds R_xlen_t maximum",
-        len
-    );
+    {
+        #[allow(clippy::cast_possible_truncation)]
+        let max = i64::MAX as usize;
+        assert!(
+            len <= max,
+            "with_r_vec: length {len} exceeds R_xlen_t maximum"
+        );
+    }
     #[cfg(target_pointer_width = "32")]
     assert!(
         len <= i32::MAX as usize,
@@ -480,13 +485,18 @@ where
         .checked_mul(ncol)
         .expect("with_r_matrix: nrow * ncol overflow");
 
-    // Validate total length fits in R_xlen_t
+    // Validate total length fits in R_xlen_t.
+    // SAFETY (lint): on a 64-bit target `usize == u64`, so `i64::MAX as usize`
+    // is the exact `R_xlen_t` ceiling and cannot truncate.
     #[cfg(target_pointer_width = "64")]
-    assert!(
-        len <= i64::MAX as usize,
-        "with_r_matrix: total length {} exceeds R_xlen_t maximum",
-        len
-    );
+    {
+        #[allow(clippy::cast_possible_truncation)]
+        let max = i64::MAX as usize;
+        assert!(
+            len <= max,
+            "with_r_matrix: total length {len} exceeds R_xlen_t maximum"
+        );
+    }
     #[cfg(target_pointer_width = "32")]
     assert!(
         len <= i32::MAX as usize,
@@ -496,8 +506,12 @@ where
 
     // Allocate, protect, and get data pointer on the R main thread
     use crate::worker::Sendable;
+    // SAFETY: `nrow`/`ncol <= i32::MAX` asserted above, so these narrowing
+    // casts cannot truncate.
+    #[allow(clippy::cast_possible_truncation)]
+    let (nrow_i32, ncol_i32) = (nrow as i32, ncol as i32);
     let (sexp, Sendable(ptr)) = with_r_thread(move || unsafe {
-        let sexp = crate::sys::Rf_allocMatrix_unchecked(T::SEXP_TYPE, nrow as i32, ncol as i32);
+        let sexp = crate::sys::Rf_allocMatrix_unchecked(T::SEXP_TYPE, nrow_i32, ncol_i32);
         crate::sys::Rf_protect_unchecked(sexp);
         let ptr = T::dataptr_mut(sexp);
         (sexp, Sendable(ptr))
@@ -565,13 +579,18 @@ where
         .try_fold(1usize, |acc, &d| acc.checked_mul(d))
         .expect("with_r_array: dimension product overflow");
 
-    // Validate total length fits in R_xlen_t
+    // Validate total length fits in R_xlen_t.
+    // SAFETY (lint): on a 64-bit target `usize == u64`, so `i64::MAX as usize`
+    // is the exact `R_xlen_t` ceiling and cannot truncate.
     #[cfg(target_pointer_width = "64")]
-    assert!(
-        total_len <= i64::MAX as usize,
-        "with_r_array: total length {} exceeds R_xlen_t maximum",
-        total_len
-    );
+    {
+        #[allow(clippy::cast_possible_truncation)]
+        let max = i64::MAX as usize;
+        assert!(
+            total_len <= max,
+            "with_r_array: total length {total_len} exceeds R_xlen_t maximum"
+        );
+    }
     #[cfg(target_pointer_width = "32")]
     assert!(
         total_len <= i32::MAX as usize,
@@ -589,7 +608,11 @@ where
         crate::sys::Rf_protect_unchecked(dim_sexp);
 
         for (slot, &d) in dim_s.iter_mut().zip(dims.iter()) {
-            *slot = d as i32;
+            // SAFETY: every `d <= i32::MAX` asserted above, so the narrowing
+            // cast cannot truncate.
+            #[allow(clippy::cast_possible_truncation)]
+            let d = d as i32;
+            *slot = d;
         }
 
         sexp.set_attr_unchecked(SEXP::dim_symbol(), dim_sexp);
@@ -973,6 +996,13 @@ impl RDataFrameBuilder {
             ncol,
             "RDataFrameBuilder: names/columns length mismatch"
         );
+        // Compact row.names `c(NA, -nrow)` are emitted as INTSXP, so `nrow` must
+        // fit in `i32`. Validate up front (panic → R error) rather than letting
+        // `-(nrow as i32)` below silently wrap for >2^31-row frames.
+        assert!(
+            nrow <= i32::MAX as usize,
+            "RDataFrameBuilder: nrow {nrow} exceeds i32 maximum for compact row.names"
+        );
 
         // Phase 1: allocate every column's backing storage serially. Native
         // columns return a freshly-protected R SEXP and its data pointer;
@@ -1056,7 +1086,11 @@ impl RDataFrameBuilder {
                     }
                 }
             }
-            debug_assert_eq!(native_protected as usize, ncol);
+            // SAFETY: `native_protected` is a non-negative running count, so the
+            // sign cast to `usize` cannot lose data.
+            #[allow(clippy::cast_sign_loss)]
+            let native_protected_usize = native_protected as usize;
+            debug_assert_eq!(native_protected_usize, ncol);
 
             // Allocate the parent list and protect it.
             let df = crate::sys::Rf_allocVector_unchecked(VECSXP, ncol as crate::R_xlen_t);
@@ -1089,7 +1123,11 @@ impl RDataFrameBuilder {
             let row_names = crate::sys::Rf_allocVector_unchecked(INTSXP, 2);
             crate::sys::Rf_protect_unchecked(row_names);
             row_names.set_integer_elt(0, i32::MIN); // NA_integer_
-            row_names.set_integer_elt(1, -(nrow as i32));
+            // SAFETY: `nrow <= i32::MAX` asserted in `build_sexp`, so the
+            // narrowing cast cannot truncate the compact row.names count.
+            #[allow(clippy::cast_possible_truncation)]
+            let neg_nrow = -(nrow as i32);
+            row_names.set_integer_elt(1, neg_nrow);
             df.set_row_names(row_names);
             crate::sys::Rf_unprotect_unchecked(1); // row_names now reachable via df
 
@@ -1336,8 +1374,11 @@ pub trait RParallelIterator {
     }
 
     /// Counts the number of elements in parallel.
+    ///
+    /// The count is returned to R as an `int`; collections larger than
+    /// `i32::MAX` saturate rather than silently wrapping.
     fn par_count(&self) -> i32 {
-        self.par_iter().count() as i32
+        i32::try_from(self.par_iter().count()).unwrap_or(i32::MAX)
     }
 
     /// Computes the parallel product of f64 elements.
@@ -1385,7 +1426,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter().filter(|&x| x.into() > threshold).count() as i32
+        i32::try_from(self.par_iter().filter(|&x| x.into() > threshold).count()).unwrap_or(i32::MAX)
     }
 
     /// Counts elements less than threshold.
@@ -1393,7 +1434,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter().filter(|&x| x.into() < threshold).count() as i32
+        i32::try_from(self.par_iter().filter(|&x| x.into() < threshold).count()).unwrap_or(i32::MAX)
     }
 
     /// Counts elements equal to value (within epsilon for floats).
@@ -1401,9 +1442,12 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter()
-            .filter(|&x| (x.into() - value).abs() <= epsilon)
-            .count() as i32
+        i32::try_from(
+            self.par_iter()
+                .filter(|&x| (x.into() - value).abs() <= epsilon)
+                .count(),
+        )
+        .unwrap_or(i32::MAX)
     }
 
     /// Computes variance in parallel.

--- a/miniextendr-api/src/optionals/regex_impl.rs
+++ b/miniextendr-api/src/optionals/regex_impl.rs
@@ -316,7 +316,10 @@ impl RCaptureGroups for CaptureGroups {
         if i < 0 {
             return None;
         }
-        self.groups.get(i as usize).and_then(|s| s.clone())
+        // SAFETY: `i >= 0` checked above, so the sign cast cannot lose data.
+        #[allow(clippy::cast_sign_loss)]
+        let i = i as usize;
+        self.groups.get(i).and_then(|s| s.clone())
     }
 
     fn get_named(&self, name: &str) -> Option<String> {

--- a/miniextendr-api/src/optionals/rust_decimal_impl.rs
+++ b/miniextendr-api/src/optionals/rust_decimal_impl.rs
@@ -473,7 +473,11 @@ impl RDecimalOps for Decimal {
     }
 
     fn round(&self, dp: i32) -> Decimal {
-        Decimal::round_dp(self, dp.max(0) as u32)
+        // SAFETY (lint): `.max(0)` makes the value non-negative before the
+        // sign cast, so it cannot lose data.
+        #[allow(clippy::cast_sign_loss)]
+        let dp = dp.max(0) as u32;
+        Decimal::round_dp(self, dp)
     }
 
     fn floor(&self) -> Decimal {

--- a/miniextendr-api/src/optionals/time_impl.rs
+++ b/miniextendr-api/src/optionals/time_impl.rs
@@ -70,7 +70,12 @@ impl_realsxp_datetime!(
     OffsetDateTime,
     "POSIXct",
     |secs: f64| {
+        // `whole_secs` saturates on overflow (no UB); `nanos` is bounded to
+        // `[0, 1e9) < i32::MAX` because `secs - secs.floor() ∈ [0, 1)`. Any
+        // out-of-range timestamp is rejected by `checked_add` below.
+        #[allow(clippy::cast_possible_truncation)]
         let whole_secs = secs.floor() as i64;
+        #[allow(clippy::cast_possible_truncation)]
         let nanos = ((secs - secs.floor()) * 1_000_000_000.0) as i32;
         let duration = time::Duration::new(whole_secs, nanos);
         UNIX_EPOCH
@@ -79,7 +84,8 @@ impl_realsxp_datetime!(
     },
     |dt: OffsetDateTime| {
         let duration = dt - UNIX_EPOCH;
-        duration.whole_seconds() as f64 + (duration.subsec_nanoseconds() as f64 / 1_000_000_000.0)
+        duration.whole_seconds() as f64
+            + (f64::from(duration.subsec_nanoseconds()) / 1_000_000_000.0)
     },
     |sexp: SEXP| set_posixct_utc(sexp)
 );
@@ -92,6 +98,9 @@ impl_realsxp_datetime!(
     Date,
     "Date",
     |days: f64| {
+        // Saturates on overflow (no UB); out-of-range dates are rejected by
+        // `checked_add` below.
+        #[allow(clippy::cast_possible_truncation)]
         let days_i64 = days.trunc() as i64;
         let duration = time::Duration::days(days_i64);
         UNIX_EPOCH_DATE
@@ -183,7 +192,14 @@ impl RDuration for Duration {
     }
 
     fn as_milliseconds(&self) -> i64 {
-        Duration::whole_milliseconds(*self) as i64
+        // whole_milliseconds() returns i128; clamp to i64 range (saturating,
+        // not truncating) to mirror the jiff `SignedDuration` behaviour.
+        // SAFETY (lint): after clamping into `[i64::MIN, i64::MAX]` the value
+        // is representable as `i64`, so the narrowing cannot truncate.
+        #[allow(clippy::cast_possible_truncation)]
+        let ms = Duration::whole_milliseconds(*self)
+            .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64;
+        ms
     }
 
     fn whole_days(&self) -> i64 {

--- a/miniextendr-api/src/optionals/uuid_impl.rs
+++ b/miniextendr-api/src/optionals/uuid_impl.rs
@@ -205,7 +205,8 @@ pub trait RUuidOps {
 
 impl RUuidOps for Uuid {
     fn version(&self) -> i32 {
-        self.get_version_num() as i32
+        // The UUID version is a 4-bit field (0..=15), so it always fits in i32.
+        i32::try_from(self.get_version_num()).expect("UUID version fits in i32")
     }
 
     fn variant(&self) -> String {


### PR DESCRIPTION
Sweeps the residual `as <int-or-float>` casts in `miniextendr-api/src/optionals/` (issue #629), triaging each into: real overflow/lossy bug (fix), lossless widening (refactor to `From`), or pre-validated/intentional (document with `#[allow]` + `// SAFETY:`).

## What was done

I ran `cargo clippy` with `-W clippy::cast_lossless -W clippy::cast_possible_truncation -W clippy::cast_sign_loss` over the optionals files under CI's `clippy_all` feature set (plus a separate `arrow,log` batch for the feature-conflicting files), found **174** flagged casts, and triaged every one. Result: **zero** remaining cast-lint warnings in `optionals/`.

### Pattern 2/3 — real overflow/lossy fixes (behaviour-changing: saturate/error instead of silent wrap)

- `rayon_bridge.rs` `RDataFrameBuilder::build_sexp`: assert `nrow <= i32::MAX` **before** emitting compact row.names `c(NA, -nrow)` (an INTSXP) — was silently truncating for >2^31-row frames.
- `rayon_bridge.rs` `par_count` / `par_count_gt` / `par_count_lt` / `par_count_eq`: `i32::try_from(count).unwrap_or(i32::MAX)` instead of `count() as i32`.
- `jiff_impl.rs` `span_vec_to_rcrd`: `i32::try_from(get_minutes()/seconds/ms/us/ns).unwrap_or(i32::MAX)` instead of `as i32` — saturate, never wrap.
- `time_impl.rs` / `jiff_impl.rs` `as_milliseconds`: clamp the i128 into `[i64::MIN, i64::MAX]` before narrowing (the `time` one previously did a bare `whole_milliseconds() as i64` that could truncate).
- `indexmap_impl.rs` `len` / `get_index_of`: saturate at `i32::MAX`.

### Lossless widenings refactored to `From`/`from`

`ndarray_impl.rs` i32 stats `x as f64` → `f64::from`; `num_bigint_impl.rs` `count_ones()/trailing_zeros() as i64` → `i64::from`; `rand_impl.rs` `u32 as u64` → `u64::from`; `ordered_float_impl.rs` + `arrow_impl.rs` f32→f64 and i8/i16→i32 → `f64::from` / `i32::from`; `bytes_impl.rs` `i8 as i32` → `i32::from`.

### Pre-validated / intentional casts — documented (`#[allow(...)]` + `// SAFETY:`)

- `ndarray_impl.rs`: all R-index `as usize` casts (each guarded by `< 0` / `.max(0)` before use) — per-method `#[allow(clippy::cast_sign_loss)]` with a shared rationale.
- `rayon_bridge.rs`: `i64::MAX as usize` length ceilings (lossless on 64-bit) and `nrow/ncol/d as i32` matrix/array dims (pre-asserted `<= i32::MAX`).
- `jiff_impl.rs` / `time_impl.rs`: float→int datetime decode hoisted into a documented `posix_secs_to_timestamp` helper / annotated closures — the float→int cast saturates (no UB) and the value is then rejected by the validating constructor (`Timestamp::new` / `checked_add` / `try_days`); nanos are bounded `[0, 1e9) < i32::MAX`.
- `rand_impl.rs`: RNG scaling idioms (`u * 2^32`, `R_unif_index` floor).
- `ordered_float_impl.rs`: deliberate f64→f32 narrowings (validated by round-trip precision probes).
- `arrow_impl.rs`: documented-truncation `f64 days/seconds → i32/i64` (Arrow Date32/Timestamp store integer units).
- `uuid_impl.rs`: 4-bit version field via `i32::try_from(...).expect(...)`.

`datafusion_impl.rs` and `log_impl.rs` contain no int/float `as` casts (nothing to fix).

## Verification

- `cargo clippy -p miniextendr-api --features <clippy_all list> --all-targets -- -D warnings` → **EXIT 0** (CI bar passes).
- Same feature set + the three cast lints, `--lib` → **zero** cast-lint warnings, **zero** errors in `optionals/`.
- `arrow,log` batch (not in CI's curated list, conflicts excluded) verified separately → zero cast warnings, zero errors.
- `cargo fmt --all`.
- Pure-logic unit tests for the changed casts pass: `ordered_float` (7), `num_bigint` (15), `rand_impl` (18). R-linked tests (ndarray/rayon/indexmap with the R thread) need the R harness; the changes there are either no-logic annotations or simple saturation/assert additions.

## Caveats (behaviour changes from pattern 2/3 fixes)

These only bite at >2^31 magnitudes that were previously silently corrupting:
- `RDataFrameBuilder` now **panics** (→ R error) for a >`i32::MAX`-row frame instead of writing a wrapped negative row-count.
- `par_count*`, `indexmap::len`/`get_index_of`, and jiff span fields now **saturate at `i32::MAX`** instead of wrapping.
- `as_milliseconds` (time + jiff) now **clamps** to the i64 range instead of truncating an i128.

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
