### PR TITLE
test(minirextendr): mirror CI version-check as a suite test (#914)

### DIFF
--- a/minirextendr/tests/testthat/test-version-consistency.R
+++ b/minirextendr/tests/testthat/test-version-consistency.R
@@ -1,0 +1,69 @@
+# Mirror of CI's version-check job: Cargo.toml [workspace.package] version must
+# equal rpkg/DESCRIPTION Version (X.Y.Z base, ignoring R dev suffixes like .9000).
+# Skipped when run outside the monorepo (e.g. installed-package context).
+# Closes #914.
+
+test_that("Cargo.toml workspace version matches rpkg/DESCRIPTION Version", {
+  skip_if_no_local_repo()
+
+  repo <- find_miniextendr_repo()
+
+  # --- Read Cargo.toml workspace.package version ----------------------------
+  cargo_toml <- file.path(repo, "Cargo.toml")
+  expect_true(file.exists(cargo_toml), info = "Cargo.toml not found at repo root")
+
+  lines <- readLines(cargo_toml)
+
+  # Find the [workspace.package] section and extract its version = "..." line.
+  # Replicate CI: sed -n '/\[workspace\.package\]/,/^\[/{ s/^version = "(.*)"/\1/p; }'
+  in_section <- FALSE
+  cargo_version <- NULL
+  for (line in lines) {
+    if (grepl("^\\[workspace\\.package\\]", line)) {
+      in_section <- TRUE
+      next
+    }
+    if (in_section && grepl("^\\[", line)) {
+      break  # reached next section
+    }
+    if (in_section) {
+      m <- regmatches(line, regexpr('^version = "([^"]+)"', line, perl = TRUE))
+      if (length(m) == 1L && nzchar(m)) {
+        cargo_version <- sub('^version = "([^"]+)"', "\\1", m, perl = TRUE)
+        break
+      }
+    }
+  }
+  expect_false(is.null(cargo_version),
+               info = "Could not find version in [workspace.package] section of Cargo.toml")
+
+  # --- Read rpkg/DESCRIPTION Version ----------------------------------------
+  desc_path <- file.path(repo, "rpkg", "DESCRIPTION")
+  expect_true(file.exists(desc_path), info = "rpkg/DESCRIPTION not found")
+
+  desc <- read.dcf(desc_path, fields = "Version")
+  r_version <- as.character(desc[1, "Version"])
+  expect_false(is.na(r_version), info = "Version field missing from rpkg/DESCRIPTION")
+
+  # --- Compare base X.Y.Z (allow R dev suffix X.Y.Z.9000 to match X.Y.Z) ---
+  strip_base <- function(v) {
+    m <- regmatches(v, regexpr("^[0-9]+\\.[0-9]+\\.[0-9]+", v, perl = TRUE))
+    if (length(m) == 0L || !nzchar(m)) NA_character_ else m
+  }
+
+  cargo_base <- strip_base(cargo_version)
+  r_base <- strip_base(r_version)
+
+  expect_false(is.na(cargo_base),
+               info = sprintf("Cargo.toml version '%s' is not X.Y.Z format", cargo_version))
+  expect_false(is.na(r_base),
+               info = sprintf("DESCRIPTION Version '%s' is not X.Y.Z format", r_version))
+
+  expect_equal(
+    cargo_base, r_base,
+    info = sprintf(
+      "Version mismatch: Cargo.toml [workspace.package] = %s, rpkg/DESCRIPTION = %s.\nRun: ./scripts/bump-version.sh %s",
+      cargo_version, r_version, cargo_version
+    )
+  )
+})

--- a/reviews/2026-06-11-disk-full-e2e-test-corruption.md
+++ b/reviews/2026-06-11-disk-full-e2e-test-corruption.md
@@ -1,0 +1,52 @@
+# Disk-full disguised as three different e2e test corruption bugs
+
+**Date**: 2026-06-11
+**Context**: implementing #914 (version-consistency testthat test); running
+`just minirextendr-test` in an agent worktree during an 8-agent parallel sprint.
+
+## What was attempted
+
+Full `just minirextendr-test` runs to validate a new (pure-R, no-compile) test
+file before opening a PR.
+
+## What went wrong
+
+Three consecutive runs failed in `test-templates.R` e2e build tests
+(lines 419/506/565) with *different* errors each time:
+
+1. `internal error 1 in R_decompress1 with libdeflate` /
+   `lazy-load database '.../mxroundtrip.rdb' is corrupt`
+2. `error[E0786]: found invalid metadata files for crate miniextendr_macros`
+   followed by a cascade of `unresolved imports crate::sys::*_unchecked`
+   (the proc-macro that generates the `_unchecked` variants failed to load)
+3. Finally the honest one: `rustc-LLVM ERROR: IO failure on output stream:
+   No space left on device`
+
+Failure set was non-deterministic across runs (1 failure, then 3, then 1),
+which initially looked like parallel-agent races on shared caches.
+
+## Root cause
+
+The disk was at 100% (246 MiB free; 884 Gi used). Truncated writes during
+`R CMD INSTALL` and cargo builds produced corrupt `.rdb` lazy-load databases
+and dylibs with invalid metadata. Errors 1 and 2 are *downstream corruption
+symptoms* — only the third run surfaced the actual ENOSPC. The multi-GB
+`target/` dirs in 4+ parallel agent worktrees plus temp-dir e2e builds
+(~1.2 GB in `$TMPDIR`) tipped it over.
+
+## Fix
+
+None in code — environmental. The new `test-version-consistency.R` is pure R
+(reads two text files) and unaffected; 526 suite tests pass apart from the
+disk-induced e2e flakes.
+
+## Lessons
+
+- `R_decompress1`/`lazy-load database is corrupt` and rustc
+  `invalid metadata files for crate` during *fresh* builds: check `df -h`
+  before chasing toolchain/race theories.
+- An `E0786 invalid metadata` on a proc-macro crate cascades into bogus
+  "unresolved import" errors for everything the macro generates — the first
+  error is the only meaningful one.
+- Multi-agent worktree sprints carry 2–3 GB of `target/` per agent
+  (CLAUDE.md already warns); budget disk before dispatching a fleet.


### PR DESCRIPTION
Adds a `minirextendr` testthat test mirroring CI's `version-check` job — `Cargo.toml [workspace.package]` version must equal `rpkg/DESCRIPTION` Version (stripped to `X.Y.Z`, so R dev suffixes like `X.Y.Z.9000` match) — so local test runs catch drift before push. The CI job stays in place; this is additive. Closes #914.

<details><summary>🤖 AI-written implementation notes</summary>

## What

- `minirextendr/tests/testthat/test-version-consistency.R` — one `test_that()` that:
  - locates the monorepo root via the existing `find_miniextendr_repo()` helper and skips via `skip_if_no_local_repo()` outside the monorepo (installed-package context);
  - extracts `version = "..."` from the `[workspace.package]` section of the root `Cargo.toml` with a section-scoped line scan (stops at the next `[` header), replicating CI's `sed -n '/\[workspace\.package\]/,/^\[/{...}'` semantics — it cannot pick up a crate's `[package]` version;
  - reads `rpkg/DESCRIPTION` `Version:` via `read.dcf()`;
  - strips both to `X.Y.Z` with `^[0-9]+\.[0-9]+\.[0-9]+` (same rule as the job's `grep -oE`), so `0.1.0.9000` matches `0.1.0`;
  - on mismatch, fails with the same remediation hint as CI: `Run: ./scripts/bump-version.sh <cargo_version>`.
- `reviews/2026-06-11-disk-full-e2e-test-corruption.md` — post-mortem (house convention): during validation, a full disk (ENOSPC, 246 MiB free) masqueraded as three *different* e2e failures in `test-templates.R` (corrupt lazy-load `.rdb`, `E0786 invalid metadata` on the macros crate cascading into bogus unresolved-import errors, and finally the honest `No space left on device`). Unrelated to this change.

## Test evidence

- Targeted run: `testthat::test_file("minirextendr/tests/testthat/test-version-consistency.R")` → 7 expectations pass, 0 fail.
- Negative check (fake repo via `MINIEXTENDR_LOCAL_PATH`): `0.2.0` vs `0.1.0.9000` → fails with the mismatch + bump-version message; `0.1.0` vs `0.1.0.9000` → passes (dev-suffix rule verified).
- Full `just minirextendr-test`: `[ FAIL 1 | WARN 2 | SKIP 3 | PASS 526 ]` — the single failure is the disk-full e2e corruption in `test-templates.R:565` documented in the review file (non-deterministic across runs; pure-R test here cannot affect compiled e2e builds).

## Scope

Deliberately a small, single-test PR per the issue. No Rust changes, no wrapper regen, CI `version-check` job untouched.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)