### PR TITLE
docs(r6): document $set()/@R6method extension pattern

### DIFF
--- a/docs/CLASS_SYSTEMS.md
+++ b/docs/CLASS_SYSTEMS.md
@@ -240,6 +240,40 @@ s$area           # 25
 - Active bindings (computed properties)
 - Reference semantics (modify in place)
 
+### Extending a generated R6 class from R
+
+When you need to add R-only methods to a miniextendr-scaffolded R6 class (e.g. convenience
+wrappers, formatting helpers, or methods that delegate to other R packages), roxygen2 8.0.0
+lets you document those additions outside the generated class body.
+
+**Primary form** — place a roxygen block directly above a `$set()` call; roxygen2
+auto-associates it with the class:
+
+```r
+#' @description Return a formatted label for the object.
+#' @return A character string.
+Rectangle$set("public", "label", function() {
+  paste0("Rectangle(", self$get_width(), " x ", private$.height, ")")
+})
+```
+
+**Fallback form** — when the `$set()` call escapes roxygen2's source-tracing (e.g. it lives
+inside a helper function or a conditional block), attach a `@R6method` tag to a bare `NULL`:
+
+```r
+#' @R6method Rectangle$label
+#' @description Return a formatted label for the object.
+#' @return A character string.
+NULL
+
+Rectangle$set("public", "label", function() {
+  paste0("Rectangle(", self$get_width(), " x ", private$.height, ")")
+})
+```
+
+The `@R6method ClassName$method_name` tag tells roxygen2 where to anchor the documentation
+even when it cannot trace the code attachment itself.
+
 ### Field Access via Sidecar
 
 For R6 and Env classes, the sidecar pattern (`#[r_data]` + `RSidecar`) provides


### PR DESCRIPTION
Closes #370.

## Summary

- Adds an "Extending a generated R6 class from R" subsection to `docs/CLASS_SYSTEMS.md` explaining how end-users document R-only methods they add to miniextendr-scaffolded R6 classes via `$set()`.
- Primary pattern: roxygen block directly above the `$set()` call — roxygen2 8.0.0 auto-associates it.
- Fallback pattern: `#' @R6method ClassName$method_name` above `NULL` for cases where `$set()` escapes roxygen2's source tracing.
- Template audit: `grep -rn '$set(' minirextendr/inst/templates/` — zero hits, no existing patterns need updating.
- Does NOT touch `site/` (regenerated automatically on main-push by the Pages workflow).

## #369 — recommended wontfix

> **Note for maintainer**: #369 ($set() migration for inline method docs) is recommended **wontfix** — the inline form already renders identically under roxygen2 8.0.0 per the rd-R6 vignette; migrating buys zero output delta at the cost of `$set()` install-time overhead + total R6 snapshot/fixture/cross-package rebaseline. Leaving #369 open for maintainer decision.

## Test plan

- [ ] No build required (docs-only change)
- [ ] Verify section appears correctly in `docs/CLASS_SYSTEMS.md` under "R6 Style"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>