### PR TITLE
fix(registry): atomic temp+rename in artifact writers

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -931,11 +931,31 @@ pub fn write_r_wrappers_to_file(path: &str) {
         return;
     }
 
-    std::fs::write(path, content.as_bytes())
-        .unwrap_or_else(|e| panic!("failed to write {path}: {e}"));
+    // Write via a sibling temp file then rename for atomicity.
+    //
+    // A plain `std::fs::write` truncates in place; a concurrent reader (e.g. a
+    // second `R CMD INSTALL` process) can observe a torn file. `rename(2)` is
+    // atomic on POSIX — the destination is replaced in a single syscall, so
+    // readers always see either the old or the new content. On Windows, `rename`
+    // fails when the destination exists, so we remove it first; that window is
+    // benign (worst case the reader gets "file not found" and retries, which is
+    // the same outcome as a torn write).
+    let dest = std::path::Path::new(path);
+    let tmp = dest.with_extension("tmp");
+    std::fs::write(&tmp, content.as_bytes())
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", tmp.display()));
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(dest);
+    std::fs::rename(&tmp, dest).unwrap_or_else(|e| {
+        panic!(
+            "failed to rename {} → {}: {e}",
+            tmp.display(),
+            dest.display()
+        )
+    });
 
     if !existing.is_empty() {
-        let filename = std::path::Path::new(path)
+        let filename = dest
             .file_name()
             .and_then(|f| f.to_str())
             .unwrap_or("wrappers.R");

--- a/miniextendr-api/src/wasm_registry_writer.rs
+++ b/miniextendr-api/src/wasm_registry_writer.rs
@@ -314,8 +314,24 @@ pub fn write_wasm_registry_to_file(path: &str) {
         return;
     }
 
-    std::fs::write(path, content.as_bytes())
-        .unwrap_or_else(|e| panic!("failed to write {path}: {e}"));
+    // Write via a sibling temp file then rename for atomicity.
+    //
+    // Matches the strategy in `write_r_wrappers_to_file`: `rename(2)` is atomic
+    // on POSIX, so concurrent readers always see a complete file. On Windows,
+    // `rename` fails when the destination exists, so we remove it first.
+    let dest = std::path::Path::new(path);
+    let tmp = dest.with_extension("tmp");
+    std::fs::write(&tmp, content.as_bytes())
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", tmp.display()));
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(dest);
+    std::fs::rename(&tmp, dest).unwrap_or_else(|e| {
+        panic!(
+            "failed to rename {} → {}: {e}",
+            tmp.display(),
+            dest.display()
+        )
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace in-place write with temp+rename in both cdylib artifact writers to eliminate torn-file races.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `write_r_wrappers_to_file` (in `miniextendr-api/src/registry.rs`) now writes to a sibling `.tmp` file and renames it into place instead of calling `std::fs::write` directly on the destination.
- `write_wasm_registry_to_file` (in `miniextendr-api/src/wasm_registry_writer.rs`) receives the same treatment.
- The semantic-equality early-return (`wrappers_semantically_equal` / content equality check) is unchanged. The rename only fires when a write is actually needed.
- On POSIX, `rename(2)` is atomic: concurrent readers always see either the complete old file or the complete new one. The torn-file window (#967 root cause) is eliminated.
- On Windows, `rename` fails when the destination already exists, so a `#[cfg(windows)]` `remove_file` is called first. That window is benign: worst case a concurrent reader gets "file not found" rather than a torn read.

Fixes #967

## Test plan
- [ ] `cargo check -p miniextendr-api` passes (no new compiler errors)
- [ ] `cargo fmt --all` produces no diff
- [ ] Verify CI green (clippy_default + clippy_all)

## Notes
- The `.tmp` extension is used for the temp file (`path.with_extension("tmp")`). Both output paths are in the package source tree where write permission is guaranteed during a build, so no cross-device rename risk.

---
_Drafted by Claude (claude-sonnet-4-6). Reviewed by the author._

</details>