### PR TITLE
chore(rust-llm-docs): refresh generated corpus + add cargo-revendor

### DIFF
--- a/rust-llm-docs/generate-miniextendr-docs.sh
+++ b/rust-llm-docs/generate-miniextendr-docs.sh
@@ -30,11 +30,23 @@ echo ">> cargo doc (macros, engine, lint, cli)"
 RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="-Z unstable-options --output-format json" \
   cargo doc --no-deps -p miniextendr-macros -p miniextendr-engine -p miniextendr-lint -p miniextendr-cli
 
+echo ">> cargo doc (cargo-revendor — standalone workspace)"
+(cd "$ROOT/cargo-revendor" && RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="-Z unstable-options --output-format json" \
+  cargo doc --no-deps)
+
 # json basename -> output basename  (cli's lib crate is named `miniextendr`)
 gen() {
   local json="$1" out="$2"
   python3 "$HERE/rustdoc_megadoc.py"        "target/doc/${json}.json" "$GEN/${out}.md" >/dev/null
   python3 "$HERE/rustdoc_impl_inventory.py" "target/doc/${json}.json" --out "$GEN/${out}-impl-inventory.md" >/dev/null
+  echo "   ${out}.md + ${out}-impl-inventory.md"
+}
+
+# like gen() but for the cargo-revendor standalone workspace (separate target/)
+gen_revendor() {
+  local json="$1" out="$2"
+  python3 "$HERE/rustdoc_megadoc.py"        "$ROOT/cargo-revendor/target/doc/${json}.json" "$GEN/${out}.md" >/dev/null
+  python3 "$HERE/rustdoc_impl_inventory.py" "$ROOT/cargo-revendor/target/doc/${json}.json" --out "$GEN/${out}-impl-inventory.md" >/dev/null
   echo "   ${out}.md + ${out}-impl-inventory.md"
 }
 
@@ -44,6 +56,7 @@ gen miniextendr_macros miniextendr-macros
 gen miniextendr_engine miniextendr-engine
 gen miniextendr_lint   miniextendr-lint
 gen miniextendr        miniextendr-cli
+gen_revendor cargo_revendor cargo-revendor
 
 # Conversion-only inventory — the dedup-audit lens.
 python3 "$HERE/rustdoc_impl_inventory.py" target/doc/miniextendr_api.json \

--- a/rust-llm-docs/generated/cargo-revendor-impl-inventory.md
+++ b/rust-llm-docs/generated/cargo-revendor-impl-inventory.md
@@ -1,0 +1,112 @@
+# Trait impl inventory
+
+Source: `cargo-revendor/target/doc/cargo_revendor.json`
+
+Traits with impls: 28
+
+## Summary (impl count per trait)
+
+| Trait | # impls | # non-blanket non-synthetic |
+|---|---|---|
+| `Same` | 9 | 0 |
+| `UnsafeUnpin` | 9 | 0 |
+| `Sync` | 9 | 0 |
+| `TryInto` | 9 | 0 |
+| `TryFrom` | 9 | 0 |
+| `Send` | 9 | 0 |
+| `Any` | 9 | 0 |
+| `From` | 9 | 0 |
+| `Freeze` | 9 | 0 |
+| `Into` | 9 | 0 |
+| `BorrowMut` | 9 | 0 |
+| `Borrow` | 9 | 0 |
+| `RefUnwindSafe` | 9 | 0 |
+| `UnwindSafe` | 9 | 0 |
+| `Unpin` | 9 | 0 |
+| `ToOwned` | 5 | 0 |
+| `CloneToUninit` | 5 | 0 |
+| `Clone` | 5 | 5 |
+| `Debug` | 4 | 4 |
+| `Copy` | 2 | 2 |
+| `PartialEq` | 1 | 1 |
+| `StructuralPartialEq` | 1 | 1 |
+| `Args` | 1 | 1 |
+| `FromArgMatches` | 1 | 1 |
+| `CommandFactory` | 1 | 1 |
+| `Drop` | 1 | 1 |
+| `Serialize` | 1 | 1 |
+| `Parser` | 1 | 1 |
+
+## `Clone` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Mode` | `` | concrete | 1 | src/main.rs:258 |
+| `Verbosity` | `` | concrete | 1 | src/main.rs:55 |
+| `LocalPackage` | `` | concrete | 1 | src/metadata.rs:8 |
+| `StripConfig` | `` | concrete | 1 | src/strip.rs:8 |
+| `LockPackage` | `` | concrete | 1 | src/verify.rs:23 |
+
+## `Debug` — 4 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Verbosity` | `` | concrete | 1 | src/main.rs:55 |
+| `LocalPackage` | `` | concrete | 1 | src/metadata.rs:8 |
+| `StripConfig` | `` | concrete | 1 | src/strip.rs:8 |
+| `LockPackage` | `` | concrete | 1 | src/verify.rs:23 |
+
+## `Copy` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Mode` | `` | concrete | 0 | src/main.rs:258 |
+| `Verbosity` | `` | concrete | 0 | src/main.rs:55 |
+
+## `PartialEq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Mode` | `` | concrete | 1 | src/main.rs:258 |
+
+## `StructuralPartialEq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Mode` | `` | concrete | 0 | src/main.rs:258 |
+
+## `Args` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Cli` | `` | concrete | 3 | src/main.rs:70 |
+
+## `FromArgMatches` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Cli` | `` | concrete | 4 | src/main.rs:70 |
+
+## `CommandFactory` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Cli` | `` | concrete | 2 | src/main.rs:70 |
+
+## `Drop` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ManifestGuard` | `` | concrete | 1 | src/manifest_guard.rs:58 |
+
+## `Serialize` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `JsonOutput` | `` | concrete | 1 | src/main.rs:381 |
+
+## `Parser` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Cli` | `` | concrete | 0 | src/main.rs:70 |

--- a/rust-llm-docs/generated/cargo-revendor.md
+++ b/rust-llm-docs/generated/cargo-revendor.md
@@ -1,0 +1,637 @@
+# cargo_revendor v0.1.0
+
+cargo-revendor: vendor Rust dependencies for R packages and monorepos.
+
+`cargo-revendor` is a thin orchestrator over `cargo metadata`, `cargo
+package`, and `cargo vendor`. It calls cargo for the parts cargo does
+well, and only does the additional work cargo does not.
+
+Capabilities beyond plain `cargo vendor`:
+
+- Workspace path dependencies are packaged via `cargo package`, which
+  resolves `*.workspace = true` inheritance into a standalone manifest.
+- Inter-crate `path = "../sibling"` references are rewritten to the
+  sibling's vendor directory.
+- Opt-in stripping of `tests/`, `benches/`, `examples/`, and `[[bin]]`
+  targets, plus the matching `Cargo.toml` sections.
+- `--freeze` rewrites the target manifest to resolve everything from
+  `vendor/` and regenerates `Cargo.lock` with `--offline`.
+- `--compress` tars and xz-compresses `vendor/` for shipping.
+- `--verify` is a CI-only check that asserts agreement between
+  `Cargo.lock`, `vendor/`, and any compressed tarball.
+- Three-tier cache (`.revendor-cache`, `.revendor-cache-external`,
+  `.revendor-cache-local`) gates re-vendoring. Source files of local
+  crates participate in the cache key because pure source edits leave
+  `Cargo.lock` untouched.
+- Phase modes (`--external-only`, `--local-only`) split the pipeline
+  for CI cases where the external dep set rebuilds rarely.
+- `--sync` mirrors `cargo vendor --sync`, unioning multiple disjoint
+  workspaces into a single `vendor/` tree.
+- JSON output for machine consumption.
+
+See `README.md` in this crate for the full pipeline walkthrough and
+flag reference.
+
+---
+
+## Structs
+
+### `Verbosity`
+
+Verbosity level (0=quiet, 1=-v, 2=-vv, 3=-vvv)
+
+**Methods:**
+
+#### `debug`
+
+```rust
+debug(self: Self) -> bool
+```
+
+#### `info`
+
+```rust
+info(self: Self) -> bool
+```
+
+#### `trace`
+
+```rust
+trace(self: Self) -> bool
+```
+
+### `manifest_guard::ManifestGuard`
+
+Snapshot + auto-restore of a single file.
+
+Construct before any mutation to the file; the snapshotted bytes are
+restored unconditionally when the guard is dropped — including on panic
+unwind or early `?` return.
+
+Use `finish()` to dismiss the guard when the mutation is intentional and
+should persist (rare — typical cargo-revendor usage is always transient).
+
+**Methods:**
+
+#### `finish`
+
+```rust
+finish(self: Self)
+```
+
+Dismiss the guard so Drop does nothing. Use when the mutation is
+intended to persist (cargo-revendor doesn't currently do this, but
+the option is here for future callers).
+
+#### `snapshot`
+
+```rust
+snapshot(path: &Path) -> Result<Self>
+```
+
+Capture the file's current bytes. The guard arms immediately — any
+subsequent mutation to the file will be reverted on drop.
+
+### `metadata::LocalPackage`
+
+A local (path-based) package discovered in the dependency tree
+
+**Fields:**
+
+- `name`: `String`
+- `version`: `String`
+- `path`: `std::path::PathBuf`
+- `manifest_path`: `std::path::PathBuf`
+
+### `strip::StripConfig`
+
+Configuration for what to strip from vendored crates
+
+**Fields:**
+
+- `tests`: `bool`
+- `benches`: `bool`
+- `examples`: `bool`
+- `bins`: `bool`
+- `toml_only`: `bool`
+  - Strip TOML sections only — leave source-related directories
+
+**Methods:**
+
+#### `all`
+
+```rust
+all() -> Self
+```
+
+Strip everything (directories and TOML sections)
+
+#### `any`
+
+```rust
+any(self: &Self) -> bool
+```
+
+Whether any stripping is enabled
+
+#### `toml_only`
+
+```rust
+toml_only() -> Self
+```
+
+Strip TOML sections for all source-target categories without
+deleting `tests/` / `benches/` / `examples/` directories. See #330.
+
+### `verify::LockPackage`
+
+One `[[package]]` entry from a Cargo.lock.
+
+**Fields:**
+
+- `name`: `String`
+- `version`: `String`
+- `source`: `String`
+  - Empty string for local path/workspace packages; `registry+...` or
+
+---
+
+## Functions
+
+### `cache::is_cached`
+
+```rust
+is_cached(lockfile: &std::path::Path, sync_manifests: &[std::path::PathBuf], vendor_dir: &std::path::Path, local_crate_paths: &[std::path::PathBuf]) -> anyhow::Result<bool>
+```
+
+Check whether `vendor_dir` is up to date relative to `lockfile` plus the
+source trees of `local_crate_paths`, plus any additional manifests
+supplied via `--sync` (#229). Each sync manifest's sibling `Cargo.lock`
+and `Cargo.toml` are hashed into the key.
+
+### `cache::is_cached_external`
+
+```rust
+is_cached_external(lockfile: &std::path::Path, sync_manifests: &[std::path::PathBuf], vendor_dir: &std::path::Path) -> anyhow::Result<bool>
+```
+
+Check whether the external deps are up to date relative to `lockfile` and
+sync manifests. Ignores local crate source trees — pure source edits don't
+change external deps.
+
+### `cache::is_cached_local`
+
+```rust
+is_cached_local(vendor_dir: &std::path::Path, local_crate_paths: &[std::path::PathBuf]) -> anyhow::Result<bool>
+```
+
+Check whether the local crates are up to date relative to their source
+trees. Ignores Cargo.lock / sync manifests — lockfile changes don't affect
+the local crate packaging output.
+
+### `cache::save_cache`
+
+```rust
+save_cache(lockfile: &std::path::Path, sync_manifests: &[std::path::PathBuf], vendor_dir: &std::path::Path, local_crate_paths: &[std::path::PathBuf]) -> anyhow::Result<()>
+```
+
+Save the current hash to the cache file.
+
+### `cache::save_cache_external`
+
+```rust
+save_cache_external(lockfile: &std::path::Path, sync_manifests: &[std::path::PathBuf], vendor_dir: &std::path::Path) -> anyhow::Result<()>
+```
+
+Save the external-only cache file.
+
+### `cache::save_cache_local`
+
+```rust
+save_cache_local(vendor_dir: &std::path::Path, local_crate_paths: &[std::path::PathBuf]) -> anyhow::Result<()>
+```
+
+Save the local-only cache file.
+
+### `checksum::recompute_cargo_checksum_json`
+
+```rust
+recompute_cargo_checksum_json(crate_dir: &std::path::Path) -> anyhow::Result<()>
+```
+
+Recompute `.cargo-checksum.json` for a single vendored crate directory.
+
+Preserves the original `package` field (the registry `.crate` SHA-256 that
+matches the committed `Cargo.lock`'s `checksum =` line) and rewrites the
+`files` map with SHA-256s of every regular file currently present in
+`crate_dir/`, excluding `.cargo-checksum.json` itself.
+
+POSIX-relative paths (forward slashes) are used in the `files` map, as
+required by cargo's directory source format.
+
+### `checksum::recompute_checksums`
+
+```rust
+recompute_checksums(vendor_dir: &std::path::Path) -> anyhow::Result<()>
+```
+
+Recompute `.cargo-checksum.json` for every crate directory in `vendor_dir`.
+
+This replaces `clear_checksums`: instead
+of writing `{"files":{}}` (empty files map, null package), we preserve the
+original `package` hash (matching the committed `Cargo.lock`) and recompute
+the `files` map from the trimmed disk contents.
+
+Called after CRAN-trim so that cargo's offline source-replacement can verify
+both the lockfile consistency (via the `package` field) and the file
+integrity (via the `files` map).
+
+### `find_workspace_root`
+
+```rust
+find_workspace_root(dir: &std::path::Path) -> anyhow::Result<std::path::PathBuf>
+```
+
+Find workspace root by walking up from a directory
+
+### `metadata::check_duplicate_sources`
+
+```rust
+check_duplicate_sources(meta: &cargo_metadata::Metadata) -> anyhow::Result<()>
+```
+
+Error out when two different sources resolve to the same (name, version).
+
+Mirrors upstream cargo/src/cargo/ops/vendor.rs's duplicate-source check:
+two git repos that happen to publish the same crate name + version would
+otherwise silently last-write-wins during extraction, making the vendored
+contents depend on dep-graph iteration order. Upstream hard-errors; we do
+too.
+
+Common legitimate case this does NOT flag: the SAME (name, version) from
+the SAME source appearing multiple times in `meta.packages` (cargo can
+emit dupes when a package is reached via different dep paths). Only
+DIFFERENT sources for the same (name, version) key are errors.
+
+### `metadata::discover_from_patch_config`
+
+```rust
+discover_from_patch_config(manifest_path: &std::path::Path) -> anyhow::Result<Vec<LocalPackage>>
+```
+
+Discover local package overrides from `[patch."<url>"]` tables in
+`.cargo/config.toml`.
+
+Cargo's config search order walks up from the manifest directory, checking
+`<dir>/.cargo/config.toml` at each level, then falls back to
+`$HOME/.cargo/config.toml`. This function mirrors that walk.
+
+For each `[patch."<url>"]` table (the URL may have or lack the `git+`
+scheme prefix — both forms are accepted), entries of the form
+`<crate-name> = { path = "<path>" }` are collected. The `path` is resolved
+relative to the config file that declares it. For each entry, the target
+crate's `Cargo.toml` is read to extract the version, and a `LocalPackage`
+is returned.
+
+Entries where the `path` does not contain a readable `Cargo.toml` are
+silently skipped (the dep may not exist yet on this machine).
+
+On TOML parse errors in a config file, returns an error with the file path
+and position so the caller can report it loudly.
+
+### `metadata::discover_patch_url_map`
+
+```rust
+discover_patch_url_map(manifest_path: &std::path::Path) -> anyhow::Result<std::collections::BTreeMap<String, String>>
+```
+
+Map each `[patch."<url>"]` crate to the git URL it is patched from.
+
+This is the provenance the lockfile needs but `discover_from_patch_config`
+discards: when cargo resolves with a `[patch."<url>"]` path override active,
+the framework crates land in `Cargo.lock` as local (no `source`) entries.
+For the offline tarball, those entries must instead carry
+`source = "git+<url>#<sha>"` so cargo's `[source."git+<url>"]` replacement
+can redirect them to `vendored-sources`. This function recovers the
+`crate-name -> <url>` mapping from the same `.cargo/config.toml` walk so the
+lockfile can be stamped after resolution. See [`crate::vendor::stamp_framework_git_sources`].
+
+The returned URL is normalized: any leading `git+` scheme prefix is stripped
+(cargo accepts `[patch."https://…"]` and `[patch."git+https://…"]`
+interchangeably; the lockfile/source-replacement form is `git+<url>`, which
+the stamper re-adds). Only entries whose `path` resolves to a readable
+`Cargo.toml` are included — an unresolvable patch path means the crate is
+vendored from its real git source, which is already lockfile-correct and
+must not be stamped.
+
+### `metadata::discover_workspace_members`
+
+```rust
+discover_workspace_members(workspace_root: &std::path::Path) -> anyhow::Result<Vec<LocalPackage>>
+```
+
+Discover all workspace members from a workspace root Cargo.toml
+
+### `metadata::load_metadata`
+
+```rust
+load_metadata(manifest_path: &std::path::Path) -> anyhow::Result<cargo_metadata::Metadata>
+```
+
+Load cargo metadata for the given manifest.
+
+Runs `cargo metadata` with the working directory set to the manifest's
+parent so that cargo's CWD-relative config discovery picks up that crate's
+`.cargo/config.toml`. For an R package in dev/source mode this carries the
+`[patch."<git-url>"]` table that redirects the framework crates to the local
+workspace checkout — so a cross-crate feature/dep rename (touching both a
+framework crate and its consumer) resolves against the PR's sources instead
+of git@main (#883). Without the CWD pin cargo would search upward from the
+process CWD (the repo root for `just vendor`) and never find the patch.
+
+### `metadata::partition_packages`
+
+```rust
+partition_packages(meta: &cargo_metadata::Metadata, target_manifest: &std::path::Path, git_overrides: &[LocalPackage]) -> anyhow::Result<(Vec<LocalPackage>, Vec<String>)>
+```
+
+Partition packages into local (path deps) and external (registry/git)
+
+Local packages are those whose source is a local path and whose
+manifest is NOT inside the target package's src/rust directory
+(i.e., they're workspace siblings, not the package itself).
+
+`git_overrides` allows callers to reclassify git-sourced deps as local
+when the same crate is available in a local source root (e.g., a monorepo
+where `--source-root` points at the workspace containing the git dep).
+Any git dep whose name matches an entry in `git_overrides` is treated as
+local and vendored from the local path rather than fetched from git.
+Pass `&[]` when `--source-root` is not in use.
+
+Returns an error if a git dep matches a `git_overrides` entry by name but
+the resolved git version differs from the local version — a version mismatch
+means the local checkout is not the same code the lockfile pinned, and
+silently vendoring the wrong source would produce broken builds.
+
+### `package::package_local_crates`
+
+```rust
+package_local_crates(local_pkgs: &[crate::metadata::LocalPackage], all_patch_pkgs: &[crate::metadata::LocalPackage], _target_manifest: &std::path::Path, staging_dir: &std::path::Path, allow_dirty: bool, v: crate::Verbosity) -> anyhow::Result<Vec<(String, std::path::PathBuf)>>
+```
+
+Package each local crate, returning (name, crate_archive_path) pairs
+
+`local_pkgs` — crates to actually package
+`all_patch_pkgs` — ALL workspace crates (for [patch.crates-io] config)
+
+### `path_to_toml`
+
+```rust
+path_to_toml(path: &std::path::Path) -> String
+```
+
+Convert a path to a TOML-safe string (forward slashes, no \\?\ prefix)
+
+### `strip::prune_dangling_feature_refs`
+
+```rust
+prune_dangling_feature_refs(content: &str, removed_deps: &[String]) -> String
+```
+
+Remove feature array entries that reference removed dependencies.
+
+Cargo validates ALL `[features]` entries at parse time regardless of which
+features are enabled. After dev-dependencies are stripped, any feature
+referencing `"<dep>/..."`, `"<dep>?/..."`, or exactly `"<dep>"` for a
+removed dep becomes a dangling reference that breaks every consumer.
+
+Exact-match items (`"<dep>"`) are only pruned when no `[features]` entry
+of the same name exists in this crate. Otherwise the string refers to the
+crate's own feature, not the dep — e.g. toml ships
+`default = ["std", "serde", "parse", "display"]` where `"serde"` is the
+feature key, not the dev-dep.
+
+If a feature's array becomes empty after pruning, it is kept as `[]`
+(a valid, harmless feature flag). Non-referencing features are unchanged.
+
+### `strip::strip_vendor_dir`
+
+```rust
+strip_vendor_dir(vendor_dir: &std::path::Path, config: &StripConfig, v: crate::Verbosity) -> anyhow::Result<Vec<String>>
+```
+
+Strip all vendored crates in a vendor directory.
+Returns list of stripped items for reporting.
+
+### `vendor::compress_vendor`
+
+```rust
+compress_vendor(vendor_dir: &std::path::Path, tarball_path: &std::path::Path, blank_md: bool, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Compress vendor/ into a .tar.xz tarball
+
+### `vendor::copy_lock_to_vendor`
+
+```rust
+copy_lock_to_vendor(lockfile: &std::path::Path, vendor_dir: &std::path::Path, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Copy `Cargo.lock` to the vendor directory for use by `--freeze` /
+`regenerate_lockfile`.
+
+Checksums are retained — cargo-revendor now writes valid `.cargo-checksum.json`
+files (with `package` fields matching the lockfile's `checksum = "..."` lines),
+so the lock no longer needs to be stripped before copying.
+
+### `vendor::extract_crate_archive`
+
+```rust
+extract_crate_archive(crate_path: &std::path::Path, vendor_dir: &std::path::Path, pkg_name: &str, pkg_version: Option<&str>, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Extract a .crate archive OR copy a directory into the vendor directory.
+
+Local workspace crates always land at flat `vendor/<name>/` — they are
+single-version by construction, so the #214 flat-slot non-determinism
+(which motivates `--versioned-dirs` for transitive deps) can't apply.
+`pkg_version` is kept only to clean up versioned placeholders that
+`cargo vendor --versioned-dirs` may have created for patched crates.
+
+### `vendor::freeze_manifest`
+
+```rust
+freeze_manifest(manifest_path: &std::path::Path, vendor_dir: &std::path::Path, local_pkgs: &[crate::metadata::LocalPackage], versioned_dirs: bool, strict: bool, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Freeze: rewrite Cargo.toml so all sources resolve from vendor/.
+
+1. Rewrites git deps to vendor/ path deps
+2. Strips all `[patch.*]` sections (they reference sources outside vendor/)
+3. Adds `[patch.crates-io]` with vendor paths for transitive local deps
+
+After freezing, the manifest is self-contained: `cargo build --offline`
+works with only the vendor directory, no network or workspace context.
+
+### `vendor::generate_cargo_config`
+
+```rust
+generate_cargo_config(manifest_path: &std::path::Path, vendor_dir: &std::path::Path, _local_pkgs: &[crate::metadata::LocalPackage]) -> anyhow::Result<String>
+```
+
+Generate a .cargo/config.toml for source replacement.
+
+Returns the config content as a string. Also writes it to
+`<vendor_dir>/../src/rust/.cargo/config.toml` if that path exists.
+
+### `vendor::regenerate_lockfile`
+
+```rust
+regenerate_lockfile(manifest_path: &std::path::Path, vendor_dir: &std::path::Path, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Regenerate Cargo.lock from vendored sources (freeze-consistent copy).
+
+The vendor/ directory contains a Cargo.lock (with registry checksums
+retained) produced by `copy_lock_to_vendor` during the same vendoring run.
+Copying it directly to the manifest's Cargo.lock is the most reliable
+approach: it is exactly consistent with what was vendored, avoiding
+version-drift that can occur when `cargo generate-lockfile --offline`
+resolves from the local index cache (which may have been updated by a
+subsequent `cargo vendor` run).
+
+### `vendor::resolve_framework_rev`
+
+```rust
+resolve_framework_rev(candidate_paths: &[std::path::PathBuf], v: crate::Verbosity) -> String
+```
+
+Resolve the commit sha to stamp as framework-crate provenance in Cargo.lock.
+
+Tries `git rev-parse HEAD` in each candidate checkout (the local framework
+crate dirs) in turn; falls back to [`PLACEHOLDER_GIT_REV`] with a warning.
+The value is provenance only — cargo's `[source."git+<url>"]` replacement
+keys on the URL, never the commit — so a placeholder still builds offline.
+
+### `vendor::resolve_workspace_inheritance`
+
+```rust
+resolve_workspace_inheritance(vendor_crate_dir: &std::path::Path, original_crate_dir: &std::path::Path, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Resolve `*.workspace = true` fields in a directly-copied crate's Cargo.toml
+
+When cargo package can't run (unpublished deps), we copy the crate directly.
+But workspace inheritance (`version.workspace = true`, etc.) won't resolve
+outside the workspace. This function reads the workspace root's
+`[workspace.package]` and replaces the inherited fields.
+
+### `vendor::rewrite_local_path_deps`
+
+```rust
+rewrite_local_path_deps(vendor_dir: &std::path::Path, local_pkgs: &[crate::metadata::LocalPackage], v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Rewrite inter-crate path dependencies so local crates reference each other
+in `vendor/`. Local crates always land at flat `vendor/<name>/` — they are
+single-version by construction, so the #214 rationale for versioned dirs
+doesn't apply.
+
+### `vendor::run_cargo_vendor`
+
+```rust
+run_cargo_vendor(manifest_path: &std::path::Path, vendor_dir: &std::path::Path, local_pkgs: &[crate::metadata::LocalPackage], sync_manifests: &[std::path::PathBuf], versioned_dirs: bool, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Run `cargo vendor` for external (registry/git) dependencies.
+
+`sync_manifests` mirrors `cargo vendor --sync <path>`: additional
+manifests whose dep graphs are unioned into the same output tree.
+Use case (#229): one R-package workspace plus a disjoint benchmarks
+workspace sharing one offline artifact; two packages pinning different
+versions of the same transitive dep both coexist in `vendor/` as
+separate dirs.
+
+### `vendor::stamp_framework_git_sources`
+
+```rust
+stamp_framework_git_sources(lockfile: &std::path::Path, patch_url_map: &std::collections::BTreeMap<String, String>, rev: &str, v: crate::Verbosity) -> anyhow::Result<usize>
+```
+
+Stamp `source = "git+<url>#<rev>"` onto the framework crates' `[[package]]`
+entries in `lockfile`.
+
+Why this exists: the lock is resolved with the dev `[patch."<url>"]` path
+override active (so a cross-crate feature rename resolves against the LOCAL
+workspace, not git@main — see #883). That resolution records the framework
+crates as local (no `source`) entries. The offline tarball install, however,
+needs `source = "git+<url>#<sha>"` so cargo's `[source."git+<url>"]`
+replacement can redirect them to `vendored-sources`. We reconstruct that
+attribution here rather than re-resolving against the bare git URL (which is
+exactly the step that fails on a cross-crate rename).
+
+`patch_url_map` is `crate-name -> <url>` (no `git+` prefix; see
+[`crate::metadata::discover_patch_url_map`]). Only packages named in the map
+are touched; for those, any existing `source`/`path` is replaced and the new
+`source` line is placed immediately after `version` to match cargo's own
+canonical key order (and the `grep -A3` lock-shape check). Returns the number
+of `[[package]]` entries stamped.
+
+### `vendor::strip_vendor_path_deps`
+
+```rust
+strip_vendor_path_deps(vendor_dir: &std::path::Path, v: crate::Verbosity) -> anyhow::Result<()>
+```
+
+Strip relative path dependencies (`path = "../..."`) from all vendored crate manifests.
+
+When `cargo vendor` vendors crates from a git workspace, the vendored Cargo.toml
+files retain intra-workspace path deps (e.g., `path = "../sibling-crate"`). During
+offline builds with cargo source replacement, these path deps cause cargo to resolve
+siblings as path sources instead of through the directory source, which conflicts
+with Cargo.lock entries that record them as git (or registry) sources. Stripping the
+path keys forces cargo to resolve by name from the replaced source.
+
+This runs BEFORE `rewrite_local_path_deps`, which adds back correct path deps
+for local/workspace crates only.
+
+### `verify::parse_lockfile`
+
+```rust
+parse_lockfile(lockfile: &std::path::Path) -> anyhow::Result<Vec<LockPackage>>
+```
+
+Parse a Cargo.lock into its `[[package]]` entries.
+
+### `verify::verify_lock_matches_vendor`
+
+```rust
+verify_lock_matches_vendor(lockfile: &std::path::Path, vendor_dir: &std::path::Path) -> anyhow::Result<()>
+```
+
+Assert that every foreign-source package in `lockfile` has a corresponding
+directory in `vendor_dir` whose `Cargo.toml` reports the same version.
+
+Local path packages (empty `source`) are skipped — they are the crates
+being vendored *from*, not *into*.
+
+### `verify::verify_tarball_matches_vendor`
+
+```rust
+verify_tarball_matches_vendor(tarball: &std::path::Path, vendor_dir: &std::path::Path) -> anyhow::Result<()>
+```
+
+Assert that extracting `tarball` yields the same files with the same
+contents as `vendor_dir`.
+
+Uses byte-level hashing so drift in a single vendored `.rs` is caught.
+
+---
+
+## Constants
+
+### `cache::CACHE_FILE: &str`
+
+### `cache::CACHE_FILE_EXTERNAL: &str`
+
+### `cache::CACHE_FILE_LOCAL: &str`

--- a/rust-llm-docs/generated/conversion-impl-inventory.md
+++ b/rust-llm-docs/generated/conversion-impl-inventory.md
@@ -8,8 +8,8 @@ Traits with impls: 9
 
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
-| `TryFromSexp` | 434 | 434 |
-| `IntoR` | 325 | 325 |
+| `TryFromSexp` | 442 | 442 |
+| `IntoR` | 329 | 329 |
 | `IntoRAs` | 135 | 135 |
 | `TryCoerce` | 95 | 93 |
 | `Coerce` | 53 | 53 |
@@ -18,7 +18,7 @@ Traits with impls: 9
 | `RSerializeNative` | 1 | 1 |
 | `RDeserializeNative` | 1 | 1 |
 
-## `TryFromSexp` — 434 impls
+## `TryFromSexp` — 442 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -29,39 +29,39 @@ Traits with impls: 9
 | `Factor<'a>` | `<'a>` | concrete | 2 | miniextendr-api/src/factor.rs:222 |
 | `FactorVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:517 |
 | `FactorOptionVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:570 |
-| `crate::coerce::Coerced<T, R>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/from_r.rs:1014 |
-| `Vec<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1153 |
-| `Vec<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1154 |
-| `Vec<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1155 |
-| `Vec<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1156 |
-| `Vec<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1157 |
-| `Vec<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1158 |
-| `Vec<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1159 |
-| `Vec<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1160 |
-| `Vec<f32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1161 |
-| `Vec<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1164 |
-| `std::collections::HashSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1220 |
-| `std::collections::HashSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1221 |
-| `std::collections::HashSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1222 |
-| `std::collections::HashSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1223 |
-| `std::collections::HashSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1224 |
-| `std::collections::HashSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1225 |
-| `std::collections::HashSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1226 |
-| `std::collections::HashSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1227 |
-| `std::collections::BTreeSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1229 |
-| `std::collections::BTreeSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1230 |
-| `std::collections::BTreeSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1231 |
-| `std::collections::BTreeSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1232 |
-| `std::collections::BTreeSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1233 |
-| `std::collections::BTreeSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1234 |
-| `std::collections::BTreeSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1235 |
-| `std::collections::BTreeSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1236 |
-| `std::collections::HashSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1255 |
-| `std::collections::BTreeSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1256 |
-| `crate::externalptr::ExternalPtr<T>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1278 |
-| `Option<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1325 |
-| `Vec<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1354 |
-| `Vec<Option<crate::externalptr::ExternalPtr<T>>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1399 |
+| `crate::coerce::Coerced<T, R>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/from_r.rs:1016 |
+| `Vec<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1155 |
+| `Vec<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1156 |
+| `Vec<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1157 |
+| `Vec<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1158 |
+| `Vec<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1159 |
+| `Vec<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1160 |
+| `Vec<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1161 |
+| `Vec<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1162 |
+| `Vec<f32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1163 |
+| `Vec<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1166 |
+| `std::collections::HashSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1222 |
+| `std::collections::HashSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1223 |
+| `std::collections::HashSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1224 |
+| `std::collections::HashSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1225 |
+| `std::collections::HashSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1226 |
+| `std::collections::HashSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1227 |
+| `std::collections::HashSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1228 |
+| `std::collections::HashSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1229 |
+| `std::collections::BTreeSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1231 |
+| `std::collections::BTreeSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1232 |
+| `std::collections::BTreeSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1233 |
+| `std::collections::BTreeSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1234 |
+| `std::collections::BTreeSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1235 |
+| `std::collections::BTreeSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1236 |
+| `std::collections::BTreeSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1237 |
+| `std::collections::BTreeSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1238 |
+| `std::collections::HashSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1257 |
+| `std::collections::BTreeSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1258 |
+| `crate::externalptr::ExternalPtr<T>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1280 |
+| `Option<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1327 |
+| `Vec<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1356 |
+| `Vec<Option<crate::externalptr::ExternalPtr<T>>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1401 |
 | `Box<[T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:337 |
 | `i32` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:426 |
 | `f64` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:502 |
@@ -75,15 +75,15 @@ Traits with impls: 9
 | `Option<&[T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:660 |
 | `Option<&mut [T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:687 |
 | `Result<T, ()>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:718 |
-| `[T; N]` | `<T, N> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:755 |
-| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:793 |
-| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:818 |
-| `Option<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:844 |
-| `Option<std::collections::HashMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:895 |
-| `Option<std::collections::BTreeMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:899 |
-| `Option<std::collections::HashSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:928 |
-| `Option<std::collections::BTreeSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:932 |
-| `Vec<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:943 |
+| `[T; N]` | `<T, N> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:757 |
+| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:795 |
+| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:820 |
+| `Option<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:846 |
+| `Option<std::collections::HashMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:897 |
+| `Option<std::collections::BTreeMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:901 |
+| `Option<std::collections::HashSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:930 |
+| `Option<std::collections::BTreeSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:934 |
+| `Vec<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:945 |
 | `i8` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:269 |
 | `i16` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:283 |
 | `u16` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:297 |
@@ -123,10 +123,10 @@ Traits with impls: 9
 | `std::collections::HashSet<String>` | `` | concrete | 2 | miniextendr-api/src/from_r/cow_and_paths.rs:278 |
 | `std::collections::BTreeSet<String>` | `` | concrete | 2 | miniextendr-api/src/from_r/cow_and_paths.rs:282 |
 | `std::borrow::Cow<'static, [T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:34 |
-| `Option<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
-| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `std::path::PathBuf` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `Vec<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
+| `Option<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
+| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `Vec<Option<std::ffi::OsString>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
 | `std::ffi::OsString` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
 | `Vec<std::ffi::OsString>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
@@ -160,7 +160,6 @@ Traits with impls: 9
 | `Vec<Option<f64>>` | `` | concrete | 2 | miniextendr-api/src/from_r/na_vectors.rs:62 |
 | `Vec<Option<i32>>` | `` | concrete | 2 | miniextendr-api/src/from_r/na_vectors.rs:63 |
 | `Vec<Option<bool>>` | `` | concrete | 3 | miniextendr-api/src/from_r/na_vectors.rs:66 |
-| `Option<&'static i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static mut i32` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static i32` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `Option<&'static mut i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
@@ -172,7 +171,7 @@ Traits with impls: 9
 | `Vec<Option<&'static [i32]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
 | `Vec<&'static mut [i32]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
 | `Vec<Option<&'static mut [i32]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
-| `Option<&'static f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
+| `Option<&'static i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static mut f64` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `&'static f64` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `Option<&'static mut f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
@@ -184,7 +183,7 @@ Traits with impls: 9
 | `Vec<Option<&'static [f64]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
 | `Vec<&'static mut [f64]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
 | `Vec<Option<&'static mut [f64]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
-| `&'static mut u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `Option<&'static f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `&'static u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
 | `Option<&'static mut u8>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
 | `Vec<&'static u8>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
@@ -196,6 +195,9 @@ Traits with impls: 9
 | `Vec<&'static mut [u8]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
 | `Vec<Option<&'static mut [u8]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
 | `Option<&'static u8>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `&'static mut u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `Option<&'static crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
+| `&'static mut crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `Option<&'static mut crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<&'static crate::RLogical>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<Option<&'static crate::RLogical>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
@@ -205,8 +207,6 @@ Traits with impls: 9
 | `Vec<Option<&'static [crate::RLogical]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<&'static mut [crate::RLogical]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<Option<&'static mut [crate::RLogical]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
-| `Option<&'static crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
-| `&'static mut crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `&'static crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `&'static crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static mut crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
@@ -218,13 +218,21 @@ Traits with impls: 9
 | `Vec<Option<&'static [crate::Rcomplex]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
 | `Vec<&'static mut [crate::Rcomplex]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
 | `Vec<Option<&'static mut [crate::Rcomplex]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
-| `&'static mut crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
+| `&'static mut crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static str>` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:121 |
 | `char` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:199 |
 | `String` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:245 |
 | `Option<String>` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:317 |
 | `&'static str` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:47 |
+| `(A)` | `<A> +1wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:111 |
+| `(A, B)` | `<A, B> +2wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:112 |
+| `(A, B, C)` | `<A, B, C> +3wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:113 |
+| `(A, B, C, D)` | `<A, B, C, D> +4wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:114 |
+| `(A, B, C, D, E)` | `<A, B, C, D, E> +5wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:115 |
+| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F> +6wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:116 |
+| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G> +7wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:117 |
+| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H> +8wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:118 |
 | `List` | `` | concrete | 2 | miniextendr-api/src/list.rs:1202 |
 | `Option<List>` | `` | concrete | 2 | miniextendr-api/src/list.rs:1257 |
 | `Option<ListMut>` | `` | concrete | 2 | miniextendr-api/src/list.rs:1269 |
@@ -277,12 +285,12 @@ Traits with impls: 9
 | `SignedDuration` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Vec<SignedDuration>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Option<SignedDuration>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
-| `Option<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Vec<Option<Timestamp>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `Option<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
+| `Vec<Option<Timestamp>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
 | `JiffZonedVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
 | `JiffZonedVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
 | `Vec<Option<Date>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
@@ -309,27 +317,27 @@ Traits with impls: 9
 | `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2920 |
 | `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:300 |
 | `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3065 |
+| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
+| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
+| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
+| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
@@ -337,34 +345,34 @@ Traits with impls: 9
 | `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
@@ -372,13 +380,13 @@ Traits with impls: 9
 | `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
+| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `BigInt` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:202 |
 | `BigUint` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:214 |
 | `Option<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:226 |
@@ -415,10 +423,10 @@ Traits with impls: 9
 | `Vec<OffsetDateTime>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Option<OffsetDateTime>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
-| `Option<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `ArrayVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:102 |
 | `Option<TinyVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:178 |
 | `Option<ArrayVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:227 |
@@ -459,32 +467,32 @@ Traits with impls: 9
 
 ### `TryFromSexp` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/from_r/references.rs:449** (12 impls): `Option<&'static f64>`, `&'static mut f64`, `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`
-- **miniextendr-api/src/from_r/references.rs:451** (12 impls): `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `Option<&'static crate::RLogical>`, `&'static mut crate::RLogical`, `&'static crate::RLogical`
-- **miniextendr-api/src/from_r/references.rs:452** (12 impls): `&'static crate::Rcomplex`, `Option<&'static mut crate::Rcomplex>`, `Vec<&'static crate::Rcomplex>`, `Vec<Option<&'static crate::Rcomplex>>`, `Vec<&'static mut crate::Rcomplex>`, `Vec<Option<&'static mut crate::Rcomplex>>`, `Vec<&'static [crate::Rcomplex]>`, `Vec<Option<&'static [crate::Rcomplex]>>`, `Vec<&'static mut [crate::Rcomplex]>`, `Vec<Option<&'static mut [crate::Rcomplex]>>`, `&'static mut crate::Rcomplex`, `Option<&'static crate::Rcomplex>`
-- **miniextendr-api/src/from_r/references.rs:448** (12 impls): `Option<&'static i32>`, `&'static mut i32`, `&'static i32`, `Option<&'static mut i32>`, `Vec<&'static i32>`, `Vec<Option<&'static i32>>`, `Vec<&'static mut i32>`, `Vec<Option<&'static mut i32>>`, `Vec<&'static [i32]>`, `Vec<Option<&'static [i32]>>`, `Vec<&'static mut [i32]>`, `Vec<Option<&'static mut [i32]>>`
-- **miniextendr-api/src/from_r/references.rs:450** (12 impls): `&'static mut u8`, `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`, `Array1<u32>`
+- **miniextendr-api/src/from_r/references.rs:449** (12 impls): `&'static mut f64`, `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`, `Option<&'static f64>`
+- **miniextendr-api/src/from_r/references.rs:451** (12 impls): `Option<&'static crate::RLogical>`, `&'static mut crate::RLogical`, `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `&'static crate::RLogical`
+- **miniextendr-api/src/from_r/references.rs:452** (12 impls): `&'static crate::Rcomplex`, `Option<&'static mut crate::Rcomplex>`, `Vec<&'static crate::Rcomplex>`, `Vec<Option<&'static crate::Rcomplex>>`, `Vec<&'static mut crate::Rcomplex>`, `Vec<Option<&'static mut crate::Rcomplex>>`, `Vec<&'static [crate::Rcomplex]>`, `Vec<Option<&'static [crate::Rcomplex]>>`, `Vec<&'static mut [crate::Rcomplex]>`, `Vec<Option<&'static mut [crate::Rcomplex]>>`, `Option<&'static crate::Rcomplex>`, `&'static mut crate::Rcomplex`
+- **miniextendr-api/src/from_r/references.rs:448** (12 impls): `&'static mut i32`, `&'static i32`, `Option<&'static mut i32>`, `Vec<&'static i32>`, `Vec<Option<&'static i32>>`, `Vec<&'static mut i32>`, `Vec<Option<&'static mut i32>>`, `Vec<&'static [i32]>`, `Vec<Option<&'static [i32]>>`, `Vec<&'static mut [i32]>`, `Vec<Option<&'static mut [i32]>>`, `Option<&'static i32>`
+- **miniextendr-api/src/from_r/references.rs:450** (12 impls): `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`, `&'static mut u8`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`, `Array4<i16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`, `Array2<u16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
 - **miniextendr-api/src/optionals/ndarray_impl.rs:676** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`, `Array1<i8>`
 - **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`, `ArrayD<u64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`, `Array5<bool>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`, `Array4<i16>`, `ArrayD<i16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`, `Array2<u16>`, `Array5<u16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`, `Array3<usize>`, `Array6<usize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`, `Array3<i64>`, `Array6<i64>`
+- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Option<Date>`, `Vec<Option<Date>>`, `Date`, `Vec<Date>`
+- **miniextendr-api/src/from_r/cow_and_paths.rs:369** (4 impls): `std::path::PathBuf`, `Vec<std::path::PathBuf>`, `Option<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Timestamp`, `Vec<Timestamp>`, `Option<Timestamp>`, `Vec<Option<Timestamp>>`
 - **miniextendr-api/src/from_r/cow_and_paths.rs:392** (4 impls): `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Option<Date>>`, `Date`, `Vec<Date>`, `Option<Date>`
 - **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<OffsetDateTime>`, `Option<OffsetDateTime>`, `Vec<Option<OffsetDateTime>>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `Vec<Option<SignedDuration>>`, `SignedDuration`, `Vec<SignedDuration>`, `Option<SignedDuration>`
-- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Option<Date>>`, `Date`, `Vec<Date>`, `Option<Date>`
-- **miniextendr-api/src/from_r/cow_and_paths.rs:369** (4 impls): `Option<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `Vec<std::path::PathBuf>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Option<Timestamp>>`, `Timestamp`, `Vec<Timestamp>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecRef`, `JiffTimestampVecMut`
+- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecMut`, `JiffTimestampVecRef`
 - **miniextendr-api/src/optionals/jiff_impl.rs:923** (2 impls): `JiffZonedVecMut`, `JiffZonedVecRef`
 
-## `IntoR` — 325 impls
+## `IntoR` — 329 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -508,81 +516,84 @@ Traits with impls: 9
 | `DataFrame` | `` | concrete | 4 | miniextendr-api/src/dataframe.rs:563 |
 | `FactorVec<T>` | `<T>` | concrete | 4 | miniextendr-api/src/factor.rs:501 |
 | `FactorOptionVec<T>` | `<T>` | concrete | 4 | miniextendr-api/src/factor.rs:610 |
-| `HashSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1008 |
-| `BTreeSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1008 |
-| `HashSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1009 |
-| `BTreeSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1009 |
-| `BTreeSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1010 |
-| `HashSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1010 |
-| `Option<Vec<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1019 |
-| `Option<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1046 |
-| `Option<std::collections::HashMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1073 |
-| `Option<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1100 |
-| `Option<std::collections::HashSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1127 |
-| `Option<std::collections::BTreeSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1154 |
-| `Option<std::collections::HashSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1211 |
-| `Option<std::collections::BTreeSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1215 |
-| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1260 |
-| `&[String]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1278 |
-| `&[&str]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1296 |
+| `HashSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1011 |
+| `BTreeSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1011 |
+| `HashSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1012 |
+| `BTreeSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1012 |
+| `HashSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1013 |
+| `BTreeSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1013 |
+| `Option<Vec<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1022 |
+| `Option<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1049 |
+| `Option<std::collections::HashMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1076 |
+| `Option<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1103 |
+| `Option<std::collections::HashSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1130 |
+| `Option<std::collections::BTreeSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1157 |
+| `Option<std::collections::HashSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1214 |
+| `Option<std::collections::BTreeSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1218 |
+| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1263 |
+| `&[String]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1281 |
+| `&[&str]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1299 |
 | `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:130 |
-| `Vec<std::borrow::Cow<'_, str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1314 |
-| `Vec<Option<std::borrow::Cow<'_, str>>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1333 |
-| `Vec<Option<&str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1386 |
-| `Vec<&str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1437 |
-| `Vec<Vec<T>>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:1458 |
-| `Vec<&[T]>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1506 |
-| `Vec<&[String]>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1546 |
-| `Vec<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1584 |
-| `Vec<Option<f64>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1671 |
-| `Vec<Option<i32>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1672 |
+| `Vec<std::borrow::Cow<'_, str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1317 |
+| `Vec<Option<std::borrow::Cow<'_, str>>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1336 |
+| `Vec<Option<&str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1389 |
+| `Vec<&str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1440 |
+| `Vec<Vec<T>>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:1461 |
+| `Vec<&[T]>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1509 |
+| `Vec<&[String]>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1549 |
+| `Vec<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1587 |
+| `Vec<Option<f64>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1674 |
+| `Vec<Option<i32>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1675 |
 | `()` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:169 |
-| `Vec<Option<i64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1710 |
-| `Vec<Option<u64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1711 |
-| `Vec<Option<isize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1712 |
-| `Vec<Option<usize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1714 |
-| `Vec<Option<i8>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1733 |
-| `Vec<Option<i16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1734 |
-| `Vec<Option<u16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1735 |
-| `Vec<Option<u32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1736 |
-| `Vec<Option<f32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1737 |
-| `Vec<bool>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1770 |
-| `&[bool]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1790 |
-| `Vec<Option<bool>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1833 |
-| `Vec<Option<crate::Rboolean>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1842 |
+| `Vec<Option<i64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1713 |
+| `Vec<Option<u64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1714 |
+| `Vec<Option<isize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1715 |
+| `Vec<Option<usize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1717 |
+| `Vec<Option<i8>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1736 |
+| `Vec<Option<i16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1737 |
+| `Vec<Option<u16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1738 |
+| `Vec<Option<u32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1739 |
+| `Vec<Option<f32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1740 |
+| `Vec<bool>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1773 |
+| `&[bool]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1793 |
+| `Vec<crate::Rboolean>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1813 |
+| `&[crate::Rboolean]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1833 |
 | `std::convert::Infallible` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:185 |
-| `Vec<Option<crate::RLogical>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1850 |
-| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1862 |
-| `(A, B)` | `<A, B>` | concrete | 5 | miniextendr-api/src/into_r.rs:1974 |
-| `(A, B, C)` | `<A, B, C>` | concrete | 5 | miniextendr-api/src/into_r.rs:1975 |
-| `(A, B, C, D)` | `<A, B, C, D>` | concrete | 5 | miniextendr-api/src/into_r.rs:1976 |
-| `(A, B, C, D, E)` | `<A, B, C, D, E>` | concrete | 5 | miniextendr-api/src/into_r.rs:1977 |
-| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F>` | concrete | 5 | miniextendr-api/src/into_r.rs:1978 |
-| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G>` | concrete | 5 | miniextendr-api/src/into_r.rs:1979 |
-| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H>` | concrete | 5 | miniextendr-api/src/into_r.rs:1980 |
-| `Vec<Box<[T]>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2083 |
-| `Vec<Box<[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2113 |
-| `Vec<[T; N]>` | `<T, N> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2130 |
-| `Vec<Option<Vec<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2198 |
-| `Vec<Option<Vec<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2215 |
-| `Vec<Option<std::collections::HashSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2220 |
-| `Vec<Option<std::collections::HashSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2237 |
-| `Vec<Option<std::collections::BTreeSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2242 |
-| `Vec<Option<std::collections::BTreeSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2259 |
+| `Vec<Option<bool>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1876 |
+| `Vec<Option<crate::Rboolean>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1885 |
+| `Vec<Option<crate::RLogical>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1893 |
+| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1905 |
+| `(A)` | `<A>` | concrete | 5 | miniextendr-api/src/into_r.rs:2016 |
+| `(A, B)` | `<A, B>` | concrete | 5 | miniextendr-api/src/into_r.rs:2017 |
+| `(A, B, C)` | `<A, B, C>` | concrete | 5 | miniextendr-api/src/into_r.rs:2018 |
+| `(A, B, C, D)` | `<A, B, C, D>` | concrete | 5 | miniextendr-api/src/into_r.rs:2019 |
+| `(A, B, C, D, E)` | `<A, B, C, D, E>` | concrete | 5 | miniextendr-api/src/into_r.rs:2020 |
+| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F>` | concrete | 5 | miniextendr-api/src/into_r.rs:2021 |
+| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G>` | concrete | 5 | miniextendr-api/src/into_r.rs:2022 |
+| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H>` | concrete | 5 | miniextendr-api/src/into_r.rs:2023 |
+| `Vec<Box<[T]>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2126 |
+| `Vec<Box<[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2156 |
+| `Vec<[T; N]>` | `<T, N> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2173 |
+| `Vec<Option<Vec<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2241 |
+| `Vec<Option<Vec<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2258 |
 | `i32` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:226 |
-| `Vec<Option<std::collections::HashMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2264 |
+| `Vec<Option<std::collections::HashSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2263 |
 | `f64` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:227 |
-| `Vec<Option<std::collections::BTreeMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2278 |
 | `u8` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:228 |
+| `Vec<Option<std::collections::HashSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2280 |
+| `Vec<Option<std::collections::BTreeSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2285 |
 | `crate::Rcomplex` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:229 |
-| `Vec<Option<&[T]>>` | `<T>` | concrete | 4 | miniextendr-api/src/into_r.rs:2294 |
-| `Vec<Option<&[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2309 |
-| `Vec<std::collections::HashSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2317 |
-| `Vec<std::collections::BTreeSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2336 |
-| `Vec<std::collections::HashSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2354 |
-| `Vec<std::collections::BTreeSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2360 |
-| `Vec<std::collections::HashMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2383 |
-| `Vec<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2387 |
+| `Vec<Option<std::collections::BTreeSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2302 |
+| `Vec<Option<std::collections::HashMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2307 |
+| `Vec<Option<std::collections::BTreeMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2321 |
+| `Vec<Option<&[T]>>` | `<T>` | concrete | 4 | miniextendr-api/src/into_r.rs:2337 |
+| `Vec<Option<&[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2352 |
+| `Vec<std::collections::HashSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2360 |
+| `Vec<std::collections::BTreeSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2379 |
+| `Vec<std::collections::HashSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2397 |
+| `Vec<std::collections::BTreeSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2403 |
+| `Vec<std::collections::HashMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2426 |
+| `Vec<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2430 |
 | `Option<crate::Rcomplex>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:272 |
 | `i8` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:332 |
 | `i16` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:333 |
@@ -608,21 +619,22 @@ Traits with impls: 9
 | `Vec<u64>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:641 |
 | `Vec<isize>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:642 |
 | `Vec<usize>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:644 |
-| `[T; N]` | `<T, N>` | concrete | 5 | miniextendr-api/src/into_r.rs:660 |
-| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:686 |
-| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:716 |
-| `std::borrow::Cow<'_, [T]>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:752 |
-| `std::borrow::Cow<'_, str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:772 |
-| `Option<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `std::path::PathBuf` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `&std::path::Path` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `Vec<Option<std::ffi::OsString>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `std::ffi::OsString` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `&std::ffi::OsStr` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `Option<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
+| `Vec<u32>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:647 |
+| `[T; N]` | `<T, N>` | concrete | 5 | miniextendr-api/src/into_r.rs:663 |
+| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:689 |
+| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:719 |
+| `std::borrow::Cow<'_, [T]>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:755 |
+| `std::borrow::Cow<'_, str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:775 |
+| `Option<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Vec<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `std::path::PathBuf` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `&std::path::Path` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Option<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `Vec<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `Vec<Option<std::ffi::OsString>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `std::ffi::OsString` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `&std::ffi::OsStr` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
 | `Altrep<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r/altrep.rs:152 |
 | `crate::altrep_sexp::AltrepSexp` | `` | concrete | 4 | miniextendr-api/src/into_r/altrep.rs:192 |
 | `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r/collections.rs:116 |
@@ -706,20 +718,20 @@ Traits with impls: 9
 | `Option<Zoned>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:238 |
 | `Vec<Zoned>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:316 |
 | `Vec<Option<Zoned>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:422 |
-| `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
-| `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `SignedDuration` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Vec<Option<SignedDuration>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
 | `JiffZonedVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `log::LevelFilter` | `` | concrete | 4 | miniextendr-api/src/optionals/log_impl.rs:332 |
 | `RDVector<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1334 |
 | `RDMatrix<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1347 |
@@ -774,14 +786,14 @@ Traits with impls: 9
 | `Vec<JsonValue>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:626 |
 | `Vec<Option<JsonValue>>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:653 |
 | `Table` | `` | concrete | 4 | miniextendr-api/src/optionals/tabled_impl.rs:196 |
-| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
-| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `OffsetDateTime` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `TinyVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:140 |
 | `ArrayVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:159 |
 | `Option<TinyVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:202 |
@@ -816,20 +828,20 @@ Traits with impls: 9
 
 ### `IntoR` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/into_r.rs:955** (5 impls): `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`, `Option<std::ffi::OsString>`
-- **miniextendr-api/src/into_r.rs:939** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
-- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`, `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`
-- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `Option<SignedDuration>`, `Vec<SignedDuration>`, `SignedDuration`, `Vec<Option<SignedDuration>>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`, `Option<Timestamp>`
+- **miniextendr-api/src/into_r.rs:958** (5 impls): `Option<std::ffi::OsString>`, `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`
+- **miniextendr-api/src/into_r.rs:942** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
+- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`, `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `SignedDuration`, `Vec<Option<SignedDuration>>`, `Option<SignedDuration>`, `Vec<SignedDuration>`
+- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`
+- **miniextendr-api/src/into_r.rs:1013** (2 impls): `HashSet<u16>`, `BTreeSet<u16>`
 - **miniextendr-api/src/into_r.rs:577** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r.rs:1009** (2 impls): `HashSet<i16>`, `BTreeSet<i16>`
+- **miniextendr-api/src/into_r.rs:1012** (2 impls): `HashSet<i16>`, `BTreeSet<i16>`
 - **miniextendr-api/src/into_r.rs:578** (2 impls): `Vec<i16>`, `&[i16]`
-- **miniextendr-api/src/into_r.rs:1010** (2 impls): `BTreeSet<u16>`, `HashSet<u16>`
 - **miniextendr-api/src/into_r.rs:579** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r.rs:582** (2 impls): `Vec<f32>`, `&[f32]`
-- **miniextendr-api/src/into_r.rs:1008** (2 impls): `HashSet<i8>`, `BTreeSet<i8>`
+- **miniextendr-api/src/into_r.rs:1011** (2 impls): `HashSet<i8>`, `BTreeSet<i8>`
 
 ## `IntoRAs` — 135 impls
 
@@ -886,20 +898,20 @@ Traits with impls: 9
 | `crate::RLogical` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:575 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:619 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:626 |
-| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
+| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:634 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:634 |
-| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
-| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
+| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
+| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
 | `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:637 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:637 |
-| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
-| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
+| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
+| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:640 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:640 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:641 |
@@ -916,22 +928,22 @@ Traits with impls: 9
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:709 |
 | `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:744 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:744 |
-| `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
-| `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
+| `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
 | `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
+| `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:747 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:747 |
-| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
+| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:753 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:769 |
 | `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:786 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:786 |
-| `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
-| `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
+| `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
+| `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:789 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:789 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:792 |
@@ -944,20 +956,20 @@ Traits with impls: 9
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:828 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:829 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:829 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:831 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:831 |
-| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
-| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
+| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
+| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:834 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:834 |
-| `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
-| `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
+| `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
+| `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
 | `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:837 |
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:837 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:842 |
@@ -973,37 +985,37 @@ Traits with impls: 9
 
 ### `IntoRAs` — for-types sharing a source span (likely macro-expanded / co-located)
 
+- **miniextendr-api/src/into_r_as.rs:830** (2 impls): `&[i64]`, `Vec<i64>`
+- **miniextendr-api/src/into_r_as.rs:832** (2 impls): `Vec<u16>`, `&[u16]`
+- **miniextendr-api/src/into_r_as.rs:833** (2 impls): `&[u32]`, `Vec<u32>`
+- **miniextendr-api/src/into_r_as.rs:745** (2 impls): `Vec<i16>`, `&[i16]`
+- **miniextendr-api/src/into_r_as.rs:835** (2 impls): `Vec<usize>`, `&[usize]`
+- **miniextendr-api/src/into_r_as.rs:746** (2 impls): `&[u8]`, `Vec<u8>`
+- **miniextendr-api/src/into_r_as.rs:836** (2 impls): `&[f32]`, `Vec<f32>`
+- **miniextendr-api/src/into_r_as.rs:748** (2 impls): `Vec<u32>`, `&[u32]`
+- **miniextendr-api/src/into_r_as.rs:633** (2 impls): `&[i8]`, `Vec<i8>`
+- **miniextendr-api/src/into_r_as.rs:635** (2 impls): `Vec<u8>`, `&[u8]`
+- **miniextendr-api/src/into_r_as.rs:787** (2 impls): `Vec<u64>`, `&[u64]`
+- **miniextendr-api/src/into_r_as.rs:636** (2 impls): `&[u16]`, `Vec<u16>`
+- **miniextendr-api/src/into_r_as.rs:788** (2 impls): `&[isize]`, `Vec<isize>`
+- **miniextendr-api/src/into_r_as.rs:638** (2 impls): `Vec<isize>`, `&[isize]`
+- **miniextendr-api/src/into_r_as.rs:639** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:641** (2 impls): `Vec<usize>`, `&[usize]`
 - **miniextendr-api/src/into_r_as.rs:828** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:642** (2 impls): `&[f32]`, `Vec<f32>`
 - **miniextendr-api/src/into_r_as.rs:829** (2 impls): `&[i32]`, `Vec<i32>`
 - **miniextendr-api/src/into_r_as.rs:831** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:832** (2 impls): `&[u16]`, `Vec<u16>`
 - **miniextendr-api/src/into_r_as.rs:744** (2 impls): `Vec<i8>`, `&[i8]`
 - **miniextendr-api/src/into_r_as.rs:834** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:745** (2 impls): `&[i16]`, `Vec<i16>`
-- **miniextendr-api/src/into_r_as.rs:835** (2 impls): `&[usize]`, `Vec<usize>`
 - **miniextendr-api/src/into_r_as.rs:747** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r_as.rs:837** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:748** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:634** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:786** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:635** (2 impls): `&[u8]`, `Vec<u8>`
-- **miniextendr-api/src/into_r_as.rs:787** (2 impls): `&[u64]`, `Vec<u64>`
 - **miniextendr-api/src/into_r_as.rs:637** (2 impls): `Vec<i64>`, `&[i64]`
 - **miniextendr-api/src/into_r_as.rs:789** (2 impls): `Vec<usize>`, `&[usize]`
-- **miniextendr-api/src/into_r_as.rs:638** (2 impls): `&[isize]`, `Vec<isize>`
 - **miniextendr-api/src/into_r_as.rs:640** (2 impls): `Vec<u64>`, `&[u64]`
 - **miniextendr-api/src/into_r_as.rs:827** (2 impls): `Vec<i8>`, `&[i8]`
 - **miniextendr-api/src/into_r_as.rs:643** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:830** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:833** (2 impls): `Vec<u32>`, `&[u32]`
-- **miniextendr-api/src/into_r_as.rs:746** (2 impls): `Vec<u8>`, `&[u8]`
-- **miniextendr-api/src/into_r_as.rs:836** (2 impls): `Vec<f32>`, `&[f32]`
-- **miniextendr-api/src/into_r_as.rs:633** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r_as.rs:636** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:788** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:639** (2 impls): `Vec<u32>`, `&[u32]`
 
 ## `TryCoerce` — 93 impls
 
@@ -1049,14 +1061,14 @@ Traits with impls: 9
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
-| `i8` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
-| `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
-| `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `u32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i8` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `u16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
@@ -1064,8 +1076,6 @@ Traits with impls: 9
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
-| `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
-| `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
@@ -1073,6 +1083,8 @@ Traits with impls: 9
 | `u16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `u32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
+| `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
+| `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:566 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:587 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:608 |
@@ -1105,9 +1117,9 @@ Traits with impls: 9
 
 ### `TryCoerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/coerce.rs:561** (9 impls): `usize`, `isize`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`
+- **miniextendr-api/src/coerce.rs:561** (9 impls): `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `usize`, `isize`
 - **miniextendr-api/src/coerce.rs:541** (9 impls): `i8`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64`, `usize`, `isize`
-- **miniextendr-api/src/coerce.rs:551** (8 impls): `i8`, `i16`, `i32`, `i64`, `u32`, `u64`, `usize`, `isize`
+- **miniextendr-api/src/coerce.rs:551** (8 impls): `i64`, `u32`, `u64`, `usize`, `isize`, `i8`, `i16`, `i32`
 - **miniextendr-api/src/coerce.rs:556** (7 impls): `i32`, `i64`, `u16`, `u32`, `u64`, `usize`, `isize`
 - **miniextendr-api/src/coerce.rs:536** (5 impls): `u32`, `u64`, `usize`, `i64`, `isize`
 
@@ -1149,9 +1161,9 @@ Traits with impls: 9
 | `i32` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:310 |
 | `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
+| `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `i8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `u16` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
-| `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `f64` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:663 |
 | `&[T]` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:974 |
 | `Vec<T>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:982 |
@@ -1172,7 +1184,7 @@ Traits with impls: 9
 ### `Coerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
 - **miniextendr-api/src/coerce.rs:212** (5 impls): `u8`, `u8`, `u8`, `u8`, `u8`
-- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `i8`, `u16`, `u8`
+- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 
 ## `AltrepSerialize` — 27 impls
 
@@ -1210,7 +1222,7 @@ Traits with impls: 9
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2065 |
+| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2108 |
 
 ## `RSerializeNative` — 1 impls
 

--- a/rust-llm-docs/generated/conversion-manual-vs-macro.md
+++ b/rust-llm-docs/generated/conversion-manual-vs-macro.md
@@ -2,6 +2,12 @@
 
 Source: `target/doc/miniextendr_api.json`
 
+> **Caveat**: the "macro already exists for this shape" flags count
+> feature-gated optionals (jiff, uuid, bitvec, ...) as absorbable
+> hand-rolled impls, but most have bespoke element conversions a
+> shape-macro cannot express. Treat the headline counts as an upper
+> bound on the dedup opportunity, not a work list.
+
 ## TryFromSexp
 
 - shape `Option<_>`: **52 hand-rolled**, 17 macro-generated  <== macro already exists for this shape
@@ -33,14 +39,14 @@ Source: `target/doc/miniextendr_api.json`
     - `Option<TomlValue>` (3 items) — miniextendr-api/src/optionals/toml_impl.rs:167
     - `Option<Url>` (2 items) — miniextendr-api/src/optionals/url_impl.rs:89
     - `Option<Uuid>` (2 items) — miniextendr-api/src/optionals/uuid_impl.rs:58
-    - `Option<Vec<T>>` (3 items) — miniextendr-api/src/from_r.rs:844
+    - `Option<Vec<T>>` (3 items) — miniextendr-api/src/from_r.rs:846
     - `Option<Zoned>` (2 items) — miniextendr-api/src/optionals/jiff_impl.rs:209
     - `Option<bool>` (3 items) — miniextendr-api/src/from_r/logical.rs:118
     - `Option<crate::RLogical>` (3 items) — miniextendr-api/src/from_r/logical.rs:142
     - `Option<crate::Rboolean>` (3 items) — miniextendr-api/src/from_r/logical.rs:62
     - `Option<crate::Rcomplex>` (3 items) — miniextendr-api/src/from_r/logical.rs:250
     - `Option<crate::SEXP>` (3 items) — miniextendr-api/src/from_r.rs:551
-    - `Option<crate::externalptr::ExternalPtr<T>>` (3 items) — miniextendr-api/src/from_r.rs:1325
+    - `Option<crate::externalptr::ExternalPtr<T>>` (3 items) — miniextendr-api/src/from_r.rs:1327
     - `Option<f32>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:445
     - `Option<f64>` (3 items) — miniextendr-api/src/from_r/logical.rs:196
     - `Option<i16>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:403
@@ -48,10 +54,10 @@ Source: `target/doc/miniextendr_api.json`
     - `Option<i64>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:603
     - `Option<i8>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:389
     - `Option<isize>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:788
-    - `Option<std::collections::BTreeMap<String, V>>` (2 items) — miniextendr-api/src/from_r.rs:899
-    - `Option<std::collections::BTreeSet<T>>` (2 items) — miniextendr-api/src/from_r.rs:932
-    - `Option<std::collections::HashMap<String, V>>` (2 items) — miniextendr-api/src/from_r.rs:895
-    - `Option<std::collections::HashSet<T>>` (2 items) — miniextendr-api/src/from_r.rs:928
+    - `Option<std::collections::BTreeMap<String, V>>` (2 items) — miniextendr-api/src/from_r.rs:901
+    - `Option<std::collections::BTreeSet<T>>` (2 items) — miniextendr-api/src/from_r.rs:934
+    - `Option<std::collections::HashMap<String, V>>` (2 items) — miniextendr-api/src/from_r.rs:897
+    - `Option<std::collections::HashSet<T>>` (2 items) — miniextendr-api/src/from_r.rs:930
     - `Option<u16>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:417
     - `Option<u32>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:431
     - `Option<u64>` (3 items) — miniextendr-api/src/from_r/coerced_scalars.rs:617
@@ -74,29 +80,29 @@ Source: `target/doc/miniextendr_api.json`
     - `Vec<TomlValue>` (2 items) — miniextendr-api/src/optionals/toml_impl.rs:170
     - `Vec<Url>` (2 items) — miniextendr-api/src/optionals/url_impl.rs:135
     - `Vec<Uuid>` (2 items) — miniextendr-api/src/optionals/uuid_impl.rs:77
-    - `Vec<Vec<T>>` (3 items) — miniextendr-api/src/from_r.rs:943
+    - `Vec<Vec<T>>` (3 items) — miniextendr-api/src/from_r.rs:945
     - `Vec<Zoned>` (2 items) — miniextendr-api/src/optionals/jiff_impl.rs:265
-    - `Vec<bool>` (3 items) — miniextendr-api/src/from_r.rs:1164
+    - `Vec<bool>` (3 items) — miniextendr-api/src/from_r.rs:1166
     - `Vec<crate::RLogical>` (2 items) — miniextendr-api/src/from_r/collections.rs:216
     - `Vec<crate::Rboolean>` (2 items) — miniextendr-api/src/from_r/na_vectors.rs:101
     - `Vec<crate::Rcomplex>` (2 items) — miniextendr-api/src/from_r/collections.rs:217
     - `Vec<crate::altrep_data::Logical>` (2 items) — miniextendr-api/src/from_r/na_vectors.rs:162
-    - `Vec<crate::externalptr::ExternalPtr<T>>` (3 items) — miniextendr-api/src/from_r.rs:1354
-    - `Vec<f32>` (3 items) — miniextendr-api/src/from_r.rs:1161
+    - `Vec<crate::externalptr::ExternalPtr<T>>` (3 items) — miniextendr-api/src/from_r.rs:1356
+    - `Vec<f32>` (3 items) — miniextendr-api/src/from_r.rs:1163
     - `Vec<f64>` (2 items) — miniextendr-api/src/from_r/collections.rs:214
-    - `Vec<i16>` (3 items) — miniextendr-api/src/from_r.rs:1154
+    - `Vec<i16>` (3 items) — miniextendr-api/src/from_r.rs:1156
     - `Vec<i32>` (2 items) — miniextendr-api/src/from_r/collections.rs:213
-    - `Vec<i64>` (3 items) — miniextendr-api/src/from_r.rs:1155
-    - `Vec<i8>` (3 items) — miniextendr-api/src/from_r.rs:1153
-    - `Vec<isize>` (3 items) — miniextendr-api/src/from_r.rs:1156
+    - `Vec<i64>` (3 items) — miniextendr-api/src/from_r.rs:1157
+    - `Vec<i8>` (3 items) — miniextendr-api/src/from_r.rs:1155
+    - `Vec<isize>` (3 items) — miniextendr-api/src/from_r.rs:1158
     - `Vec<std::borrow::Cow<'static, str>>` (2 items) — miniextendr-api/src/from_r/cow_and_paths.rs:84
     - `Vec<std::collections::BTreeMap<String, V>>` (2 items) — miniextendr-api/src/from_r/collections.rs:148
     - `Vec<std::collections::HashMap<String, V>>` (2 items) — miniextendr-api/src/from_r/collections.rs:144
-    - `Vec<u16>` (3 items) — miniextendr-api/src/from_r.rs:1157
-    - `Vec<u32>` (3 items) — miniextendr-api/src/from_r.rs:1158
-    - `Vec<u64>` (3 items) — miniextendr-api/src/from_r.rs:1159
+    - `Vec<u16>` (3 items) — miniextendr-api/src/from_r.rs:1159
+    - `Vec<u32>` (3 items) — miniextendr-api/src/from_r.rs:1160
+    - `Vec<u64>` (3 items) — miniextendr-api/src/from_r.rs:1161
     - `Vec<u8>` (2 items) — miniextendr-api/src/from_r/collections.rs:215
-    - `Vec<usize>` (3 items) — miniextendr-api/src/from_r.rs:1160
+    - `Vec<usize>` (3 items) — miniextendr-api/src/from_r.rs:1162
 - shape `Vec<Option<_>>`: **34 hand-rolled**, 27 macro-generated  <== macro already exists for this shape
     - `Vec<Option<&'static str>>` (2 items) — miniextendr-api/src/from_r/cow_and_paths.rs:231
     - `Vec<Option<AhoCorasick>>` (3 items) — miniextendr-api/src/optionals/aho_corasick_impl.rs:104
@@ -118,7 +124,7 @@ Source: `target/doc/miniextendr_api.json`
     - `Vec<Option<bool>>` (3 items) — miniextendr-api/src/from_r/na_vectors.rs:66
     - `Vec<Option<crate::RLogical>>` (2 items) — miniextendr-api/src/from_r/na_vectors.rs:185
     - `Vec<Option<crate::Rboolean>>` (2 items) — miniextendr-api/src/from_r/na_vectors.rs:131
-    - `Vec<Option<crate::externalptr::ExternalPtr<T>>>` (3 items) — miniextendr-api/src/from_r.rs:1399
+    - `Vec<Option<crate::externalptr::ExternalPtr<T>>>` (3 items) — miniextendr-api/src/from_r.rs:1401
     - `Vec<Option<f32>>` (3 items) — miniextendr-api/src/from_r/na_vectors.rs:322
     - `Vec<Option<f64>>` (2 items) — miniextendr-api/src/from_r/na_vectors.rs:62
     - `Vec<Option<i16>>` (3 items) — miniextendr-api/src/from_r/na_vectors.rs:315
@@ -157,8 +163,8 @@ Source: `target/doc/miniextendr_api.json`
     - `Option<TomlValue>` (4 items) — miniextendr-api/src/optionals/toml_impl.rs:236
     - `Option<Url>` (4 items) — miniextendr-api/src/optionals/url_impl.rs:128
     - `Option<Uuid>` (4 items) — miniextendr-api/src/optionals/uuid_impl.rs:72
-    - `Option<Vec<String>>` (5 items) — miniextendr-api/src/into_r.rs:1046
-    - `Option<Vec<T>>` (5 items) — miniextendr-api/src/into_r.rs:1019
+    - `Option<Vec<String>>` (5 items) — miniextendr-api/src/into_r.rs:1049
+    - `Option<Vec<T>>` (5 items) — miniextendr-api/src/into_r.rs:1022
     - `Option<Zoned>` (4 items) — miniextendr-api/src/optionals/jiff_impl.rs:238
     - `Option<bool>` (5 items) — miniextendr-api/src/into_r/large_integers.rs:295
     - `Option<crate::RLogical>` (5 items) — miniextendr-api/src/into_r/large_integers.rs:269
@@ -171,20 +177,64 @@ Source: `target/doc/miniextendr_api.json`
     - `Option<i64>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:348
     - `Option<i8>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:375
     - `Option<isize>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:350
-    - `Option<std::collections::BTreeMap<String, V>>` (5 items) — miniextendr-api/src/into_r.rs:1100
-    - `Option<std::collections::BTreeSet<String>>` (5 items) — miniextendr-api/src/into_r.rs:1215
-    - `Option<std::collections::BTreeSet<T>>` (5 items) — miniextendr-api/src/into_r.rs:1154
-    - `Option<std::collections::HashMap<String, V>>` (5 items) — miniextendr-api/src/into_r.rs:1073
-    - `Option<std::collections::HashSet<String>>` (5 items) — miniextendr-api/src/into_r.rs:1211
-    - `Option<std::collections::HashSet<T>>` (5 items) — miniextendr-api/src/into_r.rs:1127
+    - `Option<std::collections::BTreeMap<String, V>>` (5 items) — miniextendr-api/src/into_r.rs:1103
+    - `Option<std::collections::BTreeSet<String>>` (5 items) — miniextendr-api/src/into_r.rs:1218
+    - `Option<std::collections::BTreeSet<T>>` (5 items) — miniextendr-api/src/into_r.rs:1157
+    - `Option<std::collections::HashMap<String, V>>` (5 items) — miniextendr-api/src/into_r.rs:1076
+    - `Option<std::collections::HashSet<String>>` (5 items) — miniextendr-api/src/into_r.rs:1214
+    - `Option<std::collections::HashSet<T>>` (5 items) — miniextendr-api/src/into_r.rs:1130
     - `Option<u16>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:377
     - `Option<u32>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:378
     - `Option<u64>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:349
     - `Option<usize>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:352
+- shape `Vec<_>`: **43 hand-rolled**, 11 macro-generated  <== macro already exists for this shape
+    - `Vec<&[String]>` (5 items) — miniextendr-api/src/into_r.rs:1549
+    - `Vec<&[T]>` (5 items) — miniextendr-api/src/into_r.rs:1509
+    - `Vec<&str>` (5 items) — miniextendr-api/src/into_r.rs:1440
+    - `Vec<BigInt>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:322
+    - `Vec<BigUint>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:327
+    - `Vec<Box<[String]>>` (4 items) — miniextendr-api/src/into_r.rs:2156
+    - `Vec<Box<[T]>>` (4 items) — miniextendr-api/src/into_r.rs:2126
+    - `Vec<Complex<f64>>` (4 items) — miniextendr-api/src/optionals/num_complex_impl.rs:201
+    - `Vec<Decimal>` (4 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:291
+    - `Vec<JsonValue>` (4 items) — miniextendr-api/src/optionals/serde_impl.rs:626
+    - `Vec<List>` (4 items) — miniextendr-api/src/list.rs:1104
+    - `Vec<OrderedFloat<f32>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:240
+    - `Vec<OrderedFloat<f64>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:235
+    - `Vec<RFlags<T>>` (2 items) — miniextendr-api/src/optionals/bitflags_impl.rs:390
+    - `Vec<String>` (5 items) — miniextendr-api/src/into_r.rs:1263
+    - `Vec<T>` (4 items) — miniextendr-api/src/newtype.rs:97
+    - `Vec<TomlValue>` (4 items) — miniextendr-api/src/optionals/toml_impl.rs:252
+    - `Vec<Url>` (4 items) — miniextendr-api/src/optionals/url_impl.rs:176
+    - `Vec<Uuid>` (4 items) — miniextendr-api/src/optionals/uuid_impl.rs:118
+    - `Vec<Vec<String>>` (5 items) — miniextendr-api/src/into_r.rs:1587
+    - `Vec<Vec<T>>` (5 items) — miniextendr-api/src/into_r.rs:1461
+    - `Vec<Zoned>` (4 items) — miniextendr-api/src/optionals/jiff_impl.rs:316
+    - `Vec<[T; N]>` (4 items) — miniextendr-api/src/into_r.rs:2173
+    - `Vec<bool>` (5 items) — miniextendr-api/src/into_r.rs:1773
+    - `Vec<crate::RLogical>` (5 items) — miniextendr-api/src/into_r.rs:383
+    - `Vec<crate::Rboolean>` (5 items) — miniextendr-api/src/into_r.rs:1813
+    - `Vec<crate::Rcomplex>` (5 items) — miniextendr-api/src/into_r.rs:384
+    - `Vec<crate::externalptr::ExternalPtr<T>>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:404
+    - `Vec<f64>` (5 items) — miniextendr-api/src/into_r.rs:381
+    - `Vec<i32>` (5 items) — miniextendr-api/src/into_r.rs:380
+    - `Vec<i64>` (5 items) — miniextendr-api/src/into_r.rs:640
+    - `Vec<isize>` (5 items) — miniextendr-api/src/into_r.rs:642
+    - `Vec<std::borrow::Cow<'_, str>>` (5 items) — miniextendr-api/src/into_r.rs:1317
+    - `Vec<std::collections::BTreeMap<String, V>>` (4 items) — miniextendr-api/src/into_r.rs:2430
+    - `Vec<std::collections::BTreeSet<String>>` (4 items) — miniextendr-api/src/into_r.rs:2403
+    - `Vec<std::collections::BTreeSet<T>>` (4 items) — miniextendr-api/src/into_r.rs:2379
+    - `Vec<std::collections::HashMap<String, V>>` (4 items) — miniextendr-api/src/into_r.rs:2426
+    - `Vec<std::collections::HashSet<String>>` (4 items) — miniextendr-api/src/into_r.rs:2397
+    - `Vec<std::collections::HashSet<T>>` (4 items) — miniextendr-api/src/into_r.rs:2360
+    - `Vec<u32>` (5 items) — miniextendr-api/src/into_r.rs:647
+    - `Vec<u64>` (5 items) — miniextendr-api/src/into_r.rs:641
+    - `Vec<u8>` (5 items) — miniextendr-api/src/into_r.rs:382
+    - `Vec<usize>` (5 items) — miniextendr-api/src/into_r.rs:644
 - shape `Vec<Option<_>>`: **42 hand-rolled**, 7 macro-generated  <== macro already exists for this shape
-    - `Vec<Option<&[String]>>` (4 items) — miniextendr-api/src/into_r.rs:2309
-    - `Vec<Option<&[T]>>` (4 items) — miniextendr-api/src/into_r.rs:2294
-    - `Vec<Option<&str>>` (5 items) — miniextendr-api/src/into_r.rs:1386
+    - `Vec<Option<&[String]>>` (4 items) — miniextendr-api/src/into_r.rs:2352
+    - `Vec<Option<&[T]>>` (4 items) — miniextendr-api/src/into_r.rs:2337
+    - `Vec<Option<&str>>` (5 items) — miniextendr-api/src/into_r.rs:1389
     - `Vec<Option<BigInt>>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:332
     - `Vec<Option<BigUint>>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:337
     - `Vec<Option<Complex<f64>>>` (4 items) — miniextendr-api/src/optionals/num_complex_impl.rs:247
@@ -194,83 +244,42 @@ Source: `target/doc/miniextendr_api.json`
     - `Vec<Option<OrderedFloat<f32>>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:250
     - `Vec<Option<OrderedFloat<f64>>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:245
     - `Vec<Option<RFlags<T>>>` (2 items) — miniextendr-api/src/optionals/bitflags_impl.rs:406
-    - `Vec<Option<String>>` (5 items) — miniextendr-api/src/into_r.rs:1862
+    - `Vec<Option<String>>` (5 items) — miniextendr-api/src/into_r.rs:1905
     - `Vec<Option<T>>` (5 items) — miniextendr-api/src/newtype.rs:203
     - `Vec<Option<TomlValue>>` (4 items) — miniextendr-api/src/optionals/toml_impl.rs:279
     - `Vec<Option<Url>>` (4 items) — miniextendr-api/src/optionals/url_impl.rs:224
     - `Vec<Option<Uuid>>` (4 items) — miniextendr-api/src/optionals/uuid_impl.rs:145
-    - `Vec<Option<Vec<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2215
-    - `Vec<Option<Vec<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2198
+    - `Vec<Option<Vec<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2258
+    - `Vec<Option<Vec<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2241
     - `Vec<Option<Zoned>>` (4 items) — miniextendr-api/src/optionals/jiff_impl.rs:422
-    - `Vec<Option<bool>>` (5 items) — miniextendr-api/src/into_r.rs:1833
-    - `Vec<Option<crate::RLogical>>` (5 items) — miniextendr-api/src/into_r.rs:1850
-    - `Vec<Option<crate::Rboolean>>` (5 items) — miniextendr-api/src/into_r.rs:1842
+    - `Vec<Option<bool>>` (5 items) — miniextendr-api/src/into_r.rs:1876
+    - `Vec<Option<crate::RLogical>>` (5 items) — miniextendr-api/src/into_r.rs:1893
+    - `Vec<Option<crate::Rboolean>>` (5 items) — miniextendr-api/src/into_r.rs:1885
     - `Vec<Option<crate::externalptr::ExternalPtr<T>>>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:419
-    - `Vec<Option<f32>>` (4 items) — miniextendr-api/src/into_r.rs:1737
-    - `Vec<Option<f64>>` (5 items) — miniextendr-api/src/into_r.rs:1671
-    - `Vec<Option<i16>>` (4 items) — miniextendr-api/src/into_r.rs:1734
-    - `Vec<Option<i32>>` (5 items) — miniextendr-api/src/into_r.rs:1672
-    - `Vec<Option<i64>>` (4 items) — miniextendr-api/src/into_r.rs:1710
-    - `Vec<Option<i8>>` (4 items) — miniextendr-api/src/into_r.rs:1733
-    - `Vec<Option<isize>>` (4 items) — miniextendr-api/src/into_r.rs:1712
-    - `Vec<Option<std::borrow::Cow<'_, str>>>` (5 items) — miniextendr-api/src/into_r.rs:1333
-    - `Vec<Option<std::collections::BTreeMap<String, V>>>` (4 items) — miniextendr-api/src/into_r.rs:2278
-    - `Vec<Option<std::collections::BTreeSet<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2259
-    - `Vec<Option<std::collections::BTreeSet<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2242
-    - `Vec<Option<std::collections::HashMap<String, V>>>` (4 items) — miniextendr-api/src/into_r.rs:2264
-    - `Vec<Option<std::collections::HashSet<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2237
-    - `Vec<Option<std::collections::HashSet<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2220
-    - `Vec<Option<u16>>` (4 items) — miniextendr-api/src/into_r.rs:1735
-    - `Vec<Option<u32>>` (4 items) — miniextendr-api/src/into_r.rs:1736
-    - `Vec<Option<u64>>` (4 items) — miniextendr-api/src/into_r.rs:1711
-    - `Vec<Option<usize>>` (4 items) — miniextendr-api/src/into_r.rs:1714
-- shape `Vec<_>`: **41 hand-rolled**, 11 macro-generated  <== macro already exists for this shape
-    - `Vec<&[String]>` (5 items) — miniextendr-api/src/into_r.rs:1546
-    - `Vec<&[T]>` (5 items) — miniextendr-api/src/into_r.rs:1506
-    - `Vec<&str>` (5 items) — miniextendr-api/src/into_r.rs:1437
-    - `Vec<BigInt>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:322
-    - `Vec<BigUint>` (4 items) — miniextendr-api/src/optionals/num_bigint_impl.rs:327
-    - `Vec<Box<[String]>>` (4 items) — miniextendr-api/src/into_r.rs:2113
-    - `Vec<Box<[T]>>` (4 items) — miniextendr-api/src/into_r.rs:2083
-    - `Vec<Complex<f64>>` (4 items) — miniextendr-api/src/optionals/num_complex_impl.rs:201
-    - `Vec<Decimal>` (4 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:291
-    - `Vec<JsonValue>` (4 items) — miniextendr-api/src/optionals/serde_impl.rs:626
-    - `Vec<List>` (4 items) — miniextendr-api/src/list.rs:1104
-    - `Vec<OrderedFloat<f32>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:240
-    - `Vec<OrderedFloat<f64>>` (4 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:235
-    - `Vec<RFlags<T>>` (2 items) — miniextendr-api/src/optionals/bitflags_impl.rs:390
-    - `Vec<String>` (5 items) — miniextendr-api/src/into_r.rs:1260
-    - `Vec<T>` (4 items) — miniextendr-api/src/newtype.rs:97
-    - `Vec<TomlValue>` (4 items) — miniextendr-api/src/optionals/toml_impl.rs:252
-    - `Vec<Url>` (4 items) — miniextendr-api/src/optionals/url_impl.rs:176
-    - `Vec<Uuid>` (4 items) — miniextendr-api/src/optionals/uuid_impl.rs:118
-    - `Vec<Vec<String>>` (5 items) — miniextendr-api/src/into_r.rs:1584
-    - `Vec<Vec<T>>` (5 items) — miniextendr-api/src/into_r.rs:1458
-    - `Vec<Zoned>` (4 items) — miniextendr-api/src/optionals/jiff_impl.rs:316
-    - `Vec<[T; N]>` (4 items) — miniextendr-api/src/into_r.rs:2130
-    - `Vec<bool>` (5 items) — miniextendr-api/src/into_r.rs:1770
-    - `Vec<crate::RLogical>` (5 items) — miniextendr-api/src/into_r.rs:383
-    - `Vec<crate::Rcomplex>` (5 items) — miniextendr-api/src/into_r.rs:384
-    - `Vec<crate::externalptr::ExternalPtr<T>>` (4 items) — miniextendr-api/src/into_r/large_integers.rs:404
-    - `Vec<f64>` (5 items) — miniextendr-api/src/into_r.rs:381
-    - `Vec<i32>` (5 items) — miniextendr-api/src/into_r.rs:380
-    - `Vec<i64>` (5 items) — miniextendr-api/src/into_r.rs:640
-    - `Vec<isize>` (5 items) — miniextendr-api/src/into_r.rs:642
-    - `Vec<std::borrow::Cow<'_, str>>` (5 items) — miniextendr-api/src/into_r.rs:1314
-    - `Vec<std::collections::BTreeMap<String, V>>` (4 items) — miniextendr-api/src/into_r.rs:2387
-    - `Vec<std::collections::BTreeSet<String>>` (4 items) — miniextendr-api/src/into_r.rs:2360
-    - `Vec<std::collections::BTreeSet<T>>` (4 items) — miniextendr-api/src/into_r.rs:2336
-    - `Vec<std::collections::HashMap<String, V>>` (4 items) — miniextendr-api/src/into_r.rs:2383
-    - `Vec<std::collections::HashSet<String>>` (4 items) — miniextendr-api/src/into_r.rs:2354
-    - `Vec<std::collections::HashSet<T>>` (4 items) — miniextendr-api/src/into_r.rs:2317
-    - `Vec<u64>` (5 items) — miniextendr-api/src/into_r.rs:641
-    - `Vec<u8>` (5 items) — miniextendr-api/src/into_r.rs:382
-    - `Vec<usize>` (5 items) — miniextendr-api/src/into_r.rs:644
-- shape `&[_]`: **4 hand-rolled**, 4 macro-generated  <== macro already exists for this shape
-    - `&[&str]` (5 items) — miniextendr-api/src/into_r.rs:1296
-    - `&[String]` (5 items) — miniextendr-api/src/into_r.rs:1278
+    - `Vec<Option<f32>>` (4 items) — miniextendr-api/src/into_r.rs:1740
+    - `Vec<Option<f64>>` (5 items) — miniextendr-api/src/into_r.rs:1674
+    - `Vec<Option<i16>>` (4 items) — miniextendr-api/src/into_r.rs:1737
+    - `Vec<Option<i32>>` (5 items) — miniextendr-api/src/into_r.rs:1675
+    - `Vec<Option<i64>>` (4 items) — miniextendr-api/src/into_r.rs:1713
+    - `Vec<Option<i8>>` (4 items) — miniextendr-api/src/into_r.rs:1736
+    - `Vec<Option<isize>>` (4 items) — miniextendr-api/src/into_r.rs:1715
+    - `Vec<Option<std::borrow::Cow<'_, str>>>` (5 items) — miniextendr-api/src/into_r.rs:1336
+    - `Vec<Option<std::collections::BTreeMap<String, V>>>` (4 items) — miniextendr-api/src/into_r.rs:2321
+    - `Vec<Option<std::collections::BTreeSet<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2302
+    - `Vec<Option<std::collections::BTreeSet<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2285
+    - `Vec<Option<std::collections::HashMap<String, V>>>` (4 items) — miniextendr-api/src/into_r.rs:2307
+    - `Vec<Option<std::collections::HashSet<String>>>` (4 items) — miniextendr-api/src/into_r.rs:2280
+    - `Vec<Option<std::collections::HashSet<T>>>` (4 items) — miniextendr-api/src/into_r.rs:2263
+    - `Vec<Option<u16>>` (4 items) — miniextendr-api/src/into_r.rs:1738
+    - `Vec<Option<u32>>` (4 items) — miniextendr-api/src/into_r.rs:1739
+    - `Vec<Option<u64>>` (4 items) — miniextendr-api/src/into_r.rs:1714
+    - `Vec<Option<usize>>` (4 items) — miniextendr-api/src/into_r.rs:1717
+- shape `&[_]`: **5 hand-rolled**, 4 macro-generated  <== macro already exists for this shape
+    - `&[&str]` (5 items) — miniextendr-api/src/into_r.rs:1299
+    - `&[String]` (5 items) — miniextendr-api/src/into_r.rs:1281
     - `&[T]` (5 items) — miniextendr-api/src/into_r.rs:386
-    - `&[bool]` (5 items) — miniextendr-api/src/into_r.rs:1790
+    - `&[bool]` (5 items) — miniextendr-api/src/into_r.rs:1793
+    - `&[crate::Rboolean]` (5 items) — miniextendr-api/src/into_r.rs:1833
 
 ## IntoRAs
 
@@ -306,58 +315,58 @@ Source: `target/doc/miniextendr_api.json`
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:467
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:495
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:554
-- shape `bool`: **4 hand-rolled**, 0 macro-generated
-    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:349
-    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:446
-    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:480
-    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:568
-- shape `f64`: **4 hand-rolled**, 0 macro-generated
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:346
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:360
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:475
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:529
-- shape `i64`: **4 hand-rolled**, 0 macro-generated
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:338
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:440
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:468
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:561
 - shape `f32`: **4 hand-rolled**, 0 macro-generated
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:345
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:374
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:474
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:547
-- shape `i16`: **3 hand-rolled**, 0 macro-generated
-    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:333
-    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:395
-    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:466
-- shape `isize`: **3 hand-rolled**, 0 macro-generated
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:339
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:442
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:469
-- shape `u64`: **3 hand-rolled**, 0 macro-generated
-    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:341
-    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:441
-    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:472
+- shape `f64`: **4 hand-rolled**, 0 macro-generated
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:346
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:360
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:475
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:529
+- shape `bool`: **4 hand-rolled**, 0 macro-generated
+    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:349
+    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:446
+    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:480
+    - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:568
+- shape `i64`: **4 hand-rolled**, 0 macro-generated
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:338
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:440
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:468
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:561
 - shape `u32`: **3 hand-rolled**, 0 macro-generated
     - `u32` (1 items) — miniextendr-api/src/into_r_as.rs:340
     - `u32` (1 items) — miniextendr-api/src/into_r_as.rs:432
     - `u32` (1 items) — miniextendr-api/src/into_r_as.rs:471
-- shape `u8`: **3 hand-rolled**, 0 macro-generated
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:334
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:418
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:457
-- shape `u16`: **3 hand-rolled**, 0 macro-generated
-    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:335
-    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:425
-    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:470
-- shape `usize`: **3 hand-rolled**, 0 macro-generated
-    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:342
-    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:443
-    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:473
 - shape `i8`: **3 hand-rolled**, 0 macro-generated
     - `i8` (1 items) — miniextendr-api/src/into_r_as.rs:332
     - `i8` (1 items) — miniextendr-api/src/into_r_as.rs:388
     - `i8` (1 items) — miniextendr-api/src/into_r_as.rs:465
+- shape `u16`: **3 hand-rolled**, 0 macro-generated
+    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:335
+    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:425
+    - `u16` (1 items) — miniextendr-api/src/into_r_as.rs:470
+- shape `i16`: **3 hand-rolled**, 0 macro-generated
+    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:333
+    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:395
+    - `i16` (1 items) — miniextendr-api/src/into_r_as.rs:466
+- shape `u64`: **3 hand-rolled**, 0 macro-generated
+    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:341
+    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:441
+    - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:472
+- shape `isize`: **3 hand-rolled**, 0 macro-generated
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:339
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:442
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:469
+- shape `u8`: **3 hand-rolled**, 0 macro-generated
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:334
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:418
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:457
+- shape `usize`: **3 hand-rolled**, 0 macro-generated
+    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:342
+    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:443
+    - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:473
 
 ## Coerce
 
@@ -374,14 +383,14 @@ Source: `target/doc/miniextendr_api.json`
     - `Option<crate::Rboolean>` (1 items) — miniextendr-api/src/coerce.rs:288
     - `Option<f64>` (1 items) — miniextendr-api/src/coerce.rs:260
     - `Option<i32>` (1 items) — miniextendr-api/src/coerce.rs:268
-- shape `bool`: **3 hand-rolled**, 0 macro-generated
-    - `bool` (1 items) — miniextendr-api/src/coerce.rs:224
-    - `bool` (1 items) — miniextendr-api/src/coerce.rs:235
-    - `bool` (1 items) — miniextendr-api/src/coerce.rs:242
 - shape `f64`: **3 hand-rolled**, 0 macro-generated
     - `f64` (1 items) — miniextendr-api/src/coerce.rs:143
     - `f64` (1 items) — miniextendr-api/src/coerce.rs:663
     - `f64` (1 items) — miniextendr-api/src/optionals/ordered_float_impl.rs:24
+- shape `bool`: **3 hand-rolled**, 0 macro-generated
+    - `bool` (1 items) — miniextendr-api/src/coerce.rs:224
+    - `bool` (1 items) — miniextendr-api/src/coerce.rs:235
+    - `bool` (1 items) — miniextendr-api/src/coerce.rs:242
 - shape `u8`: **1 hand-rolled**, 8 macro-generated  <== macro already exists for this shape
     - `u8` (1 items) — miniextendr-api/src/coerce.rs:145
 
@@ -426,25 +435,25 @@ Source: `target/doc/miniextendr_api.json`
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:104
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:119
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:91
+- shape `isize`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
+    - `isize` (2 items) — miniextendr-api/src/coerce.rs:373
+    - `isize` (2 items) — miniextendr-api/src/coerce.rs:882
 - shape `i64`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `i64` (2 items) — miniextendr-api/src/coerce.rs:372
     - `i64` (2 items) — miniextendr-api/src/coerce.rs:852
 - shape `u64`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `u64` (2 items) — miniextendr-api/src/coerce.rs:377
     - `u64` (2 items) — miniextendr-api/src/coerce.rs:869
-- shape `isize`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
-    - `isize` (2 items) — miniextendr-api/src/coerce.rs:373
-    - `isize` (2 items) — miniextendr-api/src/coerce.rs:882
 - shape `usize`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `usize` (2 items) — miniextendr-api/src/coerce.rs:378
     - `usize` (2 items) — miniextendr-api/src/coerce.rs:890
+- shape `i16`: **1 hand-rolled**, 3 macro-generated  <== macro already exists for this shape
+    - `i16` (2 items) — miniextendr-api/src/coerce.rs:370
+- shape `u32`: **1 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
+    - `u32` (2 items) — miniextendr-api/src/coerce.rs:376
 - shape `u16`: **1 hand-rolled**, 3 macro-generated  <== macro already exists for this shape
     - `u16` (2 items) — miniextendr-api/src/coerce.rs:375
 - shape `i8`: **1 hand-rolled**, 2 macro-generated  <== macro already exists for this shape
     - `i8` (2 items) — miniextendr-api/src/coerce.rs:369
 - shape `u8`: **1 hand-rolled**, 1 macro-generated  <== macro already exists for this shape
     - `u8` (2 items) — miniextendr-api/src/coerce.rs:374
-- shape `i16`: **1 hand-rolled**, 3 macro-generated  <== macro already exists for this shape
-    - `i16` (2 items) — miniextendr-api/src/coerce.rs:370
-- shape `u32`: **1 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
-    - `u32` (2 items) — miniextendr-api/src/coerce.rs:376

--- a/rust-llm-docs/generated/miniextendr-api-impl-inventory.md
+++ b/rust-llm-docs/generated/miniextendr-api-impl-inventory.md
@@ -8,31 +8,31 @@ Traits with impls: 190
 
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
-| `TryFromSexp` | 434 | 434 |
-| `IntoR` | 325 | 325 |
+| `TryFromSexp` | 442 | 442 |
+| `IntoR` | 329 | 329 |
 | `From` | 255 | 49 |
 | `BorrowMut` | 201 | 1 |
 | `Borrow` | 201 | 1 |
 | `Tap` | 200 | 0 |
 | `TryInto` | 200 | 0 |
-| `Same` | 200 | 0 |
+| `UnsafeUnpin` | 200 | 0 |
 | `Pointable` | 200 | 0 |
-| `Freeze` | 200 | 0 |
-| `Into` | 200 | 0 |
 | `Unpin` | 200 | 0 |
 | `Pipe` | 200 | 0 |
 | `FmtForward` | 200 | 0 |
 | `Any` | 200 | 0 |
-| `UnsafeUnpin` | 200 | 0 |
-| `SupersetOf` | 200 | 0 |
-| `Conv` | 200 | 0 |
-| `Send` | 200 | 7 |
-| `UnwindSafe` | 200 | 0 |
 | `Sync` | 200 | 10 |
-| `IntoEither` | 200 | 0 |
 | `TryConv` | 200 | 0 |
+| `IntoEither` | 200 | 0 |
 | `TryFrom` | 200 | 0 |
+| `Send` | 200 | 7 |
+| `SupersetOf` | 200 | 0 |
+| `UnwindSafe` | 200 | 0 |
+| `Same` | 200 | 0 |
+| `Freeze` | 200 | 0 |
+| `Conv` | 200 | 0 |
 | `RefUnwindSafe` | 200 | 0 |
+| `Into` | 200 | 0 |
 | `TypedExternal` | 198 | 198 |
 | `Allocation` | 137 | 0 |
 | `IntoRAs` | 135 | 135 |
@@ -42,8 +42,8 @@ Traits with impls: 190
 | `Debug` | 92 | 92 |
 | `RClone` | 87 | 1 |
 | `ToOwned` | 86 | 0 |
-| `CloneToUninit` | 86 | 0 |
 | `Clone` | 86 | 86 |
+| `CloneToUninit` | 86 | 0 |
 | `AltVec` | 64 | 64 |
 | `InferBase` | 64 | 64 |
 | `AltrepLen` | 64 | 64 |
@@ -60,12 +60,12 @@ Traits with impls: 190
 | `AltrepSerialize` | 27 | 27 |
 | `AltrepExtract` | 22 | 1 |
 | `RDisplay` | 22 | 1 |
-| `ToString` | 21 | 0 |
 | `Display` | 21 | 21 |
-| `Deref` | 20 | 20 |
-| `Receiver` | 20 | 0 |
-| `RDefault` | 20 | 1 |
+| `ToString` | 21 | 0 |
 | `Error` | 20 | 20 |
+| `RDefault` | 20 | 1 |
+| `Receiver` | 20 | 0 |
+| `Deref` | 20 | 20 |
 | `RError` | 19 | 1 |
 | `Default` | 19 | 19 |
 | `AltIntegerData` | 16 | 16 |
@@ -79,57 +79,71 @@ Traits with impls: 190
 | `AltString` | 10 | 10 |
 | `AltStringData` | 10 | 10 |
 | `AtomicElement` | 9 | 9 |
-| `DerefMut` | 8 | 8 |
 | `AltRaw` | 8 | 8 |
+| `DerefMut` | 8 | 8 |
 | `AltRawData` | 8 | 8 |
-| `IntoIterator` | 7 | 2 |
 | `AltLogicalData` | 7 | 7 |
-| `AltLogical` | 7 | 7 |
 | `WidensToF64` | 7 | 7 |
-| `AsRef` | 6 | 6 |
-| `Parsable` | 6 | 0 |
-| `AltComplexData` | 6 | 6 |
+| `IntoIterator` | 7 | 2 |
+| `AltLogical` | 7 | 7 |
 | `Formattable` | 6 | 0 |
+| `AltComplexData` | 6 | 6 |
+| `Parsable` | 6 | 0 |
+| `AsRef` | 6 | 6 |
 | `AltComplex` | 6 | 6 |
 | `RNdArrayOps` | 6 | 6 |
-| `IteratorRandom` | 5 | 0 |
-| `ROrd` | 5 | 1 |
-| `Iterator` | 5 | 5 |
-| `RPartialOrd` | 5 | 1 |
 | `ExactSizeIterator` | 5 | 5 |
 | `IntoList` | 5 | 5 |
-| `RNativeType` | 5 | 5 |
+| `ROrd` | 5 | 1 |
 | `TryFromList` | 5 | 5 |
-| `Rng` | 4 | 0 |
-| `IntoRecords` | 4 | 0 |
-| `TryRng` | 4 | 1 |
+| `RPartialOrd` | 5 | 1 |
+| `RNativeType` | 5 | 5 |
+| `IteratorRandom` | 5 | 0 |
+| `Iterator` | 5 | 5 |
 | `RngCore` | 4 | 0 |
-| `TryRngCore` | 4 | 0 |
-| `PartialOrd` | 4 | 4 |
+| `IntoRecords` | 4 | 0 |
 | `WidensToI32` | 4 | 4 |
-| `Ord` | 4 | 4 |
 | `RngExt` | 4 | 0 |
+| `PartialOrd` | 4 | 4 |
+| `Rng` | 4 | 0 |
+| `TryRng` | 4 | 1 |
+| `TryRngCore` | 4 | 0 |
+| `Ord` | 4 | 4 |
 | `Comparable` | 4 | 0 |
-| `TryCryptoRng` | 3 | 0 |
 | `AsNamedListExt` | 3 | 3 |
-| `IntoRAltrep` | 3 | 1 |
 | `AsNamedVectorExt` | 3 | 3 |
 | `CryptoRng` | 3 | 0 |
+| `TryCryptoRng` | 3 | 0 |
+| `IntoRAltrep` | 3 | 1 |
 | `AsRNativeExt` | 3 | 1 |
+| `Protector` | 2 | 2 |
+| `RNdIndex` | 2 | 2 |
+| `RNdSlice` | 2 | 2 |
+| `ThreadLocalArenaOps` | 2 | 2 |
 | `ParallelBridge` | 2 | 0 |
 | `RNdSlice2D` | 2 | 2 |
 | `RSourced` | 2 | 2 |
 | `FromDataFrame` | 2 | 2 |
-| `ThreadLocalArenaOps` | 2 | 2 |
 | `AsMut` | 2 | 2 |
 | `Storage` | 2 | 2 |
+| `AltrepClass` | 2 | 2 |
 | `AsDataFrameExt` | 2 | 1 |
-| `RNdIndex` | 2 | 2 |
 | `IntoDataFrame` | 2 | 2 |
 | `RDateTimeFormat` | 2 | 2 |
-| `Protector` | 2 | 2 |
-| `AltrepClass` | 2 | 2 |
-| `RNdSlice` | 2 | 2 |
+| `RUrlOps` | 1 | 1 |
+| `RTomlOps` | 1 | 1 |
+| `RZoned` | 1 | 1 |
+| `BitOr` | 1 | 1 |
+| `RFromStr` | 1 | 1 |
+| `Deserializer` | 1 | 1 |
+| `FusedIterator` | 1 | 1 |
+| `RAhoCorasickOps` | 1 | 1 |
+| `Serializer` | 1 | 1 |
+| `AltListData` | 1 | 1 |
+| `RawStorageMut` | 1 | 1 |
+| `RDateTime` | 1 | 1 |
+| `MatchArg` | 1 | 1 |
+| `AltrepSexpExt` | 1 | 1 |
 | `CheckedBitPattern` | 1 | 0 |
 | `RDistributions` | 1 | 1 |
 | `IsContiguous` | 1 | 1 |
@@ -152,8 +166,6 @@ Traits with impls: 190
 | `DoubleEndedIterator` | 1 | 1 |
 | `Not` | 1 | 1 |
 | `RBigUintBitOps` | 1 | 1 |
-| `AltListData` | 1 | 1 |
-| `AltrepSexpExt` | 1 | 1 |
 | `RawStorage` | 1 | 1 |
 | `RCaptureGroups` | 1 | 1 |
 | `RBorshOps` | 1 | 1 |
@@ -179,27 +191,15 @@ Traits with impls: 190
 | `ROrderedFloatOps` | 1 | 1 |
 | `RSerialize` | 1 | 1 |
 | `RDate` | 1 | 1 |
+| `SexpExt` | 1 | 1 |
 | `RDeserialize` | 1 | 1 |
+| `AltList` | 1 | 1 |
 | `RMatrixOps` | 1 | 1 |
 | `AsVctrsExt` | 1 | 1 |
 | `RIndexMapOps` | 1 | 1 |
 | `RDeserializeNative` | 1 | 1 |
-| `RUrlOps` | 1 | 1 |
-| `RTomlOps` | 1 | 1 |
-| `RZoned` | 1 | 1 |
-| `BitOr` | 1 | 1 |
-| `RFromStr` | 1 | 1 |
-| `Deserializer` | 1 | 1 |
-| `SexpExt` | 1 | 1 |
-| `FusedIterator` | 1 | 1 |
-| `AltList` | 1 | 1 |
-| `RAhoCorasickOps` | 1 | 1 |
-| `Serializer` | 1 | 1 |
-| `RawStorageMut` | 1 | 1 |
-| `RDateTime` | 1 | 1 |
-| `MatchArg` | 1 | 1 |
 
-## `TryFromSexp` — 434 impls
+## `TryFromSexp` — 442 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -210,39 +210,39 @@ Traits with impls: 190
 | `Factor<'a>` | `<'a>` | concrete | 2 | miniextendr-api/src/factor.rs:222 |
 | `FactorVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:517 |
 | `FactorOptionVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:570 |
-| `crate::coerce::Coerced<T, R>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/from_r.rs:1014 |
-| `Vec<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1153 |
-| `Vec<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1154 |
-| `Vec<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1155 |
-| `Vec<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1156 |
-| `Vec<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1157 |
-| `Vec<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1158 |
-| `Vec<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1159 |
-| `Vec<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1160 |
-| `Vec<f32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1161 |
-| `Vec<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1164 |
-| `std::collections::HashSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1220 |
-| `std::collections::HashSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1221 |
-| `std::collections::HashSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1222 |
-| `std::collections::HashSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1223 |
-| `std::collections::HashSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1224 |
-| `std::collections::HashSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1225 |
-| `std::collections::HashSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1226 |
-| `std::collections::HashSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1227 |
-| `std::collections::BTreeSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1229 |
-| `std::collections::BTreeSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1230 |
-| `std::collections::BTreeSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1231 |
-| `std::collections::BTreeSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1232 |
-| `std::collections::BTreeSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1233 |
-| `std::collections::BTreeSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1234 |
-| `std::collections::BTreeSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1235 |
-| `std::collections::BTreeSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1236 |
-| `std::collections::HashSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1255 |
-| `std::collections::BTreeSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1256 |
-| `crate::externalptr::ExternalPtr<T>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1278 |
-| `Option<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1325 |
-| `Vec<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1354 |
-| `Vec<Option<crate::externalptr::ExternalPtr<T>>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1399 |
+| `crate::coerce::Coerced<T, R>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/from_r.rs:1016 |
+| `Vec<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1155 |
+| `Vec<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1156 |
+| `Vec<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1157 |
+| `Vec<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1158 |
+| `Vec<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1159 |
+| `Vec<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1160 |
+| `Vec<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1161 |
+| `Vec<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1162 |
+| `Vec<f32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1163 |
+| `Vec<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1166 |
+| `std::collections::HashSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1222 |
+| `std::collections::HashSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1223 |
+| `std::collections::HashSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1224 |
+| `std::collections::HashSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1225 |
+| `std::collections::HashSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1226 |
+| `std::collections::HashSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1227 |
+| `std::collections::HashSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1228 |
+| `std::collections::HashSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1229 |
+| `std::collections::BTreeSet<i8>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1231 |
+| `std::collections::BTreeSet<i16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1232 |
+| `std::collections::BTreeSet<i64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1233 |
+| `std::collections::BTreeSet<isize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1234 |
+| `std::collections::BTreeSet<u16>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1235 |
+| `std::collections::BTreeSet<u32>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1236 |
+| `std::collections::BTreeSet<u64>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1237 |
+| `std::collections::BTreeSet<usize>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1238 |
+| `std::collections::HashSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1257 |
+| `std::collections::BTreeSet<bool>` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:1258 |
+| `crate::externalptr::ExternalPtr<T>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1280 |
+| `Option<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1327 |
+| `Vec<crate::externalptr::ExternalPtr<T>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1356 |
+| `Vec<Option<crate::externalptr::ExternalPtr<T>>>` | `<T>` | concrete | 3 | miniextendr-api/src/from_r.rs:1401 |
 | `Box<[T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:337 |
 | `i32` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:426 |
 | `f64` | `` | concrete | 3 | miniextendr-api/src/from_r.rs:502 |
@@ -256,15 +256,15 @@ Traits with impls: 190
 | `Option<&[T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:660 |
 | `Option<&mut [T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:687 |
 | `Result<T, ()>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:718 |
-| `[T; N]` | `<T, N> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:755 |
-| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:793 |
-| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:818 |
-| `Option<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:844 |
-| `Option<std::collections::HashMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:895 |
-| `Option<std::collections::BTreeMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:899 |
-| `Option<std::collections::HashSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:928 |
-| `Option<std::collections::BTreeSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:932 |
-| `Vec<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:943 |
+| `[T; N]` | `<T, N> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:757 |
+| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:795 |
+| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r.rs:820 |
+| `Option<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:846 |
+| `Option<std::collections::HashMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:897 |
+| `Option<std::collections::BTreeMap<String, V>>` | `<V> +1wc` | concrete | 2 | miniextendr-api/src/from_r.rs:901 |
+| `Option<std::collections::HashSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:930 |
+| `Option<std::collections::BTreeSet<T>>` | `<T> +2wc` | concrete | 2 | miniextendr-api/src/from_r.rs:934 |
+| `Vec<Vec<T>>` | `<T> +2wc` | concrete | 3 | miniextendr-api/src/from_r.rs:945 |
 | `i8` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:269 |
 | `i16` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:283 |
 | `u16` | `` | concrete | 3 | miniextendr-api/src/from_r/coerced_scalars.rs:297 |
@@ -304,10 +304,10 @@ Traits with impls: 190
 | `std::collections::HashSet<String>` | `` | concrete | 2 | miniextendr-api/src/from_r/cow_and_paths.rs:278 |
 | `std::collections::BTreeSet<String>` | `` | concrete | 2 | miniextendr-api/src/from_r/cow_and_paths.rs:282 |
 | `std::borrow::Cow<'static, [T]>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:34 |
-| `Option<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
-| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `std::path::PathBuf` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `Vec<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
+| `Option<std::path::PathBuf>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
+| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:369 |
 | `Vec<Option<std::ffi::OsString>>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
 | `std::ffi::OsString` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
 | `Vec<std::ffi::OsString>` | `` | concrete | 3 | miniextendr-api/src/from_r/cow_and_paths.rs:392 |
@@ -341,7 +341,6 @@ Traits with impls: 190
 | `Vec<Option<f64>>` | `` | concrete | 2 | miniextendr-api/src/from_r/na_vectors.rs:62 |
 | `Vec<Option<i32>>` | `` | concrete | 2 | miniextendr-api/src/from_r/na_vectors.rs:63 |
 | `Vec<Option<bool>>` | `` | concrete | 3 | miniextendr-api/src/from_r/na_vectors.rs:66 |
-| `Option<&'static i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static mut i32` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static i32` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `Option<&'static mut i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
@@ -353,7 +352,7 @@ Traits with impls: 190
 | `Vec<Option<&'static [i32]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
 | `Vec<&'static mut [i32]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
 | `Vec<Option<&'static mut [i32]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:448 |
-| `Option<&'static f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
+| `Option<&'static i32>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:448 |
 | `&'static mut f64` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `&'static f64` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `Option<&'static mut f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
@@ -365,7 +364,7 @@ Traits with impls: 190
 | `Vec<Option<&'static [f64]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
 | `Vec<&'static mut [f64]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
 | `Vec<Option<&'static mut [f64]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:449 |
-| `&'static mut u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `Option<&'static f64>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:449 |
 | `&'static u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
 | `Option<&'static mut u8>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
 | `Vec<&'static u8>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
@@ -377,6 +376,9 @@ Traits with impls: 190
 | `Vec<&'static mut [u8]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
 | `Vec<Option<&'static mut [u8]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:450 |
 | `Option<&'static u8>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `&'static mut u8` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:450 |
+| `Option<&'static crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
+| `&'static mut crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `Option<&'static mut crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<&'static crate::RLogical>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<Option<&'static crate::RLogical>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
@@ -386,8 +388,6 @@ Traits with impls: 190
 | `Vec<Option<&'static [crate::RLogical]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<&'static mut [crate::RLogical]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
 | `Vec<Option<&'static mut [crate::RLogical]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:451 |
-| `Option<&'static crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
-| `&'static mut crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `&'static crate::RLogical` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:451 |
 | `&'static crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static mut crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
@@ -399,13 +399,21 @@ Traits with impls: 190
 | `Vec<Option<&'static [crate::Rcomplex]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
 | `Vec<&'static mut [crate::Rcomplex]>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
 | `Vec<Option<&'static mut [crate::Rcomplex]>>` | `` | concrete | 2 | miniextendr-api/src/from_r/references.rs:452 |
-| `&'static mut crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
+| `&'static mut crate::Rcomplex` | `` | concrete | 3 | miniextendr-api/src/from_r/references.rs:452 |
 | `Option<&'static str>` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:121 |
 | `char` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:199 |
 | `String` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:245 |
 | `Option<String>` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:317 |
 | `&'static str` | `` | concrete | 3 | miniextendr-api/src/from_r/strings.rs:47 |
+| `(A)` | `<A> +1wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:111 |
+| `(A, B)` | `<A, B> +2wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:112 |
+| `(A, B, C)` | `<A, B, C> +3wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:113 |
+| `(A, B, C, D)` | `<A, B, C, D> +4wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:114 |
+| `(A, B, C, D, E)` | `<A, B, C, D, E> +5wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:115 |
+| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F> +6wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:116 |
+| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G> +7wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:117 |
+| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H> +8wc` | concrete | 3 | miniextendr-api/src/from_r/tuples.rs:118 |
 | `List` | `` | concrete | 2 | miniextendr-api/src/list.rs:1202 |
 | `Option<List>` | `` | concrete | 2 | miniextendr-api/src/list.rs:1257 |
 | `Option<ListMut>` | `` | concrete | 2 | miniextendr-api/src/list.rs:1269 |
@@ -458,12 +466,12 @@ Traits with impls: 190
 | `SignedDuration` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Vec<SignedDuration>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Option<SignedDuration>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
-| `Option<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Vec<Option<Timestamp>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `Option<Timestamp>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
+| `Vec<Option<Timestamp>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
 | `JiffZonedVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
 | `JiffZonedVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
 | `Vec<Option<Date>>` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
@@ -490,27 +498,27 @@ Traits with impls: 190
 | `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2920 |
 | `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:300 |
 | `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3065 |
+| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
 | `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
+| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
 | `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
+| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
+| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
 | `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
@@ -518,34 +526,34 @@ Traits with impls: 190
 | `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
 | `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
 | `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
 | `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
 | `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
 | `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
@@ -553,13 +561,13 @@ Traits with impls: 190
 | `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
 | `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
+| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
 | `BigInt` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:202 |
 | `BigUint` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:214 |
 | `Option<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:226 |
@@ -596,10 +604,10 @@ Traits with impls: 190
 | `Vec<OffsetDateTime>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Option<OffsetDateTime>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
-| `Option<Date>` | `` | concrete | 3 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `ArrayVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:102 |
 | `Option<TinyVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:178 |
 | `Option<ArrayVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:227 |
@@ -640,32 +648,32 @@ Traits with impls: 190
 
 ### `TryFromSexp` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/from_r/references.rs:449** (12 impls): `Option<&'static f64>`, `&'static mut f64`, `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`
-- **miniextendr-api/src/from_r/references.rs:451** (12 impls): `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `Option<&'static crate::RLogical>`, `&'static mut crate::RLogical`, `&'static crate::RLogical`
-- **miniextendr-api/src/from_r/references.rs:452** (12 impls): `&'static crate::Rcomplex`, `Option<&'static mut crate::Rcomplex>`, `Vec<&'static crate::Rcomplex>`, `Vec<Option<&'static crate::Rcomplex>>`, `Vec<&'static mut crate::Rcomplex>`, `Vec<Option<&'static mut crate::Rcomplex>>`, `Vec<&'static [crate::Rcomplex]>`, `Vec<Option<&'static [crate::Rcomplex]>>`, `Vec<&'static mut [crate::Rcomplex]>`, `Vec<Option<&'static mut [crate::Rcomplex]>>`, `&'static mut crate::Rcomplex`, `Option<&'static crate::Rcomplex>`
-- **miniextendr-api/src/from_r/references.rs:448** (12 impls): `Option<&'static i32>`, `&'static mut i32`, `&'static i32`, `Option<&'static mut i32>`, `Vec<&'static i32>`, `Vec<Option<&'static i32>>`, `Vec<&'static mut i32>`, `Vec<Option<&'static mut i32>>`, `Vec<&'static [i32]>`, `Vec<Option<&'static [i32]>>`, `Vec<&'static mut [i32]>`, `Vec<Option<&'static mut [i32]>>`
-- **miniextendr-api/src/from_r/references.rs:450** (12 impls): `&'static mut u8`, `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`, `Array1<u32>`
+- **miniextendr-api/src/from_r/references.rs:449** (12 impls): `&'static mut f64`, `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`, `Option<&'static f64>`
+- **miniextendr-api/src/from_r/references.rs:451** (12 impls): `Option<&'static crate::RLogical>`, `&'static mut crate::RLogical`, `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `&'static crate::RLogical`
+- **miniextendr-api/src/from_r/references.rs:452** (12 impls): `&'static crate::Rcomplex`, `Option<&'static mut crate::Rcomplex>`, `Vec<&'static crate::Rcomplex>`, `Vec<Option<&'static crate::Rcomplex>>`, `Vec<&'static mut crate::Rcomplex>`, `Vec<Option<&'static mut crate::Rcomplex>>`, `Vec<&'static [crate::Rcomplex]>`, `Vec<Option<&'static [crate::Rcomplex]>>`, `Vec<&'static mut [crate::Rcomplex]>`, `Vec<Option<&'static mut [crate::Rcomplex]>>`, `Option<&'static crate::Rcomplex>`, `&'static mut crate::Rcomplex`
+- **miniextendr-api/src/from_r/references.rs:448** (12 impls): `&'static mut i32`, `&'static i32`, `Option<&'static mut i32>`, `Vec<&'static i32>`, `Vec<Option<&'static i32>>`, `Vec<&'static mut i32>`, `Vec<Option<&'static mut i32>>`, `Vec<&'static [i32]>`, `Vec<Option<&'static [i32]>>`, `Vec<&'static mut [i32]>`, `Vec<Option<&'static mut [i32]>>`, `Option<&'static i32>`
+- **miniextendr-api/src/from_r/references.rs:450** (12 impls): `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`, `&'static mut u8`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`, `Array4<i16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`, `Array2<u16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
 - **miniextendr-api/src/optionals/ndarray_impl.rs:676** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`, `Array1<i8>`
 - **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`, `ArrayD<u64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`, `Array5<bool>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`, `Array4<i16>`, `ArrayD<i16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`, `Array2<u16>`, `Array5<u16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`, `Array3<usize>`, `Array6<usize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`, `Array3<i64>`, `Array6<i64>`
+- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Option<Date>`, `Vec<Option<Date>>`, `Date`, `Vec<Date>`
+- **miniextendr-api/src/from_r/cow_and_paths.rs:369** (4 impls): `std::path::PathBuf`, `Vec<std::path::PathBuf>`, `Option<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Timestamp`, `Vec<Timestamp>`, `Option<Timestamp>`, `Vec<Option<Timestamp>>`
 - **miniextendr-api/src/from_r/cow_and_paths.rs:392** (4 impls): `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Option<Date>>`, `Date`, `Vec<Date>`, `Option<Date>`
 - **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<OffsetDateTime>`, `Option<OffsetDateTime>`, `Vec<Option<OffsetDateTime>>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `Vec<Option<SignedDuration>>`, `SignedDuration`, `Vec<SignedDuration>`, `Option<SignedDuration>`
-- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Option<Date>>`, `Date`, `Vec<Date>`, `Option<Date>`
-- **miniextendr-api/src/from_r/cow_and_paths.rs:369** (4 impls): `Option<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `Vec<std::path::PathBuf>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Option<Timestamp>>`, `Timestamp`, `Vec<Timestamp>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecRef`, `JiffTimestampVecMut`
+- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecMut`, `JiffTimestampVecRef`
 - **miniextendr-api/src/optionals/jiff_impl.rs:923** (2 impls): `JiffZonedVecMut`, `JiffZonedVecRef`
 
-## `IntoR` — 325 impls
+## `IntoR` — 329 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -689,81 +697,84 @@ Traits with impls: 190
 | `DataFrame` | `` | concrete | 4 | miniextendr-api/src/dataframe.rs:563 |
 | `FactorVec<T>` | `<T>` | concrete | 4 | miniextendr-api/src/factor.rs:501 |
 | `FactorOptionVec<T>` | `<T>` | concrete | 4 | miniextendr-api/src/factor.rs:610 |
-| `HashSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1008 |
-| `BTreeSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1008 |
-| `HashSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1009 |
-| `BTreeSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1009 |
-| `BTreeSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1010 |
-| `HashSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1010 |
-| `Option<Vec<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1019 |
-| `Option<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1046 |
-| `Option<std::collections::HashMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1073 |
-| `Option<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1100 |
-| `Option<std::collections::HashSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1127 |
-| `Option<std::collections::BTreeSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1154 |
-| `Option<std::collections::HashSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1211 |
-| `Option<std::collections::BTreeSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1215 |
-| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1260 |
-| `&[String]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1278 |
-| `&[&str]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1296 |
+| `HashSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1011 |
+| `BTreeSet<i8>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1011 |
+| `HashSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1012 |
+| `BTreeSet<i16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1012 |
+| `HashSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1013 |
+| `BTreeSet<u16>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1013 |
+| `Option<Vec<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1022 |
+| `Option<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1049 |
+| `Option<std::collections::HashMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1076 |
+| `Option<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 5 | miniextendr-api/src/into_r.rs:1103 |
+| `Option<std::collections::HashSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1130 |
+| `Option<std::collections::BTreeSet<T>>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1157 |
+| `Option<std::collections::HashSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1214 |
+| `Option<std::collections::BTreeSet<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1218 |
+| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1263 |
+| `&[String]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1281 |
+| `&[&str]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1299 |
 | `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:130 |
-| `Vec<std::borrow::Cow<'_, str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1314 |
-| `Vec<Option<std::borrow::Cow<'_, str>>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1333 |
-| `Vec<Option<&str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1386 |
-| `Vec<&str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1437 |
-| `Vec<Vec<T>>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:1458 |
-| `Vec<&[T]>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1506 |
-| `Vec<&[String]>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1546 |
-| `Vec<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1584 |
-| `Vec<Option<f64>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1671 |
-| `Vec<Option<i32>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1672 |
+| `Vec<std::borrow::Cow<'_, str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1317 |
+| `Vec<Option<std::borrow::Cow<'_, str>>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1336 |
+| `Vec<Option<&str>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1389 |
+| `Vec<&str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1440 |
+| `Vec<Vec<T>>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:1461 |
+| `Vec<&[T]>` | `<T>` | concrete | 5 | miniextendr-api/src/into_r.rs:1509 |
+| `Vec<&[String]>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1549 |
+| `Vec<Vec<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1587 |
+| `Vec<Option<f64>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1674 |
+| `Vec<Option<i32>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1675 |
 | `()` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:169 |
-| `Vec<Option<i64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1710 |
-| `Vec<Option<u64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1711 |
-| `Vec<Option<isize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1712 |
-| `Vec<Option<usize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1714 |
-| `Vec<Option<i8>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1733 |
-| `Vec<Option<i16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1734 |
-| `Vec<Option<u16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1735 |
-| `Vec<Option<u32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1736 |
-| `Vec<Option<f32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1737 |
-| `Vec<bool>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1770 |
-| `&[bool]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1790 |
-| `Vec<Option<bool>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1833 |
-| `Vec<Option<crate::Rboolean>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1842 |
+| `Vec<Option<i64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1713 |
+| `Vec<Option<u64>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1714 |
+| `Vec<Option<isize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1715 |
+| `Vec<Option<usize>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1717 |
+| `Vec<Option<i8>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1736 |
+| `Vec<Option<i16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1737 |
+| `Vec<Option<u16>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1738 |
+| `Vec<Option<u32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1739 |
+| `Vec<Option<f32>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:1740 |
+| `Vec<bool>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1773 |
+| `&[bool]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1793 |
+| `Vec<crate::Rboolean>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1813 |
+| `&[crate::Rboolean]` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1833 |
 | `std::convert::Infallible` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:185 |
-| `Vec<Option<crate::RLogical>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1850 |
-| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1862 |
-| `(A, B)` | `<A, B>` | concrete | 5 | miniextendr-api/src/into_r.rs:1974 |
-| `(A, B, C)` | `<A, B, C>` | concrete | 5 | miniextendr-api/src/into_r.rs:1975 |
-| `(A, B, C, D)` | `<A, B, C, D>` | concrete | 5 | miniextendr-api/src/into_r.rs:1976 |
-| `(A, B, C, D, E)` | `<A, B, C, D, E>` | concrete | 5 | miniextendr-api/src/into_r.rs:1977 |
-| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F>` | concrete | 5 | miniextendr-api/src/into_r.rs:1978 |
-| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G>` | concrete | 5 | miniextendr-api/src/into_r.rs:1979 |
-| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H>` | concrete | 5 | miniextendr-api/src/into_r.rs:1980 |
-| `Vec<Box<[T]>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2083 |
-| `Vec<Box<[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2113 |
-| `Vec<[T; N]>` | `<T, N> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2130 |
-| `Vec<Option<Vec<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2198 |
-| `Vec<Option<Vec<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2215 |
-| `Vec<Option<std::collections::HashSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2220 |
-| `Vec<Option<std::collections::HashSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2237 |
-| `Vec<Option<std::collections::BTreeSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2242 |
-| `Vec<Option<std::collections::BTreeSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2259 |
+| `Vec<Option<bool>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1876 |
+| `Vec<Option<crate::Rboolean>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1885 |
+| `Vec<Option<crate::RLogical>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1893 |
+| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:1905 |
+| `(A)` | `<A>` | concrete | 5 | miniextendr-api/src/into_r.rs:2016 |
+| `(A, B)` | `<A, B>` | concrete | 5 | miniextendr-api/src/into_r.rs:2017 |
+| `(A, B, C)` | `<A, B, C>` | concrete | 5 | miniextendr-api/src/into_r.rs:2018 |
+| `(A, B, C, D)` | `<A, B, C, D>` | concrete | 5 | miniextendr-api/src/into_r.rs:2019 |
+| `(A, B, C, D, E)` | `<A, B, C, D, E>` | concrete | 5 | miniextendr-api/src/into_r.rs:2020 |
+| `(A, B, C, D, E, F)` | `<A, B, C, D, E, F>` | concrete | 5 | miniextendr-api/src/into_r.rs:2021 |
+| `(A, B, C, D, E, F, G)` | `<A, B, C, D, E, F, G>` | concrete | 5 | miniextendr-api/src/into_r.rs:2022 |
+| `(A, B, C, D, E, F, G, H)` | `<A, B, C, D, E, F, G, H>` | concrete | 5 | miniextendr-api/src/into_r.rs:2023 |
+| `Vec<Box<[T]>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2126 |
+| `Vec<Box<[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2156 |
+| `Vec<[T; N]>` | `<T, N> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2173 |
+| `Vec<Option<Vec<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2241 |
+| `Vec<Option<Vec<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2258 |
 | `i32` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:226 |
-| `Vec<Option<std::collections::HashMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2264 |
+| `Vec<Option<std::collections::HashSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2263 |
 | `f64` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:227 |
-| `Vec<Option<std::collections::BTreeMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2278 |
 | `u8` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:228 |
+| `Vec<Option<std::collections::HashSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2280 |
+| `Vec<Option<std::collections::BTreeSet<T>>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2285 |
 | `crate::Rcomplex` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:229 |
-| `Vec<Option<&[T]>>` | `<T>` | concrete | 4 | miniextendr-api/src/into_r.rs:2294 |
-| `Vec<Option<&[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2309 |
-| `Vec<std::collections::HashSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2317 |
-| `Vec<std::collections::BTreeSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2336 |
-| `Vec<std::collections::HashSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2354 |
-| `Vec<std::collections::BTreeSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2360 |
-| `Vec<std::collections::HashMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2383 |
-| `Vec<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2387 |
+| `Vec<Option<std::collections::BTreeSet<String>>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2302 |
+| `Vec<Option<std::collections::HashMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2307 |
+| `Vec<Option<std::collections::BTreeMap<String, V>>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2321 |
+| `Vec<Option<&[T]>>` | `<T>` | concrete | 4 | miniextendr-api/src/into_r.rs:2337 |
+| `Vec<Option<&[String]>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2352 |
+| `Vec<std::collections::HashSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2360 |
+| `Vec<std::collections::BTreeSet<T>>` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/into_r.rs:2379 |
+| `Vec<std::collections::HashSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2397 |
+| `Vec<std::collections::BTreeSet<String>>` | `` | concrete | 4 | miniextendr-api/src/into_r.rs:2403 |
+| `Vec<std::collections::HashMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2426 |
+| `Vec<std::collections::BTreeMap<String, V>>` | `<V>` | concrete | 4 | miniextendr-api/src/into_r.rs:2430 |
 | `Option<crate::Rcomplex>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:272 |
 | `i8` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:332 |
 | `i16` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:333 |
@@ -789,21 +800,22 @@ Traits with impls: 190
 | `Vec<u64>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:641 |
 | `Vec<isize>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:642 |
 | `Vec<usize>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:644 |
-| `[T; N]` | `<T, N>` | concrete | 5 | miniextendr-api/src/into_r.rs:660 |
-| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:686 |
-| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:716 |
-| `std::borrow::Cow<'_, [T]>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:752 |
-| `std::borrow::Cow<'_, str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:772 |
-| `Option<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `std::path::PathBuf` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `&std::path::Path` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:939 |
-| `Vec<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `Vec<Option<std::ffi::OsString>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `std::ffi::OsString` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `&std::ffi::OsStr` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
-| `Option<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:955 |
+| `Vec<u32>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:647 |
+| `[T; N]` | `<T, N>` | concrete | 5 | miniextendr-api/src/into_r.rs:663 |
+| `std::collections::VecDeque<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:689 |
+| `std::collections::BinaryHeap<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:719 |
+| `std::borrow::Cow<'_, [T]>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r.rs:755 |
+| `std::borrow::Cow<'_, str>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:775 |
+| `Option<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Vec<std::path::PathBuf>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Vec<Option<std::path::PathBuf>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `std::path::PathBuf` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `&std::path::Path` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:942 |
+| `Option<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `Vec<std::ffi::OsString>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `Vec<Option<std::ffi::OsString>>` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `std::ffi::OsString` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
+| `&std::ffi::OsStr` | `` | concrete | 5 | miniextendr-api/src/into_r.rs:958 |
 | `Altrep<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r/altrep.rs:152 |
 | `crate::altrep_sexp::AltrepSexp` | `` | concrete | 4 | miniextendr-api/src/into_r/altrep.rs:192 |
 | `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 5 | miniextendr-api/src/into_r/collections.rs:116 |
@@ -887,20 +899,20 @@ Traits with impls: 190
 | `Option<Zoned>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:238 |
 | `Vec<Zoned>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:316 |
 | `Vec<Option<Zoned>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:422 |
-| `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
-| `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `SignedDuration` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
 | `Vec<Option<SignedDuration>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:484 |
+| `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
 | `JiffZonedVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `log::LevelFilter` | `` | concrete | 4 | miniextendr-api/src/optionals/log_impl.rs:332 |
 | `RDVector<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1334 |
 | `RDMatrix<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1347 |
@@ -955,14 +967,14 @@ Traits with impls: 190
 | `Vec<JsonValue>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:626 |
 | `Vec<Option<JsonValue>>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:653 |
 | `Table` | `` | concrete | 4 | miniextendr-api/src/optionals/tabled_impl.rs:196 |
-| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
-| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `OffsetDateTime` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `TinyVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:140 |
 | `ArrayVec<[T; N]>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:159 |
 | `Option<TinyVec<[T; N]>>` | `<T, N> +2wc` | concrete | 3 | miniextendr-api/src/optionals/tinyvec_impl.rs:202 |
@@ -997,20 +1009,20 @@ Traits with impls: 190
 
 ### `IntoR` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/into_r.rs:955** (5 impls): `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`, `Option<std::ffi::OsString>`
-- **miniextendr-api/src/into_r.rs:939** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
-- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`, `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`
-- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `Option<SignedDuration>`, `Vec<SignedDuration>`, `SignedDuration`, `Vec<Option<SignedDuration>>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`, `Option<Timestamp>`
+- **miniextendr-api/src/into_r.rs:958** (5 impls): `Option<std::ffi::OsString>`, `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`
+- **miniextendr-api/src/into_r.rs:942** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
+- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`, `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:484** (4 impls): `SignedDuration`, `Vec<Option<SignedDuration>>`, `Option<SignedDuration>`, `Vec<SignedDuration>`
+- **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`
+- **miniextendr-api/src/into_r.rs:1013** (2 impls): `HashSet<u16>`, `BTreeSet<u16>`
 - **miniextendr-api/src/into_r.rs:577** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r.rs:1009** (2 impls): `HashSet<i16>`, `BTreeSet<i16>`
+- **miniextendr-api/src/into_r.rs:1012** (2 impls): `HashSet<i16>`, `BTreeSet<i16>`
 - **miniextendr-api/src/into_r.rs:578** (2 impls): `Vec<i16>`, `&[i16]`
-- **miniextendr-api/src/into_r.rs:1010** (2 impls): `BTreeSet<u16>`, `HashSet<u16>`
 - **miniextendr-api/src/into_r.rs:579** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r.rs:582** (2 impls): `Vec<f32>`, `&[f32]`
-- **miniextendr-api/src/into_r.rs:1008** (2 impls): `HashSet<i8>`, `BTreeSet<i8>`
+- **miniextendr-api/src/into_r.rs:1011** (2 impls): `HashSet<i8>`, `BTreeSet<i8>`
 
 ## `From` — 49 impls
 
@@ -1078,18 +1090,6 @@ Traits with impls: 190
 |---|---|---|---|---|
 | `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1546 |
 
-## `Send` — 7 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:406 |
-| `WorkerUnprotectGuard` | `` | concrete | 0 | miniextendr-api/src/gc_protect.rs:1383 |
-| `TraitDispatchEntry` | `` | concrete | 0 | miniextendr-api/src/registry.rs:327 |
-| `AltrepRegistration` | `` | concrete | 0 | miniextendr-api/src/registry.rs:344 |
-| `SEXP` | `` | concrete | 0 | miniextendr-api/src/sexp.rs:70 |
-| `R_CallMethodDef` | `` | concrete | 0 | miniextendr-api/src/sys.rs:1153 |
-| `R_altrep_class_t` | `` | concrete | 0 | miniextendr-api/src/sys/altrep.rs:197 |
-
 ## `Sync` — 10 impls
 
 | for-type | generics | kind | #items | span |
@@ -1104,6 +1104,18 @@ Traits with impls: 190
 | `SEXP` | `` | concrete | 0 | miniextendr-api/src/sexp.rs:71 |
 | `R_CallMethodDef` | `` | concrete | 0 | miniextendr-api/src/sys.rs:1152 |
 | `R_altrep_class_t` | `` | concrete | 0 | miniextendr-api/src/sys/altrep.rs:198 |
+
+## `Send` — 7 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:406 |
+| `WorkerUnprotectGuard` | `` | concrete | 0 | miniextendr-api/src/gc_protect.rs:1383 |
+| `TraitDispatchEntry` | `` | concrete | 0 | miniextendr-api/src/registry.rs:327 |
+| `AltrepRegistration` | `` | concrete | 0 | miniextendr-api/src/registry.rs:344 |
+| `SEXP` | `` | concrete | 0 | miniextendr-api/src/sexp.rs:70 |
+| `R_CallMethodDef` | `` | concrete | 0 | miniextendr-api/src/sys.rs:1153 |
+| `R_altrep_class_t` | `` | concrete | 0 | miniextendr-api/src/sys/altrep.rs:197 |
 
 ## `TypedExternal` — 198 impls
 
@@ -1363,20 +1375,20 @@ Traits with impls: 190
 | `crate::RLogical` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:575 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:619 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:626 |
-| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
+| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:633 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:634 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:634 |
-| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
-| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
+| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:635 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
+| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:636 |
 | `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:637 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:637 |
-| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
-| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
+| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:638 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
+| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:639 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:640 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:640 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:641 |
@@ -1393,22 +1405,22 @@ Traits with impls: 190
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:709 |
 | `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:744 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:744 |
-| `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
-| `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
+| `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:745 |
 | `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
+| `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:746 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:747 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:747 |
-| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
+| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:748 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:753 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:769 |
 | `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:786 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:786 |
-| `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
-| `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
+| `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:787 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
+| `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:788 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:789 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:789 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:792 |
@@ -1421,20 +1433,20 @@ Traits with impls: 190
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:828 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:829 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:829 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:830 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:831 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:831 |
-| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
-| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
+| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:832 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
+| `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:833 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:834 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:834 |
-| `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
-| `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
+| `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:835 |
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
+| `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:836 |
 | `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:837 |
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:837 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:842 |
@@ -1450,37 +1462,37 @@ Traits with impls: 190
 
 ### `IntoRAs` — for-types sharing a source span (likely macro-expanded / co-located)
 
+- **miniextendr-api/src/into_r_as.rs:830** (2 impls): `&[i64]`, `Vec<i64>`
+- **miniextendr-api/src/into_r_as.rs:832** (2 impls): `Vec<u16>`, `&[u16]`
+- **miniextendr-api/src/into_r_as.rs:833** (2 impls): `&[u32]`, `Vec<u32>`
+- **miniextendr-api/src/into_r_as.rs:745** (2 impls): `Vec<i16>`, `&[i16]`
+- **miniextendr-api/src/into_r_as.rs:835** (2 impls): `Vec<usize>`, `&[usize]`
+- **miniextendr-api/src/into_r_as.rs:746** (2 impls): `&[u8]`, `Vec<u8>`
+- **miniextendr-api/src/into_r_as.rs:836** (2 impls): `&[f32]`, `Vec<f32>`
+- **miniextendr-api/src/into_r_as.rs:748** (2 impls): `Vec<u32>`, `&[u32]`
+- **miniextendr-api/src/into_r_as.rs:633** (2 impls): `&[i8]`, `Vec<i8>`
+- **miniextendr-api/src/into_r_as.rs:635** (2 impls): `Vec<u8>`, `&[u8]`
+- **miniextendr-api/src/into_r_as.rs:787** (2 impls): `Vec<u64>`, `&[u64]`
+- **miniextendr-api/src/into_r_as.rs:636** (2 impls): `&[u16]`, `Vec<u16>`
+- **miniextendr-api/src/into_r_as.rs:788** (2 impls): `&[isize]`, `Vec<isize>`
+- **miniextendr-api/src/into_r_as.rs:638** (2 impls): `Vec<isize>`, `&[isize]`
+- **miniextendr-api/src/into_r_as.rs:639** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:641** (2 impls): `Vec<usize>`, `&[usize]`
 - **miniextendr-api/src/into_r_as.rs:828** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:642** (2 impls): `&[f32]`, `Vec<f32>`
 - **miniextendr-api/src/into_r_as.rs:829** (2 impls): `&[i32]`, `Vec<i32>`
 - **miniextendr-api/src/into_r_as.rs:831** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:832** (2 impls): `&[u16]`, `Vec<u16>`
 - **miniextendr-api/src/into_r_as.rs:744** (2 impls): `Vec<i8>`, `&[i8]`
 - **miniextendr-api/src/into_r_as.rs:834** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:745** (2 impls): `&[i16]`, `Vec<i16>`
-- **miniextendr-api/src/into_r_as.rs:835** (2 impls): `&[usize]`, `Vec<usize>`
 - **miniextendr-api/src/into_r_as.rs:747** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r_as.rs:837** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:748** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:634** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:786** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:635** (2 impls): `&[u8]`, `Vec<u8>`
-- **miniextendr-api/src/into_r_as.rs:787** (2 impls): `&[u64]`, `Vec<u64>`
 - **miniextendr-api/src/into_r_as.rs:637** (2 impls): `Vec<i64>`, `&[i64]`
 - **miniextendr-api/src/into_r_as.rs:789** (2 impls): `Vec<usize>`, `&[usize]`
-- **miniextendr-api/src/into_r_as.rs:638** (2 impls): `&[isize]`, `Vec<isize>`
 - **miniextendr-api/src/into_r_as.rs:640** (2 impls): `Vec<u64>`, `&[u64]`
 - **miniextendr-api/src/into_r_as.rs:827** (2 impls): `Vec<i8>`, `&[i8]`
 - **miniextendr-api/src/into_r_as.rs:643** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:830** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:833** (2 impls): `Vec<u32>`, `&[u32]`
-- **miniextendr-api/src/into_r_as.rs:746** (2 impls): `Vec<u8>`, `&[u8]`
-- **miniextendr-api/src/into_r_as.rs:836** (2 impls): `Vec<f32>`, `&[f32]`
-- **miniextendr-api/src/into_r_as.rs:633** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r_as.rs:636** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:788** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:639** (2 impls): `Vec<u32>`, `&[u32]`
 
 ## `TryCoerce` — 93 impls
 
@@ -1526,14 +1538,14 @@ Traits with impls: 190
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:541 |
-| `i8` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
-| `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
-| `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `u32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i8` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
+| `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:551 |
 | `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `u16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
@@ -1541,8 +1553,6 @@ Traits with impls: 190
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
 | `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:556 |
-| `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
-| `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `i64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
@@ -1550,6 +1560,8 @@ Traits with impls: 190
 | `u16` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `u32` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `u64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
+| `usize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
+| `isize` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:561 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:566 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:587 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/coerce.rs:608 |
@@ -1582,9 +1594,9 @@ Traits with impls: 190
 
 ### `TryCoerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/coerce.rs:561** (9 impls): `usize`, `isize`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`
+- **miniextendr-api/src/coerce.rs:561** (9 impls): `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `usize`, `isize`
 - **miniextendr-api/src/coerce.rs:541** (9 impls): `i8`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64`, `usize`, `isize`
-- **miniextendr-api/src/coerce.rs:551** (8 impls): `i8`, `i16`, `i32`, `i64`, `u32`, `u64`, `usize`, `isize`
+- **miniextendr-api/src/coerce.rs:551** (8 impls): `i64`, `u32`, `u64`, `usize`, `isize`, `i8`, `i16`, `i32`
 - **miniextendr-api/src/coerce.rs:556** (7 impls): `i32`, `i64`, `u16`, `u32`, `u64`, `usize`, `isize`
 - **miniextendr-api/src/coerce.rs:536** (5 impls): `u32`, `u64`, `usize`, `i64`, `isize`
 
@@ -2102,9 +2114,9 @@ Traits with impls: 190
 | `i32` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:310 |
 | `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
+| `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `i8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `u16` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
-| `u8` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:546 |
 | `f64` | `` | concrete | 1 | miniextendr-api/src/coerce.rs:663 |
 | `&[T]` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:974 |
 | `Vec<T>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:982 |
@@ -2125,7 +2137,7 @@ Traits with impls: 190
 ### `Coerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
 - **miniextendr-api/src/coerce.rs:212** (5 impls): `u8`, `u8`, `u8`, `u8`, `u8`
-- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `i8`, `u16`, `u8`
+- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 
 ## `RCopy` — 1 impls
 
@@ -2455,42 +2467,6 @@ Traits with impls: 190
 | `TypedListError` | `` | concrete | 1 | miniextendr-api/src/typed_list.rs:230 |
 | `VctrsBuildError` | `` | concrete | 1 | miniextendr-api/src/vctrs.rs:78 |
 
-## `Deref` — 20 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Coerced<T, R>` | `<T, R>` | concrete | 2 | miniextendr-api/src/coerce.rs:954 |
-| `ExternalPtr<T>` | `<T>` | concrete | 2 | miniextendr-api/src/externalptr.rs:1516 |
-| `Factor<'_>` | `` | concrete | 2 | miniextendr-api/src/factor.rs:213 |
-| `FactorMut<'_>` | `` | concrete | 2 | miniextendr-api/src/factor.rs:309 |
-| `FactorVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:488 |
-| `FactorOptionVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:546 |
-| `Protected<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/gc_protect.rs:1039 |
-| `Root<'a>` | `<'a>` | concrete | 2 | miniextendr-api/src/gc_protect.rs:837 |
-| `OwnedProtect` | `` | concrete | 2 | miniextendr-api/src/gc_protect.rs:925 |
-| `TlsRoot` | `` | concrete | 2 | miniextendr-api/src/gc_protect/tls.rs:221 |
-| `Altrep<T>` | `<T>` | concrete | 2 | miniextendr-api/src/into_r/altrep.rs:132 |
-| `RPrimitive<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:150 |
-| `RStringArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:234 |
-| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:117 |
-| `JiffTimestampVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
-| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
-| `JiffZonedVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
-| `JiffZonedVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
-| `RCow<'_, T>` | `<T>` | concrete | 2 | miniextendr-api/src/rcow.rs:146 |
-| `ArenaGuard<'_, M>` | `<M>` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:788 |
-
-### `Deref` — for-types sharing a source span (likely macro-expanded / co-located)
-
-- **miniextendr-api/src/optionals/jiff_impl.rs:923** (2 impls): `JiffZonedVecMut`, `JiffZonedVecRef`
-- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecMut`, `JiffTimestampVecRef`
-
-## `RDefault` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:412 |
-
 ## `Error` — 20 impls
 
 | for-type | generics | kind | #items | span |
@@ -2515,6 +2491,42 @@ Traits with impls: 190
 | `RSerdeError` | `` | concrete | 1 | miniextendr-api/src/serde/error.rs:74 |
 | `TypedListError` | `` | concrete | 0 | miniextendr-api/src/typed_list.rs:263 |
 | `VctrsBuildError` | `` | concrete | 0 | miniextendr-api/src/vctrs.rs:123 |
+
+## `RDefault` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:412 |
+
+## `Deref` — 20 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Coerced<T, R>` | `<T, R>` | concrete | 2 | miniextendr-api/src/coerce.rs:954 |
+| `ExternalPtr<T>` | `<T>` | concrete | 2 | miniextendr-api/src/externalptr.rs:1516 |
+| `Factor<'_>` | `` | concrete | 2 | miniextendr-api/src/factor.rs:213 |
+| `FactorMut<'_>` | `` | concrete | 2 | miniextendr-api/src/factor.rs:309 |
+| `FactorVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:488 |
+| `FactorOptionVec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/factor.rs:546 |
+| `Protected<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/gc_protect.rs:1039 |
+| `Root<'a>` | `<'a>` | concrete | 2 | miniextendr-api/src/gc_protect.rs:837 |
+| `OwnedProtect` | `` | concrete | 2 | miniextendr-api/src/gc_protect.rs:925 |
+| `TlsRoot` | `` | concrete | 2 | miniextendr-api/src/gc_protect/tls.rs:221 |
+| `Altrep<T>` | `<T>` | concrete | 2 | miniextendr-api/src/into_r/altrep.rs:132 |
+| `RPrimitive<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:150 |
+| `RStringArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:234 |
+| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:117 |
+| `JiffTimestampVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffTimestampVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffZonedVecMut` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
+| `JiffZonedVecRef` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
+| `RCow<'_, T>` | `<T>` | concrete | 2 | miniextendr-api/src/rcow.rs:146 |
+| `ArenaGuard<'_, M>` | `<M>` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:788 |
+
+### `Deref` — for-types sharing a source span (likely macro-expanded / co-located)
+
+- **miniextendr-api/src/optionals/jiff_impl.rs:882** (2 impls): `JiffTimestampVecRef`, `JiffTimestampVecMut`
+- **miniextendr-api/src/optionals/jiff_impl.rs:923** (2 impls): `JiffZonedVecMut`, `JiffZonedVecRef`
 
 ## `RError` — 1 impls
 
@@ -2732,19 +2744,6 @@ Traits with impls: 190
 | `f64` | `` | concrete | 2 | miniextendr-api/src/named_vector.rs:66 |
 | `u8` | `` | concrete | 2 | miniextendr-api/src/named_vector.rs:85 |
 
-## `DerefMut` — 8 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Coerced<T, R>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:963 |
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1525 |
-| `FactorMut<'_>` | `` | concrete | 1 | miniextendr-api/src/factor.rs:318 |
-| `FactorVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/factor.rs:495 |
-| `FactorOptionVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/factor.rs:553 |
-| `Altrep<T>` | `<T>` | concrete | 1 | miniextendr-api/src/into_r/altrep.rs:141 |
-| `JiffTimestampVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
-| `JiffZonedVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
-
 ## `AltRaw` — 8 impls
 
 | for-type | generics | kind | #items | span |
@@ -2757,6 +2756,19 @@ Traits with impls: 190
 | `std::borrow::Cow<'static, [u8]>` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/builtins.rs:495 |
 | `&'static [u8]` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/static_slices.rs:318 |
 | `UInt8Array` | `` | concrete | 4 | miniextendr-api/src/optionals/arrow_impl.rs:1866 |
+
+## `DerefMut` — 8 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Coerced<T, R>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:963 |
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1525 |
+| `FactorMut<'_>` | `` | concrete | 1 | miniextendr-api/src/factor.rs:318 |
+| `FactorVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/factor.rs:495 |
+| `FactorOptionVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/factor.rs:553 |
+| `Altrep<T>` | `<T>` | concrete | 1 | miniextendr-api/src/into_r/altrep.rs:141 |
+| `JiffTimestampVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffZonedVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
 
 ## `AltRawData` — 8 impls
 
@@ -2771,13 +2783,6 @@ Traits with impls: 190
 | `IterRawData<I>` | `<I>` | concrete | 3 | miniextendr-api/src/altrep_data/iter/state.rs:561 |
 | `UInt8Array` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:1674 |
 
-## `IntoIterator` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `StrVec` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:295 |
-| `&'a ProtectedStrVec` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:644 |
-
 ## `AltLogicalData` — 7 impls
 
 | for-type | generics | kind | #items | span |
@@ -2789,18 +2794,6 @@ Traits with impls: 190
 | `SparseIterLogicalData<I>` | `<I>` | concrete | 2 | miniextendr-api/src/altrep_data/iter/sparse.rs:417 |
 | `IterLogicalData<I>` | `<I>` | concrete | 2 | miniextendr-api/src/altrep_data/iter/state.rs:462 |
 | `BooleanArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:1688 |
-
-## `AltLogical` — 7 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `SparseIterLogicalData<I>` | `<I>` | concrete | 4 | miniextendr-api/src/altrep_data/iter/sparse.rs:466 |
-| `IterLogicalData<I>` | `<I>` | concrete | 4 | miniextendr-api/src/altrep_data/iter/state.rs:509 |
-| `[bool; N]` | `<N>` | concrete | 4 | miniextendr-api/src/altrep_impl/arrays.rs:162 |
-| `Vec<bool>` | `` | concrete | 10 | miniextendr-api/src/altrep_impl/builtins.rs:353 |
-| `Box<[bool]>` | `` | concrete | 10 | miniextendr-api/src/altrep_impl/builtins.rs:450 |
-| `&'static [bool]` | `` | concrete | 6 | miniextendr-api/src/altrep_impl/static_slices.rs:245 |
-| `BooleanArray` | `` | concrete | 10 | miniextendr-api/src/optionals/arrow_impl.rs:1867 |
 
 ## `WidensToF64` — 7 impls
 
@@ -2814,16 +2807,24 @@ Traits with impls: 190
 | `u16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:224 |
 | `u32` | `` | concrete | 0 | miniextendr-api/src/markers.rs:225 |
 
-## `AsRef` — 6 impls
+## `IntoIterator` — 2 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1532 |
-| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:158 |
-| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:165 |
-| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:242 |
-| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:249 |
-| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:241 |
+| `StrVec` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:295 |
+| `&'a ProtectedStrVec` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:644 |
+
+## `AltLogical` — 7 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `SparseIterLogicalData<I>` | `<I>` | concrete | 4 | miniextendr-api/src/altrep_data/iter/sparse.rs:466 |
+| `IterLogicalData<I>` | `<I>` | concrete | 4 | miniextendr-api/src/altrep_data/iter/state.rs:509 |
+| `[bool; N]` | `<N>` | concrete | 4 | miniextendr-api/src/altrep_impl/arrays.rs:162 |
+| `Vec<bool>` | `` | concrete | 10 | miniextendr-api/src/altrep_impl/builtins.rs:353 |
+| `Box<[bool]>` | `` | concrete | 10 | miniextendr-api/src/altrep_impl/builtins.rs:450 |
+| `&'static [bool]` | `` | concrete | 6 | miniextendr-api/src/altrep_impl/static_slices.rs:245 |
+| `BooleanArray` | `` | concrete | 10 | miniextendr-api/src/optionals/arrow_impl.rs:1867 |
 
 ## `AltComplexData` — 6 impls
 
@@ -2835,6 +2836,17 @@ Traits with impls: 190
 | `std::borrow::Cow<'static, [crate::Rcomplex]>` | `` | concrete | 3 | miniextendr-api/src/altrep_data/builtins.rs:1202 |
 | `IterComplexData<I>` | `<I> +1wc` | concrete | 3 | miniextendr-api/src/altrep_data/iter/coerce.rs:747 |
 | `SparseIterComplexData<I>` | `<I> +1wc` | concrete | 3 | miniextendr-api/src/altrep_data/iter/sparse.rs:628 |
+
+## `AsRef` — 6 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1532 |
+| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:158 |
+| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:165 |
+| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:242 |
+| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:249 |
+| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:241 |
 
 ## `AltComplex` — 6 impls
 
@@ -2858,28 +2870,6 @@ Traits with impls: 190
 | `Array2<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1969 |
 | `ArrayD<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2034 |
 
-## `ROrd` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:174 |
-
-## `Iterator` — 5 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 4 | miniextendr-api/src/externalptr.rs:1632 |
-| `StrVecIter` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:234 |
-| `StrVecCowIter` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:269 |
-| `ProtectedStrVecIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:591 |
-| `ProtectedStrVecCowIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:622 |
-
-## `RPartialOrd` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:215 |
-
 ## `ExactSizeIterator` — 5 impls
 
 | for-type | generics | kind | #items | span |
@@ -2900,15 +2890,11 @@ Traits with impls: 190
 | `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:836 |
 | `std::collections::BTreeSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:861 |
 
-## `RNativeType` — 5 impls
+## `ROrd` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `i32` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:209 |
-| `f64` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:230 |
-| `u8` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:251 |
-| `RLogical` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:273 |
-| `Rcomplex` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:295 |
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:174 |
 
 ## `TryFromList` — 5 impls
 
@@ -2920,11 +2906,40 @@ Traits with impls: 190
 | `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/list.rs:846 |
 | `std::collections::BTreeSet<T>` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/list.rs:871 |
 
-## `TryRng` — 1 impls
+## `RPartialOrd` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `RRng` | `` | concrete | 4 | miniextendr-api/src/optionals/rand_impl.rs:128 |
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:215 |
+
+## `RNativeType` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `i32` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:209 |
+| `f64` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:230 |
+| `u8` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:251 |
+| `RLogical` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:273 |
+| `Rcomplex` | `` | concrete | 4 | miniextendr-api/src/sexp_types.rs:295 |
+
+## `Iterator` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 4 | miniextendr-api/src/externalptr.rs:1632 |
+| `StrVecIter` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:234 |
+| `StrVecCowIter` | `` | concrete | 3 | miniextendr-api/src/strvec.rs:269 |
+| `ProtectedStrVecIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:591 |
+| `ProtectedStrVecCowIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:622 |
+
+## `WidensToI32` — 4 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `i8` | `` | concrete | 0 | miniextendr-api/src/markers.rs:214 |
+| `i16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:215 |
+| `u8` | `` | concrete | 0 | miniextendr-api/src/markers.rs:216 |
+| `u16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:217 |
 
 ## `PartialOrd` — 4 impls
 
@@ -2935,14 +2950,11 @@ Traits with impls: 190
 | `RWrapperPriority` | `` | concrete | 1 | miniextendr-api/src/registry.rs:209 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
 
-## `WidensToI32` — 4 impls
+## `TryRng` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `i8` | `` | concrete | 0 | miniextendr-api/src/markers.rs:214 |
-| `i16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:215 |
-| `u8` | `` | concrete | 0 | miniextendr-api/src/markers.rs:216 |
-| `u16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:217 |
+| `RRng` | `` | concrete | 4 | miniextendr-api/src/optionals/rand_impl.rs:128 |
 
 ## `Ord` — 4 impls
 
@@ -2961,12 +2973,6 @@ Traits with impls: 190
 | `[(K, V); N]` | `<K, V, N>` | concrete | 0 | miniextendr-api/src/convert.rs:883 |
 | `&[(K, V)]` | `<K, V>` | concrete | 0 | miniextendr-api/src/convert.rs:884 |
 
-## `IntoRAltrep` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2065 |
-
 ## `AsNamedVectorExt` — 3 impls
 
 | for-type | generics | kind | #items | span |
@@ -2975,11 +2981,45 @@ Traits with impls: 190
 | `[(K, V); N]` | `<K, V, N>` | concrete | 0 | miniextendr-api/src/convert.rs:902 |
 | `&[(K, V)]` | `<K, V>` | concrete | 0 | miniextendr-api/src/convert.rs:903 |
 
+## `IntoRAltrep` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2108 |
+
 ## `AsRNativeExt` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:838 |
+
+## `Protector` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ProtectScope` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:216 |
+| `crate::protect_pool::ProtectPool` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:223 |
+
+## `RNdIndex` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ArrayD<f64>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2447 |
+| `ArrayD<i32>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2601 |
+
+## `RNdSlice` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Array1<f64>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2160 |
+| `Array1<i32>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2193 |
+
+## `ThreadLocalArenaOps` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ThreadLocalArena` | `` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:1111 |
+| `ThreadLocalHashArena` | `` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:1121 |
 
 ## `RNdSlice2D` — 2 impls
 
@@ -3002,13 +3042,6 @@ Traits with impls: 190
 | `Vec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/dataframe.rs:758 |
 | `SerdeRows<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:256 |
 
-## `ThreadLocalArenaOps` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ThreadLocalArena` | `` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:1111 |
-| `ThreadLocalHashArena` | `` | concrete | 2 | miniextendr-api/src/refcount_protect.rs:1121 |
-
 ## `AsMut` — 2 impls
 
 | for-type | generics | kind | #items | span |
@@ -3023,18 +3056,18 @@ Traits with impls: 190
 | `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::Dyn>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1251 |
 | `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::U1>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1276 |
 
+## `AltrepClass` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `JiffTimestampVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
+| `JiffZonedVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
+
 ## `AsDataFrameExt` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:851 |
-
-## `RNdIndex` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ArrayD<f64>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2447 |
-| `ArrayD<i32>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2601 |
 
 ## `IntoDataFrame` — 2 impls
 
@@ -3050,26 +3083,89 @@ Traits with impls: 190
 | `OffsetDateTime` | `` | concrete | 2 | miniextendr-api/src/optionals/time_impl.rs:287 |
 | `Date` | `` | concrete | 2 | miniextendr-api/src/optionals/time_impl.rs:299 |
 
-## `Protector` — 2 impls
+## `RUrlOps` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `ProtectScope` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:216 |
-| `crate::protect_pool::ProtectPool` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:223 |
+| `Url` | `` | concrete | 12 | miniextendr-api/src/optionals/url_impl.rs:300 |
 
-## `AltrepClass` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `JiffTimestampVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:882 |
-| `JiffZonedVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:923 |
-
-## `RNdSlice` — 2 impls
+## `RTomlOps` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `Array1<f64>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2160 |
-| `Array1<i32>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2193 |
+| `TomlValue` | `` | concrete | 16 | miniextendr-api/src/optionals/toml_impl.rs:624 |
+
+## `RZoned` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Zoned` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:782 |
+
+## `BitOr` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:152 |
+
+## `RFromStr` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:336 |
+
+## `Deserializer` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:89 |
+
+## `FusedIterator` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:1668 |
+
+## `RAhoCorasickOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `AhoCorasick` | `` | concrete | 6 | miniextendr-api/src/optionals/aho_corasick_impl.rs:305 |
+
+## `Serializer` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RSerializer` | `` | concrete | 37 | miniextendr-api/src/serde/ser.rs:51 |
+
+## `AltListData` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `IterListData<I>` | `<I> +1wc` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:643 |
+
+## `RawStorageMut` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1230 |
+
+## `RDateTime` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `DateTime` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:663 |
+
+## `MatchArg` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `log::LevelFilter` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:283 |
+
+## `AltrepSexpExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/altrep_ext.rs:54 |
 
 ## `RDistributions` — 1 impls
 
@@ -3190,18 +3286,6 @@ Traits with impls: 190
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `BigUint` | `` | concrete | 10 | miniextendr-api/src/optionals/num_bigint_impl.rs:809 |
-
-## `AltListData` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `IterListData<I>` | `<I> +1wc` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:643 |
-
-## `AltrepSexpExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/altrep_ext.rs:54 |
 
 ## `RawStorage` — 1 impls
 
@@ -3341,11 +3425,23 @@ Traits with impls: 190
 |---|---|---|---|---|
 | `Date` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:836 |
 
+## `SexpExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::SEXP` | `` | concrete | 85 | miniextendr-api/src/sexp_ext.rs:457 |
+
 ## `RDeserialize` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:275 |
+
+## `AltList` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `IterListData<I>` | `<I>` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:687 |
 
 ## `RMatrixOps` — 1 impls
 
@@ -3370,87 +3466,3 @@ Traits with impls: 190
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:146 |
-
-## `RUrlOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Url` | `` | concrete | 12 | miniextendr-api/src/optionals/url_impl.rs:300 |
-
-## `RTomlOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `TomlValue` | `` | concrete | 16 | miniextendr-api/src/optionals/toml_impl.rs:624 |
-
-## `RZoned` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Zoned` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:782 |
-
-## `BitOr` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:152 |
-
-## `RFromStr` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:336 |
-
-## `Deserializer` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:89 |
-
-## `SexpExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `crate::SEXP` | `` | concrete | 85 | miniextendr-api/src/sexp_ext.rs:457 |
-
-## `FusedIterator` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:1668 |
-
-## `AltList` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `IterListData<I>` | `<I>` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:687 |
-
-## `RAhoCorasickOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `AhoCorasick` | `` | concrete | 6 | miniextendr-api/src/optionals/aho_corasick_impl.rs:305 |
-
-## `Serializer` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RSerializer` | `` | concrete | 37 | miniextendr-api/src/serde/ser.rs:51 |
-
-## `RawStorageMut` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1230 |
-
-## `RDateTime` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `DateTime` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:663 |
-
-## `MatchArg` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `log::LevelFilter` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:283 |

--- a/rust-llm-docs/generated/miniextendr-cli.md
+++ b/rust-llm-docs/generated/miniextendr-cli.md
@@ -1,5 +1,12 @@
 # miniextendr v0.1.0
 
+`miniextendr` — maintainer CLI for miniextendr-based R packages.
+
+Wraps the configure/install/document/vendor development loop in one
+binary (`miniextendr <command>`). This is a binary-only crate; the
+framework runtime lives in `miniextendr-api` and the scaffolding for
+end-user packages in the `minirextendr` R package.
+
 ---
 
 ## Structs

--- a/rust-llm-docs/generated/miniextendr-engine.md
+++ b/rust-llm-docs/generated/miniextendr-engine.md
@@ -107,7 +107,7 @@ Builder for configuring and initializing the R runtime.
 #### Example
 
 ```ignore
-let engine = REngine::new()
+let engine = REngine::build()
     .with_args(&["R", "--quiet", "--no-save"])
     .interactive(false)
     .signal_handlers(false)

--- a/rust-llm-docs/generated/miniextendr-lint.md
+++ b/rust-llm-docs/generated/miniextendr-lint.md
@@ -149,7 +149,7 @@ A single lint diagnostic with structured metadata.
 **Fields:**
 
 - `code`: `crate::lint_code::LintCode`
-  - Stable rule code (e.g. `MXL101`).
+  - Stable rule code (e.g. `MXL106`).
 - `severity`: `Severity`
   - Severity level.
 - `path`: `std::path::PathBuf`

--- a/rust-llm-docs/generated/miniextendr-macros.md
+++ b/rust-llm-docs/generated/miniextendr-macros.md
@@ -13,8 +13,9 @@ Primary macros and derives:
 - Helpers: `typed_list` for typed list builders.
 
 R wrapper generation is driven by Rust doc comments (roxygen tags are
-extracted). The `document` binary collects these wrappers and writes
-`R/miniextendr_wrappers.R` during package build.
+extracted). During package build, the cdylib link pass loads the crate
+into R and calls `miniextendr_write_wrappers`, which walks the linkme
+`#[distributed_slice]` tables and writes `R/<pkg>-wrappers.R`.
 
 ### Quick start
 


### PR DESCRIPTION
## Summary

- Regenerated all five workspace-crate LLM doc files (`miniextendr-api`, `-macros`, `-engine`, `-lint`, `-cli`) against current source — picks up all API changes since the last refresh
- Added **cargo-revendor** as a new entry: `generated/cargo-revendor.md` (22K) + `generated/cargo-revendor-impl-inventory.md` (2.8K), generated from its standalone workspace
- Updated `generate-miniextendr-docs.sh` with a `gen_revendor()` helper so future runs include cargo-revendor automatically

## What changed in the generated files

| File | Change |
|---|---|
| `cargo-revendor.md` | **New** — full API digest for the standalone binary crate |
| `cargo-revendor-impl-inventory.md` | **New** — trait impl inventory |
| `miniextendr-api-impl-inventory.md` | Updated — ~1 054 lines touched (new impls from recent PRs) |
| `conversion-impl-inventory.md` | Updated — 462 lines touched |
| `conversion-manual-vs-macro.md` | Updated — 267 lines touched |
| `miniextendr-cli.md` | Minor update (+7 lines) |
| `miniextendr-engine.md`, `-lint.md`, `-macros.md` | Minor updates |

## Test plan

- [ ] `bash rust-llm-docs/generate-miniextendr-docs.sh` runs clean end-to-end (including the new cargo-revendor step)
- [ ] `generated/cargo-revendor.md` is non-empty and contains expected symbols (`vendor`, `strip`, `metadata`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)