### PR TITLE
refactor(api): consolidate altrep_impl knob-matrix macros (#682)

### DIFF
--- a/miniextendr-api/src/altrep_impl/macros.rs
+++ b/miniextendr-api/src/altrep_impl/macros.rs
@@ -42,53 +42,17 @@
 /// ```
 #[macro_export]
 macro_rules! impl_altinteger_from_data {
-    ($ty:ty) => {
-        // Default: materializing DATAPTR — allocates INTSXP in data2 on first DATAPTR call.
-        // Without this, R's default DATAPTR errors with "cannot access data pointer".
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_integer_dataptr!($ty);
-        $crate::__impl_altinteger_methods!($ty);
-        $crate::impl_inferbase_integer!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!(
+    // Default (no knobs): materializing DATAPTR — allocates INTSXP in data2 on
+    // first DATAPTR call. Without this, R's default DATAPTR errors with
+    // "cannot access data pointer". See `__impl_alt_family!` for the knob matrix.
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altinteger_methods,
             impl_inferbase_integer,
-            dataptr(i32)
-        );
-    };
-    ($ty:ty, serialize) => {
-        // Serialize + materializing DATAPTR (default for computed types)
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_integer_dataptr!($ty);
-        $crate::__impl_altinteger_methods!($ty);
-        $crate::impl_inferbase_integer!($ty);
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altinteger_methods,
-            impl_inferbase_integer,
-            subset
-        );
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altinteger_methods,
-            impl_inferbase_integer,
-            dataptr(i32),
-            serialize
-        );
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altinteger_methods,
-            impl_inferbase_integer,
-            subset,
-            serialize
+            dataptr: dataptr(i32),
+            default: materializing(i32)
+            $(, $knob)*
         );
     };
 }
@@ -345,82 +309,71 @@ macro_rules! __impl_altvec_string_dataptr {
     };
 }
 
-/// Internal macro: impl AltVec with materializing dataptr for logical ALTREP.
+/// Internal macro: impl AltVec with a *materializing* dataptr for a given element type.
 ///
-/// Thin wrapper: provides a trivial `AltrepDataptr` (no direct pointer) and
-/// delegates to `__impl_altvec_dataptr` which materializes via `RNativeType::elt`.
+/// Thin wrapper, parameterised by element type: installs a trivial
+/// `AltrepDataptr<$elem>` (no direct pointer — `dataptr` returns `None`) and
+/// delegates to [`__impl_altvec_dataptr`], which materializes into `data2` via
+/// `RNativeType::elt`. The 5 per-family aliases below pin `$elem` so the derive
+/// and the public `impl_alt*_from_data!` macros can reference them by a stable
+/// per-family name.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __impl_altvec_materializing_dataptr {
+    ($ty:ty, $elem:ty) => {
+        impl $crate::altrep_data::AltrepDataptr<$elem> for $ty {
+            fn dataptr(&mut self, _writable: bool) -> Option<*mut $elem> {
+                None
+            }
+        }
+        $crate::__impl_altvec_dataptr!($ty, $elem);
+    };
+}
+
+/// Internal macro: materializing dataptr for logical ALTREP.
+///
 /// R logicals are stored as `i32` but accessed through `RLogical` for type safety.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_altvec_logical_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<$crate::RLogical> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::RLogical> {
-                None
-            }
-        }
-        $crate::__impl_altvec_dataptr!($ty, $crate::RLogical);
+        $crate::__impl_altvec_materializing_dataptr!($ty, $crate::RLogical);
     };
 }
 
-/// Internal macro: impl AltVec with materializing dataptr for integer ALTREP.
-///
-/// Internal macro: impl AltVec with materializing dataptr for integer ALTREP.
-///
-/// Thin wrapper: provides a trivial `AltrepDataptr` (no direct pointer) and
-/// delegates to `__impl_altvec_dataptr` which materializes via `RNativeType::elt`.
+/// Internal macro: materializing dataptr for integer ALTREP.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_altvec_integer_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<i32> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut i32> {
-                None
-            }
-        }
-        $crate::__impl_altvec_dataptr!($ty, i32);
+        $crate::__impl_altvec_materializing_dataptr!($ty, i32);
     };
 }
 
-/// Internal macro: impl AltVec with materializing dataptr for real ALTREP.
+/// Internal macro: materializing dataptr for real ALTREP.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_altvec_real_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<f64> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut f64> {
-                None
-            }
-        }
-        $crate::__impl_altvec_dataptr!($ty, f64);
+        $crate::__impl_altvec_materializing_dataptr!($ty, f64);
     };
 }
 
-/// Internal macro: impl AltVec with materializing dataptr for raw ALTREP.
+/// Internal macro: materializing dataptr for raw ALTREP.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_altvec_raw_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<u8> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut u8> {
-                None
-            }
-        }
-        $crate::__impl_altvec_dataptr!($ty, u8);
+        $crate::__impl_altvec_materializing_dataptr!($ty, u8);
     };
 }
 
-/// Internal macro: impl AltVec with materializing dataptr for complex ALTREP.
+/// Internal macro: materializing dataptr for complex ALTREP.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_altvec_complex_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<$crate::Rcomplex> for $ty {
-            fn dataptr(&mut self, _writable: bool) -> Option<*mut $crate::Rcomplex> {
-                None
-            }
-        }
-        $crate::__impl_altvec_dataptr!($ty, $crate::Rcomplex);
+        $crate::__impl_altvec_materializing_dataptr!($ty, $crate::Rcomplex);
     };
 }
 
@@ -438,9 +391,10 @@ macro_rules! __impl_altvec_extract_subset {
                 _call: $crate::SEXP,
             ) -> $crate::SEXP {
                 // Validate that indx is an integer vector before calling INTEGER().
-                // Return NULL to signal R to use default subsetting if not.
+                // Return C NULL (not R_NilValue) to signal R to use default
+                // subsetting if not — R checks `!= NULL` here.
                 if $crate::SexpExt::type_of(&indx) != $crate::SEXPTYPE::INTSXP {
-                    return core::ptr::null_mut();
+                    return $crate::SEXP::null();
                 }
 
                 // Convert indx SEXP to slice using SexpExt (avoids raw-ptr-deref lint)
@@ -548,99 +502,115 @@ macro_rules! __impl_alt_no_na {
 }
 // endregion
 
-// region: Parametric macro: __impl_alt_from_data!
+// region: Canonical emission macros: __impl_altvec_flavor! / __impl_alt_from_data! / __impl_alt_family!
 //
-// This internal macro generates the standard ALTREP trait implementations
-// (Altrep, AltVec, family-specific methods, InferBase) for a given type.
-// The 7 public `impl_alt*_from_data!` macros delegate to this with
-// family-specific parameters.
+// Three layers, each with a single responsibility:
+//
+// 1. `__impl_altvec_flavor!` — maps an AltVec *flavor* token to the macro
+//    that emits the `impl AltVec` (typed direct pointer, materializing,
+//    STRSXP materialization, or extract_subset).
+// 2. `__impl_alt_from_data!` — the canonical emitter: Altrep base
+//    (with/without serialize) + AltVec flavor + family methods + InferBase.
+//    Exactly two arms — every knob combination reduces to these.
+// 3. `__impl_alt_family!` — the knob matrix: maps the public macros'
+//    user-facing knob spellings (`dataptr` / `serialize` / `subset`, in
+//    canonical order) to a flavor + optional serialize. Parameterised by the
+//    family's `dataptr:` and `default:` flavors so one matrix serves all
+//    six knob-bearing families.
 
+/// Internal macro: emit the `impl AltVec` for a given flavor.
+///
+/// Flavors:
+/// - `dataptr($elem)` — typed direct pointer via `AltrepDataptr<$elem>`,
+///   falling back to data2 materialization.
+/// - `materializing($elem)` — trivial `AltrepDataptr<$elem>` returning `None`
+///   plus the same `__impl_altvec_dataptr!` (pure data2 materialization).
+/// - `string_dataptr` — whole-vector STRSXP materialization (string family).
+/// - `subset` — `Extract_subset` support via `AltrepExtractSubset`.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __impl_altvec_flavor {
+    ($ty:ty, dataptr($elem:ty)) => {
+        $crate::__impl_altvec_dataptr!($ty, $elem);
+    };
+    ($ty:ty, materializing($elem:ty)) => {
+        $crate::__impl_altvec_materializing_dataptr!($ty, $elem);
+    };
+    ($ty:ty, string_dataptr) => {
+        $crate::__impl_altvec_string_dataptr!($ty);
+    };
+    ($ty:ty, subset) => {
+        $crate::__impl_altvec_extract_subset!($ty);
+    };
+}
+
+/// Internal macro: canonical ALTREP emission.
+///
+/// Generates the standard ALTREP trait implementations (Altrep base, AltVec
+/// flavor, family-specific methods, InferBase) for a given type. The two arms
+/// differ only in serialization support on the Altrep base impl.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_alt_from_data {
-    // Base: no options
-    ($ty:ty, $methods:ident, $inferbase:ident) => {
+    ($ty:ty, $methods:ident, $inferbase:ident, $flavor:ident $(($elem:ty))?) => {
         $crate::__impl_altrep_base!($ty);
-        impl $crate::altrep_traits::AltVec for $ty {}
+        $crate::__impl_altvec_flavor!($ty, $flavor $(($elem))?);
         $crate::$methods!($ty);
         $crate::$inferbase!($ty);
     };
-    // Base: explicit guard
-    ($ty:ty, $methods:ident, $inferbase:ident, @guard $guard:ident) => {
-        $crate::__impl_altrep_base!($ty, $guard);
-        impl $crate::altrep_traits::AltVec for $ty {}
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
-    };
-    // Dataptr with element type
-    ($ty:ty, $methods:ident, $inferbase:ident, dataptr($elem:ty)) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_dataptr!($ty, $elem);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
-    };
-    // String dataptr (materialization into STRSXP)
-    ($ty:ty, $methods:ident, $inferbase:ident, string_dataptr) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
-    };
-    // String dataptr + explicit guard
-    ($ty:ty, $methods:ident, $inferbase:ident, string_dataptr, @guard $guard:ident) => {
-        $crate::__impl_altrep_base!($ty, $guard);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
-    };
-    // Serialize only
-    ($ty:ty, $methods:ident, $inferbase:ident, serialize) => {
+    ($ty:ty, $methods:ident, $inferbase:ident, $flavor:ident $(($elem:ty))?, serialize) => {
         $crate::__impl_altrep_base!($ty, with_serialize);
-        impl $crate::altrep_traits::AltVec for $ty {}
+        $crate::__impl_altvec_flavor!($ty, $flavor $(($elem))?);
         $crate::$methods!($ty);
         $crate::$inferbase!($ty);
     };
-    // Serialize + explicit guard
-    ($ty:ty, $methods:ident, $inferbase:ident, serialize, @guard $guard:ident) => {
-        $crate::__impl_altrep_base!($ty, $guard, with_serialize);
-        impl $crate::altrep_traits::AltVec for $ty {}
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+}
+
+/// Internal macro: the per-family knob matrix.
+///
+/// Maps the user-facing knob list of the public `impl_alt*_from_data!` macros
+/// (`dataptr` / `serialize` / `subset`, canonical order) to a canonical
+/// [`__impl_alt_from_data!`] invocation. The family supplies:
+/// - `dataptr:` — the AltVec flavor for the `dataptr` knob,
+/// - `default:` — the AltVec flavor when no `dataptr`/`subset` knob is given
+///   (the materializing/data2 path).
+///
+/// Valid knob combinations (anything else is a compile error):
+///
+/// ```ignore
+/// ()                    // default flavor
+/// (dataptr)             // direct-pointer flavor
+/// (serialize)           // default flavor + serialize
+/// (subset)              // extract_subset flavor
+/// (dataptr, serialize)
+/// (subset, serialize)
+/// ```
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __impl_alt_family {
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, $dff $(($dfe))?);
     };
-    // Subset only
-    ($ty:ty, $methods:ident, $inferbase:ident, subset) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_extract_subset!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, dataptr) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, $dpf $(($dpe))?);
     };
-    // Dataptr + serialize
-    ($ty:ty, $methods:ident, $inferbase:ident, dataptr($elem:ty), serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_dataptr!($ty, $elem);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, serialize) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, $dff $(($dfe))?, serialize);
     };
-    // String dataptr + serialize
-    ($ty:ty, $methods:ident, $inferbase:ident, string_dataptr, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, subset) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, subset);
     };
-    // String dataptr + serialize + explicit guard
-    ($ty:ty, $methods:ident, $inferbase:ident, string_dataptr, serialize, @guard $guard:ident) => {
-        $crate::__impl_altrep_base!($ty, $guard, with_serialize);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, dataptr, serialize) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, $dpf $(($dpe))?, serialize);
     };
-    // Subset + serialize
-    ($ty:ty, $methods:ident, $inferbase:ident, subset, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_extract_subset!($ty);
-        $crate::$methods!($ty);
-        $crate::$inferbase!($ty);
+    ($ty:ty, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, subset, serialize) => {
+        $crate::__impl_alt_from_data!($ty, $methods, $inferbase, subset, serialize);
     };
 }
 // endregion
@@ -722,45 +692,14 @@ macro_rules! __impl_altinteger_methods {
 /// ```
 #[macro_export]
 macro_rules! impl_altreal_from_data {
-    ($ty:ty) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_real_dataptr!($ty);
-        $crate::__impl_altreal_methods!($ty);
-        $crate::impl_inferbase_real!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!(
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altreal_methods,
             impl_inferbase_real,
-            dataptr(f64)
-        );
-    };
-    ($ty:ty, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_real_dataptr!($ty);
-        $crate::__impl_altreal_methods!($ty);
-        $crate::impl_inferbase_real!($ty);
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altreal_methods,
-            impl_inferbase_real,
-            dataptr(f64),
-            serialize
-        );
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!($ty, __impl_altreal_methods, impl_inferbase_real, subset);
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altreal_methods,
-            impl_inferbase_real,
-            subset,
-            serialize
+            dataptr: dataptr(f64),
+            default: materializing(f64)
+            $(, $knob)*
         );
     };
 }
@@ -833,50 +772,16 @@ macro_rules! __impl_altreal_methods {
 /// ```
 #[macro_export]
 macro_rules! impl_altlogical_from_data {
-    ($ty:ty) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_logical_dataptr!($ty);
-        $crate::__impl_altlogical_methods!($ty);
-        $crate::impl_inferbase_logical!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!(
+    // Note the asymmetry: the `dataptr` knob is typed `i32` (R's LGLSXP storage),
+    // while the materializing default goes through `RLogical` for type safety.
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altlogical_methods,
             impl_inferbase_logical,
-            dataptr(i32)
-        );
-    };
-    ($ty:ty, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_logical_dataptr!($ty);
-        $crate::__impl_altlogical_methods!($ty);
-        $crate::impl_inferbase_logical!($ty);
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altlogical_methods,
-            impl_inferbase_logical,
-            dataptr(i32),
-            serialize
-        );
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altlogical_methods,
-            impl_inferbase_logical,
-            subset
-        );
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altlogical_methods,
-            impl_inferbase_logical,
-            subset,
-            serialize
+            dataptr: dataptr(i32),
+            default: materializing($crate::RLogical)
+            $(, $knob)*
         );
     };
 }
@@ -945,40 +850,14 @@ macro_rules! __impl_altlogical_methods {
 /// ```
 #[macro_export]
 macro_rules! impl_altraw_from_data {
-    ($ty:ty) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_raw_dataptr!($ty);
-        $crate::__impl_altraw_methods!($ty);
-        $crate::impl_inferbase_raw!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!($ty, __impl_altraw_methods, impl_inferbase_raw, dataptr(u8));
-    };
-    ($ty:ty, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_raw_dataptr!($ty);
-        $crate::__impl_altraw_methods!($ty);
-        $crate::impl_inferbase_raw!($ty);
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altraw_methods,
             impl_inferbase_raw,
-            dataptr(u8),
-            serialize
-        );
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!($ty, __impl_altraw_methods, impl_inferbase_raw, subset);
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altraw_methods,
-            impl_inferbase_raw,
-            subset,
-            serialize
+            dataptr: dataptr(u8),
+            default: materializing(u8)
+            $(, $knob)*
         );
     };
 }
@@ -1018,45 +897,16 @@ macro_rules! __impl_altraw_methods {
 /// ```
 #[macro_export]
 macro_rules! impl_altstring_from_data {
-    ($ty:ty) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::__impl_altstring_methods!($ty);
-        $crate::impl_inferbase_string!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!(
+    // String vectors have no contiguous typed pointer; the default and `dataptr`
+    // knobs both route through `string_dataptr` (whole-vector STRSXP materialization).
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altstring_methods,
             impl_inferbase_string,
-            string_dataptr
-        );
-    };
-    ($ty:ty, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_string_dataptr!($ty);
-        $crate::__impl_altstring_methods!($ty);
-        $crate::impl_inferbase_string!($ty);
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altstring_methods,
-            impl_inferbase_string,
-            string_dataptr,
-            serialize
-        );
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!($ty, __impl_altstring_methods, impl_inferbase_string, subset);
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altstring_methods,
-            impl_inferbase_string,
-            subset,
-            serialize
+            dataptr: string_dataptr,
+            default: string_dataptr
+            $(, $knob)*
         );
     };
 }
@@ -1190,50 +1040,14 @@ macro_rules! __impl_altcomplex_methods {
 /// - `subset`: Enable optimized subsetting (requires `AltrepExtractSubset`)
 #[macro_export]
 macro_rules! impl_altcomplex_from_data {
-    ($ty:ty) => {
-        $crate::__impl_altrep_base!($ty);
-        $crate::__impl_altvec_complex_dataptr!($ty);
-        $crate::__impl_altcomplex_methods!($ty);
-        $crate::impl_inferbase_complex!($ty);
-    };
-    ($ty:ty, dataptr) => {
-        $crate::__impl_alt_from_data!(
+    ($ty:ty $(, $knob:ident)*) => {
+        $crate::__impl_alt_family!(
             $ty,
             __impl_altcomplex_methods,
             impl_inferbase_complex,
-            dataptr($crate::Rcomplex)
-        );
-    };
-    ($ty:ty, serialize) => {
-        $crate::__impl_altrep_base!($ty, with_serialize);
-        $crate::__impl_altvec_complex_dataptr!($ty);
-        $crate::__impl_altcomplex_methods!($ty);
-        $crate::impl_inferbase_complex!($ty);
-    };
-    ($ty:ty, subset) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altcomplex_methods,
-            impl_inferbase_complex,
-            subset
-        );
-    };
-    ($ty:ty, dataptr, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altcomplex_methods,
-            impl_inferbase_complex,
-            dataptr($crate::Rcomplex),
-            serialize
-        );
-    };
-    ($ty:ty, subset, serialize) => {
-        $crate::__impl_alt_from_data!(
-            $ty,
-            __impl_altcomplex_methods,
-            impl_inferbase_complex,
-            subset,
-            serialize
+            dataptr: dataptr($crate::Rcomplex),
+            default: materializing($crate::Rcomplex)
+            $(, $knob)*
         );
     };
 }

--- a/miniextendr-api/tests/altrep_from_data_matrix.rs
+++ b/miniextendr-api/tests/altrep_from_data_matrix.rs
@@ -1,0 +1,190 @@
+//! Compile-time coverage for the full `impl_alt*_from_data!` knob matrix.
+//!
+//! The public ALTREP family macros accept an optional knob list
+//! (`dataptr` / `serialize` / `subset`, in canonical order) that routes
+//! through the internal `__impl_alt_family!` knob matrix. Most knob
+//! combinations have no production call site inside this crate (e.g. the
+//! `subset` arms), so this test instantiates every supported combination to
+//! guarantee the matrix keeps expanding to valid impls.
+//!
+//! These fixtures are compile-only: the generated `Altrep`/`AltVec`/family
+//! impls are never invoked (that requires a live R runtime — covered by the
+//! rpkg fixtures).
+// Fixture structs exist solely to host macro-generated impls.
+#![allow(dead_code)]
+
+use miniextendr_api::SEXP;
+use miniextendr_api::altrep_data::{
+    AltIntegerData, AltLogicalData, AltStringData, AltrepDataptr, AltrepExtract,
+    AltrepExtractSubset, AltrepLen, AltrepSerialize, Logical,
+};
+
+// region: Fixture helpers
+
+/// Declare an integer-family fixture: `AltrepLen` + `AltIntegerData`.
+macro_rules! int_fixture {
+    ($name:ident) => {
+        struct $name(Vec<i32>);
+
+        impl AltrepLen for $name {
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+        }
+
+        impl AltIntegerData for $name {
+            fn elt(&self, i: usize) -> i32 {
+                self.0[i]
+            }
+        }
+    };
+}
+
+/// Manual (non-TypedExternal) `AltrepExtract`. Serialize-knob fixtures must
+/// NOT use this — they implement `TypedExternal` and get `AltrepExtract`
+/// through its blanket impl.
+macro_rules! fixture_extract {
+    ($name:ident) => {
+        impl AltrepExtract for $name {
+            unsafe fn altrep_extract_ref(_x: SEXP) -> &'static Self {
+                unreachable!("compile-time fixture — never dispatched")
+            }
+
+            unsafe fn altrep_extract_mut(_x: SEXP) -> &'static mut Self {
+                unreachable!("compile-time fixture — never dispatched")
+            }
+        }
+    };
+}
+
+macro_rules! fixture_dataptr {
+    ($name:ident, $elem:ty) => {
+        impl AltrepDataptr<$elem> for $name {
+            fn dataptr(&mut self, _writable: bool) -> Option<*mut $elem> {
+                None
+            }
+        }
+    };
+}
+
+/// The `serialize` knob additionally requires `TypedExternal`: the generated
+/// `Altrep::unserialize` reconstructs the value via `ExternalPtr::new_unchecked`.
+macro_rules! fixture_serialize {
+    ($name:ident) => {
+        impl miniextendr_api::externalptr::TypedExternal for $name {
+            const TYPE_NAME: &'static str = stringify!($name);
+            const TYPE_NAME_CSTR: &'static [u8] = concat!(stringify!($name), "\0").as_bytes();
+            const TYPE_ID_CSTR: &'static [u8] =
+                concat!(module_path!(), "::", stringify!($name), "\0").as_bytes();
+        }
+
+        impl AltrepSerialize for $name {
+            fn serialized_state(&self) -> SEXP {
+                unreachable!("compile-time fixture — never dispatched")
+            }
+
+            fn unserialize(_state: SEXP) -> Option<Self> {
+                None
+            }
+        }
+    };
+}
+
+macro_rules! fixture_subset {
+    ($name:ident) => {
+        impl AltrepExtractSubset for $name {
+            fn extract_subset(&self, _indices: &[i32]) -> Option<SEXP> {
+                None
+            }
+        }
+    };
+}
+// endregion
+
+// region: Integer family — all six knob combinations
+
+int_fixture!(IntBasic);
+fixture_extract!(IntBasic);
+miniextendr_api::impl_altinteger_from_data!(IntBasic);
+
+int_fixture!(IntDataptr);
+fixture_extract!(IntDataptr);
+fixture_dataptr!(IntDataptr, i32);
+miniextendr_api::impl_altinteger_from_data!(IntDataptr, dataptr);
+
+int_fixture!(IntSerialize);
+fixture_serialize!(IntSerialize);
+miniextendr_api::impl_altinteger_from_data!(IntSerialize, serialize);
+
+int_fixture!(IntSubset);
+fixture_extract!(IntSubset);
+fixture_subset!(IntSubset);
+miniextendr_api::impl_altinteger_from_data!(IntSubset, subset);
+
+int_fixture!(IntDataptrSerialize);
+fixture_dataptr!(IntDataptrSerialize, i32);
+fixture_serialize!(IntDataptrSerialize);
+miniextendr_api::impl_altinteger_from_data!(IntDataptrSerialize, dataptr, serialize);
+
+int_fixture!(IntSubsetSerialize);
+fixture_subset!(IntSubsetSerialize);
+fixture_serialize!(IntSubsetSerialize);
+miniextendr_api::impl_altinteger_from_data!(IntSubsetSerialize, subset, serialize);
+// endregion
+
+// region: Logical family — asymmetric element types (dataptr: i32, materializing: RLogical)
+
+struct LglBasic(Vec<bool>);
+
+impl AltrepLen for LglBasic {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl AltLogicalData for LglBasic {
+    fn elt(&self, i: usize) -> Logical {
+        Logical::from(self.0[i])
+    }
+}
+
+fixture_extract!(LglBasic);
+miniextendr_api::impl_altlogical_from_data!(LglBasic);
+// endregion
+
+// region: String family — default and `dataptr` both route to string_dataptr
+
+struct StrBasic(Vec<Option<String>>);
+
+impl AltrepLen for StrBasic {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl AltStringData for StrBasic {
+    fn elt(&self, i: usize) -> Option<&str> {
+        self.0[i].as_deref()
+    }
+}
+
+fixture_extract!(StrBasic);
+miniextendr_api::impl_altstring_from_data!(StrBasic, dataptr);
+// endregion
+
+#[test]
+fn knob_matrix_compiles() {
+    // The test is the successful expansion above; spot-check a few of the
+    // generated associated consts so the impls are demonstrably present.
+    use miniextendr_api::altrep_traits::{AltInteger, AltVec, Altrep};
+
+    const {
+        assert!(!<IntBasic as Altrep>::HAS_SERIALIZED_STATE);
+        assert!(<IntSerialize as Altrep>::HAS_SERIALIZED_STATE);
+        assert!(<IntDataptrSerialize as Altrep>::HAS_SERIALIZED_STATE);
+        assert!(<IntBasic as AltVec>::HAS_DATAPTR);
+        assert!(<IntSubset as AltVec>::HAS_EXTRACT_SUBSET);
+        assert!(<IntSubsetSerialize as AltVec>::HAS_EXTRACT_SUBSET);
+        assert!(<IntBasic as AltInteger>::HAS_ELT);
+    }
+}


### PR DESCRIPTION
Consolidates the declarative ALTREP macro layer in `miniextendr-api/src/altrep_impl/macros.rs` per option (b) of the issue: one canonical knob matrix, all public spellings delegate. Closes #682.

<details><summary>🤖 AI-written implementation notes</summary>

## What changed

New layering (each layer has one responsibility):

```
impl_alt<family>_from_data!   1 forwarding arm per family (was 6 arms x 6 families)
  → __impl_alt_family!        THE knob matrix: dataptr/serialize/subset → flavor
    → __impl_alt_from_data!   2 arms (serialize split; was 14 arms)
      → __impl_altvec_flavor! AltVec flavor dispatch (dataptr/materializing/string/subset)
```

- The 5 per-family `__impl_altvec_*_dataptr!` materializing macros (identical except element type) are now one-line aliases of a new parameterised `__impl_altvec_materializing_dataptr!($ty, $elem)`. The per-family names are kept because the proc-macro derive references them (`materializing_dataptr_macro`).
- Dead arms of `__impl_alt_from_data!` removed (`@guard` variants, bare/serialize-only `impl AltVec {}` arms) — grep shows zero callers; the derive emits components directly since #711.
- Family asymmetries are now explicit parameters: logical's `dataptr` knob is typed `i32` (LGLSXP storage) while its materializing default goes through `RLogical`; string's `dataptr` and default both route to `string_dataptr`.

## Latent bug found and fixed

`__impl_altvec_extract_subset!` emitted `return core::ptr::null_mut();` where the newtype `SEXP` is expected — a type error. The `subset` arms of every public family macro had **zero instantiations anywhere** (rpkg, optionals, cross-package, derive fixtures), so this never compiled and never failed. Fixed to `$crate::SEXP::null()` (C NULL, per the ALTREP fall-back protocol documented on `SEXP::null()`). The new compile-coverage test would have caught this.

## New test

`miniextendr-api/tests/altrep_from_data_matrix.rs` — compile-coverage for the full knob matrix: all 6 integer-family combinations (incl. the previously never-instantiated `subset` / `subset, serialize`), logical (asymmetric element types), and string `dataptr`. Plus const-assertions on the generated `HAS_*` flags.

## Equivalence evidence

- `cargo expand -p miniextendr-api --features nalgebra altrep_impl::builtins` and `optionals::nalgebra_impl` are **token-for-token identical** before/after (covers `serialize`, `dataptr, serialize`, `dataptr` arms across families; the bare arm differs from `serialize` only by `with_serialize` on the base macro).
- Line counts: `macros.rs` 1240 → 1054 (−186); diff −346/+160. Plus 190 lines of new test.

## Test battery

- `just test`: 59 suites ok; the only failure is the pre-existing trybuild UI drift (2/129 cases in `impl_trait_return_no_into_r.stderr` / `non_into_r_return.stderr`) — fails identically on clean origin/main with changes stashed; main CI is green, so the snapshots match CI's toolchain and regenerating locally (rustc 1.95.0 renders the "and $N others" trait list differently) would break CI. Not touched.
- `just rcmdinstall` + `just devtools-test`: `[ FAIL 0 | WARN 0 | SKIP 19 | PASS 6472 ]`. No generated-wrapper churn (API-internal refactor).
- gctorture(TRUE) pass over the no-arg ALTREP fixtures (incl. `make_no_lowlevel_altrep` — the bare macro arm — and the data2-materializing paths): clean.
- Both CI clippy variants (`clippy_default` + `clippy_all` feature list from ci.yml) green; `cargo fmt --all` applied.

## Notes / non-changes

- The structural file split (`altrep_impl/{macros,builtins}.rs`) flagged in the issue had already landed.
- User-facing surface unchanged: every knob spelling that compiled before compiles after. Invalid knob spellings still fail at compile time, though the "no rules expected" error now points at the hidden `__impl_alt_family!` matrix instead of the public macro.
- Option (a) (move everything into the proc-macro derives) remains possible as an end-state; nothing surfaced here changes that calculus, so no new issue — #682 already records it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)