### PR TITLE
docs: fix stale doc comments and document conversion asymmetries (#974, #975)

### DIFF
--- a/docs/CONVERSION_MATRIX.md
+++ b/docs/CONVERSION_MATRIX.md
@@ -190,7 +190,7 @@ With `#[miniextendr(strict)]`, large integer types **panic** instead of falling 
 
 ### Smart Vector Conversion (Vec of large integers)
 
-`Vec<i64>`, `Vec<u64>`, `Vec<isize>`, `Vec<usize>` check whether **all** elements fit in i32. If yes, the entire vector is INTSXP; otherwise, the entire vector is REALSXP.
+`Vec<i64>`, `Vec<u64>`, `Vec<u32>`, `Vec<isize>`, `Vec<usize>` check whether **all** elements fit in i32. If yes, the entire vector is INTSXP; otherwise, the entire vector is REALSXP.
 
 | Rust Type | All Fit in i32? | R Output Type |
 |-----------|-----------------|--------------|
@@ -198,6 +198,8 @@ With `#[miniextendr(strict)]`, large integer types **panic** instead of falling 
 | `Vec<i64>` | No (any element outside) | REALSXP |
 | `Vec<u64>` | Yes (all `<= i32::MAX`) | INTSXP |
 | `Vec<u64>` | No | REALSXP |
+| `Vec<u32>` | Yes (all `<= i32::MAX`) | INTSXP |
+| `Vec<u32>` | No | REALSXP |
 
 ### Collection Types
 
@@ -261,6 +263,21 @@ Notes:
 | `Result<T, E: Debug>` (default) | `T::into_sexp()` | **Panic** -> R error |
 | `Result<T, E: Display>` (`unwrap_in_r`) | `T::into_sexp()` | `list(error = msg)` |
 | `Result<T, ()>` | `T::into_sexp()` | NULL (R_NilValue) |
+
+### Intentional Asymmetries (argument-only / return-only)
+
+Some types deliberately support only one direction. These are design decisions,
+not gaps:
+
+| Rust Type | Direction | Why |
+|-----------|-----------|-----|
+| `Option<u8>` / `Vec<Option<u8>>` | `TryFromSexp` only (no `IntoR`) | RAWSXP has no NA sentinel; `None` has no faithful R representation. Inbound, R raw vectors never contain NA so `Option<u8>` is always `Some`. Return `Vec<u8>` instead. |
+| `Regex` (regex feature) | `TryFromSexp` only | Accept a pattern string from R as a compiled regex argument. A compiled regex has no useful R value; return the pattern `String` if needed. |
+| `AhoCorasick` (aho-corasick feature) | `TryFromSexp` only | Same shape: built from an R character vector of patterns; no meaningful outbound form. |
+| `(A, B, ...)` tuples (arity ≤ 8) | `IntoR` only | Returned as an unnamed VECSXP list. Inbound support (R list → tuple arguments) is tracked in #976. |
+
+By contrast, `Url` and `Uuid` round-trip: both directions are implemented
+because the R representation (a string) is faithful in both directions.
 
 ---
 

--- a/miniextendr-cli/src/main.rs
+++ b/miniextendr-cli/src/main.rs
@@ -1,3 +1,10 @@
+//! `miniextendr` — maintainer CLI for miniextendr-based R packages.
+//!
+//! Wraps the configure/install/document/vendor development loop in one
+//! binary (`miniextendr <command>`). This is a binary-only crate; the
+//! framework runtime lives in `miniextendr-api` and the scaffolding for
+//! end-user packages in the `minirextendr` R package.
+
 mod bridge;
 mod cli;
 mod commands;

--- a/miniextendr-engine/src/lib.rs
+++ b/miniextendr-engine/src/lib.rs
@@ -116,7 +116,7 @@ pub fn r_initialized_sentinel() -> bool {
 /// # Example
 ///
 /// ```ignore
-/// let engine = REngine::new()
+/// let engine = REngine::build()
 ///     .with_args(&["R", "--quiet", "--no-save"])
 ///     .interactive(false)
 ///     .signal_handlers(false)

--- a/miniextendr-lint/src/diagnostic.rs
+++ b/miniextendr-lint/src/diagnostic.rs
@@ -29,7 +29,7 @@ impl fmt::Display for Severity {
 /// A single lint diagnostic with structured metadata.
 #[derive(Clone, Debug)]
 pub struct Diagnostic {
-    /// Stable rule code (e.g. `MXL101`).
+    /// Stable rule code (e.g. `MXL106`).
     pub code: LintCode,
     /// Severity level.
     pub severity: Severity,

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -11,8 +11,9 @@
 //! - Helpers: `typed_list` for typed list builders.
 //!
 //! R wrapper generation is driven by Rust doc comments (roxygen tags are
-//! extracted). The `document` binary collects these wrappers and writes
-//! `R/miniextendr_wrappers.R` during package build.
+//! extracted). During package build, the cdylib link pass loads the crate
+//! into R and calls `miniextendr_write_wrappers`, which walks the linkme
+//! `#[distributed_slice]` tables and writes `R/<pkg>-wrappers.R`.
 //!
 //! ## Quick start
 //!

--- a/rust-llm-docs/rustdoc_manual_vs_macro.py
+++ b/rust-llm-docs/rustdoc_manual_vs_macro.py
@@ -72,7 +72,18 @@ def main():
         recs[term].append((for_s, span, len(imp.get("items", []) or [])))
         spancount[term][span] += 1
 
-    out = ["# Manual-vs-macro conversion impls", "", f"Source: `{args.json}`", ""]
+    out = [
+        "# Manual-vs-macro conversion impls",
+        "",
+        f"Source: `{args.json}`",
+        "",
+        "> **Caveat**: the \"macro already exists for this shape\" flags count",
+        "> feature-gated optionals (jiff, uuid, bitvec, ...) as absorbable",
+        "> hand-rolled impls, but most have bespoke element conversions a",
+        "> shape-macro cannot express. Treat the headline counts as an upper",
+        "> bound on the dedup opportunity, not a work list.",
+        "",
+    ]
     for term in traits:
         rs = recs.get(term, [])
         shape_macro = defaultdict(int)


### PR DESCRIPTION
Cleanup pass from the doc-corpus audit: the generated LLM docs surfaced doc comments describing machinery that no longer exists, plus undocumented conversion asymmetries that read as gaps.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Fix four stale doc comments surfaced by the generated corpus (#974):
  - `miniextendr-macros` crate-level docs described the deleted `document` binary; now describe the cdylib `miniextendr_write_wrappers` flow that actually generates `R/<pkg>-wrappers.R`.
  - `miniextendr-lint::Diagnostic` cited phantom rule code `MXL101` (not in the registry); now cites `MXL106`.
  - `miniextendr-engine` `REngineBuilder` example called non-existent `REngine::new()`; now `REngine::build()`.
  - `miniextendr-cli` had no crate-level docs at all; added a short `//!` block (binary-only crate, runtime lives in `miniextendr-api`).
- Document intentional conversion asymmetries in `docs/CONVERSION_MATRIX.md` (#975):
  - New "Intentional Asymmetries (argument-only / return-only)" section covering `Option<u8>`/`Vec<Option<u8>>` (RAWSXP has no NA sentinel), `Regex` and `AhoCorasick` (inbound only), and tuples (outbound only, inbound tracked in #976), contrasted with `Url`/`Uuid` which round-trip.
  - Add `Vec<u32>` to the smart vector conversion table. Note: the impl lands with #979, so that PR should merge before or alongside this one.
- Add an interpretive caveat to the header `rustdoc_manual_vs_macro.py` emits: the "macro already exists for this shape" flags count feature-gated optionals whose element conversions are bespoke, so headline counts are an upper bound on the dedup opportunity, not a work list.

## Test plan
- [x] `cargo doc --no-deps -p miniextendr-macros -p miniextendr-engine -p miniextendr-lint -p miniextendr-cli` warning-free (no regression of the #968 rustdoc cleanup)
- [x] `python3 -m py_compile rust-llm-docs/rustdoc_manual_vs_macro.py`
- [x] `cargo fmt --all --check`

## Notes
- Doc-comment and markdown changes only, no behavior change.
- The `Vec<u32>` matrix rows describe the impl added in #979 (open, CI green); merge order matters only for doc accuracy in the interim.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>