### PR TITLE
feat(build): robust Cargo-driven tools/detect-features.R + template copies (#502)

### DIFF
--- a/justfile
+++ b/justfile
@@ -895,6 +895,7 @@ templates-sources:
     rpkg/Makevars.in	rpkg/src/Makevars.in
     rpkg/Makevars.win	rpkg/src/Makevars.win
     rpkg/stub.c	rpkg/src/stub.c
+    rpkg/tools/detect-features.R	rpkg/tools/detect-features.R
     rpkg/tools/lock-shape-check.R	rpkg/tools/lock-shape-check.R
     rpkg/win.def.in	rpkg/src/win.def.in
     # === Monorepo Template (monorepo/) ===
@@ -911,6 +912,7 @@ templates-sources:
     monorepo/rpkg/Makevars.in	rpkg/src/Makevars.in
     monorepo/rpkg/Makevars.win	rpkg/src/Makevars.win
     monorepo/rpkg/stub.c	rpkg/src/stub.c
+    monorepo/rpkg/tools/detect-features.R	rpkg/tools/detect-features.R
     monorepo/rpkg/tools/lock-shape-check.R	rpkg/tools/lock-shape-check.R
     monorepo/rpkg/win.def.in	rpkg/src/win.def.in
     EOF

--- a/minirextendr/inst/templates/monorepo/rpkg/tools/detect-features.R
+++ b/minirextendr/inst/templates/monorepo/rpkg/tools/detect-features.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
+# Configure-time Cargo feature detection for {{package}}.
 #
 # Contract
 # --------

--- a/minirextendr/inst/templates/rpkg/tools/detect-features.R
+++ b/minirextendr/inst/templates/rpkg/tools/detect-features.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
+# Configure-time Cargo feature detection for {{package}}.
 #
 # Contract
 # --------

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-06-08 20:42:00
-+++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
+--- a/monorepo/rpkg/bootstrap.R	2026-06-11 23:06:08
++++ b/monorepo/rpkg/bootstrap.R	2026-06-11 23:06:08
 @@ -1,40 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -83,8 +83,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -  }
  }
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-06-10 01:05:07
-+++ b/monorepo/rpkg/configure.ac	2026-06-10 01:05:07
+--- a/monorepo/rpkg/configure.ac	2026-06-11 23:09:12
++++ b/monorepo/rpkg/configure.ac	2026-06-11 23:06:08
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -183,7 +183,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +  dnl CARGO_FEATURES not set - auto-detect via R script if available
    if test -f "${srcdir}/tools/detect-features.R"; then
      CARGO_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
-@@ -143,8 +93,9 @@
+@@ -143,15 +93,9 @@
        AC_MSG_NOTICE([Auto-detected features: $CARGO_FEATURES])
      fi
 +  else
@@ -192,17 +192,24 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +    CARGO_FEATURES=""
    fi
 -  if test -z "$CARGO_FEATURES"; then
--    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log"
+-    dnl Fallback list (used when tools/detect-features.R is absent or errors).
+-    dnl Kept in sync with what detect-features.R enables on a fully-equipped
+-    dnl machine: every optional integration feature, plus connections and jiff.
+-    dnl Excludes meta/aggregate (default, full), risky (nonapi), dev/diagnostic
+-    dnl (macro-coverage, growth-debug), the #[miniextendr] option defaults
+-    dnl (strict-default, coerce-default), the class-system selectors
+-    dnl (r6-default, s7-default), worker-default, and indicatif.
+-    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,jiff,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log,connections"
 -  fi
  fi
  
-@@ -184,4 +135,5 @@
+@@ -191,4 +135,5 @@
  
  dnl Check minimum rustc version (edition 2024 requires rustc 1.85+)
 +dnl Extract version number: "rustc 1.85.0 (..." -> "1.85.0"
  RUSTC_VERSION_NUM=`echo "$RUSTC_VERSION" | "$SED" 's/rustc \(@<:@0-9@:>@*\.@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
  RUSTC_MAJOR=`echo "$RUSTC_VERSION_NUM" | cut -d. -f1`
-@@ -232,11 +184,16 @@
+@@ -239,11 +184,16 @@
  dnl CARGO_BUILD_TARGET is AC_SUBST'd later in the Cargo target/profile section.
  
 +dnl Convenience: cargo command that includes optional toolchain selector
@@ -219,13 +226,13 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl These are used in .cargo/config.toml which Cargo reads directly
  CARGO_TARGET_DIR_CARGO="$abs_top_srcdir_cargo/rust-target"
  AC_SUBST([CARGO_TARGET_DIR_CARGO])
-@@ -244,4 +201,5 @@
+@@ -251,4 +201,5 @@
  AC_ARG_VAR([CARGO_PROFILE], [Cargo build profile (dev or release)])
  : ${CARGO_PROFILE="release"}
 +dnl Map legacy 'debug' → 'dev' (cargo rejects --profile debug)
  if test "$CARGO_PROFILE" = "debug"; then
    AC_MSG_WARN([CARGO_PROFILE=debug is invalid for cargo; using 'dev' instead])
-@@ -250,4 +208,7 @@
+@@ -257,4 +208,7 @@
  AC_SUBST([CARGO_PROFILE])
  
 +dnl Cargo output directory differs from profile name:
@@ -233,7 +240,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -256,25 +217,21 @@
+@@ -263,25 +217,21 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -271,7 +278,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl position-independent by default, so it was a no-op. See miniextendr #745.)
  if test "$is_wasm_install" = true; then
    ENV_RUSTFLAGS="$ENV_RUSTFLAGS -Zdefault-visibility=hidden"
-@@ -302,4 +259,8 @@
+@@ -309,4 +259,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -280,7 +287,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -309,21 +270,29 @@
+@@ -316,21 +270,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -320,7 +327,7 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -342,18 +311,20 @@
+@@ -349,18 +311,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -350,20 +357,20 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -582,4 +553,5 @@
+@@ -589,4 +553,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -812,5 +784,5 @@
+@@ -819,5 +784,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -828,13 +800,22 @@
+@@ -835,13 +800,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -388,9 +395,18 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl caused warnings on Linux. See #157, #158.
  
  AC_OUTPUT
+diff -ruN -U2 a/monorepo/rpkg/tools/detect-features.R b/monorepo/rpkg/tools/detect-features.R
+--- a/monorepo/rpkg/tools/detect-features.R	2026-06-11 23:08:24
++++ b/monorepo/rpkg/tools/detect-features.R	2026-06-11 23:31:56
+@@ -1,4 +1,4 @@
+ #!/usr/bin/env Rscript
+-# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
++# Configure-time Cargo feature detection for {{package}}.
+ #
+ # Contract
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-06-10 01:05:07
-+++ b/rpkg/configure.ac	2026-06-10 01:05:07
+--- a/rpkg/configure.ac	2026-06-11 23:09:12
++++ b/rpkg/configure.ac	2026-06-11 23:06:08
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -435,7 +451,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +  dnl CARGO_FEATURES not set - auto-detect via R script if available
    if test -f "${srcdir}/tools/detect-features.R"; then
      CARGO_FEATURES=$("${R_HOME}/bin/Rscript" "${srcdir}/tools/detect-features.R" 2>/dev/null || echo "")
-@@ -143,8 +145,9 @@
+@@ -143,15 +145,9 @@
        AC_MSG_NOTICE([Auto-detected features: $CARGO_FEATURES])
      fi
 +  else
@@ -444,17 +460,24 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +    CARGO_FEATURES=""
    fi
 -  if test -z "$CARGO_FEATURES"; then
--    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log"
+-    dnl Fallback list (used when tools/detect-features.R is absent or errors).
+-    dnl Kept in sync with what detect-features.R enables on a fully-equipped
+-    dnl machine: every optional integration feature, plus connections and jiff.
+-    dnl Excludes meta/aggregate (default, full), risky (nonapi), dev/diagnostic
+-    dnl (macro-coverage, growth-debug), the #[miniextendr] option defaults
+-    dnl (strict-default, coerce-default), the class-system selectors
+-    dnl (r6-default, s7-default), worker-default, and indicatif.
+-    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,jiff,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log,connections"
 -  fi
  fi
  
-@@ -184,4 +187,5 @@
+@@ -191,4 +187,5 @@
  
  dnl Check minimum rustc version (edition 2024 requires rustc 1.85+)
 +dnl Extract version number: "rustc 1.85.0 (..." -> "1.85.0"
  RUSTC_VERSION_NUM=`echo "$RUSTC_VERSION" | "$SED" 's/rustc \(@<:@0-9@:>@*\.@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
  RUSTC_MAJOR=`echo "$RUSTC_VERSION_NUM" | cut -d. -f1`
-@@ -232,11 +236,16 @@
+@@ -239,11 +236,16 @@
  dnl CARGO_BUILD_TARGET is AC_SUBST'd later in the Cargo target/profile section.
  
 +dnl Convenience: cargo command that includes optional toolchain selector
@@ -471,13 +494,13 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl These are used in .cargo/config.toml which Cargo reads directly
  CARGO_TARGET_DIR_CARGO="$abs_top_srcdir_cargo/rust-target"
  AC_SUBST([CARGO_TARGET_DIR_CARGO])
-@@ -244,4 +253,5 @@
+@@ -251,4 +253,5 @@
  AC_ARG_VAR([CARGO_PROFILE], [Cargo build profile (dev or release)])
  : ${CARGO_PROFILE="release"}
 +dnl Map legacy 'debug' → 'dev' (cargo rejects --profile debug)
  if test "$CARGO_PROFILE" = "debug"; then
    AC_MSG_WARN([CARGO_PROFILE=debug is invalid for cargo; using 'dev' instead])
-@@ -250,4 +260,7 @@
+@@ -257,4 +260,7 @@
  AC_SUBST([CARGO_PROFILE])
  
 +dnl Cargo output directory differs from profile name:
@@ -485,7 +508,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl   --profile release → target/release/
  if test "$CARGO_PROFILE" = "dev"; then
    CARGO_PROFILE_DIR="debug"
-@@ -256,25 +269,21 @@
+@@ -263,25 +269,21 @@
  fi
  
 +dnl CARGO_STATICLIB_NAME is set after pkg_rs is computed (see below)
@@ -523,7 +546,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl position-independent by default, so it was a no-op. See miniextendr #745.)
  if test "$is_wasm_install" = true; then
    ENV_RUSTFLAGS="$ENV_RUSTFLAGS -Zdefault-visibility=hidden"
-@@ -302,4 +311,8 @@
+@@ -309,4 +311,8 @@
  AC_SUBST([CARGO_BUILD_TARGET])
  
 +dnl Compute Cargo libdir path:
@@ -532,7 +555,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl Note: CARGO_PROFILE_DIR maps dev→debug, release→release
  if test -n "$CARGO_BUILD_TARGET"; then
    CARGO_LIBDIR="$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/$CARGO_PROFILE_DIR"
-@@ -309,21 +322,29 @@
+@@ -316,21 +322,29 @@
  AC_SUBST([CARGO_LIBDIR])
  
 -AC_MSG_NOTICE([R_HOME               = $R_HOME])
@@ -572,7 +595,7 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl MSYS2/MinGW tar interprets D: in paths as remote host — --force-local fixes this
  case "$host_os" in
    *msys*|*cygwin*|*mingw*) TAR_FORCE_LOCAL="--force-local" ;;
-@@ -342,18 +363,20 @@
+@@ -349,18 +363,20 @@
  
  dnl ---- Native R package include paths (for bindgen C shim compilation) ----
 +dnl Populated by minirextendr::use_native_package(). Each native package
@@ -602,20 +625,20 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl as CARGO_TARGET_DIR above).
  VENDOR_OUT="$abs_top_srcdir/vendor"
  VENDOR_OUT_CARGO="$abs_top_srcdir_cargo/vendor"
-@@ -582,4 +605,5 @@
+@@ -589,4 +605,5 @@
  
  dnl ---- output files ----
 +dnl Create .cargo directory (it's a hidden dir not included in tarball)
  dnl AC_CONFIG_FILES handles Makevars and the win.def. The cargo config is
  dnl written by AC_CONFIG_COMMANDS below because its contents differ across
-@@ -812,5 +836,5 @@
+@@ -819,5 +836,5 @@
      if test "$CARGO_MAJOR" -lt 1 || \
         (test "$CARGO_MAJOR" -eq 1 && test "$CARGO_MINOR" -lt 78); then
 -      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating" >&2
 +      echo "configure: WARNING: cargo $CARGO_VERSION cannot read Cargo.lock v$LOCKFILE_VERSION; regenerating lockfile" >&2
        rm -f "$LOCKFILE_PATH"
        $CARGO_CMD generate-lockfile --manifest-path src/rust/Cargo.toml $CARGO_OFFLINE_FLAG
-@@ -828,13 +852,22 @@
+@@ -835,13 +852,22 @@
  AC_CONFIG_COMMANDS([post-config],
  [
 +  dnl Ensure Cargo.lock exists (needed by cargo for reproducible builds)
@@ -640,3 +663,12 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl caused warnings on Linux. See #157, #158.
  
  AC_OUTPUT
+diff -ruN -U2 a/rpkg/tools/detect-features.R b/rpkg/tools/detect-features.R
+--- a/rpkg/tools/detect-features.R	2026-06-11 23:08:24
++++ b/rpkg/tools/detect-features.R	2026-06-11 23:31:56
+@@ -1,4 +1,4 @@
+ #!/usr/bin/env Rscript
+-# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
++# Configure-time Cargo feature detection for {{package}}.
+ #
+ # Contract

--- a/reviews/2026-06-12-mxroundtrip-rdb-corrupt-flake.md
+++ b/reviews/2026-06-12-mxroundtrip-rdb-corrupt-flake.md
@@ -1,0 +1,31 @@
+# test-templates.R:565 — mxroundtrip lazy-load .rdb "corrupt" failure (pre-existing)
+
+**What was attempted**: full `just minirextendr-test` run while implementing #502
+(tools/detect-features.R). One failure in the standalone e2e test that scaffolds,
+builds, and installs a throwaway `mxroundtrip` package.
+
+**What went wrong**: `miniextendr_build(pkg_path, install = TRUE)` →
+`devtools::document` → `pkgload::load_all` → `pkgload::unregister` fails with:
+
+```
+internal error 1 in R_decompress1 with libdeflate
+Error in env_get_list(...): lazy-load database '.../library/mxroundtrip/R/mxroundtrip.rdb' is corrupt
+```
+
+First seen alongside a genuine disk-full event (`ld: write() failed, errno=28`,
+disk at 98% / 256Mi free from parallel agent worktrees). But the .rdb failure
+**reproduced twice more with 19Gi free**, including once on **clean origin/main
+with all working-tree changes stashed** — so it is a pre-existing flake/regression
+on main, unrelated to #502.
+
+**Root cause**: not fully diagnosed. The install completes (`* DONE (mxroundtrip)`),
+then the *subsequent* `devtools::document` in the same session unloads the
+namespace and hits the corrupt lazy-load db. Suspects: R 4.6.0's libdeflate-backed
+`R_decompress1` reading an .rdb written by a staged install moments earlier,
+or pkgload unregister racing the freshly-installed lazy-load db. The remaining
+55 templates tests (and 519/520 of the full suite) pass.
+
+**Fix**: none in this PR (out of scope for #502); tracked as a follow-up issue.
+If it bites again: check whether `mxroundtrip.rdb` is truncated (size 0 / short)
+vs genuinely mis-compressed, and whether retrying `document()` in a fresh R
+session passes.

--- a/rpkg/configure
+++ b/rpkg/configure
@@ -2075,7 +2075,7 @@ printf '%s\n' "$as_me: Auto-detected features: $CARGO_FEATURES" >&6;}
     fi
   fi
   if test -z "$CARGO_FEATURES"; then
-    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log"
+                                CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,jiff,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log,connections"
   fi
 fi
 

--- a/rpkg/configure.ac
+++ b/rpkg/configure.ac
@@ -144,7 +144,14 @@ if test -z "${CARGO_FEATURES+x}"; then
     fi
   fi
   if test -z "$CARGO_FEATURES"; then
-    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log"
+    dnl Fallback list (used when tools/detect-features.R is absent or errors).
+    dnl Kept in sync with what detect-features.R enables on a fully-equipped
+    dnl machine: every optional integration feature, plus connections and jiff.
+    dnl Excludes meta/aggregate (default, full), risky (nonapi), dev/diagnostic
+    dnl (macro-coverage, growth-debug), the #[miniextendr] option defaults
+    dnl (strict-default, coerce-default), the class-system selectors
+    dnl (r6-default, s7-default), worker-default, and indicatif.
+    CARGO_FEATURES="worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,jiff,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,arrow,datafusion,log,connections"
   fi
 fi
 


### PR DESCRIPTION
Replaces the static hand-maintained `rpkg/tools/detect-features.R` with a robust Cargo-driven configure-time detection script, syncs the `configure.ac` fallback list with it, and adds the two minirextendr template copies with templates-approve sync. Closes #502.

<details><summary>🤖 AI-written implementation notes</summary>

## What changed

- **`rpkg/tools/detect-features.R`** (rewritten): parses `[features]` from `src/rust/Cargo.toml` (base R only — runs at `./configure` time on end-user machines with no package library), enables everything minus a principled denylist, then applies conditional rules:
  - Denylist (never auto-enabled): `default`/`full` (meta/aggregate), `nonapi` (R CMD check non-API WARNINGs), `macro-coverage`/`growth-debug` (dev/diagnostic), `strict-default`/`coerce-default`/`r6-default`/`s7-default`/`worker-default` (opt-in codegen semantics; r6/s7 are mutually exclusive so neither is auto-picked), `indicatif` (not in the default integration set).
  - Conditional: `vctrs` ⇔ `requireNamespace("vctrs", quietly = TRUE)`; `connections` ⇔ R >= 4.3 (`R_new_custom_connection` API floor).
  - Contract (documented in the header): single comma-separated feature string on stdout, all diagnostics to stderr, any internal failure → empty stdout + nonzero exit so configure's `2>/dev/null || echo ""` wrapper falls back to the hardcoded list. Cargo.toml is resolved relative to the script's own path, so it works regardless of cwd.
- **`rpkg/configure.ac`** (+ regenerated `configure`, same autoconf 2.73, 1-line delta): fallback list synced to the script's fully-equipped output — adds `jiff` and `connections`, which the previous committed script already enabled but the fallback had silently drifted from. Exclusion rationale documented inline.
- **Templates**: `minirextendr/inst/templates/{rpkg,monorepo}/rpkg/tools/detect-features.R` added (identical modulo `{{package}}` header), registered in the `templates-sources` manifest in the justfile, and `patches/templates.patch` regenerated via `just templates-approve`. `just templates-check` passes.
- **`reviews/2026-06-12-mxroundtrip-rdb-corrupt-flake.md`**: post-mortem for a pre-existing test failure found during verification (below).

## Detected vs fallback on this machine

`Rscript tools/detect-features.R` → 35 features, exactly equal (as a set) to the updated configure.ac fallback. With an empty R library (vctrs absent) the script correctly drops `vctrs` with a stderr diagnostic; with the script placed where no Cargo.toml is reachable it prints nothing and exits 1, and the simulated configure capture (`2>/dev/null || echo ""`) yields the empty string → fallback path.

## Test evidence

- `just configure`: logs `Auto-detected features: …` (35 features) and writes them into Makevars.
- `just rcmdinstall`: full release build of rpkg with the detected feature set (incl. arrow/datafusion/jiff/connections/vctrs) — exit 0; installed package loads (`library(miniextendr)` from the worktree rv library).
- `just templates-approve` + `just templates-check`: pass.
- `just minirextendr-test`: **519 PASS / 1 FAIL** — the failure is `test-templates.R:565` (standalone e2e mxroundtrip build): `lazy-load database … mxroundtrip.rdb is corrupt` / `internal error 1 in R_decompress1 with libdeflate`. Reproduced on **clean origin/main with this branch's changes stashed**, so it is pre-existing and unrelated; first sighting coincided with a disk-full event but persists with 19Gi free. Tracked in #1000 with a post-mortem in `reviews/`. All feature-detection tests (`test-feature-detect-configure.R`) pass.
- No Rust touched — fmt/clippy not applicable.

## Follow-up issues

- #1000 — pre-existing `test-templates.R:565` mxroundtrip `.rdb` corrupt flake (R 4.6 / libdeflate).
- #1001 — unify minirextendr's marker-based `generate_empty_detect_script()` machinery with this robust Cargo-driven design (the #502 plan preferred one design; rewriting the tested `add_feature_rule()` subsystem was out of scope here).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)