### PR TITLE
tooling: quarterly skill freshness audit + repair Flight-14 skill drift (#626)

### DIFF
--- a/.claude/skills/miniextendr-architecture/SKILL.md
+++ b/.claude/skills/miniextendr-architecture/SKILL.md
@@ -251,7 +251,7 @@ framework crates.
 - Changing how `#[miniextendr]` parses attributes, generates C wrappers, or
   generates R wrapper fragments? That is `miniextendr-macros`.
 - Changing the ordering or output format of `R/miniextendr-wrappers.R`? That
-  is `miniextendr-api/src/registry.rs` (the `write_wrappers` /
+  is `miniextendr-api/src/registry.rs` (the `miniextendr_write_wrappers` /
   `collect_r_wrappers` entry points) or `miniextendr-macros` (the fragments
   emitted into `MX_R_WRAPPERS`).
 - Adding a build-time source-level lint? That is `miniextendr-lint`.

--- a/.claude/skills/miniextendr-class-systems/SKILL.md
+++ b/.claude/skills/miniextendr-class-systems/SKILL.md
@@ -142,7 +142,7 @@ R6 generates an `R6::R6Class(...)` definition with:
 
 For void instance methods (`-> ()` return type), the generated R method body ends
 with `invisible(self)` to support method chaining. See `method_return_builder.rs`
-`build_r6_return` around L302.
+`build_r6_body` around L260.
 
 The `DotCallBuilder` uses `.null_call_attribution()` for the R6 finalizer and
 deep_clone methods — `match.call()` in those contexts captures an internal
@@ -345,7 +345,7 @@ later, unpredictably.
 - `miniextendr-macros/src/r_class_formatter.rs` — Shared utilities: `ClassDocBuilder`,
   `MethodDocBuilder`, `MethodContext`, `emit_s3_generic_guard`, `should_export_from_tags`.
 - `miniextendr-macros/src/method_return_builder.rs` — `condition_check_lines`,
-  `condition_check_inline_block`, `ReturnStrategy`; `build_r6_return` (`invisible(self)`).
+  `condition_check_inline_block`, `ReturnStrategy`; `build_r6_body` (`invisible(self)`).
 - `miniextendr-macros/src/r_wrapper_builder.rs` — `DotCallBuilder` at ~L390;
   `.null_call_attribution()` for lambda contexts.
 - `miniextendr-api/src/registry.rs` — `RWrapperPriority` enum (L210), `collect_r_wrappers`,

--- a/.claude/skills/miniextendr-connections/SKILL.md
+++ b/.claude/skills/miniextendr-connections/SKILL.md
@@ -24,7 +24,7 @@ R's `R_ext/Connections.h` states: "we do not expect future connection APIs to be
 
 The `connections` feature in miniextendr is gated for this reason. Before using it in production, verify that `R_CONNECTIONS_VERSION` matches `EXPECTED_CONNECTIONS_VERSION` (both are constants from `connection.rs`). The `check_connections_version()` function asserts this at runtime; call it during `R_init_<pkg>` when the feature is enabled.
 
-The API requires R >= 4.3.0. Use `check_runtime_connections_support()` for a runtime probe.
+The API requires R >= 4.3.0. Use `check_connections_runtime()` for a runtime probe.
 
 ### Connections from `RCustomConnection::build` are returned open
 
@@ -113,7 +113,7 @@ Panics inside `RConnectionImpl` methods are caught by `catch_connection_panic`. 
 
 ## Key files
 
-- `miniextendr-api/src/connection.rs` — `RConnectionImpl` trait, `RCustomConnection` builder, `catch_connection_panic`, `check_connections_version`, `check_runtime_connections_support`, trampolines.
+- `miniextendr-api/src/connection.rs` — `RConnectionImpl` trait, `RCustomConnection` builder, `catch_connection_panic`, `check_connections_version`, `check_connections_runtime`, trampolines.
 - `miniextendr-api/src/ffi_guard.rs` — `guarded_ffi_call_with_fallback` used by `catch_connection_panic`.
 
 ## Common pitfalls

--- a/.claude/skills/miniextendr-ffi/SKILL.md
+++ b/.claude/skills/miniextendr-ffi/SKILL.md
@@ -22,7 +22,7 @@ The FFI layer is the boundary where Rust code calls into R's C API. R uses `long
 
 ### `#[r_ffi_checked]` — thread-checked FFI wrappers
 
-`#[r_ffi_checked]` is a proc macro applied to `unsafe extern "C-unwind"` blocks in `miniextendr-api/src/ffi.rs`. For every function declared in the block, it generates two variants:
+`#[r_ffi_checked]` is a proc macro applied to `unsafe extern "C-unwind"` blocks in `miniextendr-api/src/sys.rs`. For every function declared in the block, it generates two variants:
 
 - `fn_name(args)` — the checked variant. Calls `with_r_thread(|| …)` first (a debug assertion that the current thread is R's main thread), then delegates to the underlying C symbol.
 - `fn_name_unchecked(args)` — the raw variant. No thread check. Same as calling the C symbol directly.
@@ -40,7 +40,7 @@ When to use `_unchecked`:
 
 MXL301 enforces this: using `_unchecked` outside these known-safe contexts is a lint error. See `miniextendr-lint`.
 
-The `^nonapi^` annotation in `ffi.rs` marks functions that require `#[cfg(feature = "nonapi")]`. These are R internals not part of the stable public API.
+The `^nonapi^` annotation in `sys.rs` marks functions that require `#[cfg(feature = "nonapi")]`. These are R internals not part of the stable public API.
 
 ### `with_r_unwind_protect` — the default for `#[miniextendr]` functions
 
@@ -89,7 +89,7 @@ Two RAII types from `miniextendr-api/src/gc_protect.rs`:
   // a and b are valid until scope drops
   ```
 
-For long-lived SEXPs that outlive a single `.Call` frame, use `R_PreserveObject` / `R_ReleaseObject` from the `preserve` module.
+For long-lived SEXPs that outlive a single `.Call` frame, use `R_PreserveObject` / `R_ReleaseObject` (wrapped by the `Root` handle in `miniextendr-api/src/gc_protect.rs`).
 
 ### Panic telemetry
 
@@ -147,11 +147,11 @@ Use `_unchecked` variants. The callback is guaranteed on the main thread by R's 
 
 - Single short-lived SEXP, drops at end of current block: `OwnedProtect`.
 - Multiple SEXPs with the same lifetime, all drop together: `ProtectScope`.
-- SEXP outlives the current `.Call` frame (e.g., stored in an R6 object or ExternalPtr): `R_PreserveObject` / `R_ReleaseObject` (see `miniextendr-api/src/preserve.rs`).
+- SEXP outlives the current `.Call` frame (e.g., stored in an R6 object or ExternalPtr): `R_PreserveObject` / `R_ReleaseObject` via the `Root` handle (see `miniextendr-api/src/gc_protect.rs`).
 
 ## Key files
 
-- `miniextendr-api/src/ffi.rs` — all R API declarations under `#[r_ffi_checked]`. Blocks at lines 2092, 2634, 2803, 2973, 3000, 3356, 3419, 3525, 3790.
+- `miniextendr-api/src/sys.rs` — all R API declarations under `#[r_ffi_checked]`. Blocks at lines 248, 787, 956, 1126, 1509, 1572, 1681, 1955.
 - `miniextendr-api/src/unwind_protect.rs` — `with_r_unwind_protect` (default), `with_r_unwind_protect_or_raise` (legacy), `with_r_unwind_protect_shim`, `with_r_unwind_protect_sourced`, `raise_rust_condition_via_stop`, `get_continuation_token`.
 - `miniextendr-api/src/ffi_guard.rs` — `GuardMode`, `guarded_ffi_call`, `guarded_ffi_call_with_fallback`.
 - `miniextendr-api/src/gc_protect.rs` — `OwnedProtect`, `ProtectScope`, `Root`, `ReprotectSlot`, `tls` convenience module.
@@ -170,7 +170,7 @@ Use `_unchecked` variants. The callback is guaranteed on the main thread by R's 
 
 - **`catch_unwind` does not catch R longjmps**: wrapping in `catch_unwind` alone is insufficient if the closure calls R API. Use `with_r_unwind_protect` instead, which installs an `R_UnwindProtect` cleanup handler.
 
-- **`nonapi` feature gate**: some R internal functions (not in the stable public API) are declared with `^nonapi^` in `ffi.rs`. Calling them requires `features = ["nonapi"]` in `Cargo.toml`. Without it, the checked wrapper bodies are absent (`cfg(not(feature = "nonapi"))`).
+- **`nonapi` feature gate**: some R internal functions (not in the stable public API) are declared with `^nonapi^` in `sys.rs`. Calling them requires `features = ["nonapi"]` in `Cargo.toml`. Without it, the checked wrapper bodies are absent (`cfg(not(feature = "nonapi"))`).
 
 ## Related skills
 

--- a/.claude/skills/miniextendr-rv/SKILL.md
+++ b/.claude/skills/miniextendr-rv/SKILL.md
@@ -59,7 +59,8 @@ deps but not the local package itself (we install that via
 
 The pinned `roxygen2_8.0.0.tar.gz` URL is intentional — current code targets
 roxygen2 8.0.0; the CRAN release moved on and would re-render man pages
-differently. See `journal/2026-05-17-pr2-release-workflow-cran-pins.md`.
+differently. The pin is the source of truth in `rproject.toml`, mirrored by
+`Config/roxygen2/version: 8.0.0` in `rpkg/DESCRIPTION`.
 
 ## The R-version contract (the only thing that goes wrong here)
 
@@ -208,6 +209,7 @@ If any of these fail, you're in safe mode — see the fix recipes above.
 
 - Root `CLAUDE.md` § "R version (rv + rig)" — the abbreviated version of this
   doc, intended for first-touch contributors.
-- `journal/2026-05-17-pr2-release-workflow-cran-pins.md` — context for the
+- `rproject.toml` (the `roxygen2` dependency entry) and
+  `rpkg/DESCRIPTION` (`Config/roxygen2/version`) — the source of truth for the
   pinned `roxygen2_8.0.0.tar.gz` URL.
 - `[[miniextendr-build]]` skill — what to do *after* you've sorted R/rv.

--- a/.claude/skills/miniextendr-worker/SKILL.md
+++ b/.claude/skills/miniextendr-worker/SKILL.md
@@ -166,7 +166,7 @@ On: a background thread is spawned at package load. Use for CPU-intensive work t
 
 - `miniextendr-api/src/worker.rs` — `run_on_worker`, `with_r_thread`, `Sendable<T>`, `miniextendr_runtime_init`, `miniextendr_runtime_shutdown`, `worker_loop`, `dispatch_to_worker`, `route_to_main_thread`, `WorkerMsg`, `WorkerState`.
 - `miniextendr-api/src/unwind_protect.rs` — `with_r_unwind_protect` used inside the main-thread work loop.
-- `miniextendr-api/src/ffi.rs` — `#[r_ffi_checked]` thread assertions; `is_r_main_thread()` helper.
+- `miniextendr-api/src/sys.rs` — `#[r_ffi_checked]` thread assertions; `is_r_main_thread()` helper.
 - `miniextendr-api/src/panic_telemetry.rs` — `PanicSource::Worker` telemetry fired on worker panics.
 
 ## Common pitfalls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,16 @@ GitHub Actions auto-deploys on push to `main` when `site/**`, `docs/**`, or `*/s
 
 **Always check `background/` for R API details before guessing.**
 
+## Skill freshness audit (quarterly)
+
+The Claude Code skills under `.claude/skills/<slug>/SKILL.md` cite file paths,
+symbols, and line numbers that drift as the code evolves. Run
+`bash scripts/skill-freshness-audit.sh` **once a quarter** (and repair drift in
+the same pass — source wins, fix the SKILL.md). It flags, per skill: missing
+cited paths (BLOCKING, exits non-zero so it can gate CI), symbols that grep
+finds nowhere in the repo (WARN), and out-of-range `file.rs:NNN` line cites
+(WARN). The script's header documents its known false-positive modes.
+
 ## Reviews
 
 - **Reviews** (`reviews/*.md`): when things go wrong (test/CI failure, runtime error, unexpected behavior), write a short file: *what was attempted*, *what went wrong*, *root cause*, *fix*. Accumulates institutional knowledge on non-obvious failure modes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,20 @@ form, search results, anything already in a commit message or memory file.
 
 **Always check `background/` for R API details before guessing.**
 
+### Skill freshness audit (quarterly)
+
+The Claude Code skills under `.claude/skills/<slug>/SKILL.md` cite file paths,
+symbols, and line numbers that drift as the code evolves. Run
+`bash scripts/skill-freshness-audit.sh` **once a quarter** (and repair drift in
+the same pass — source wins, fix the SKILL.md). It flags, per skill: missing
+cited paths (BLOCKING, exits non-zero so it can gate CI), symbols that grep
+finds nowhere in the repo (WARN), and out-of-range `file.rs:NNN` line cites
+(WARN). The script's header documents its known false-positive modes
+(illustrative placeholders, R functions that look like paths, generated/
+gitignored artifacts, scaffolded-package layout paths). CLAUDE.md ↔ skill
+contradictions are not auto-detected — eyeball any skill that restates a
+CLAUDE.md fact when triaging.
+
 ### Reviews
 
 - **Reviews** (`reviews/*.md`): when things go wrong (test/CI failure, runtime error, unexpected behavior), write a short file: *what was attempted*, *what went wrong*, *root cause*, *fix*. Accumulates institutional knowledge on non-obvious failure modes.

--- a/journal/2026-06-09-skill-freshness-audit.md
+++ b/journal/2026-06-09-skill-freshness-audit.md
@@ -1,0 +1,57 @@
+# Skill freshness audit — first run (2026-06-09)
+
+Closes the audit-tooling half of #626 (Flight 14 / #174 skill drift).
+
+`scripts/skill-freshness-audit.sh` was added and run for the first time against
+the 16 skills under `.claude/skills/<slug>/SKILL.md`. The script checks, per
+skill: cited path existence (BLOCKING), symbol existence via repo-wide
+`git grep` (WARN), and `file.rs:NNN` line cites (WARN). It exits non-zero on any
+BLOCKING path miss so it can gate CI. See the script header for the full
+false-positive-mode catalogue.
+
+## First-run result (before fixes)
+
+```
+Audited 16 skill(s): 4 BLOCKING, 10 WARN
+```
+
+### BLOCKING (stale paths — all genuine drift)
+
+| Skill | Stale cite | Reality |
+|-------|-----------|---------|
+| miniextendr-ffi | `miniextendr-api/src/ffi.rs` (×4 incl. Key files + nonapi) | renamed to `miniextendr-api/src/sys.rs` |
+| miniextendr-ffi | `miniextendr-api/src/preserve.rs` | no `preserve` module; primitives live in `gc_protect.rs` (`Root`) |
+| miniextendr-worker | `miniextendr-api/src/ffi.rs` | `miniextendr-api/src/sys.rs` |
+| miniextendr-rv | `journal/2026-05-17-pr2-release-workflow-cran-pins.md` (×2) | file never existed; pin source of truth is `rproject.toml` + `rpkg/DESCRIPTION` `Config/roxygen2/version` |
+
+### WARN (real symbol/line drift — also fixed)
+
+| Skill | Stale cite | Reality |
+|-------|-----------|---------|
+| miniextendr-ffi | line block list `2092, 2634, …, 3790` for the `#[r_ffi_checked]` blocks | now at `248, 787, 956, 1126, 1509, 1572, 1681, 1955` in `sys.rs` |
+| miniextendr-class-systems | `build_r6_return` (×2) | renamed to `build_r6_body` (`method_return_builder.rs:260`) |
+| miniextendr-connections | `check_runtime_connections_support` (×2) | actual fn is `check_connections_runtime` (`connection.rs:131`) |
+| miniextendr-architecture | prose abbrev `write_wrappers` | expanded to `miniextendr_write_wrappers` for precision |
+
+### WARN (documented false positives — left as-is)
+
+- `.cargo/config.toml`, `R/miniextendr-wrappers.R` etc. — generated / gitignored;
+  absent in a clean tree by design.
+- `R_ext/Connections.h` — external R header, lives in gitignored `background/`.
+- `src/rust/src/lib.rs` — describes the *scaffolded end-user package* layout, not
+  a path inside this repo (this repo's example is `rpkg/src/rust/lib.rs`).
+
+## After fixes
+
+```
+Audited 16 skill(s): 0 BLOCKING, 7 WARN   (exit 0)
+```
+
+The 7 remaining WARNs are all the documented false-positive modes above — no real
+drift remains.
+
+## Cadence
+
+Documented in `CLAUDE.md` and `AGENTS.md` under "Skill freshness audit
+(quarterly)": run `bash scripts/skill-freshness-audit.sh` once a quarter and
+repair drift in the same pass (source wins).

--- a/scripts/skill-freshness-audit.sh
+++ b/scripts/skill-freshness-audit.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Quarterly freshness audit for Claude Code skills (.claude/skills/<slug>/SKILL.md).
+#
+# Flight 14 (#174) shipped a set of skills that cite file paths, function/type/
+# macro names, and line numbers drawn from the source tree, CLAUDE.md, and
+# MEMORY.md. Those citations drift as the code evolves. This script flags the
+# drift so a maintainer can repair the skill (source wins — fix the SKILL.md,
+# not the code). See issue #626.
+#
+# WHAT IT CHECKS, per .claude/skills/*/SKILL.md
+# ---------------------------------------------
+#   1. PATH existence  (BLOCKING)
+#      Every backtick-wrapped token that contains a "/" and ends in a known
+#      code/file extension is treated as a repo-relative path. We resolve it
+#      against the repo root AND against rpkg/ (skills frequently use
+#      package-relative paths like `src/Makevars.in` or `tools/foo.R`). A token
+#      that resolves under neither root, and is not a known generated/gitignored
+#      artifact or external reference, is a BLOCKING miss for that skill.
+#
+#   2. SYMBOL existence  (WARN)
+#      Backtick-wrapped tokens shaped like real code identifiers
+#      (snake_case fns, CamelCase types, ALL_CAPS consts, `macro!`) are searched
+#      across the whole tracked repo with `git grep -wF`. A token found NOWHERE
+#      is reported as a WARN (maintainer triage) — never BLOCKING, because prose
+#      and illustrative names share this shape.
+#
+#   3. LINE-NUMBER cites  (WARN)
+#      Tokens of the form `file.ext:NNN` are checked: if the resolved file has
+#      fewer than NNN lines, the cite is out of range and reported as a WARN.
+#
+#   4. CLAUDE.md contradiction  (informational)
+#      Not auto-decided here — too prose-shaped to diff mechanically without
+#      false positives. The audit prints a reminder; a maintainer eyeballs any
+#      skill that restates a CLAUDE.md fact (build-pipeline order, attribute
+#      defaults, MXL numbers). Source wins.
+#
+# EXIT CODE
+# ---------
+#   Non-zero iff any BLOCKING miss (a cited path resolves nowhere). WARN-only
+#   runs exit 0. This lets the script gate a CI job on path drift without
+#   tripping on the inherently-noisy symbol heuristic.
+#
+# KNOWN FALSE-POSITIVE MODES (be conservative; prefer WARN over BLOCKING)
+# ----------------------------------------------------------------------
+#   * Illustrative names. Skills use placeholder paths/idents in examples
+#     (`foo.rs`, `foo/mod.rs`, `my_rule.rs`, `MyStruct`, `s4_something`,
+#     `fn_unchecked` where `fn` stands in for a real function name). These are
+#     denylisted (ILLUSTRATIVE_TOKENS) or simply surface as WARN.
+#   * R functions that look like paths (`match.arg`, `match.call`, `dyn.load`,
+#     `self.value`). These contain a "." but no "/", so the path check ignores
+#     them (only slash-containing tokens are paths).
+#   * Prose abbreviations of real symbols (`write_wrappers` for
+#     `miniextendr_write_wrappers`). Word-bounded grep won't find the short form
+#     -> shows as a symbol WARN. Harmless; maintainer ignores.
+#   * External R headers (`R_ext/Connections.h`) live in the gitignored
+#     `background/` reference tree; matched by EXTERNAL_PATH_PREFIXES -> WARN.
+#   * Generated / gitignored artifacts (`inst/vendor.tar.xz`,
+#     `R/miniextendr-wrappers.R`, `.cargo/config.toml`) won't exist in a clean
+#     tree; matched by GENERATED_PATH_SUFFIXES -> WARN, not BLOCKING.
+#
+# USAGE
+#   bash scripts/skill-freshness-audit.sh            # human report
+#   bash scripts/skill-freshness-audit.sh --quiet    # only misses + summary
+#
+# CADENCE: run quarterly (see CLAUDE.md "Skill freshness audit"). Repair drift
+# in the same pass; source wins.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+QUIET=0
+[ "${1:-}" = "--quiet" ] && QUIET=1
+
+SKILLS_GLOB=".claude/skills/*/SKILL.md"
+
+# File extensions we treat as "this token is a path", to avoid mistaking R
+# function calls (match.arg) or version strings for paths.
+PATH_EXT_RE='\.(rs|R|toml|lock|c|h|md|def|patch|yml|yaml|sh|in|R|cfg)$'
+
+# Tokens that are illustrative placeholders, never real repo objects.
+ILLUSTRATIVE_TOKENS=(
+    'foo.rs' 'foo/mod.rs' 'my_rule.rs' 'bar.rs'
+    'MyStruct' 'MyType' 'MyTrait'
+    'fn_unchecked' 's4_something' 's4_s4_something'
+    's4_my_method' 's4_s4_my_method'
+)
+
+# Generated / gitignored artifacts: absence in a clean tree is expected.
+# Matched as a *suffix* of the cited path.
+GENERATED_PATH_SUFFIXES=(
+    'inst/vendor.tar.xz'
+    'R/miniextendr-wrappers.R'
+    '.cargo/config.toml'
+    'src/rust/wasm_registry.rs'
+    'Cargo.lock'
+)
+
+# External reference trees (gitignored background/) — cited but not in-repo.
+EXTERNAL_PATH_PREFIXES=(
+    'R_ext/'
+)
+
+# Scaffolded-end-user-package layout. The getting-started / scaffolding skills
+# describe the structure of a package minirextendr GENERATES, not a path inside
+# this repo (this repo's live example lives under rpkg/src/rust/, with no nested
+# src/). Matched as prefix -> WARN, not BLOCKING.
+SCAFFOLD_PATH_PREFIXES=(
+    'src/rust/src/'
+)
+
+# Roots a package-relative path may resolve against (skills mix repo-root and
+# rpkg-relative paths freely).
+RESOLVE_ROOTS=( '.' 'rpkg' )
+
+# Pathspecs for the symbol search: the whole tracked tree minus vendored
+# crates, the rv R library, and the skills themselves (we don't want a symbol
+# to "exist" only because the skill names it).
+SYMBOL_PATHSPECS=(
+    ':!**/vendor/**'
+    ':!rv/**'
+    ':!.claude/skills/**'
+    ':!target/**'
+)
+
+c_red=''; c_yellow=''; c_green=''; c_dim=''; c_reset=''
+if [ -t 1 ]; then
+    c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_green=$'\033[32m'
+    c_dim=$'\033[2m'; c_reset=$'\033[0m'
+fi
+
+in_list() {
+    local needle="$1"; shift
+    local x
+    for x in "$@"; do [ "$x" = "$needle" ] && return 0; done
+    return 1
+}
+
+has_suffix() {
+    local s="$1" suf
+    shift
+    for suf in "$@"; do
+        case "$s" in *"$suf") return 0 ;; esac
+    done
+    return 1
+}
+
+has_prefix() {
+    local s="$1" pre
+    shift
+    for pre in "$@"; do
+        case "$s" in "$pre"*) return 0 ;; esac
+    done
+    return 1
+}
+
+# Resolve a repo path against each candidate root; echo "ok" if it exists.
+path_exists() {
+    local p="$1" root
+    for root in "${RESOLVE_ROOTS[@]}"; do
+        [ -e "$root/$p" ] && return 0
+    done
+    return 1
+}
+
+total_block=0
+total_warn=0
+audited=0
+
+for skill in $SKILLS_GLOB; do
+    [ -f "$skill" ] || continue
+    audited=$((audited + 1))
+    slug="$(basename "$(dirname "$skill")")"
+
+    block_lines=()
+    warn_lines=()
+
+    # ---- collect backtick tokens once -------------------------------------
+    # Strip leading list-prefix; pull every `...` span. The single quotes are
+    # deliberate — we match literal backticks, nothing should expand.
+    # shellcheck disable=SC2016
+    mapfile -t tokens < <(grep -oE '`[^`]+`' "$skill" | sed 's/^`//; s/`$//' | sort -u)
+
+    for tok in "${tokens[@]}"; do
+        # --- line-number cite: file.ext:NNN ---
+        if [[ "$tok" =~ ^([A-Za-z0-9_./-]+):([0-9]+)$ ]]; then
+            file="${BASH_REMATCH[1]}"
+            lineno="${BASH_REMATCH[2]}"
+            # Only meaningful if it looks like a path with an extension.
+            if [[ "$file" =~ $PATH_EXT_RE ]]; then
+                resolved=""
+                for root in "${RESOLVE_ROOTS[@]}"; do
+                    if [ -f "$root/$file" ]; then resolved="$root/$file"; break; fi
+                    # bare filename: try to locate a unique tracked match
+                done
+                if [ -z "$resolved" ] && [[ "$file" != */* ]]; then
+                    # bare filename line cite (e.g. miniextendr_trait.rs:808)
+                    match="$(git ls-files "**/$file" 2>/dev/null | head -1)"
+                    [ -n "$match" ] && resolved="$match"
+                fi
+                if [ -n "$resolved" ]; then
+                    nlines="$(wc -l < "$resolved" | tr -d ' ')"
+                    if [ "$lineno" -gt "$nlines" ]; then
+                        warn_lines+=("line-cite OUT OF RANGE: $tok (file has $nlines lines: $resolved)")
+                    fi
+                else
+                    warn_lines+=("line-cite file not found: $tok")
+                fi
+            fi
+            continue
+        fi
+
+        # --- path token (must contain a slash + known extension) ---
+        if [[ "$tok" == */* ]] && [[ "$tok" =~ $PATH_EXT_RE ]]; then
+            # Skip non-paths that happen to embed a slashed filename:
+            #   - command fragments (contain whitespace): `Rscript tools/foo.R`
+            #   - glob patterns (contain *): `R/*-wrappers.R`, `tools/*.R`
+            #   - template placeholders (contain < >): `.../<system>_class.rs`
+            case "$tok" in
+                *[[:space:]]* | *'*'* | *'<'* | *'>'*) continue ;;
+            esac
+            if in_list "$tok" "${ILLUSTRATIVE_TOKENS[@]}"; then
+                continue
+            fi
+            if has_prefix "$tok" "${EXTERNAL_PATH_PREFIXES[@]}"; then
+                warn_lines+=("external ref (not in repo): $tok")
+                continue
+            fi
+            if has_prefix "$tok" "${SCAFFOLD_PATH_PREFIXES[@]}"; then
+                warn_lines+=("scaffolded-package layout (not a repo path): $tok")
+                continue
+            fi
+            if path_exists "$tok"; then
+                continue
+            fi
+            if has_suffix "$tok" "${GENERATED_PATH_SUFFIXES[@]}"; then
+                warn_lines+=("generated/gitignored path (absent in clean tree): $tok")
+                continue
+            fi
+            block_lines+=("MISSING PATH: $tok")
+            continue
+        fi
+
+        # --- symbol token (code-shaped identifier, no slash, no dot-path) ---
+        if [[ "$tok" != */* ]] && [[ "$tok" != *.* ]]; then
+            base="${tok%!}"
+            shaped=0
+            # snake_case fn (>=1 underscore, lowercase head)
+            [[ "$base" =~ ^[a-z][a-z0-9]*(_[a-z0-9]+)+$ ]] && shaped=1
+            # CamelCase type (multi-word)
+            [[ "$base" =~ ^[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*$ ]] && shaped=1
+            # ALL_CAPS const (>=2 segments)
+            [[ "$base" =~ ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$ ]] && shaped=1
+            if [ "$shaped" -eq 1 ]; then
+                if in_list "$tok" "${ILLUSTRATIVE_TOKENS[@]}" || in_list "$base" "${ILLUSTRATIVE_TOKENS[@]}"; then
+                    continue
+                fi
+                if ! git grep -qwF "$base" -- "${SYMBOL_PATHSPECS[@]}" 2>/dev/null; then
+                    warn_lines+=("symbol not found in repo: $tok")
+                fi
+            fi
+            continue
+        fi
+    done
+
+    # ---- per-skill report -------------------------------------------------
+    nblock=${#block_lines[@]}
+    nwarn=${#warn_lines[@]}
+    total_block=$((total_block + nblock))
+    total_warn=$((total_warn + nwarn))
+
+    if [ "$nblock" -eq 0 ] && [ "$nwarn" -eq 0 ]; then
+        [ "$QUIET" -eq 1 ] || printf '%s== %-32s%s %sOK%s\n' "$c_dim" "$slug" "$c_reset" "$c_green" "$c_reset"
+        continue
+    fi
+
+    printf '== %-32s ' "$slug"
+    if [ "$nblock" -gt 0 ]; then
+        printf '%s%d BLOCKING%s' "$c_red" "$nblock" "$c_reset"
+    fi
+    if [ "$nwarn" -gt 0 ]; then
+        [ "$nblock" -gt 0 ] && printf ', '
+        printf '%s%d WARN%s' "$c_yellow" "$nwarn" "$c_reset"
+    fi
+    printf '\n'
+
+    for l in "${block_lines[@]}"; do printf '   %s[BLOCK]%s %s\n' "$c_red" "$c_reset" "$l"; done
+    for l in "${warn_lines[@]}"; do printf '   %s[warn]%s  %s\n' "$c_yellow" "$c_reset" "$l"; done
+done
+
+printf '\n'
+printf -- '----------------------------------------\n'
+printf 'Audited %d skill(s): %s%d BLOCKING%s, %s%d WARN%s\n' \
+    "$audited" \
+    "$c_red" "$total_block" "$c_reset" \
+    "$c_yellow" "$total_warn" "$c_reset"
+printf '%sContradiction check (CLAUDE.md vs skill restated facts) is manual — source wins.%s\n' "$c_dim" "$c_reset"
+
+if [ "$total_block" -gt 0 ]; then
+    printf '%sBLOCKING path misses found — repair the cited SKILL.md (source wins).%s\n' "$c_red" "$c_reset"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds a quarterly freshness-audit for the 16 Claude Code skills (`.claude/skills/<slug>/SKILL.md`) and repairs the drift it surfaced. Closes #626.

## What the script checks (`scripts/skill-freshness-audit.sh`)

Per `SKILL.md`, it extracts backtick-wrapped references and verifies them — adapted to the **actual** skill format (inline backticks + a `## Key files` section), not the issue sketch's hypothetical ```paths```/```identifiers``` fenced blocks (the skills don't use those):

1. **Path existence (BLOCKING).** Tokens containing a `/` and a known code/file extension are treated as repo-relative paths and resolved with `test -e` against the repo root **and** `rpkg/` (skills mix repo-root and package-relative paths). A token that resolves under neither — and isn't a known generated/gitignored artifact, external R header, or scaffolded-package-layout path — is BLOCKING.
2. **Symbol existence (WARN).** Tokens shaped like real identifiers (snake_case fns, CamelCase types, ALL_CAPS consts, `macro!`) are searched repo-wide with `git grep -wF` (excluding `vendor/`, `rv/`, `target/`, and the skills themselves). Found nowhere → WARN, never BLOCKING (prose shares this shape).
3. **Line cites (WARN).** `file.rs:NNN` tokens: if the resolved file has fewer than `NNN` lines, flag out-of-range.
4. **CLAUDE.md contradiction:** left as a manual triage reminder (too prose-shaped to diff mechanically without false positives).

It **skips** command fragments (whitespace), glob patterns (`*`), and `<placeholder>` tokens. Known false-positive modes are documented in the script header. **Exit code is non-zero iff any BLOCKING miss**, so it can gate a CI job on path drift without tripping on the noisy symbol heuristic.

## First-run drift (4 BLOCKING + real WARNs across 5 skills) — all fixed in-PR

| Skill | Stale | Fixed to |
|-------|-------|----------|
| ffi (×4) + worker (×1) | `miniextendr-api/src/ffi.rs` | `miniextendr-api/src/sys.rs` |
| ffi | `preserve.rs` / "preserve module" | `gc_protect.rs` (`Root`) |
| ffi | r_ffi_checked block lines `2092…3790` | `248, 787, 956, 1126, 1509, 1572, 1681, 1955` |
| rv (×2) | `journal/2026-05-17-pr2-release-workflow-cran-pins.md` (never existed) | `rproject.toml` + `rpkg/DESCRIPTION` `Config/roxygen2/version` |
| class-systems (×2) | `build_r6_return` | `build_r6_body` (`method_return_builder.rs:260`) |
| connections (×2) | `check_runtime_connections_support` | `check_connections_runtime` (`connection.rs:131`) |
| architecture | `write_wrappers` (prose abbrev) | `miniextendr_write_wrappers` |

**Post-fix: `Audited 16 skill(s): 0 BLOCKING, 7 WARN`, exit 0.** The 7 remaining WARNs are all the documented false positives (generated `.cargo/config.toml`, external `R_ext/Connections.h`, scaffolded-package `src/rust/src/lib.rs`). Nothing deferred — no follow-up issue needed.

## Cadence

Documented in `CLAUDE.md` and `AGENTS.md` under "Skill freshness audit (quarterly)": run `bash scripts/skill-freshness-audit.sh` once a quarter, repair drift in the same pass (source wins). First-run report saved to `journal/2026-06-09-skill-freshness-audit.md`.

## Verification

- `bash -n` clean; `shellcheck` clean.
- End-to-end run on a clean tree → exit 0; injected missing path → BLOCKING + exit 1; injected `init.rs:99999` → out-of-range WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
