### PR TITLE
fix(macros): report family base SEXPTYPE in ALTREP TryFromSexp diagnostic

### DIFF
--- a/miniextendr-api/src/altrep.rs
+++ b/miniextendr-api/src/altrep.rs
@@ -66,6 +66,22 @@ pub enum RBase {
     Complex,
 }
 
+impl RBase {
+    /// The [`SEXPTYPE`](crate::SEXPTYPE) an ALTREP vector of this base
+    /// presents to R.
+    pub const fn sexptype(self) -> crate::SEXPTYPE {
+        match self {
+            RBase::Int => crate::SEXPTYPE::INTSXP,
+            RBase::Real => crate::SEXPTYPE::REALSXP,
+            RBase::Logical => crate::SEXPTYPE::LGLSXP,
+            RBase::Raw => crate::SEXPTYPE::RAWSXP,
+            RBase::String => crate::SEXPTYPE::STRSXP,
+            RBase::List => crate::SEXPTYPE::VECSXP,
+            RBase::Complex => crate::SEXPTYPE::CPLXSXP,
+        }
+    }
+}
+
 /// Trait implemented by ALTREP classes via `#[miniextendr]`.
 ///
 /// This trait is automatically implemented when using the proc-macro with

--- a/miniextendr-macros/src/altrep.rs
+++ b/miniextendr-macros/src/altrep.rs
@@ -200,7 +200,7 @@ pub(crate) fn generate_direct_altrep_registration(
 
                 if !::miniextendr_api::SexpExt::is_altrep(&sexp) {
                     return Err(::miniextendr_api::SexpTypeError {
-                        expected: SEXPTYPE::INTSXP,
+                        expected: <#ident #ty_generics as ::miniextendr_api::altrep::AltrepClass>::BASE.sexptype(),
                         actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     });
                 }
@@ -234,7 +234,7 @@ pub(crate) fn generate_direct_altrep_registration(
 
                 if !::miniextendr_api::SexpExt::is_altrep(&sexp) {
                     return Err(::miniextendr_api::SexpTypeError {
-                        expected: SEXPTYPE::INTSXP,
+                        expected: <#ident #ty_generics as ::miniextendr_api::altrep::AltrepClass>::BASE.sexptype(),
                         actual: ::miniextendr_api::SexpExt::type_of(&sexp),
                     });
                 }

--- a/miniextendr-macros/src/tests.rs
+++ b/miniextendr-macros/src/tests.rs
@@ -1054,4 +1054,24 @@ fn test_derive_altrep_real_subset_accepted_with_guard_too() {
 
     crate::altrep_derive::derive_altrep_real(input).unwrap();
 }
+
+#[test]
+fn test_altrep_try_from_sexp_expected_tag_uses_family_base() {
+    // #890: the not-an-ALTREP diagnostic must report the family's base
+    // SEXPTYPE (via AltrepClass::BASE), not a hardcoded INTSXP.
+    let input: syn::DeriveInput = syn::parse2(quote::quote! {
+        pub struct DiagReal {
+            len: usize,
+        }
+    })
+    .unwrap();
+
+    let expanded = crate::altrep_derive::derive_altrep_real(input).unwrap();
+    let s = normalize_tokens(expanded);
+
+    assert!(s.contains("BASE.sexptype()"));
+    assert!(!s.contains("expected:SEXPTYPE::INTSXP"));
+    // The data1-downcast branch legitimately expects an EXTPTRSXP.
+    assert!(s.contains("expected:SEXPTYPE::EXTPTRSXP"));
+}
 // endregion


### PR DESCRIPTION
Fixes the misleading `expected: INTSXP` diagnostic for non-integer ALTREP families (closes #890).

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- The generated `Ref`/`Mut` `TryFromSexp` impls in `miniextendr-macros/src/altrep.rs` hardcoded `expected: SEXPTYPE::INTSXP` in the not-an-ALTREP error, so an `AltrepReal`/`AltrepString` type reported "expected INTSXP" on bad input.
- Adds `RBase::sexptype()` (const mapping `RBase -> SEXPTYPE`) in `miniextendr-api`, and the macro now emits `<T as AltrepClass>::BASE.sexptype()` for the expected tag. Each family reports its actual base type; the data1-downcast branch keeps `EXTPTRSXP`.
- Token-level regression test in `miniextendr-macros/src/tests.rs` asserts the real-family expansion routes through `BASE.sexptype()` and contains no hardcoded `INTSXP` expected tag.

## Test plan
- [x] `cargo test -p miniextendr-macros --lib`: 338 pass (includes the new test)
- [x] Full `just configure && just rcmdinstall && just force-document` cycle: clean; no R-side artifacts change (TryFromSexp impls are Rust-side codegen only, the issue's assumption of wrapper churn does not occur)
- [x] CI-equivalent `clippy_default` and `clippy_all` locally, both clean; `cargo fmt --all` clean

## Notes
- `RBase::sexptype()` is new (small) public API on an existing public enum; it is the natural home for the mapping and avoids the macro hardcoding a per-family table.
- No rpkg export currently takes a generated `Ref`/`Mut` argument, so there is no end-to-end R test surface for this diagnostic today; the macros unit test locks the emission.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>