### PR TITLE
fix(minirextendr): force wrapper-gen pass in bootstrap_fresh_wrappers (#963)

### DIFF
--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -109,22 +109,23 @@ miniextendr_configure <- function(path = ".") {
 #'
 #' @section Fresh-package bootstrap:
 #' A brand-new package has no generated `R/<pkg>-wrappers.R` yet. The wrappers
-#' are produced by the cdylib pass during a *source-mode* install
-#' ([`./configure`][miniextendr_configure] with no `inst/vendor.tar.xz`).
-#' A plain `devtools::install(build = TRUE)` cannot bootstrap them: its
-#' `R CMD build` step runs `bootstrap.R`, which auto-vendors into
-#' `inst/vendor.tar.xz`, and that latch flips `./configure` into offline
-#' *tarball* mode — which ships pre-generated wrappers and skips wrapper
-#' generation. With no wrappers to ship, the install either fails loudly
-#' ("tarball is missing pre-generated wrappers") or, worse, leaves the
-#' namespace empty.
+#' are produced by the cdylib pass during install, but a plain
+#' `devtools::install(build = TRUE)` cannot bootstrap them: its `R CMD build`
+#' step runs `bootstrap.R`, which auto-vendors into `inst/vendor.tar.xz`, and
+#' that latch flips `./configure` into offline *tarball* mode — which ships
+#' pre-generated wrappers and skips wrapper generation. With no wrappers to
+#' ship, the install either fails loudly ("tarball is missing pre-generated
+#' wrappers") or, worse, leaves the namespace empty.
 #'
 #' When `miniextendr_build()` detects that the wrappers file is absent, it
-#' first runs an in-place source-mode bootstrap (clear any stale latch ->
-#' configure -> `devtools::install(build = FALSE)` -> `devtools::document()`)
-#' so the wrappers exist before the normal build path runs. The bootstrap
-#' never creates `inst/vendor.tar.xz`, so it does not leak the tarball-mode
-#' latch into subsequent dev iteration. Once wrappers are present, the normal
+#' first runs a bootstrap (clear any stale latch -> configure ->
+#' `devtools::install(build = FALSE, MINIEXTENDR_FORCE_WRAPPER_GEN=1)` ->
+#' `devtools::document()`) so the wrappers exist before the normal build path
+#' runs. The `MINIEXTENDR_FORCE_WRAPPER_GEN` override forces the cdylib
+#' wrapper-gen pass regardless of which install mode configure resolves to: in
+#' a non-git tree configure's self-repair branch may legitimately re-seal the
+#' latch (cargo-revendor on PATH), and that is fine — the FORCE override
+#' ensures wrapper generation proceeds. Once wrappers are present, the normal
 #' build path runs unchanged.
 #'
 #' @param path Path to the R package root, or `NULL` to use the active project.
@@ -258,22 +259,23 @@ wrappers_file_exists <- function(pkg_path) {
   length(fs::dir_ls(r_dir, glob = "*-wrappers.R", fail = FALSE)) > 0
 }
 
-#' Bootstrap a fresh package's R wrappers via a source-mode install
+#' Bootstrap a fresh package's R wrappers via a forced wrapper-gen install
 #'
 #' On a brand-new package there is no generated `R/<pkg>-wrappers.R`. The
-#' wrappers are emitted by the cdylib pass during a *source-mode*
-#' `R CMD INSTALL` (no `inst/vendor.tar.xz` latch). A plain
+#' wrappers are emitted by the cdylib pass during install. A plain
 #' `devtools::install(build = TRUE)` can't bootstrap them because its
 #' `R CMD build` step runs `bootstrap.R`, which auto-vendors the tarball and
 #' flips `./configure` into wrapper-skipping tarball mode.
 #'
-#' This helper reproduces the proven manual workaround in-process: clear any
-#' stale latch so configure stays in source mode, re-run `./configure`, then
-#' do an in-place `devtools::install(build = FALSE)` to generate the wrappers,
-#' run `devtools::document()` so the NAMESPACE picks up the new exports, and
-#' install once more so the namespace-aware install lands. It never creates
-#' `inst/vendor.tar.xz`, so the tarball-mode latch does not leak into later
-#' dev iteration.
+#' This helper clears any stale latch, re-runs `./configure`, then does an
+#' in-place `devtools::install(build = FALSE)` with
+#' `MINIEXTENDR_FORCE_WRAPPER_GEN=1` to force the cdylib wrapper-gen pass
+#' regardless of which mode configure resolved to. In a non-git tree,
+#' configure's self-repair branch may legitimately re-seal `inst/vendor.tar.xz`
+#' (cargo-revendor on PATH + no `.git` ancestor); the FORCE override ensures
+#' the wrapper-gen pass runs even then. Once wrappers exist, `devtools::document()`
+#' is run and the package is installed once more so the namespace-aware install
+#' lands.
 #'
 #' @param pkg_path Absolute path to the package root.
 #' @return Invisibly `TRUE`.
@@ -281,25 +283,36 @@ wrappers_file_exists <- function(pkg_path) {
 bootstrap_fresh_wrappers <- function(pkg_path) {
   cli::cli_alert_info(c(
     "No generated {.path R/*-wrappers.R} found — bootstrapping wrappers ",
-    "via a source-mode install before the full build."
+    "before the full build."
   ))
 
-  # Clear any stale tarball-mode latch so ./configure resolves in source mode
-  # (where the cdylib wrapper-gen pass runs). The bootstrap install is always
-  # source-mode; leaving a latch behind would skip wrapper generation again.
+  # Clear any stale tarball-mode latch so configure gets a clean start.
+  # In a non-git tree configure's self-repair may re-seal inst/vendor.tar.xz
+  # (cargo-revendor on PATH); that is fine — MINIEXTENDR_FORCE_WRAPPER_GEN
+  # below ensures the cdylib wrapper-gen pass runs regardless of install mode.
   clear_install_mode_latch(pkg_path)
 
-  # Re-configure in source mode now that the latch is gone, so the
-  # tarball-mode .cargo/config.toml (if any) is replaced.
+  # Re-configure now that the latch is gone, so the tarball-mode
+  # .cargo/config.toml (if any) is replaced with the correct variant.
   miniextendr_configure(pkg_path)
 
   # Generate wrappers via an in-place install. build = FALSE skips R CMD build
-  # (and therefore bootstrap.R's auto-vendor), keeping configure in source mode.
+  # (and therefore bootstrap.R's auto-vendor). MINIEXTENDR_FORCE_WRAPPER_GEN=1
+  # forces the cdylib wrapper-gen pass even if configure resolved to tarball
+  # mode (e.g. because self-repair re-sealed the latch in a non-git tree).
+  old_force <- Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = NA)
+  Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = "1")
+  on.exit(
+    if (is.na(old_force)) Sys.unsetenv("MINIEXTENDR_FORCE_WRAPPER_GEN")
+    else Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = old_force),
+    add = TRUE
+  )
+
   tryCatch(
     devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
     error = function(e) {
       cli::cli_abort(c(
-        "Bootstrap install (source mode) failed",
+        "Bootstrap install failed",
         "i" = conditionMessage(e)
       ))
     }
@@ -317,6 +330,7 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
 
   # document() so NAMESPACE exports the freshly-generated wrappers, then
   # install once more so the installed package's namespace matches.
+  # MINIEXTENDR_FORCE_WRAPPER_GEN is still set via on.exit above.
   devtools::document(pkg_path)
   tryCatch(
     devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
@@ -328,7 +342,7 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
     }
   )
 
-  cli::cli_alert_success("Bootstrapped R wrappers (source mode)")
+  cli::cli_alert_success("Bootstrapped R wrappers")
   invisible(TRUE)
 }
 

--- a/minirextendr/man/miniextendr_build.Rd
+++ b/minirextendr/man/miniextendr_build.Rd
@@ -45,22 +45,23 @@ the wrappers and \code{NAMESPACE} are already in their final form, so a repeat
 \section{Fresh-package bootstrap}{
 
 A brand-new package has no generated \verb{R/<pkg>-wrappers.R} yet. The wrappers
-are produced by the cdylib pass during a \emph{source-mode} install
-(\code{\link[=miniextendr_configure]{./configure}} with no \code{inst/vendor.tar.xz}).
-A plain \code{devtools::install(build = TRUE)} cannot bootstrap them: its
-\verb{R CMD build} step runs \code{bootstrap.R}, which auto-vendors into
-\code{inst/vendor.tar.xz}, and that latch flips \code{./configure} into offline
-\emph{tarball} mode — which ships pre-generated wrappers and skips wrapper
-generation. With no wrappers to ship, the install either fails loudly
-("tarball is missing pre-generated wrappers") or, worse, leaves the
-namespace empty.
+are produced by the cdylib pass during install, but a plain
+\code{devtools::install(build = TRUE)} cannot bootstrap them: its \verb{R CMD build}
+step runs \code{bootstrap.R}, which auto-vendors into \code{inst/vendor.tar.xz}, and
+that latch flips \code{./configure} into offline \emph{tarball} mode — which ships
+pre-generated wrappers and skips wrapper generation. With no wrappers to
+ship, the install either fails loudly ("tarball is missing pre-generated
+wrappers") or, worse, leaves the namespace empty.
 
 When \code{miniextendr_build()} detects that the wrappers file is absent, it
-first runs an in-place source-mode bootstrap (clear any stale latch ->
-configure -> \code{devtools::install(build = FALSE)} -> \code{devtools::document()})
-so the wrappers exist before the normal build path runs. The bootstrap
-never creates \code{inst/vendor.tar.xz}, so it does not leak the tarball-mode
-latch into subsequent dev iteration. Once wrappers are present, the normal
+first runs a bootstrap (clear any stale latch -> configure ->
+\code{devtools::install(build = FALSE, MINIEXTENDR_FORCE_WRAPPER_GEN=1)} ->
+\code{devtools::document()}) so the wrappers exist before the normal build path
+runs. The \code{MINIEXTENDR_FORCE_WRAPPER_GEN} override forces the cdylib
+wrapper-gen pass regardless of which install mode configure resolves to: in
+a non-git tree configure's self-repair branch may legitimately re-seal the
+latch (cargo-revendor on PATH), and that is fine — the FORCE override
+ensures wrapper generation proceeds. Once wrappers are present, the normal
 build path runs unchanged.
 }
 

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -522,17 +522,20 @@ test_that("monorepo scaffolding builds and functions work end-to-end", {
 # -----------------------------------------------------------------------------
 
 # Standalone counterpart to the monorepo round-trip above, and the in-suite home
-# for the #757 / #775 / #822 regression (it lived as a standalone bash script +
-# bespoke CI job before; see #805). create_miniextendr_package() +
-# miniextendr_build() scaffold a package that sits outside any .git ancestor, so
-# a build = TRUE install's R CMD build step auto-vendors and would flip into
+# for the #757 / #775 / #822 / #963 regression (it lived as a standalone bash
+# script + bespoke CI job before; see #805). create_miniextendr_package() +
+# miniextendr_build() scaffold a package that sits outside any .git ancestor,
+# so a build = TRUE install's R CMD build step auto-vendors and would flip into
 # *tarball mode* — which skips the cdylib wrapper-gen pass. On a brand-new
 # package (no R/<pkg>-wrappers.R yet) that means the wrappers can never be
 # generated and library() exposes nothing (#822). miniextendr_build() now
-# detects the absent wrappers file and bootstraps them first via an in-place
-# source-mode install (build = FALSE), which never auto-vendors; the
-# MINIEXTENDR_FORCE_WRAPPER_GEN override still guards the wrappers-present case
-# against a leaked tarball latch (#757).
+# detects the absent wrappers file and calls bootstrap_fresh_wrappers(), which
+# clears the latch, re-runs configure, then installs with
+# MINIEXTENDR_FORCE_WRAPPER_GEN=1 (build = FALSE). The FORCE override ensures
+# the cdylib wrapper-gen pass runs even when configure's self-repair branch
+# re-seals inst/vendor.tar.xz in a non-git tree (#963). The same FORCE flag
+# guards the wrappers-present case in install_pkg() against a leaked tarball
+# latch (#757).
 #
 # Unlike the monorepo tests, create_miniextendr_package() takes no local_path, so
 # it scaffolds against miniextendr `main` and this test is network-dependent

--- a/minirextendr/tests/testthat/test-workflow-bootstrap.R
+++ b/minirextendr/tests/testthat/test-workflow-bootstrap.R
@@ -63,3 +63,64 @@ test_that("clear_install_mode_latch is a no-op when nothing is present", {
 
   expect_true(minirextendr:::clear_install_mode_latch(tmp))
 })
+
+test_that("bootstrap_fresh_wrappers sets MINIEXTENDR_FORCE_WRAPPER_GEN=1 during installs", {
+  # Verify the fix for #963: bootstrap_fresh_wrappers() must set
+  # MINIEXTENDR_FORCE_WRAPPER_GEN=1 around its devtools::install() calls so
+  # that the cdylib wrapper-gen pass runs even when configure's self-repair
+  # branch re-seals inst/vendor.tar.xz in a non-git tree.
+  #
+  # We mock devtools::install and miniextendr_configure to avoid a real compile.
+  # devtools::document is also mocked to avoid roxygenising a stub package.
+  # wrappers_file_exists is mocked to return TRUE after the first install so
+  # the function progresses to the re-install pass, exercising both call sites.
+  install_call_count <- 0L
+
+  testthat::local_mocked_bindings(
+    install = function(...) {
+      install_call_count <<- install_call_count + 1L
+      expect_equal(
+        Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN"),
+        "1",
+        info = paste("install call", install_call_count)
+      )
+      invisible(NULL)
+    },
+    .package = "devtools"
+  )
+
+  testthat::local_mocked_bindings(
+    document = function(...) invisible(NULL),
+    .package = "devtools"
+  )
+
+  # Stub out internal helpers so bootstrap_fresh_wrappers() can run to
+  # completion without a real package tree or configure script.
+  testthat::local_mocked_bindings(
+    miniextendr_configure = function(...) invisible(TRUE),
+    clear_install_mode_latch = function(...) invisible(TRUE),
+    wrappers_file_exists = function(...) TRUE,
+    .package = "minirextendr"
+  )
+
+  tmp <- make_pkg_root()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  old_force <- Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = NA)
+  on.exit(
+    if (is.na(old_force)) Sys.unsetenv("MINIEXTENDR_FORCE_WRAPPER_GEN")
+    else Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = old_force),
+    add = TRUE
+  )
+  # Ensure the var is absent before the call so we test that bootstrap sets it.
+  Sys.unsetenv("MINIEXTENDR_FORCE_WRAPPER_GEN")
+
+  minirextendr:::bootstrap_fresh_wrappers(tmp)
+
+  # Both install calls (initial wrapper-gen + re-install after document) must
+  # have been reached.
+  expect_equal(install_call_count, 2L)
+
+  # The env var must be restored (unset) after bootstrap_fresh_wrappers returns.
+  expect_equal(Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = ""), "")
+})


### PR DESCRIPTION
Fix `bootstrap_fresh_wrappers()` failing in non-git trees when `cargo-revendor` is on PATH.

<details>
<summary>AI-generated summary</summary>

## Root cause

`bootstrap_fresh_wrappers()` attempted to keep `configure` in source mode by clearing the `inst/vendor.tar.xz` latch before calling `devtools::install(build = FALSE)`. The problem: `configure`'s self-repair branch (triggered when `cargo-revendor` is on PATH and there is no `.git` ancestor) immediately **re-seals** the latch. The install then resolved to tarball mode, which skips the cdylib wrapper-gen pass and fails with "tarball is missing pre-generated wrappers".

## Fix

Rather than trying to prevent the latch from being re-sealed, set `MINIEXTENDR_FORCE_WRAPPER_GEN=1` around both `devtools::install()` calls in `bootstrap_fresh_wrappers()`. This tells `Makevars` to run the wrapper-gen pass regardless of which install mode `configure` resolved to. The env var is restored on exit via `on.exit`.

The latch-clearing step is kept (it gives `configure` a clean start and avoids unnecessarily unpacking a stale vendor tree), but the correctness of wrapper generation no longer depends on the mode.

## Files changed

- `minirextendr/R/workflow.R`: add `Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = "1")` + `on.exit` restore in `bootstrap_fresh_wrappers()`; reword the `@section Fresh-package bootstrap` in `miniextendr_build()` to drop the false "never creates the latch / stays in source mode" claim.
- `minirextendr/tests/testthat/test-workflow-bootstrap.R`: add a mocked unit test that asserts `MINIEXTENDR_FORCE_WRAPPER_GEN == "1"` during both `devtools::install()` calls and is restored (unset) after the function returns.
- `minirextendr/tests/testthat/test-templates.R`: update comment block to reference #963.

## Test note

The existing standalone e2e test (`test-templates.R` "standalone scaffolding builds in tarball mode...") exercises exactly this scenario (no-git tree + `cargo-revendor` on PATH) but requires a network compile and is skipped in standard CI (see #805). The new mocked unit test covers the `MINIEXTENDR_FORCE_WRAPPER_GEN` contract without a real compile.

</details>

Fixes #963