### PR TITLE
ci(webr): trigger webR workflow on arm64 image + smoke-script paths

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -10,9 +10,11 @@ on:
       - 'rpkg/**'
       - 'tests/cross-package/**'
       - 'tests/webr-node-smoke/**'
+      - 'tests/webr-smoke.sh'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Dockerfile.webr'
+      - 'Dockerfile.webr-arm64'
       - '.github/workflows/webr.yml'
   push:
     branches: [main]
@@ -24,9 +26,11 @@ on:
       - 'rpkg/**'
       - 'tests/cross-package/**'
       - 'tests/webr-node-smoke/**'
+      - 'tests/webr-smoke.sh'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Dockerfile.webr'
+      - 'Dockerfile.webr-arm64'
       - '.github/workflows/webr.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Why

#916 (merged as `30dd04c4`) added the native-arm64 webR dev image (`Dockerfile.webr-arm64`) and the `WEBR_ARM64=1` branch of `tests/webr-smoke.sh`, but neither path is in `webr.yml`'s `paths:` filter. So edits to the arm64 webR build/test infra never re-run the webR (wasm32) tiers that validate the webR path — the *relevant* workflow stays silent while general CI runs the full R/Rust matrix off the incidental `justfile` edit.

## What

Add `Dockerfile.webr-arm64` and `tests/webr-smoke.sh` to both the `pull_request` and `push` `paths:` filters in `.github/workflows/webr.yml`. This matches the existing conservative trigger philosophy — `Dockerfile.webr` and `tests/webr-node-smoke/**` are already listed even though the CI jobs build the amd64 mirror image; re-running the webR validation when the webR infra changes is a safe canary.

The general `justfile` trigger in `ci.yml` is intentionally **left as-is** (a justfile edit can change any build/test recipe, so the coarse trigger is the safe default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)