### PR TITLE
test(minirextendr): single-pass export + FORCE_WRAPPER_GEN propagation round-trips (#898, #911)

### DIFF
--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -212,6 +212,16 @@ miniextendr_build <- function(path = ".", install = TRUE) {
 # against a leaked tarball installs stale wrappers and library() exposes no
 # functions. The prior value is restored on exit so the override doesn't leak
 # into the rest of the R session.
+#
+# reload = FALSE: do NOT reload the freshly-installed package into the building
+# session. The default (reload = TRUE) re-registers the package's namespace from
+# its just-written installed image; the subsequent devtools::document() then runs
+# pkgload::load_all(), whose unregister() step reads that installed namespace's
+# lazy-load DB (R/<pkg>.rdb). On R >= 4.6 (libdeflate-compressed .rdb) that read
+# can fail with "internal error 1 in R_decompress1 with libdeflate" / "lazy-load
+# database is corrupt", aborting the build. The build session never needs the
+# package loaded — document() works from source — so reloading is both pointless
+# and the trigger. Skipping it makes the install -> document hand-off robust.
 install_pkg <- function(pkg_path) {
   old_force <- Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = NA)
   Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = "1")
@@ -221,7 +231,7 @@ install_pkg <- function(pkg_path) {
     add = TRUE
   )
   tryCatch(
-    devtools::install(pkg_path, upgrade = FALSE, quiet = FALSE),
+    devtools::install(pkg_path, upgrade = FALSE, quiet = FALSE, reload = FALSE),
     error = function(e) {
       cli::cli_abort(c(
         "Package installation failed",
@@ -309,7 +319,8 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
   )
 
   tryCatch(
-    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
+    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE,
+                      reload = FALSE),
     error = function(e) {
       cli::cli_abort(c(
         "Bootstrap install failed",
@@ -333,7 +344,8 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
   # MINIEXTENDR_FORCE_WRAPPER_GEN is still set via on.exit above.
   devtools::document(pkg_path)
   tryCatch(
-    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE),
+    devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE,
+                      reload = FALSE),
     error = function(e) {
       cli::cli_abort(c(
         "Bootstrap re-install (after document) failed",

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -588,3 +588,199 @@ test_that("standalone scaffolding builds in tarball mode and exposes functions",
     detach(paste0("package:", pkg_name), character.only = TRUE, unload = TRUE)
   })
 })
+
+# -----------------------------------------------------------------------------
+# miniextendr_build() single-pass export round-trip (#898, fix for #860)
+# -----------------------------------------------------------------------------
+
+# Regression for #860 / #898: adding a brand-new #[miniextendr] export must be
+# visible via library(pkg) after a SINGLE miniextendr_build() pass. The bug
+# (#860) was an ordering hazard: the wrappers file is generated *during* install,
+# and document() reads its @export tags to (re)write NAMESPACE, but install
+# collated NAMESPACE *before* document() rewrote it — so the freshly-installed
+# image lagged the on-disk NAMESPACE by one build and the new export was missing
+# until a second build. The fix snapshots NAMESPACE before/after document() and
+# reinstalls once iff it changed.
+#
+# This bug only manifests in the installed image's export set, so the assertion
+# is on getNamespaceExports() (a behavioural check) — a source-grep / deparse()
+# structural test is explicitly rejected as theater (see the brittle-deparse
+# memory rule and the dropped #523 structural test). Reproducing it requires a
+# full scaffold + cargo build + R CMD INSTALL round-trip, hence the e2e gate.
+#
+# Uses the local-repo monorepo scaffold (offline; the root `.git` keeps configure
+# in source mode so no auto-vendor / tarball-mode dance is needed), then drives
+# the real miniextendr_build() once — exercising the actual single-pass logic
+# rather than the manual generate_r_wrappers() + install_to_templib() helpers.
+test_that("miniextendr_build() exports a newly added function in a single pass (#898)", {
+  skip_e2e()
+  miniextendr_path <- find_miniextendr_repo()
+
+  tmp <- tempfile("single-pass-export-")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  suppressMessages({
+    create_miniextendr_monorepo(tmp, package = "spexport", crate_name = "spexport-rs",
+                                local_path = miniextendr_path, open = FALSE)
+  })
+  rpkg_path <- file.path(tmp, "spexport")
+
+  # The scaffold's root `.git` makes configure stay in source mode, but the
+  # monorepo's crates.io deps still need vendoring for the offline build (mirrors
+  # the monorepo e2e test above). The miniextendr framework crates are already
+  # vendored by the scaffolder.
+  suppressWarnings({
+    withr::with_dir(rpkg_path, {
+      system2("cargo", c("vendor", "--manifest-path", "src/rust/Cargo.toml", "vendor"),
+              stdout = FALSE, stderr = FALSE)
+    })
+  })
+
+  # Add a brand-new exported function whose name differs from the scaffold's
+  # add/hello, so document() produces a *new* @export — the exact shape of the
+  # #860 bug. Insert it just after the `use miniextendr_api` line.
+  lib_rs <- file.path(rpkg_path, "src", "rust", "lib.rs")
+  lib_content <- readLines(lib_rs)
+  use_idx <- grep("use miniextendr_api", lib_content)[1]
+  lib_content <- append(lib_content, c(
+    "",
+    "/// A function added after the initial scaffold.",
+    "/// @param x A number",
+    "/// @return x doubled",
+    "#[miniextendr]",
+    "pub fn mx_new_fn(x: f64) -> f64 {",
+    "    x * 2.0",
+    "}"
+  ), after = use_idx)
+  writeLines(lib_content, lib_rs)
+
+  # Install the throwaway package into a temp library so the dev/CI base library
+  # stays clean: miniextendr_build(install = TRUE) lands in .libPaths()[1].
+  templib <- file.path(tmp, "library")
+  dir.create(templib)
+
+  withr::with_libpaths(templib, action = "prefix", {
+    # The single pass under test. If #860 regresses, this build collates the
+    # stale NAMESPACE and mx_new_fn won't be in the installed image.
+    suppressMessages(
+      miniextendr_build(rpkg_path, install = TRUE)
+    )
+
+    # Behavioural assertion: the installed image's export set, not the source.
+    exports <- getNamespaceExports("spexport")
+    expect_true("mx_new_fn" %in% exports,
+                info = paste0(
+                  "mx_new_fn missing from getNamespaceExports() after a single ",
+                  "miniextendr_build() — #860 single-pass export regression. ",
+                  "Exports: ", paste(exports, collapse = ", ")
+                ))
+
+    # And it actually resolves + runs (the wrapper is wired, not just named).
+    expect_true(exists("mx_new_fn", envir = asNamespace("spexport")))
+    expect_equal(spexport::mx_new_fn(21), 42)
+
+    detach("package:spexport", character.only = TRUE, unload = TRUE)
+  })
+})
+
+# -----------------------------------------------------------------------------
+# MINIEXTENDR_FORCE_WRAPPER_GEN propagation into nested R CMD INSTALL (#911)
+# -----------------------------------------------------------------------------
+
+# Regression for #911. install_pkg() forces the cdylib wrapper-gen pass by
+# setting MINIEXTENDR_FORCE_WRAPPER_GEN=1 in the R *session* before calling
+# devtools::install(build = TRUE). #911 flagged as unverified whether that
+# in-session override survives the two subprocess hops (R CMD build -> R CMD
+# INSTALL -> make) down to Makevars.in, which is where the var is actually read
+# ([ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]). If it didn't propagate, a stale /
+# leaked-tarball build could silently ship outdated wrappers.
+#
+# Empirical finding (2026-06-11): it DOES propagate. devtools::install ->
+# pkgbuild -> callr::rcmd_safe inherits the parent R session's full environment
+# and merely *merges* rcmd_safe_env() on top (it does not replace the
+# environment), so a session Sys.setenv() reaches the make recipe two hops down.
+# No propagation fix was needed; this test locks the guarantee so a future callr/
+# pkgbuild change that sanitised the child environment would be caught.
+#
+# The probe is a minimal C package (no Rust) with a Makevars that records the
+# value of $MINIEXTENDR_FORCE_WRAPPER_GEN seen by the make recipe. It is fast
+# (one tiny C compile) but still needs build tools and a real build = TRUE
+# install, so it is skipped on CRAN.
+test_that("MINIEXTENDR_FORCE_WRAPPER_GEN propagates through install(build = TRUE) into make (#911)", {
+  testthat::skip_on_cran()
+  skip_if_not(nzchar(Sys.which("make")), "make not available")
+  skip_if_not(requireNamespace("devtools", quietly = TRUE), "devtools not available")
+  # A working C toolchain is required for R CMD build/INSTALL of the probe pkg.
+  skip_if_not(pkgbuild::has_build_tools(debug = FALSE), "C build tools not available")
+
+  tmp <- tempfile("force-propagate-")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  dir.create(tmp)
+
+  pkg_path <- file.path(tmp, "fwgprobe")
+  dir.create(file.path(pkg_path, "src"), recursive = TRUE)
+  dir.create(file.path(pkg_path, "R"))
+
+  writeLines(c(
+    "Package: fwgprobe",
+    "Title: Force-Wrapper-Gen Propagation Probe",
+    "Version: 0.0.0.9000",
+    "Authors@R: person(\"Test\", \"Author\", email = \"test@example.com\", role = c(\"aut\", \"cre\"))",
+    "Description: Records the MINIEXTENDR_FORCE_WRAPPER_GEN value seen by make.",
+    "License: MIT + file LICENSE",
+    "Encoding: UTF-8"
+  ), file.path(pkg_path, "DESCRIPTION"))
+  writeLines(c("YEAR: 2026", "COPYRIGHT HOLDER: Test Author"),
+             file.path(pkg_path, "LICENSE"))
+  writeLines(character(), file.path(pkg_path, "NAMESPACE"))
+
+  # A trivial C source so R's build system produces a SHLIB (drives make).
+  writeLines("#include <R.h>\nvoid fwgprobe_noop(void) {}",
+             file.path(pkg_path, "src", "dummy.c"))
+
+  # Makevars: before building the SHLIB, record the env var the recipe sees.
+  # `$$` escapes make's expansion so the shell reads the actual environment —
+  # exactly how rpkg's Makevars.in tests it. The result path is passed through
+  # the environment to dodge make/shell quoting of the temp path.
+  result_file <- file.path(tmp, "fwg_seen.txt")
+  Sys.setenv(FWG_RESULT_FILE = result_file)
+  on.exit(Sys.unsetenv("FWG_RESULT_FILE"), add = TRUE)
+  writeLines(c(
+    "$(SHLIB): fwg_probe",
+    "fwg_probe:",
+    "\t@echo \"[$$MINIEXTENDR_FORCE_WRAPPER_GEN]\" > \"$$FWG_RESULT_FILE\""
+  ), file.path(pkg_path, "src", "Makevars"))
+
+  templib <- file.path(tmp, "library")
+  dir.create(templib)
+
+  run_build_install <- function() {
+    unlink(result_file)
+    withr::with_libpaths(templib, action = "prefix", {
+      suppressMessages(
+        devtools::install(pkg_path, build = TRUE, upgrade = FALSE,
+                          quiet = TRUE, reload = FALSE)
+      )
+    })
+    skip_if_not(file.exists(result_file),
+                "probe Makevars did not run (no SHLIB build on this platform)")
+    trimws(readLines(result_file, warn = FALSE)[1])
+  }
+
+  # When set in the session, the make recipe two hops down must see it.
+  old_force <- Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = NA)
+  on.exit(
+    if (is.na(old_force)) Sys.unsetenv("MINIEXTENDR_FORCE_WRAPPER_GEN")
+    else Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = old_force),
+    add = TRUE
+  )
+
+  Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = "1")
+  expect_equal(run_build_install(), "[1]",
+               info = "session MINIEXTENDR_FORCE_WRAPPER_GEN=1 did not reach the nested make recipe (#911 propagation regression)")
+
+  # And when unset, the recipe must see it empty (so the guard would skip).
+  Sys.unsetenv("MINIEXTENDR_FORCE_WRAPPER_GEN")
+  expect_equal(run_build_install(), "[]",
+               info = "unset MINIEXTENDR_FORCE_WRAPPER_GEN leaked a non-empty value into the nested make recipe")
+})

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -754,13 +754,19 @@ test_that("MINIEXTENDR_FORCE_WRAPPER_GEN propagates through install(build = TRUE
   templib <- file.path(tmp, "library")
   dir.create(templib)
 
+  pak_cache_dir <- file.path(tmp, "pak_cache")
+  dir.create(pak_cache_dir, showWarnings = FALSE)
+
   run_build_install <- function() {
     unlink(result_file)
-    withr::with_libpaths(templib, action = "prefix", {
-      suppressMessages(
-        devtools::install(pkg_path, build = TRUE, upgrade = FALSE,
-                          quiet = TRUE, reload = FALSE)
-      )
+    withr::with_envvar(list(R_USER_CACHE_DIR = pak_cache_dir), {
+      withr::with_libpaths(templib, action = "prefix", {
+        suppressMessages(
+          devtools::install(pkg_path, build = TRUE, upgrade = FALSE,
+                            quiet = TRUE, reload = FALSE,
+                            dependencies = FALSE)
+        )
+      })
     })
     skip_if_not(file.exists(result_file),
                 "probe Makevars did not run (no SHLIB build on this platform)")

--- a/reviews/2026-06-11-build-document-reload-libdeflate-corrupt.md
+++ b/reviews/2026-06-11-build-document-reload-libdeflate-corrupt.md
@@ -1,0 +1,51 @@
+# miniextendr_build(): document() after install corrupts under R 4.6 libdeflate — root cause was devtools reload
+
+**Date**: 2026-06-11
+**Context**: adding the #898 single-pass-export e2e test, which drives the real
+`miniextendr_build()` against a temp-libpath monorepo scaffold.
+
+## What was attempted
+
+A compile-gated test: scaffold → add `#[miniextendr] pub fn mx_new_fn` → one
+`miniextendr_build()` → assert `getNamespaceExports()`.
+
+## What went wrong
+
+The build aborted inside `devtools::document()`:
+
+```
+internal error 1 in R_decompress1 with libdeflate
+Error in env_get_list(...): lazy-load database '.../library/<pkg>/R/<pkg>.rdb' is corrupt
+```
+
+Backtrace: `document()` → `roxygen2::roxygenise` → `pkgload::load_all` →
+`pkgload:::unregister_namespace` → reading the installed namespace's `.rdb`.
+The pre-existing standalone e2e (`test-templates.R:565`, mxroundtrip) failed
+identically on clean `main` — pre-existing, deterministic on this machine
+(R 4.6.0, libdeflate-compressed lazy-load DBs), not introduced by the new test.
+
+## Root cause
+
+`install_pkg()` called `devtools::install()` with the default `reload = TRUE`,
+which re-registers the just-installed package's namespace in the *building*
+session. The subsequent `document()` runs `pkgload::load_all()`, whose
+`unregister()` step forces that namespace's active bindings — reading the
+freshly-written `.rdb`. On R ≥ 4.6 that read intermittently dies with the
+libdeflate decompress error. The reload is pointless in a build workflow:
+`document()` works from source, and nothing in `miniextendr_build()` needs the
+package attached.
+
+A minimal R-only package does **not** reproduce it — it needs the compiled
+miniextendr wrapper shape (larger `.rdb`, native-symbol bindings), so the only
+real repro is the e2e harness itself.
+
+## Fix
+
+Pass `reload = FALSE` in all three `devtools::install()` call sites in
+`minirextendr/R/workflow.R` (`install_pkg()` and both `bootstrap_fresh_wrappers()`
+installs). With the fix the #898 e2e passes; before it, it failed with the
+corrupt-rdb error on every run.
+
+This likely also removes the `.rdb`-corrupt failure mode of the known-flaky
+standalone e2e (#1000) — its remaining failure modes observed this session were
+environmental (disk exhaustion, offline cargo resolution), not the rdb error.


### PR DESCRIPTION
Adds the missing compile-gated behavioural tests for `miniextendr_build()`: the #860 single-pass-export regression test and the #911 `MINIEXTENDR_FORCE_WRAPPER_GEN` propagation verification — plus a real `reload = FALSE` fix in `install_pkg()`/`bootstrap_fresh_wrappers()` that the e2e test uncovered. Closes #898. Closes #911.

<details><summary>🤖 AI-written implementation notes</summary>

## #898 — single-pass export e2e test

`test-templates.R`: scaffolds a local-repo monorepo (offline; root `.git` keeps configure in source mode), appends a brand-new `#[miniextendr] pub fn mx_new_fn` to the rpkg's `lib.rs`, runs the real `miniextendr_build()` **once**, and asserts on the installed image: `"mx_new_fn" %in% getNamespaceExports("spexport")` plus a live `spexport::mx_new_fn(21) == 42` call. Gated by the existing `skip_e2e()` convention (skipped on CI unless `MINIEXTENDR_RUN_E2E=1`; runs in `just minirextendr-test`).

## #911 — empirical propagation finding: **it propagates; no fix needed**

Verified with a probe package whose `src/Makevars` records `$MINIEXTENDR_FORCE_WRAPPER_GEN` as seen by the make recipe, driven through a real `devtools::install(build = TRUE)`:

- session `Sys.setenv(MINIEXTENDR_FORCE_WRAPPER_GEN = "1")` → make recipe sees `[1]`
- session unset → make recipe sees `[]`

Mechanism: `devtools::install` → `pkgbuild:::rcmd_build_tools` → `callr::rcmd_safe(..., env = c(callr::rcmd_safe_env(), env))`. `rcmd_safe_env()` is a small *additive* set (`CYGWIN`, `R_TESTS`, `R_BROWSER`, `R_PDFVIEWER`) **merged onto the inherited parent environment**, not a replacement — so the in-session override survives both subprocess hops (`R CMD build` → `R CMD INSTALL` → make) down to where `Makevars.in` reads `[ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]`. The wrappers-present/leaked-tarball regenerate path in `install_pkg()` therefore works as designed.

The new regression test locks this guarantee in both directions (a future callr/pkgbuild change that sanitised the child environment would be caught). It is C-only (no Rust compile, ~seconds), gated by `skip_on_cran()` + build-tools checks.

## Fix uncovered: `devtools::install(reload = FALSE)` in the build workflow

The #898 e2e initially failed — and the **pre-existing** standalone e2e (`test-templates.R:565`, mxroundtrip) fails identically on clean `main` — with:

```
internal error 1 in R_decompress1 with libdeflate
Error in env_get_list(...): lazy-load database '.../R/<pkg>.rdb' is corrupt
```

Root cause: `install_pkg()` used `devtools::install()`'s default `reload = TRUE`, which re-registers the just-installed namespace in the building session; the subsequent `devtools::document()` → `pkgload::load_all()` → `unregister()` then reads that namespace's freshly-written lazy-load DB and dies on R ≥ 4.6 (libdeflate-compressed `.rdb`). The reload is pointless in a build workflow (`document()` works from source), so all three `devtools::install()` call sites in `workflow.R` now pass `reload = FALSE`. With the fix, the #898 e2e passes; post-mortem in `reviews/2026-06-11-build-document-reload-libdeflate-corrupt.md`. This likely also removes the `.rdb`-corrupt failure mode of the known-flaky #1000 test.

## Test evidence

- `just minirextendr-test` (full suite): `[ FAIL 1 | WARN 1 | SKIP 3 | PASS 524 ]` — the sole failure is the pre-existing known-flaky standalone e2e at `test-templates.R:565` (#1000; failed this run on offline cargo resolution, an environmental mode unrelated to this PR — it also fails on clean `main`).
- Filtered `templates` e2e run: #898 test passed (full scaffold + cargo cold-compile + install round-trip, ~2–8 min depending on cache), #911 test passed both directions. Skips behave per convention (`skip_e2e()` / `skip_on_cran()`).
- Both edited R files parse-checked; mocked `test-workflow-bootstrap.R` tests unaffected (`function(...)` mocks absorb the new `reload` arg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>