### PR TITLE
feat(minirextendr): unify detect-features.R generator with the robust Cargo-driven design (#1001)

### DIFF
--- a/minirextendr/R/feature-detect-configure.R
+++ b/minirextendr/R/feature-detect-configure.R
@@ -53,7 +53,15 @@ use_configure_feature_detection <- function(path = ".") {
   # 1. Create tools/detect-features.R
   script_path <- usethis::proj_path("tools", "detect-features.R")
   if (fs::file_exists(script_path)) {
-    cli::cli_alert_info("{.path tools/detect-features.R} already exists")
+    existing_text <- paste(readLines(script_path, warn = FALSE), collapse = "\n")
+    if (!grepl("^## BEGIN RULES", existing_text, multiline = TRUE)) {
+      cli::cli_alert_warning(c(
+        "{.path tools/detect-features.R} already exists but has no {.code ## BEGIN RULES} marker.",
+        "i" = "Delete it and re-run {.code use_configure_feature_detection()} to upgrade to the unified design."
+      ))
+    } else {
+      cli::cli_alert_info("{.path tools/detect-features.R} already exists")
+    }
   } else {
     script_content <- generate_empty_detect_script(package_name, features_var)
     ensure_dir(dirname(script_path))
@@ -196,12 +204,18 @@ remove_feature_rule <- function(feature, path = ".") {
   invisible(removed)
 }
 
-#' Sync feature detection rules with Cargo.toml
+#' Pin explicit always-enable rules for Cargo features
 #'
 #' Reads `[features]` from `src/rust/Cargo.toml` via `cargo metadata` and adds
-#' detection rules for any features that don't have one yet. New features are
-#' added with `detect = TRUE` (always-enable) by default. Run this after adding
-#' new features to keep `tools/detect-features.R` up to date.
+#' an explicit `detect = TRUE` rule for any features that don't already have
+#' one. Useful when you want to *pin* a feature as always-enabled rather than
+#' relying on auto-discovery (e.g., to document the intent, or to override a
+#' future conditional rule before it is added).
+#'
+#' Under the unified design, features without a rule are already enabled by
+#' default (auto-discovery from Cargo.toml at configure time). Calling this
+#' function pins those features explicitly, which is semantically equivalent
+#' but makes the intent visible in `tools/detect-features.R`.
 #'
 #' Skips the `"default"` pseudo-feature and any feature that already has a rule.
 #'
@@ -213,7 +227,7 @@ remove_feature_rule <- function(feature, path = ".") {
 #'
 #' @examples
 #' \dontrun{
-#' # After adding new Cargo features:
+#' # Pin all current features as explicit always-enable rules:
 #' sync_feature_rules()
 #' #> v Added feature detection rule for 'new_feature_1'
 #' #> v Added feature detection rule for 'new_feature_2'
@@ -493,7 +507,13 @@ parse_cargo_metadata_json <- function(json) {
   list(features = features, optional_deps = optional_deps)
 }
 
-#' Generate empty detect-features.R script
+#' Generate the full robust detect-features.R skeleton
+#'
+#' Emits the Cargo-driven skeleton (parses [features] from src/rust/Cargo.toml,
+#' applies a denylist, applies conditional rules from the markers block, sorts,
+#' and cats to stdout). The empty `rules <- list()` block between the
+#' `## BEGIN RULES` / `## END RULES` markers is where [append_feature_rule()]
+#' writes per-feature predicates. `main()` consumes the global `rules`.
 #'
 #' @param package_name R package name
 #' @param features_var Features environment variable name (e.g., "CARGO_FEATURES")
@@ -501,23 +521,184 @@ parse_cargo_metadata_json <- function(json) {
 #' @noRd
 generate_empty_detect_script <- function(package_name, features_var) {
   c(
-    sprintf("# Feature detection for %s", package_name),
-    "# Called by ./configure to auto-detect available features.",
-    "# Output: comma-separated list of Cargo features to enable.",
+    "#!/usr/bin/env Rscript",
+    sprintf("# Configure-time Cargo feature detection for %s.", package_name),
     "#",
-    sprintf("# Users can override by setting the %s environment variable.", features_var),
-    "# Add rules with: minirextendr::add_feature_rule()",
+    "# Contract",
+    "# --------",
+    sprintf("#   Consumed by : ./configure (the %s block).", features_var),
+    "#                 configure runs `Rscript tools/detect-features.R` and captures",
+    "#                 stdout. The `2>/dev/null || echo \"\"` wrapper means any failure",
+    "#                 here (nonzero exit OR empty stdout) makes configure fall back",
+    "#                 to its hardcoded feature list. So a wrong-but-nonempty answer",
+    "#                 is worse than no answer: when uncertain, we ENABLE (matching",
+    "#                 the hardcoded fallback's \"all optional features on\" default).",
+    "#   Output      : a single comma-separated feature string on stdout, nothing",
+    "#                 else. Every diagnostic goes to stderr so it never pollutes the",
+    "#                 captured value.",
+    "#   Failure mode: on any internal error the script prints nothing and exits",
+    "#                 nonzero, so configure uses its fallback list.",
+    "#",
+    "# Dependencies",
+    "# ------------",
+    "#   Base R + utils ONLY. This runs at ./configure time on end-user machines",
+    "#   where no package library (not even this package) is available. Do NOT",
+    "#   library()/requireNamespace() anything beyond base/utils, and do NOT call",
+    "#   minirextendr::* (configure.ac must not depend on minirextendr).",
+    "#   (Exception: rule expressions in the ## BEGIN RULES block may use",
+    "#   requireNamespace() to probe for optional packages.)",
+    "#",
+    "# Design",
+    "# ------",
+    "#   1. Parse [features] from src/rust/Cargo.toml to discover what CAN be built.",
+    "#   2. Enable every feature by default, then subtract:",
+    "#        - a denylist of meta/aggregate/dev/option-default/risky features that",
+    "#          must never be auto-enabled (see DENY below), and",
+    "#        - conditional features whose rule says \"no\" on this machine",
+    "#          (e.g. vctrs needs the vctrs R package; connections needs R >= 4.3).",
+    "#   3. Print the survivors, comma-separated.",
+    "#",
+    sprintf("#   Override entirely by setting %s before ./configure.", features_var),
+    "#   Add/remove rules with: minirextendr::add_feature_rule() /",
+    "#     minirextendr::remove_feature_rule()",
     "",
-    "features <- character()",
+    "# Robustness wrapper: any uncaught error -> empty stdout + nonzero exit so",
+    "# configure falls back to its hardcoded list.",
+    "main <- function() {",
+    "  args <- commandArgs(trailingOnly = FALSE)",
+    "  # Locate src/rust/Cargo.toml relative to this script (configure invokes us",
+    "  # from the package root, but resolve from the script path to be safe).",
+    "  cargo_toml <- find_cargo_toml(args)",
+    "  if (is.null(cargo_toml) || !file.exists(cargo_toml)) {",
+    "    stop(\"could not locate src/rust/Cargo.toml\")",
+    "  }",
     "",
+    "  available <- parse_cargo_features(cargo_toml)",
+    "  if (length(available) == 0L) {",
+    "    stop(\"no [features] parsed from Cargo.toml\")",
+    "  }",
+    "",
+    "  # Features that must never be auto-enabled.",
+    "  #   default, full        : meta / aggregate selectors.",
+    "  #   nonapi               : triggers R CMD check non-API WARNINGs.",
+    "  #   macro-coverage,",
+    "  #   growth-debug         : development / diagnostic only (macro-coverage does",
+    "  #                          not even compile without worker-thread).",
+    "  #   strict-default,",
+    "  #   coerce-default       : project-wide #[miniextendr] option defaults -- these",
+    "  #                          change codegen semantics, so they are opt-in.",
+    "  #   r6-default,",
+    "  #   s7-default           : mutually exclusive class-system selectors; enabling",
+    "  #                          either changes the default class system. Opt-in.",
+    "  #   worker-default       : separate opt-in semantic from `worker-thread`.",
+    "  #   indicatif            : progress-bar integration, opt-in (not in the",
+    "  #                          default integration set).",
+    "  deny <- c(",
+    "    \"default\", \"full\", \"nonapi\",",
+    "    \"macro-coverage\", \"growth-debug\",",
+    "    \"strict-default\", \"coerce-default\",",
+    "    \"r6-default\", \"s7-default\", \"worker-default\",",
+    "    \"indicatif\"",
+    "  )",
+    "",
+    "  features <- setdiff(available, deny)",
+    "",
+    "  # Conditional rules injected by minirextendr::add_feature_rule().",
+    "  # A feature listed here is enabled only if its predicate returns TRUE.",
+    "  # Features NOT listed here are enabled unconditionally (default: enable).",
+    "  # Predicates must be conservative: when in doubt, return TRUE.",
+    "  for (feat in names(rules)) {",
+    "    if (feat %in% features) {",
+    "      keep <- isTRUE(tryCatch(rules[[feat]](), error = function(e) FALSE))",
+    "      if (!keep) {",
+    "        features <- setdiff(features, feat)",
+    "        message(sprintf(\"detect-features: disabling '%s' (rule not satisfied)\", feat))",
+    "      }",
+    "    }",
+    "  }",
+    "",
+    "  # Deterministic order for stable configure output / diffs.",
+    "  features <- sort(unique(features))",
+    "",
+    "  if (length(features) == 0L) {",
+    "    stop(\"rule set eliminated every feature\")",
+    "  }",
+    "",
+    "  cat(paste(features, collapse = \",\"))",
+    "}",
+    "",
+    "# Parse the [features] table of a Cargo.toml, returning feature names.",
+    "# Base-R line scanner -- no TOML library available at configure time.",
+    "parse_cargo_features <- function(path) {",
+    "  lines <- readLines(path, warn = FALSE)",
+    "  in_features <- FALSE",
+    "  names_out <- character()",
+    "  for (ln in lines) {",
+    "    trimmed <- trimws(ln)",
+    "    # Section header?",
+    "    if (grepl(\"^\\\\[\", trimmed)) {",
+    "      in_features <- identical(trimmed, \"[features]\")",
+    "      next",
+    "    }",
+    "    if (!in_features) next",
+    "    if (!nzchar(trimmed) || startsWith(trimmed, \"#\")) next",
+    "    # A feature entry looks like `name = [ ... ]`. Names are bare identifiers",
+    "    # (letters, digits, _, -). Strip an inline trailing comment first.",
+    "    code <- sub(\"#.*$\", \"\", trimmed)",
+    "    m <- regmatches(code, regexpr(\"^[A-Za-z0-9_.+-]+(?=\\\\s*=)\", code, perl = TRUE))",
+    "    if (length(m) == 1L && nzchar(m)) {",
+    "      names_out <- c(names_out, m)",
+    "    }",
+    "  }",
+    "  unique(names_out)",
+    "}",
+    "",
+    "# Resolve src/rust/Cargo.toml. Prefer a path relative to this script (so the",
+    "# script works regardless of the working directory configure runs it from),",
+    "# then fall back to the conventional path from the package root.",
+    "find_cargo_toml <- function(args) {",
+    "  file_arg <- grep(\"^--file=\", args, value = TRUE)",
+    "  candidates <- character()",
+    "  if (length(file_arg) == 1L) {",
+    "    script_path <- sub(\"^--file=\", \"\", file_arg)",
+    "    script_dir <- dirname(normalizePath(script_path, mustWork = FALSE))",
+    "    # tools/ -> ../src/rust/Cargo.toml",
+    "    candidates <- c(candidates, file.path(script_dir, \"..\", \"src\", \"rust\", \"Cargo.toml\"))",
+    "  }",
+    "  candidates <- c(candidates, file.path(\"src\", \"rust\", \"Cargo.toml\"))",
+    "  for (cand in candidates) {",
+    "    if (file.exists(cand)) return(normalizePath(cand))",
+    "  }",
+    "  NULL",
+    "}",
+    "",
+    "# Conditional rules: populated by minirextendr::add_feature_rule() between",
+    "# the markers below. main() reads this global. Features not listed here are",
+    "# enabled unconditionally (auto-discovery).",
+    "rules <- list()",
     "## BEGIN RULES (do not edit this line)",
     "## END RULES (do not edit this line)",
     "",
-    'cat(paste(features, collapse = ","))'
+    "ok <- tryCatch({",
+    "  main()",
+    "  TRUE",
+    "}, error = function(e) {",
+    "  message(sprintf(\"detect-features: %s\", conditionMessage(e)))",
+    "  FALSE",
+    "})",
+    "",
+    "if (!isTRUE(ok)) {",
+    "  quit(status = 1L, save = \"no\")",
+    "}"
   )
 }
 
 #' Append a feature rule before the END marker
+#'
+#' Inserts a single-line `rules[["name"]] <- function() EXPR` entry between the
+#' `## BEGIN RULES` / `## END RULES` markers. `main()` iterates `rules` at
+#' configure time: listed features are enabled only when the predicate returns
+#' TRUE; unlisted features are enabled unconditionally (auto-discovery).
 #'
 #' @param script_path Path to detect-features.R
 #' @param feature Feature name
@@ -532,20 +713,10 @@ append_feature_rule <- function(script_path, feature, detect) {
   }
 
   # Format the detect expression
-  if (isTRUE(detect)) {
-    detect_str <- "TRUE"
-    comment <- "always enable"
-  } else {
-    detect_str <- detect
-    comment <- "enable if condition met"
-  }
+  detect_str <- if (isTRUE(detect)) "TRUE" else detect
 
   rule_lines <- c(
-    "",
-    sprintf("# %s: %s", feature, comment),
-    sprintf("if (%s) {", detect_str),
-    sprintf('  features <- c(features, "%s")', feature),
-    "}"
+    sprintf('rules[["%s"]] <- function() %s', feature, detect_str)
   )
 
   lines <- append(lines, rule_lines, after = end_idx[1] - 1)
@@ -553,6 +724,9 @@ append_feature_rule <- function(script_path, feature, detect) {
 }
 
 #' Remove a feature rule from the script
+#'
+#' Removes the single-line `rules[["name"]] <- function() ...` entry for the
+#' given feature from within the `## BEGIN RULES` / `## END RULES` markers.
 #'
 #' @param script_path Path to detect-features.R
 #' @param feature Feature name to remove
@@ -567,37 +741,28 @@ remove_feature_rule_from_script <- function(script_path, feature) {
     return(FALSE)
   }
 
-  # Find the rule block: comment line + if block
-  # Pattern: a comment with the feature name, followed by if/features/}
-  comment_pattern <- sprintf("^# %s:", feature)
-  comment_idx <- grep(comment_pattern, lines)
-  # Only consider comments within the rules section
-  comment_idx <- comment_idx[comment_idx > begin_idx[1] & comment_idx < end_idx[1]]
+  # Match the single-line rule: rules[["name"]] <- function() EXPR
+  rule_pattern <- sprintf('^rules\\[\\["%s"\\]\\] <- function\\(\\)', feature)
+  rule_idx <- grep(rule_pattern, lines)
+  # Only consider lines within the rules section
+  rule_idx <- rule_idx[rule_idx > begin_idx[1] & rule_idx < end_idx[1]]
 
-  if (length(comment_idx) == 0) {
+  if (length(rule_idx) == 0) {
     return(FALSE)
   }
 
-  # Find the closing brace of the if block after the comment
-  block_start <- comment_idx[1]
-  closing_brace <- grep("^}", lines)
-  closing_brace <- closing_brace[closing_brace > block_start]
-  if (length(closing_brace) == 0) {
-    return(FALSE)
-  }
-  block_end <- closing_brace[1]
-
-  # Also remove any blank line before the comment
-  if (block_start > 1 && lines[block_start - 1] == "") {
-    block_start <- block_start - 1
-  }
-
-  lines <- lines[-(block_start:block_end)]
+  lines <- lines[-rule_idx[1]]
   writeLines(lines, script_path)
   TRUE
 }
 
 #' Parse detect-features.R to extract rules
+#'
+#' Reads the `## BEGIN RULES` / `## END RULES` section and extracts each
+#' single-line `rules[["name"]] <- function() EXPR` entry. Returns a named
+#' list mapping feature name to expression string (e.g., `"TRUE"` or a
+#' `requireNamespace(...)` call). Features with no rule are enabled by default
+#' (auto-discovery) and do not appear in this list.
 #'
 #' @param script_path Path to detect-features.R
 #' @return Named list of feature -> detect expression pairs
@@ -613,26 +778,13 @@ parse_detect_features_script <- function(script_path) {
 
   rules_section <- lines[(begin_idx[1] + 1):(end_idx[1] - 1)]
 
-  # Find all if(...) { ... features <- c(features, "name") ... } blocks
-  # Extract: the if-condition and the feature name from the c() call
+  # Match: rules[["name"]] <- function() EXPR
   result <- list()
-
-  if_indices <- grep("^if \\(", rules_section)
-  for (i in if_indices) {
-    # Extract condition from: if (CONDITION) {
-    condition <- sub("^if \\((.+)\\) \\{$", "\\1", rules_section[i])
-
-    # Look for the feature name in the lines following the if
-    for (j in (i + 1):length(rules_section)) {
-      if (grepl("^}", rules_section[j])) break
-      feature_match <- regmatches(
-        rules_section[j],
-        regexpr('features <- c\\(features, "([^"]+)"\\)', rules_section[j])
-      )
-      if (length(feature_match) == 1) {
-        feature_name <- sub('.*"([^"]+)".*', "\\1", feature_match)
-        result[[feature_name]] <- condition
-      }
+  rule_pattern <- '^rules\\[\\["([^"]+)"\\]\\] <- function\\(\\) (.*)$'
+  matches <- regmatches(rules_section, regexec(rule_pattern, rules_section))
+  for (m in matches) {
+    if (length(m) == 3) {
+      result[[m[[2]]]] <- m[[3]]
     }
   }
 

--- a/minirextendr/inst/templates/monorepo/rpkg/tools/detect-features.R
+++ b/minirextendr/inst/templates/monorepo/rpkg/tools/detect-features.R
@@ -1,9 +1,9 @@
 #!/usr/bin/env Rscript
-# Configure-time Cargo feature detection for {{package}}.
+# Configure-time Cargo feature detection for miniextendr.
 #
 # Contract
 # --------
-#   Consumed by : ./configure (see configure.ac, the CARGO_FEATURES block).
+#   Consumed by : ./configure (the CARGO_FEATURES block).
 #                 configure runs `Rscript tools/detect-features.R` and captures
 #                 stdout. The `2>/dev/null || echo ""` wrapper means any failure
 #                 here (nonzero exit OR empty stdout) makes configure fall back
@@ -22,6 +22,8 @@
 #   where no package library (not even this package) is available. Do NOT
 #   library()/requireNamespace() anything beyond base/utils, and do NOT call
 #   minirextendr::* (configure.ac must not depend on minirextendr).
+#   (Exception: rule expressions in the ## BEGIN RULES block may use
+#   requireNamespace() to probe for optional packages.)
 #
 # Design
 # ------
@@ -29,11 +31,13 @@
 #   2. Enable every feature by default, then subtract:
 #        - a denylist of meta/aggregate/dev/option-default/risky features that
 #          must never be auto-enabled (see DENY below), and
-#        - conditional features whose detection rule says "no" on this machine
+#        - conditional features whose rule says "no" on this machine
 #          (e.g. vctrs needs the vctrs R package; connections needs R >= 4.3).
 #   3. Print the survivors, comma-separated.
 #
 #   Override entirely by setting CARGO_FEATURES before ./configure.
+#   Add/remove rules with: minirextendr::add_feature_rule() /
+#     minirextendr::remove_feature_rule()
 
 # Robustness wrapper: any uncaught error -> empty stdout + nonzero exit so
 # configure falls back to its hardcoded list.
@@ -58,7 +62,7 @@ main <- function() {
   #   growth-debug         : development / diagnostic only (macro-coverage does
   #                          not even compile without worker-thread).
   #   strict-default,
-  #   coerce-default       : project-wide #[miniextendr] option defaults — these
+  #   coerce-default       : project-wide #[miniextendr] option defaults -- these
   #                          change codegen semantics, so they are opt-in.
   #   r6-default,
   #   s7-default           : mutually exclusive class-system selectors; enabling
@@ -76,18 +80,10 @@ main <- function() {
 
   features <- setdiff(available, deny)
 
-  # Conditional rules. A feature listed here is enabled only if its predicate
-  # is TRUE. Features NOT listed here are enabled unconditionally (default:
-  # enable). Predicates must be conservative: when in doubt, return TRUE.
-  rules <- list(
-    # vctrs: the Rust feature wraps the vctrs R package's C ABI, so it only
-    # makes sense when vctrs is installed and loadable.
-    vctrs = function() requireNamespace("vctrs", quietly = TRUE),
-    # connections: the custom-connections C API (R_new_custom_connection)
-    # requires R >= 4.3.0. getRversion() is base R.
-    connections = function() getRversion() >= "4.3.0"
-  )
-
+  # Conditional rules injected by minirextendr::add_feature_rule().
+  # A feature listed here is enabled only if its predicate returns TRUE.
+  # Features NOT listed here are enabled unconditionally (default: enable).
+  # Predicates must be conservative: when in doubt, return TRUE.
   for (feat in names(rules)) {
     if (feat %in% features) {
       keep <- isTRUE(tryCatch(rules[[feat]](), error = function(e) FALSE))
@@ -109,7 +105,7 @@ main <- function() {
 }
 
 # Parse the [features] table of a Cargo.toml, returning feature names.
-# Base-R line scanner — no TOML library available at configure time.
+# Base-R line scanner -- no TOML library available at configure time.
 parse_cargo_features <- function(path) {
   lines <- readLines(path, warn = FALSE)
   in_features <- FALSE
@@ -152,6 +148,15 @@ find_cargo_toml <- function(args) {
   }
   NULL
 }
+
+# Conditional rules: populated by minirextendr::add_feature_rule() between
+# the markers below. main() reads this global. Features not listed here are
+# enabled unconditionally (auto-discovery).
+rules <- list()
+## BEGIN RULES (do not edit this line)
+rules[["vctrs"]] <- function() requireNamespace("vctrs", quietly = TRUE)
+rules[["connections"]] <- function() getRversion() >= "4.3.0"
+## END RULES (do not edit this line)
 
 ok <- tryCatch({
   main()

--- a/minirextendr/inst/templates/rpkg/tools/detect-features.R
+++ b/minirextendr/inst/templates/rpkg/tools/detect-features.R
@@ -1,9 +1,9 @@
 #!/usr/bin/env Rscript
-# Configure-time Cargo feature detection for {{package}}.
+# Configure-time Cargo feature detection for miniextendr.
 #
 # Contract
 # --------
-#   Consumed by : ./configure (see configure.ac, the CARGO_FEATURES block).
+#   Consumed by : ./configure (the CARGO_FEATURES block).
 #                 configure runs `Rscript tools/detect-features.R` and captures
 #                 stdout. The `2>/dev/null || echo ""` wrapper means any failure
 #                 here (nonzero exit OR empty stdout) makes configure fall back
@@ -22,6 +22,8 @@
 #   where no package library (not even this package) is available. Do NOT
 #   library()/requireNamespace() anything beyond base/utils, and do NOT call
 #   minirextendr::* (configure.ac must not depend on minirextendr).
+#   (Exception: rule expressions in the ## BEGIN RULES block may use
+#   requireNamespace() to probe for optional packages.)
 #
 # Design
 # ------
@@ -29,11 +31,13 @@
 #   2. Enable every feature by default, then subtract:
 #        - a denylist of meta/aggregate/dev/option-default/risky features that
 #          must never be auto-enabled (see DENY below), and
-#        - conditional features whose detection rule says "no" on this machine
+#        - conditional features whose rule says "no" on this machine
 #          (e.g. vctrs needs the vctrs R package; connections needs R >= 4.3).
 #   3. Print the survivors, comma-separated.
 #
 #   Override entirely by setting CARGO_FEATURES before ./configure.
+#   Add/remove rules with: minirextendr::add_feature_rule() /
+#     minirextendr::remove_feature_rule()
 
 # Robustness wrapper: any uncaught error -> empty stdout + nonzero exit so
 # configure falls back to its hardcoded list.
@@ -58,7 +62,7 @@ main <- function() {
   #   growth-debug         : development / diagnostic only (macro-coverage does
   #                          not even compile without worker-thread).
   #   strict-default,
-  #   coerce-default       : project-wide #[miniextendr] option defaults — these
+  #   coerce-default       : project-wide #[miniextendr] option defaults -- these
   #                          change codegen semantics, so they are opt-in.
   #   r6-default,
   #   s7-default           : mutually exclusive class-system selectors; enabling
@@ -76,18 +80,10 @@ main <- function() {
 
   features <- setdiff(available, deny)
 
-  # Conditional rules. A feature listed here is enabled only if its predicate
-  # is TRUE. Features NOT listed here are enabled unconditionally (default:
-  # enable). Predicates must be conservative: when in doubt, return TRUE.
-  rules <- list(
-    # vctrs: the Rust feature wraps the vctrs R package's C ABI, so it only
-    # makes sense when vctrs is installed and loadable.
-    vctrs = function() requireNamespace("vctrs", quietly = TRUE),
-    # connections: the custom-connections C API (R_new_custom_connection)
-    # requires R >= 4.3.0. getRversion() is base R.
-    connections = function() getRversion() >= "4.3.0"
-  )
-
+  # Conditional rules injected by minirextendr::add_feature_rule().
+  # A feature listed here is enabled only if its predicate returns TRUE.
+  # Features NOT listed here are enabled unconditionally (default: enable).
+  # Predicates must be conservative: when in doubt, return TRUE.
   for (feat in names(rules)) {
     if (feat %in% features) {
       keep <- isTRUE(tryCatch(rules[[feat]](), error = function(e) FALSE))
@@ -109,7 +105,7 @@ main <- function() {
 }
 
 # Parse the [features] table of a Cargo.toml, returning feature names.
-# Base-R line scanner — no TOML library available at configure time.
+# Base-R line scanner -- no TOML library available at configure time.
 parse_cargo_features <- function(path) {
   lines <- readLines(path, warn = FALSE)
   in_features <- FALSE
@@ -152,6 +148,15 @@ find_cargo_toml <- function(args) {
   }
   NULL
 }
+
+# Conditional rules: populated by minirextendr::add_feature_rule() between
+# the markers below. main() reads this global. Features not listed here are
+# enabled unconditionally (auto-discovery).
+rules <- list()
+## BEGIN RULES (do not edit this line)
+rules[["vctrs"]] <- function() requireNamespace("vctrs", quietly = TRUE)
+rules[["connections"]] <- function() getRversion() >= "4.3.0"
+## END RULES (do not edit this line)
 
 ok <- tryCatch({
   main()

--- a/minirextendr/tests/testthat/test-feature-detect-configure.R
+++ b/minirextendr/tests/testthat/test-feature-detect-configure.R
@@ -75,36 +75,129 @@ test_that("parse_detect_features_script returns empty list for no rules", {
 })
 
 test_that("generated detect script is valid R and outputs features", {
-  tmp <- tempfile(fileext = ".R")
-  on.exit(unlink(tmp), add = TRUE)
+  # The robust skeleton requires src/rust/Cargo.toml, so we build a fixture tree.
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "tools"), recursive = TRUE)
+  dir.create(file.path(tmp, "src", "rust"), recursive = TRUE)
 
+  # Cargo.toml with exactly the features under test
+  writeLines(c(
+    "[package]",
+    'name = "mypkg"',
+    'version = "0.1.0"',
+    "",
+    "[features]",
+    "rayon = []",
+    "vctrs = []"
+  ), file.path(tmp, "src", "rust", "Cargo.toml"))
+
+  script_path <- file.path(tmp, "tools", "detect-features.R")
   lines <- minirextendr:::generate_empty_detect_script("mypkg", "CARGO_FEATURES")
-  writeLines(lines, tmp)
-  minirextendr:::append_feature_rule(tmp, "rayon", TRUE)
-  minirextendr:::append_feature_rule(tmp, "vctrs", "FALSE")
+  writeLines(lines, script_path)
+  # rayon: always enable; vctrs: rule returns FALSE -> disabled
+  minirextendr:::append_feature_rule(script_path, "rayon", TRUE)
+  minirextendr:::append_feature_rule(script_path, "vctrs", "FALSE")
 
-  # Execute the script
-  output <- system2(
-    file.path(R.home("bin"), "Rscript"), tmp,
-    stdout = TRUE, stderr = FALSE
-  )
+  # Execute from the fixture root so relative Cargo.toml lookup works
+  output <- withr::with_dir(tmp, {
+    system2(
+      file.path(R.home("bin"), "Rscript"), script_path,
+      stdout = TRUE, stderr = FALSE
+    )
+  })
   expect_equal(output, "rayon")
 })
 
 test_that("generated detect script outputs multiple features comma-separated", {
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "tools"), recursive = TRUE)
+  dir.create(file.path(tmp, "src", "rust"), recursive = TRUE)
+
+  writeLines(c(
+    "[package]",
+    'name = "mypkg"',
+    'version = "0.1.0"',
+    "",
+    "[features]",
+    "rayon = []",
+    "serde = []"
+  ), file.path(tmp, "src", "rust", "Cargo.toml"))
+
+  script_path <- file.path(tmp, "tools", "detect-features.R")
+  lines <- minirextendr:::generate_empty_detect_script("mypkg", "CARGO_FEATURES")
+  writeLines(lines, script_path)
+  minirextendr:::append_feature_rule(script_path, "rayon", TRUE)
+  minirextendr:::append_feature_rule(script_path, "serde", TRUE)
+
+  output <- withr::with_dir(tmp, {
+    system2(
+      file.path(R.home("bin"), "Rscript"), script_path,
+      stdout = TRUE, stderr = FALSE
+    )
+  })
+  expect_equal(output, "rayon,serde")
+})
+
+test_that("generated detect script auto-enables features with no rule", {
+  # A feature present in Cargo.toml but with NO rule is enabled by default
+  # (auto-discovery). This is the new default-enable paradigm.
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "tools"), recursive = TRUE)
+  dir.create(file.path(tmp, "src", "rust"), recursive = TRUE)
+
+  writeLines(c(
+    "[package]",
+    'name = "mypkg"',
+    'version = "0.1.0"',
+    "",
+    "[features]",
+    "rayon = []",
+    "auto_enabled = []"
+  ), file.path(tmp, "src", "rust", "Cargo.toml"))
+
+  script_path <- file.path(tmp, "tools", "detect-features.R")
+  lines <- minirextendr:::generate_empty_detect_script("mypkg", "CARGO_FEATURES")
+  writeLines(lines, script_path)
+  # Only add a rule for rayon; auto_enabled has no rule -> enabled by default
+  minirextendr:::append_feature_rule(script_path, "rayon", TRUE)
+
+  output <- withr::with_dir(tmp, {
+    system2(
+      file.path(R.home("bin"), "Rscript"), script_path,
+      stdout = TRUE, stderr = FALSE
+    )
+  })
+  # Both features should be present (sorted)
+  expect_equal(output, "auto_enabled,rayon")
+})
+
+test_that("rpkg detect-features.R matches generator output (regenerable invariant)", {
+  # The shipped rpkg/tools/detect-features.R must equal what the generator
+  # produces for ("miniextendr", "CARGO_FEATURES") plus the two canonical rules.
   tmp <- tempfile(fileext = ".R")
   on.exit(unlink(tmp), add = TRUE)
 
-  lines <- minirextendr:::generate_empty_detect_script("mypkg", "CARGO_FEATURES")
+  lines <- minirextendr:::generate_empty_detect_script("miniextendr", "CARGO_FEATURES")
   writeLines(lines, tmp)
-  minirextendr:::append_feature_rule(tmp, "rayon", TRUE)
-  minirextendr:::append_feature_rule(tmp, "serde", TRUE)
+  minirextendr:::append_feature_rule(tmp, "vctrs", 'requireNamespace("vctrs", quietly = TRUE)')
+  minirextendr:::append_feature_rule(tmp, "connections", 'getRversion() >= "4.3.0"')
 
-  output <- system2(
-    file.path(R.home("bin"), "Rscript"), tmp,
-    stdout = TRUE, stderr = FALSE
+  generated <- readLines(tmp, warn = FALSE)
+  # Path to the shipped rpkg file (relative to the test file's package root)
+  rpkg_path <- system.file("../../rpkg/tools/detect-features.R",
+    package = "minirextendr", mustWork = FALSE
   )
-  expect_equal(output, "rayon,serde")
+  if (!nzchar(rpkg_path) || !file.exists(rpkg_path)) {
+    # Fallback: find it relative to this test file
+    rpkg_path <- file.path(
+      dirname(dirname(dirname(testthat::test_path()))),
+      "rpkg", "tools", "detect-features.R"
+    )
+  }
+  skip_if(!file.exists(rpkg_path), "rpkg/tools/detect-features.R not found (running outside repo)")
+
+  shipped <- readLines(rpkg_path, warn = FALSE)
+  expect_equal(generated, shipped)
 })
 
 test_that("patch_configure_ac_for_detection patches old-style block", {

--- a/patches/templates.patch
+++ b/patches/templates.patch
@@ -1,6 +1,6 @@
 diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
---- a/monorepo/rpkg/bootstrap.R	2026-06-12 18:16:38
-+++ b/monorepo/rpkg/bootstrap.R	2026-06-12 18:16:38
+--- a/monorepo/rpkg/bootstrap.R	2026-06-08 20:42:00
++++ b/monorepo/rpkg/bootstrap.R	2026-04-28 10:42:41
 @@ -1,40 +1,11 @@
 -# bootstrap.R - Run before package build (Config/build/bootstrap: TRUE).
 -# Invoked by pkgbuild (devtools::build, r-lib/actions/check-r-package) in
@@ -83,8 +83,8 @@ diff -ruN -U2 a/monorepo/rpkg/bootstrap.R b/monorepo/rpkg/bootstrap.R
 -  }
  }
 diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
---- a/monorepo/rpkg/configure.ac	2026-06-12 18:18:53
-+++ b/monorepo/rpkg/configure.ac	2026-06-12 18:19:25
+--- a/monorepo/rpkg/configure.ac	2026-06-13 05:35:07
++++ b/monorepo/rpkg/configure.ac	2026-06-13 05:35:07
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -395,18 +395,9 @@ diff -ruN -U2 a/monorepo/rpkg/configure.ac b/monorepo/rpkg/configure.ac
 +dnl caused warnings on Linux. See #157, #158.
  
  AC_OUTPUT
-diff -ruN -U2 a/monorepo/rpkg/tools/detect-features.R b/monorepo/rpkg/tools/detect-features.R
---- a/monorepo/rpkg/tools/detect-features.R	2026-06-12 18:16:38
-+++ b/monorepo/rpkg/tools/detect-features.R	2026-06-12 18:16:38
-@@ -1,4 +1,4 @@
- #!/usr/bin/env Rscript
--# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
-+# Configure-time Cargo feature detection for {{package}}.
- #
- # Contract
 diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
---- a/rpkg/configure.ac	2026-06-12 18:18:53
-+++ b/rpkg/configure.ac	2026-06-12 18:19:02
+--- a/rpkg/configure.ac	2026-06-13 05:35:07
++++ b/rpkg/configure.ac	2026-06-13 05:35:07
 @@ -1,3 +1,3 @@
 -AC_INIT([miniextendr], [0.1.0])
 +AC_INIT([{{package}}], [0.1.0])
@@ -663,12 +654,3 @@ diff -ruN -U2 a/rpkg/configure.ac b/rpkg/configure.ac
 +dnl caused warnings on Linux. See #157, #158.
  
  AC_OUTPUT
-diff -ruN -U2 a/rpkg/tools/detect-features.R b/rpkg/tools/detect-features.R
---- a/rpkg/tools/detect-features.R	2026-06-12 18:16:38
-+++ b/rpkg/tools/detect-features.R	2026-06-12 18:16:38
-@@ -1,4 +1,4 @@
- #!/usr/bin/env Rscript
--# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
-+# Configure-time Cargo feature detection for {{package}}.
- #
- # Contract

--- a/rpkg/tools/detect-features.R
+++ b/rpkg/tools/detect-features.R
@@ -1,9 +1,9 @@
 #!/usr/bin/env Rscript
-# Configure-time Cargo feature detection for miniextendr (rpkg demo package).
+# Configure-time Cargo feature detection for miniextendr.
 #
 # Contract
 # --------
-#   Consumed by : ./configure (see configure.ac, the CARGO_FEATURES block).
+#   Consumed by : ./configure (the CARGO_FEATURES block).
 #                 configure runs `Rscript tools/detect-features.R` and captures
 #                 stdout. The `2>/dev/null || echo ""` wrapper means any failure
 #                 here (nonzero exit OR empty stdout) makes configure fall back
@@ -22,6 +22,8 @@
 #   where no package library (not even this package) is available. Do NOT
 #   library()/requireNamespace() anything beyond base/utils, and do NOT call
 #   minirextendr::* (configure.ac must not depend on minirextendr).
+#   (Exception: rule expressions in the ## BEGIN RULES block may use
+#   requireNamespace() to probe for optional packages.)
 #
 # Design
 # ------
@@ -29,11 +31,13 @@
 #   2. Enable every feature by default, then subtract:
 #        - a denylist of meta/aggregate/dev/option-default/risky features that
 #          must never be auto-enabled (see DENY below), and
-#        - conditional features whose detection rule says "no" on this machine
+#        - conditional features whose rule says "no" on this machine
 #          (e.g. vctrs needs the vctrs R package; connections needs R >= 4.3).
 #   3. Print the survivors, comma-separated.
 #
 #   Override entirely by setting CARGO_FEATURES before ./configure.
+#   Add/remove rules with: minirextendr::add_feature_rule() /
+#     minirextendr::remove_feature_rule()
 
 # Robustness wrapper: any uncaught error -> empty stdout + nonzero exit so
 # configure falls back to its hardcoded list.
@@ -58,7 +62,7 @@ main <- function() {
   #   growth-debug         : development / diagnostic only (macro-coverage does
   #                          not even compile without worker-thread).
   #   strict-default,
-  #   coerce-default       : project-wide #[miniextendr] option defaults — these
+  #   coerce-default       : project-wide #[miniextendr] option defaults -- these
   #                          change codegen semantics, so they are opt-in.
   #   r6-default,
   #   s7-default           : mutually exclusive class-system selectors; enabling
@@ -76,18 +80,10 @@ main <- function() {
 
   features <- setdiff(available, deny)
 
-  # Conditional rules. A feature listed here is enabled only if its predicate
-  # is TRUE. Features NOT listed here are enabled unconditionally (default:
-  # enable). Predicates must be conservative: when in doubt, return TRUE.
-  rules <- list(
-    # vctrs: the Rust feature wraps the vctrs R package's C ABI, so it only
-    # makes sense when vctrs is installed and loadable.
-    vctrs = function() requireNamespace("vctrs", quietly = TRUE),
-    # connections: the custom-connections C API (R_new_custom_connection)
-    # requires R >= 4.3.0. getRversion() is base R.
-    connections = function() getRversion() >= "4.3.0"
-  )
-
+  # Conditional rules injected by minirextendr::add_feature_rule().
+  # A feature listed here is enabled only if its predicate returns TRUE.
+  # Features NOT listed here are enabled unconditionally (default: enable).
+  # Predicates must be conservative: when in doubt, return TRUE.
   for (feat in names(rules)) {
     if (feat %in% features) {
       keep <- isTRUE(tryCatch(rules[[feat]](), error = function(e) FALSE))
@@ -109,7 +105,7 @@ main <- function() {
 }
 
 # Parse the [features] table of a Cargo.toml, returning feature names.
-# Base-R line scanner — no TOML library available at configure time.
+# Base-R line scanner -- no TOML library available at configure time.
 parse_cargo_features <- function(path) {
   lines <- readLines(path, warn = FALSE)
   in_features <- FALSE
@@ -152,6 +148,15 @@ find_cargo_toml <- function(args) {
   }
   NULL
 }
+
+# Conditional rules: populated by minirextendr::add_feature_rule() between
+# the markers below. main() reads this global. Features not listed here are
+# enabled unconditionally (auto-discovery).
+rules <- list()
+## BEGIN RULES (do not edit this line)
+rules[["vctrs"]] <- function() requireNamespace("vctrs", quietly = TRUE)
+rules[["connections"]] <- function() getRversion() >= "4.3.0"
+## END RULES (do not edit this line)
 
 ok <- tryCatch({
   main()


### PR DESCRIPTION
## Summary

- **The collision was live**: scaffolded packages shipped the robust, marker-less `rpkg/tools/detect-features.R`, so `add_feature_rule()` aborted at `"Could not find '## END RULES' marker"` on any fresh scaffold.
- Unified using the **rules-list variant** (not the if-block sketch from the issue — if-blocks break the default-enable paradigm since features are already enabled unless a rule gates them).
- `generate_empty_detect_script()` now emits the full robust skeleton (Cargo.toml parser, denylist, tryCatch failure wrapper) with a top-level `rules <- list()` block between column-0 markers. `main()` reads the global `rules`; features with no rule are auto-enabled (auto-discovery).
- `append_feature_rule()` / `remove_feature_rule_from_script()` / `parse_detect_features_script()` retargeted to `rules[["name"]] <- function() EXPR` single-line format. Parse returns the same `list(name = "expr-string")` shape — existing assertions keep passing unchanged.
- `sync_feature_rules()` kept; roxygen updated to describe it as "pin explicit always-enable rules" (discovery is now automatic).
- `rpkg/tools/detect-features.R` regenerated as exact output of `generate_empty_detect_script("miniextendr","CARGO_FEATURES")` + 2 `append_feature_rule` calls (`vctrs`, `connections`). Template copies are byte-identical to rpkg (no `{{package}}` substitution — package name `miniextendr` matches across rpkg + both templates).
- `patches/templates.patch` regenerated via `just templates-approve`; the detect-features.R hunk from the old patch is gone (templates are now byte-identical to rpkg for this file).

**Note on serialization with PR #908 (`feat/use-local-miniextendr`):** Both PRs touch `patches/templates.patch`. This PR was branched from `origin/main` (neither PR was merged first). Whichever merges second must rebase and re-run `just templates-approve` before merging.

## Verification

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 51 ]  # just minirextendr-test feature-detect
```

`Rscript rpkg/tools/detect-features.R` stdout:
```
aho-corasick,arrow,bitflags,bitvec,borsh,bytes,connections,datafusion,either,indexmap,jiff,log,nalgebra,ndarray,num-bigint,num-complex,num-traits,ordered-float,rand,rand_distr,raw_conversions,rayon,regex,rust_decimal,serde,serde_json,sha2,tabled,time,tinyvec,toml,url,uuid,vctrs,worker-thread
```

`just templates-check`: PASS

Tests ported/added:
- **Ported** (2): "generated detect script is valid R and outputs features" + "...comma-separated" — now build fixture trees (`tmp/tools/detect-features.R` + `tmp/src/rust/Cargo.toml`) and run from `withr::with_dir(tmp, ...)`.
- **Added** (1): "generated detect script auto-enables features with no rule" — verifies the new auto-discovery paradigm.
- **Added** (1): "rpkg detect-features.R matches generator output (regenerable invariant)" — builds the script from `generate_empty_detect_script(...)` + 2 `append_feature_rule` calls and `expect_equal`s against the shipped rpkg file.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)