### PR TITLE
feat(lint): MXL302 — flag into_sexp() inside vec!/array literals (UAF idiom)

### DIFF
--- a/miniextendr-lint/CLAUDE.md
+++ b/miniextendr-lint/CLAUDE.md
@@ -22,6 +22,7 @@ Build-time static analysis. Runs from a downstream crate's `build.rs` (via the `
 - **MXL203** — redundant `internal` + `noexport`.
 - **MXL300** — direct `Rf_error`/`Rf_errorcall` → replace with `panic!()` (framework converts to R error via tagged-SEXP transport).
 - **MXL301** — `_unchecked` FFI outside known-safe contexts (ALTREP callbacks, `with_r_unwind_protect`, `with_r_thread`).
+- **MXL302** — `into_sexp()`/`into_sexp_unchecked()` inside a `vec!`/`&[…]` literal (the use-after-free idiom, #307/#1025) → wrap each element in `__scope.protect_raw(…)` via a `ProtectScope`, or prefer the `IntoList`/`DataFrameRow` derives. Raw-text scanner: tracks `vec!`/`&[` bracket depth and flags `into_sexp(` while inside; the safe `vec![…].into_sexp()` whole-vec form is not flagged. Escape hatch: `// mxl::allow(MXL302)`.
 
 ## Adding a rule
 - New file under `rules/`, register in `rules.rs`, add code to `lint_code.rs`.

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -199,6 +199,11 @@ pub struct FileData {
     pub rf_error_calls: Vec<(String, usize)>,
     /// Lines containing `ffi::*_unchecked()` calls: (function_name, line_number).
     pub ffi_unchecked_calls: Vec<(String, usize)>,
+    /// `into_sexp()` / `into_sexp_unchecked()` calls that appear *inside* a `vec!`/array
+    /// literal: (call_name, line_number). This is the use-after-free idiom — each later
+    /// `into_sexp` allocates and can GC an earlier, still-unprotected element of the same
+    /// literal. (MXL302)
+    pub vec_into_sexp_calls: Vec<(String, usize)>,
 
     // R reserved-word parameter names
     /// Maps fn/method name → list of (param_name, line) for params that are R reserved words.
@@ -452,6 +457,7 @@ fn parse_file(path: &Path) -> Result<FileData, String> {
     let lines: Vec<&str> = src.lines().collect();
     scan_rf_error_calls(&lines, &mut data);
     scan_ffi_unchecked_calls(&lines, &mut data);
+    scan_vec_into_sexp_calls(&lines, &mut data);
 
     Ok(data)
 }
@@ -893,4 +899,121 @@ fn scan_rf_error_calls(lines: &[&str], data: &mut FileData) {
         }
     }
 }
+
+// region: MXL302 — `into_sexp()` inside a `vec!`/array literal (use-after-free idiom)
+
+/// `into_sexp` call spellings that build a fresh, unprotected SEXP.
+const INTO_SEXP_CALLS: &[&str] = &["into_sexp(", "into_sexp_unchecked("];
+
+/// Scan raw source text for `into_sexp()` / `into_sexp_unchecked()` calls that appear
+/// *inside* a `vec!` or `&[...]` literal — the use-after-free idiom (#307, #1025).
+///
+/// Each `into_sexp` allocates a new SEXP. When several appear as elements of one literal
+/// (`vec![(k, a.into_sexp()), (k, b.into_sexp())]`), building `b` can trigger a GC that
+/// collects the still-unprotected `a` (and vice versa), because nothing roots the earlier
+/// elements until the whole `Vec` is handed to `List::from_raw_pairs`. The fix is to route
+/// each element through the protected builder path (`__scope.protect_raw(x.into_sexp())`
+/// with a `ProtectScope`), exactly as the `IntoList` / `DataFrameRow` derives now do.
+///
+/// # Heuristic and scope
+///
+/// This is a deliberately narrow raw-text scanner (consistent with MXL300/MXL301):
+/// it tracks bracket depth opened by a `vec![` or `&[` literal and flags an `into_sexp(`
+/// call only while that depth is open. This is what makes it precise:
+///
+/// - **Flags** `vec![ ... into_sexp() ... ]` — the call is an element *inside* the literal.
+/// - **Does NOT flag** `vec![1, 2, 3].into_sexp()` — the `]` closes the literal before the
+///   `.into_sexp()` call, so depth is back to 0 (the whole `Vec` is converted as one SEXP,
+///   which is safe — there are no sibling unprotected SEXPs).
+///
+/// The protected builder path is treated as a true negative: an `into_sexp(` whose element
+/// routes through a `protect_raw(...)` / `protect(...)` / `protect_with_index(...)` call
+/// (`__scope.protect_raw(x.into_sexp())`) is *not* flagged. This is exactly the form the
+/// `IntoList` / `DataFrameRow` derives emit, and the recommended hand-written fix.
+///
+/// Known limits (false negatives, by design — to keep zero false positives):
+/// - Only `vec![` and `&[` literal opens are tracked; bare `[ ... ]` array literals are
+///   not, because a leading `[` is ambiguous with indexing (`arr[i]`). Array-literal sites
+///   are rare in this codebase; promote the scanner if one appears.
+/// - The protect-detection is per-element and line-local in spirit: an element whose
+///   `protect(...)`/`protect_raw(...)` wrapper sits on an earlier line than its `into_sexp(`
+///   is still recognised (the flag persists until the next element-separating `,`), but a
+///   contrived element that opens a protect call yet smuggles an *unprotected* sibling
+///   `into_sexp(` after the same comma-free span would be missed. No such shape exists in
+///   the corpus.
+fn scan_vec_into_sexp_calls(lines: &[&str], data: &mut FileData) {
+    // Bracket depth opened specifically by a `vec![` / `&[` literal. Nested `[` inside the
+    // literal increment it too; `]` decrements. We never let it go negative.
+    let mut literal_depth: i32 = 0;
+    // Whether the *current literal element* already routes its value through a protect call
+    // (`protect_raw(...)` / `protect(...)`). Reset at each element-separating `,` and at
+    // each literal open. This is what makes the protected builder path (the form emitted by
+    // the `IntoList` / `DataFrameRow` derives) a true negative.
+    let mut element_protected = false;
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        // Strip inline `//` comments so commented-out idioms / doc prose don't trip us.
+        let code_part = match line.find("//") {
+            Some(pos) => &line[..pos],
+            None => *line,
+        };
+
+        let bytes = code_part.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            // Detect a `vec![` / `&[` literal open (look-behind).
+            if bytes[i] == b'[' {
+                let opens_literal =
+                    code_part[..i].ends_with("vec!") || (i > 0 && bytes[i - 1] == b'&');
+                if opens_literal || literal_depth > 0 {
+                    // Either a fresh literal open, or a nested `[` while already inside one.
+                    literal_depth += 1;
+                    element_protected = false;
+                }
+                i += 1;
+                continue;
+            }
+            if bytes[i] == b']' {
+                if literal_depth > 0 {
+                    literal_depth -= 1;
+                }
+                i += 1;
+                continue;
+            }
+            if literal_depth > 0 {
+                // An element separator resets the per-element protected flag.
+                if bytes[i] == b',' {
+                    element_protected = false;
+                    i += 1;
+                    continue;
+                }
+                // A `protect_raw(` / `protect(` call before `into_sexp(` in this element
+                // means the value is rooted as it is built — the protected builder path.
+                if code_part[i..].starts_with("protect_raw(")
+                    || code_part[i..].starts_with("protect(")
+                    || code_part[i..].starts_with("protect_with_index(")
+                {
+                    element_protected = true;
+                }
+                // Flag a raw `into_sexp(` element call (not wrapped in a protect call).
+                for pattern in INTO_SEXP_CALLS {
+                    if code_part[i..].starts_with(pattern)
+                        && !element_protected
+                        && !is_suppressed(lines, line_idx, "MXL302")
+                    {
+                        let call_name = &pattern[..pattern.len() - 1];
+                        data.vec_into_sexp_calls
+                            .push((call_name.to_string(), line_idx + 1));
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+}
+// endregion
 // endregion

--- a/miniextendr-lint/src/lint_code.rs
+++ b/miniextendr-lint/src/lint_code.rs
@@ -44,6 +44,8 @@ pub enum LintCode {
     MXL300,
     /// `_unchecked` FFI call outside guard context.
     MXL301,
+    /// `into_sexp()` call inside a `vec!`/array literal — unprotected SEXP across allocations (UAF).
+    MXL302,
     // endregion
 }
 
@@ -75,7 +77,8 @@ impl LintCode {
             | Self::MXL112
             | Self::MXL203
             | Self::MXL300
-            | Self::MXL301 => Severity::Warning,
+            | Self::MXL301
+            | Self::MXL302 => Severity::Warning,
         }
     }
 }

--- a/miniextendr-lint/src/rules.rs
+++ b/miniextendr-lint/src/rules.rs
@@ -13,6 +13,7 @@ pub mod r_reserved_params;
 pub mod rf_error;
 pub mod s4_method_prefix;
 pub mod vctrs_self_ctor;
+pub mod vec_into_sexp;
 
 use crate::crate_index::CrateIndex;
 use crate::diagnostic::Diagnostic;
@@ -38,6 +39,9 @@ pub fn run_all_rules(index: &CrateIndex) -> Vec<Diagnostic> {
 
     // Per-file: sys::*_unchecked() usage (MXL301)
     ffi_unchecked::check(index, &mut diagnostics);
+
+    // Per-file: into_sexp() inside a vec!/array literal (MXL302)
+    vec_into_sexp::check(index, &mut diagnostics);
 
     // Per-file: s4_* method name on #[miniextendr(s4)] impl (MXL111)
     s4_method_prefix::check(index, &mut diagnostics);

--- a/miniextendr-lint/src/rules/vec_into_sexp.rs
+++ b/miniextendr-lint/src/rules/vec_into_sexp.rs
@@ -1,0 +1,45 @@
+//! `into_sexp()` inside a `vec!`/array literal — use-after-free idiom.
+//!
+//! - MXL302: Warns on `into_sexp()` / `into_sexp_unchecked()` calls that appear as
+//!   elements *inside* a `vec!` or `&[...]` literal.
+//!
+//!   Each `into_sexp` allocates a fresh SEXP. When several occur in one literal
+//!   (`vec![(k, a.into_sexp()), (k, b.into_sexp())]`), nothing roots the earlier
+//!   elements until the whole `Vec` reaches `List::from_raw_pairs`, so building a
+//!   later element can trigger a GC that collects an earlier, still-unprotected one
+//!   — a use-after-free. This recurred enough (#307, the 2026-05-07 gctorture audit)
+//!   that the `IntoList` / `DataFrameRow` derives now wrap every element in
+//!   `__scope.protect_raw(...)`; this lint stops new hand-written sites from
+//!   reintroducing the raw form silently.
+
+use crate::crate_index::CrateIndex;
+use crate::diagnostic::Diagnostic;
+use crate::lint_code::LintCode;
+
+pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
+    for (path, data) in &index.file_data {
+        for (call_name, line) in &data.vec_into_sexp_calls {
+            diagnostics.push(
+                Diagnostic::new(
+                    LintCode::MXL302,
+                    path,
+                    *line,
+                    format!(
+                        "`{}()` is called inside a `vec!`/array literal. Each `into_sexp` \
+                         allocates; an earlier element built this way is left unprotected \
+                         across the next element's allocation — a use-after-free under GC.",
+                        call_name
+                    ),
+                )
+                .with_help(
+                    "Protect each element as it is built: open a `ProtectScope` and wrap each \
+                     call, e.g. `__scope.protect_raw(x.into_sexp())`, then hand the `Vec` to \
+                     `List::from_raw_pairs` / `from_raw_values`. The `IntoList` and \
+                     `DataFrameRow` derives already do this — prefer them over a hand-rolled \
+                     literal. Suppress an intentional, provably-safe site with \
+                     `// mxl::allow(MXL302)`.",
+                ),
+            );
+        }
+    }
+}

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -867,3 +867,246 @@ fn mxl120_no_false_positive_for_consuming_self_on_vctrs() {
 }
 
 // endregion
+
+// region: MXL302 — into_sexp() inside a vec!/array literal (use-after-free idiom)
+
+#[test]
+fn mxl302_into_sexp_inside_vec_literal_fires() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let _ = List::from_raw_pairs(vec![
+                ("a", a.into_sexp()),
+                ("b", b.into_sexp()),
+            ]);
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL302"),
+        "expected MXL302 for into_sexp() inside vec! literal, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_single_line_pair_literal_fires() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // The minimal positive shape from the issue: `vec![ (k, into_sexp(v)) ]`.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let _ = List::from_raw_pairs(vec![("a", self.a.into_sexp()), ("b", self.b.into_sexp())]);
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL302"),
+        "expected MXL302 for single-line pair literal with into_sexp, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_unchecked_variant_fires() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let _ = vec![unsafe { a.into_sexp_unchecked() }, unsafe { b.into_sexp_unchecked() }];
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| format!("{}", d.code) == "MXL302"),
+        "expected MXL302 for into_sexp_unchecked inside vec! literal, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_whole_vec_into_sexp_does_not_fire() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // SAFE: into_sexp() is called on the *whole* vec, after the literal closes — the entire
+    // Vec is converted as a single SEXP, with no sibling unprotected SEXPs.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let _sexp = vec![self.start, self.end].into_sexp();
+            let _other = vec![1i32, 2, 3].into_sexp();
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL302"),
+        "MXL302 must NOT fire on the safe `vec![..].into_sexp()` whole-vec form, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_no_literal_does_not_fire() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // SAFE: plain `into_sexp()` outside any literal.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let s = self.value.into_sexp();
+            let _ = s;
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL302"),
+        "MXL302 must NOT fire on a bare into_sexp() outside any literal, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_protected_builder_does_not_fire() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // SAFE-by-construction: this is the exact form the `IntoList` / `DataFrameRow` derives
+    // emit — every element's `into_sexp()` is wrapped in `__scope.protect_raw(...)`, so the
+    // value is rooted as it is built. MXL302 must treat this as a true negative.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            unsafe {
+                let __scope = ProtectScope::new();
+                let _ = List::from_raw_pairs(vec![
+                    ("a", __scope.protect_raw(self.a.into_sexp())),
+                    ("b", __scope.protect_raw(self.b.into_sexp())),
+                ]);
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL302"),
+        "MXL302 must NOT fire on the protected builder form (protect_raw-wrapped into_sexp), got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_hoisted_protected_vars_does_not_fire() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // SAFE: into_sexp() is hoisted out of the literal entirely into protected variables.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            let scope = ProtectScope::new();
+            let a = scope.protect_raw(self.a.into_sexp());
+            let b = scope.protect_raw(self.b.into_sexp());
+            let _ = List::from_raw_pairs(vec![("a", a), ("b", b)]);
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL302"),
+        "MXL302 must NOT fire when into_sexp() is hoisted out of the literal into protected vars, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl302_suppressed_by_allow_comment() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        pub fn build() {
+            // mxl::allow(MXL302)
+            let _ = List::from_raw_pairs(vec![("a", a.into_sexp()), ("b", b.into_sexp())]);
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL302"),
+        "MXL302 must be suppressed by `// mxl::allow(MXL302)`, got: {:?}",
+        report.diagnostics
+    );
+}
+
+// endregion

--- a/rpkg/src/rust/conversions.rs
+++ b/rpkg/src/rust/conversions.rs
@@ -1450,10 +1450,17 @@ pub fn conv_as_named_list_array() -> AsNamedList<[(String, f64); 2]> {
 #[miniextendr]
 pub fn conv_as_named_list_heterogeneous() -> AsNamedList<Vec<(String, miniextendr_api::SEXP)>> {
     use miniextendr_api::IntoR;
+    // NOTE: This `AsNamedList<Vec<(String, SEXP)>>` fixture is inherently GC-fragile and
+    // cannot be fully fixed at this call site — the raw SEXP values are converted to a
+    // list by `AsNamedList::into_sexp` in a *later* frame (the generated wrapper), so any
+    // protect scope opened here would unprotect before that conversion runs. Tracked in
+    // #1030 (deferred-SEXP-value `AsNamedList` GC-safety). The values are built and
+    // immediately consumed on the main thread with no intervening user GC, so the existing
+    // tests pass; MXL302 is suppressed deliberately rather than masking a fixable site.
     AsNamedList(vec![
-        ("name".into(), "Alice".to_string().into_sexp()),
-        ("age".into(), 30i32.into_sexp()),
-        ("score".into(), 95.5f64.into_sexp()),
+        ("name".into(), "Alice".to_string().into_sexp()), // mxl::allow(MXL302)
+        ("age".into(), 30i32.into_sexp()),                // mxl::allow(MXL302)
+        ("score".into(), 95.5f64.into_sexp()),            // mxl::allow(MXL302)
     ])
 }
 

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -21,7 +21,16 @@ pub struct WithBoxedSlice {
 impl ::miniextendr_api::list::IntoList for WithBoxedSlice {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![("data", self.data.into_vec().into_sexp())])
+        // Protect each value as it is built so it survives `from_raw_pairs`'s internal
+        // allocations (VECSXP + names STRSXP via `charsxp`) — mirrors `#[derive(IntoList)]`.
+        // SAFETY: IntoList runs on the R main thread.
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![(
+                "data",
+                __scope.protect_raw(self.data.into_vec().into_sexp()),
+            )])
+        }
     }
 }
 
@@ -41,7 +50,14 @@ pub struct WithArrayAsList {
 impl ::miniextendr_api::list::IntoList for WithArrayAsList {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![("coords", self.coords.to_vec().into_sexp())])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![(
+                "coords",
+                __scope.protect_raw(self.coords.to_vec().into_sexp()),
+            )])
+        }
     }
 }
 
@@ -55,7 +71,14 @@ impl ::miniextendr_api::list::IntoList for WithHashSet {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
         let tags_vec: Vec<String> = self.tags.into_iter().collect();
-        ::miniextendr_api::List::from_raw_pairs(vec![("tags", tags_vec.into_sexp())])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![(
+                "tags",
+                __scope.protect_raw(tags_vec.into_sexp()),
+            )])
+        }
     }
 }
 
@@ -69,7 +92,14 @@ impl ::miniextendr_api::list::IntoList for WithBTreeSet {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
         let cats_vec: Vec<i32> = self.categories.into_iter().collect();
-        ::miniextendr_api::List::from_raw_pairs(vec![("categories", cats_vec.into_sexp())])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![(
+                "categories",
+                __scope.protect_raw(cats_vec.into_sexp()),
+            )])
+        }
     }
 }
 
@@ -84,11 +114,21 @@ pub struct MixedCollections {
 impl ::miniextendr_api::list::IntoList for MixedCollections {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("vec_field", self.vec_field.into_sexp()),
-            ("array_field", self.array_field.to_vec().into_sexp()),
-            ("boxed_field", self.boxed_field.into_vec().into_sexp()),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![
+                ("vec_field", __scope.protect_raw(self.vec_field.into_sexp())),
+                (
+                    "array_field",
+                    __scope.protect_raw(self.array_field.to_vec().into_sexp()),
+                ),
+                (
+                    "boxed_field",
+                    __scope.protect_raw(self.boxed_field.into_vec().into_sexp()),
+                ),
+            ])
+        }
     }
 }
 
@@ -104,10 +144,14 @@ pub struct WithSkip {
 impl ::miniextendr_api::list::IntoList for WithSkip {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("name", self.name.into_sexp()),
-            ("value", self.value.into_sexp()),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![
+                ("name", __scope.protect_raw(self.name.into_sexp())),
+                ("value", __scope.protect_raw(self.value.into_sexp())),
+            ])
+        }
     }
 }
 
@@ -122,10 +166,14 @@ pub struct WithRename {
 impl ::miniextendr_api::list::IntoList for WithRename {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("label", self.name.into_sexp()),
-            ("value", self.value.into_sexp()),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see WithBoxedSlice).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![
+                ("label", __scope.protect_raw(self.name.into_sexp())),
+                ("value", __scope.protect_raw(self.value.into_sexp())),
+            ])
+        }
     }
 }
 
@@ -283,14 +331,20 @@ pub struct WithOptMapAsList {
 impl IntoList for WithOptMapAsList {
     fn into_list(self) -> miniextendr_api::List {
         use miniextendr_api::{IntoR, SEXP};
-        let counts_sexp = match self.counts {
-            Some(m) => m.into_list().into_sexp(),
-            None => SEXP::nil(),
-        };
-        miniextendr_api::List::from_raw_pairs(vec![
-            ("id", self.id.into_sexp()),
-            ("counts", counts_sexp),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect both values as built — the
+        // pre-built `counts_sexp` must survive `self.id.into_sexp()` and `from_raw_pairs`'s
+        // internal allocations. Mirrors `#[derive(IntoList)]`.
+        unsafe {
+            let __scope = miniextendr_api::gc_protect::ProtectScope::new();
+            let counts_sexp = __scope.protect_raw(match self.counts {
+                Some(m) => m.into_list().into_sexp(),
+                None => SEXP::nil(),
+            });
+            miniextendr_api::List::from_raw_pairs(vec![
+                ("id", __scope.protect_raw(self.id.into_sexp())),
+                ("counts", counts_sexp),
+            ])
+        }
     }
 }
 

--- a/rpkg/src/rust/dataframe_examples.rs
+++ b/rpkg/src/rust/dataframe_examples.rs
@@ -30,10 +30,19 @@ pub struct SimplePerson {
 impl ::miniextendr_api::list::IntoList for SimplePerson {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("name", self.name.into_sexp()),
-            ("age", self.age.into_sexp()),
-        ])
+        // Wrap each `into_sexp()` in `__scope.protect_raw` so an earlier field SEXP stays
+        // rooted across the next field's allocation — otherwise the raw
+        // `vec![(name, into_sexp(...)), ...]` form is a use-after-free under GC. This
+        // mirrors what `#[derive(IntoList)]` generates; see MXL302 /
+        // reviews/2026-05-07-gctorture-audit.md.
+        // SAFETY: IntoList runs on the R main thread.
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::list::List::from_raw_pairs(vec![
+                ("name", __scope.protect_raw(self.name.into_sexp())),
+                ("age", __scope.protect_raw(self.age.into_sexp())),
+            ])
+        }
     }
 }
 

--- a/rpkg/src/rust/dataframe_reader_roundtrip_test.rs
+++ b/rpkg/src/rust/dataframe_reader_roundtrip_test.rs
@@ -56,10 +56,15 @@ pub struct RListBoxRow {
 impl ::miniextendr_api::list::IntoList for RListBoxRow {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("tag", self.tag.into_sexp()),
-            ("xs", self.xs.into_vec().into_sexp()),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect each value as built so it
+        // survives `from_raw_pairs`'s internal allocations — mirrors `#[derive(IntoList)]`.
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![
+                ("tag", __scope.protect_raw(self.tag.into_sexp())),
+                ("xs", __scope.protect_raw(self.xs.into_vec().into_sexp())),
+            ])
+        }
     }
 }
 
@@ -105,11 +110,15 @@ impl ::miniextendr_api::list::IntoList for WithIntMap {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
         let (keys, vals): (Vec<i32>, Vec<f64>) = self.tally.into_iter().unzip();
-        ::miniextendr_api::List::from_raw_pairs(vec![
-            ("id", self.id.into_sexp()),
-            ("tally_keys", keys.into_sexp()),
-            ("tally_values", vals.into_sexp()),
-        ])
+        // SAFETY: IntoList runs on the R main thread. Protect-as-built (see RListBoxRow).
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![
+                ("id", __scope.protect_raw(self.id.into_sexp())),
+                ("tally_keys", __scope.protect_raw(keys.into_sexp())),
+                ("tally_values", __scope.protect_raw(vals.into_sexp())),
+            ])
+        }
     }
 }
 

--- a/rpkg/src/rust/dataframe_struct_flatten_test.rs
+++ b/rpkg/src/rust/dataframe_struct_flatten_test.rs
@@ -134,7 +134,15 @@ pub struct FlatSkip {
 impl ::miniextendr_api::list::IntoList for FlatSkip {
     fn into_list(self) -> ::miniextendr_api::List {
         use ::miniextendr_api::IntoR;
-        ::miniextendr_api::List::from_raw_pairs(vec![("id", self.id.into_sexp())])
+        // SAFETY: IntoList runs on the R main thread. Protect the value as built so it
+        // survives `from_raw_pairs`'s internal allocations — mirrors `#[derive(IntoList)]`.
+        unsafe {
+            let __scope = ::miniextendr_api::gc_protect::ProtectScope::new();
+            ::miniextendr_api::List::from_raw_pairs(vec![(
+                "id",
+                __scope.protect_raw(self.id.into_sexp()),
+            )])
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1025.

Adds **MXL302**, a build-time lint that flags the `vec![(k, into_sexp(v)), …]` use-after-free idiom and points at the protected builder path. Also fixes every genuine instance the new rule surfaced in the existing corpus.

<details>
<summary>AI-written details (Claude Opus 4.8)</summary>

## The rule

`into_sexp()` allocates a fresh SEXP. When several appear as elements of one `vec!`/`&[…]` literal, nothing roots the earlier elements until the whole `Vec` reaches `List::from_raw_pairs`, so building a later element can trigger a GC that collects an earlier, still-unprotected one — a use-after-free. This recurred enough (#307, the 2026-05-07 gctorture audit) that the `IntoList` / `DataFrameRow` derives now wrap every element in `__scope.protect_raw(...)`. MXL302 stops new hand-written sites from reintroducing the raw form silently.

- **MXL number:** `MXL302` — next free in the P2 Safety band (after MXL300/MXL301), the natural home for a GC-discipline rule.
- **Severity:** Warning (matches the other P2 safety rules).
- **Escape hatch:** `// mxl::allow(MXL302)` — the same per-line allow-comment mechanism MXL300/MXL301 use (current line or the line directly above). `MINIEXTENDR_LINT=0` disables all rules globally.

## Detection heuristic and its limits

Raw-text scanner (`crate_index.rs::scan_vec_into_sexp_calls`), consistent with the MXL300/MXL301 scanners:

- Tracks bracket depth opened by a `vec![` or `&[` literal; flags an `into_sexp(` / `into_sexp_unchecked(` call **only while that depth is open**.
- **Flags:** `vec![ … into_sexp() … ]` (call is an element inside the literal).
- **Does NOT flag** `vec![1,2,3].into_sexp()` — the `]` closes the literal before the call, so depth is 0 (the whole `Vec` becomes one SEXP — no sibling unprotected SEXPs).
- **Does NOT flag** the protected builder form `__scope.protect_raw(x.into_sexp())` — a per-element flag records when a `protect_raw(` / `protect(` / `protect_with_index(` call wraps the element. This is exactly what the `IntoList`/`DataFrameRow` derives emit and the recommended hand-written fix.

Known limits (false negatives, chosen to keep **zero false positives**):
- Only `vec![` and `&[` opens are tracked; a bare `[ … ]` array literal is not (a leading `[` is ambiguous with indexing). No such site exists in the corpus.
- Protect-detection is per-element (reset at each element-separating `,`); a contrived element that opens a protect call yet smuggles an unprotected sibling `into_sexp(` in the same comma-free span would be missed. No such shape exists in the corpus.

## Corpus verification (no false positives)

I ran the lint's `run()` over every crate root that runs the lint via `build.rs`, both without features and with the feature-gated modules walked (`CARGO_FEATURE_*` set for nonapi/connections/rayon/rand/serde/ndarray/either):

| crate | files | MXL302 (before fixes) | MXL302 (after fixes) |
|---|---|---|---|
| miniextendr-api | 102–117 | 0 | 0 |
| miniextendr-macros | 50 | 0 | 0 |
| miniextendr-engine | 2 | 0 | 0 |
| rpkg/src/rust | 91–101 | **18** | **0** |
| tests/cross-package/* | 1 each | 0 | 0 |

The 18 rpkg hits were **all genuine** instances of the idiom in hand-written `IntoList` impls (test fixtures in `dataframe_collections_test.rs`, `dataframe_reader_roundtrip_test.rs`, `dataframe_struct_flatten_test.rs`) plus the `dataframe_examples.rs` `SimplePerson` impl. Per the issue's instruction ("fix that site if it is genuinely the UAF idiom"), each was fixed with the derive's `ProtectScope` + `protect_raw(...)` pattern.

One site **cannot** be fixed locally and is suppressed with `// mxl::allow(MXL302)`: `conv_as_named_list_heterogeneous()` builds raw `SEXP` values whose list conversion (`AsNamedList<Vec<(String, SEXP)>>::into_sexp`) is deferred to a *later* frame by the generated wrapper — so no protect scope opened in the builder can span the conversion. This is structural GC-fragility of the raw-SEXP-value `AsNamedList` shape, tracked in **#1030** rather than masked.

## What I ran (all sandbox-disabled where compiling)

- `cargo test -p miniextendr-lint` → **38 passed, 1 ignored** (9 new MXL302 tests).
- `cargo clippy -p miniextendr-lint --all-targets -- -D warnings` → clean.
- `cargo check` on `rpkg/src/rust` (the modified fixtures) → compiles.
- `cargo fmt --all --check` (root) and `cargo fmt --check` (rpkg rust crate) → clean.
- Corpus scan (throwaway example, since removed) → table above.

## Follow-up filed

- **#1030** — `AsNamedList<Vec<(String, SEXP)>>` deferred-conversion path is GC-fragile (the one suppressed site).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)