### PR TITLE
fix(api): add IntoR for Vec<u32>, Vec<Rboolean>, and &[Rboolean] (#973)

### DIFF
--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -642,6 +642,9 @@ impl_vec_smart_i64_into_r!(u64, |x: u64| x <= i32::MAX as u64);
 impl_vec_smart_i64_into_r!(isize, |x: isize| x > i32::MIN as isize
     && x <= i32::MAX as isize);
 impl_vec_smart_i64_into_r!(usize, |x: usize| x <= i32::MAX as usize);
+// Matches Vec<Option<u32>> (impl_vec_option_coerce_into_r!(u32 => i64)):
+// INTSXP while everything fits, REALSXP otherwise.
+impl_vec_smart_i64_into_r!(u32, |x: u32| x <= i32::MAX as u32);
 // endregion
 
 mod altrep;
@@ -1803,6 +1806,46 @@ impl IntoR for &[bool] {
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         let n = self.len();
         unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&v| i32::from(v))) }
+    }
+}
+
+/// Convert `Vec<Rboolean>` to R logical vector (no NA: Rboolean is TRUE/FALSE only).
+impl IntoR for Vec<crate::Rboolean> {
+    type Error = std::convert::Infallible;
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(self.into_sexp())
+    }
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(unsafe { self.into_sexp_unchecked() })
+    }
+    fn into_sexp(self) -> crate::SEXP {
+        let n = self.len();
+        logical_iter_to_lglsxp(n, self.into_iter().map(|b| b as i32))
+    }
+
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
+        let n = self.len();
+        unsafe { logical_iter_to_lglsxp_unchecked(n, self.into_iter().map(|b| b as i32)) }
+    }
+}
+
+/// Convert `&[Rboolean]` to R logical vector (no NA: Rboolean is TRUE/FALSE only).
+impl IntoR for &[crate::Rboolean] {
+    type Error = std::convert::Infallible;
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(self.into_sexp())
+    }
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(unsafe { self.into_sexp_unchecked() })
+    }
+    fn into_sexp(self) -> crate::SEXP {
+        let n = self.len();
+        logical_iter_to_lglsxp(n, self.iter().map(|&b| b as i32))
+    }
+
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
+        let n = self.len();
+        unsafe { logical_iter_to_lglsxp_unchecked(n, self.iter().map(|&b| b as i32)) }
     }
 }
 

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -353,6 +353,54 @@ fn large_int_vec_u64_any_large_yields_realsxp() {
     });
 }
 
+/// Vec<u32> — all fit → INTSXP, values round-trip (#973).
+#[test]
+fn large_int_vec_u32_all_fit_yields_intsxp() {
+    r_test_utils::with_r_thread(|| {
+        let v = vec![0u32, 1, i32::MAX as u32];
+        let sexp = v.into_sexp();
+        assert_eq!(sexp.type_of(), SEXPTYPE::INTSXP);
+        let back: Vec<u32> = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(back, vec![0u32, 1, i32::MAX as u32]);
+    });
+}
+
+/// Vec<u32> — any value above i32::MAX → REALSXP (#973).
+#[test]
+fn large_int_vec_u32_any_large_yields_realsxp() {
+    r_test_utils::with_r_thread(|| {
+        let v = vec![1u32, u32::MAX];
+        let sexp = v.into_sexp();
+        assert_eq!(sexp.type_of(), SEXPTYPE::REALSXP);
+        let back: Vec<u32> = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(back, vec![1u32, u32::MAX]);
+    });
+}
+
+/// Vec<Rboolean> → LGLSXP, values round-trip (#973).
+#[test]
+fn vec_rboolean_yields_lglsxp() {
+    r_test_utils::with_r_thread(|| {
+        let v = vec![Rboolean::TRUE, Rboolean::FALSE, Rboolean::TRUE];
+        let sexp = v.into_sexp();
+        assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
+        let back: Vec<Rboolean> = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(back, vec![Rboolean::TRUE, Rboolean::FALSE, Rboolean::TRUE]);
+    });
+}
+
+/// &[Rboolean] → LGLSXP (#973).
+#[test]
+fn slice_rboolean_yields_lglsxp() {
+    r_test_utils::with_r_thread(|| {
+        let v = [Rboolean::FALSE, Rboolean::TRUE];
+        let sexp = v.as_slice().into_sexp();
+        assert_eq!(sexp.type_of(), SEXPTYPE::LGLSXP);
+        let back: Vec<Rboolean> = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(back, vec![Rboolean::FALSE, Rboolean::TRUE]);
+    });
+}
+
 // endregion
 
 // region: from_r/coerced_scalars.rs — multi-source scalar inbound conversions


### PR DESCRIPTION
Fills two vector-shape conversion gaps the corpus audit surfaced: `Vec<u32>` and `Vec<Rboolean>` had scalar/Option/Vec<Option<_>> forms but no plain Vec form.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `Vec<u32>` joins the `impl_vec_smart_i64_into_r!` family with guard `x <= i32::MAX`: INTSXP while every value fits, REALSXP otherwise. This matches `Vec<Option<u32>>`, which already delegates to the smart-i64 path. Previously returning `Vec<u32>` from a `#[miniextendr]` fn was a compile error while `Vec<Option<u32>>` worked.
- `Vec<Rboolean>` and `&[Rboolean]` emit LGLSXP via the existing `logical_iter_to_lglsxp` helpers, alongside the `Vec<bool>` / `&[bool]` pair (no NA in the non-Option forms; `Rboolean` is TRUE/FALSE only).
- Four round-trip tests in `conversion_coverage.rs` cover INTSXP/REALSXP selection for `Vec<u32>` and LGLSXP for both `Rboolean` shapes.
- Closes #973.

## Test plan
- [x] `cargo test -p miniextendr-api --test conversion_coverage` (88 passed, incl. 4 new)
- [x] `cargo fmt --all` clean
- [x] clippy_default (`--workspace --all-targets --locked -- -D warnings`) green
- [x] clippy_all (CI's `full-codegen` + curated integration feature list from ci.yml) green

## Notes
- No SEXP storage across allocations (single output vector, then writes), so no gctorture fixture per the #430 convention.
- The committed rust-llm-docs corpus gains two impls from this; regeneration is deferred to after #978 (generator overhaul) merges to avoid churn conflicts.
- Scalar `u32` still always widens to REALSXP (`impl_into_r_via_coerce!(u32 => f64)`); this PR leaves that pre-existing scalar/vector asymmetry untouched.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>