### PR TITLE
test(ci): nightly gctorture2 full-suite torture job (#1024)

### DIFF
--- a/.github/workflows/gctorture-nightly.yml
+++ b/.github/workflows/gctorture-nightly.yml
@@ -1,0 +1,151 @@
+name: gctorture nightly
+
+# Full-suite gctorture2 sweep over rpkg's testthat suite. Surfaces the long-tail
+# use-after-free class that the fast per-function gctorture(TRUE) sweep (run
+# inline elsewhere) misses: any SEXP reachable through Rust state but not rooted
+# in R's protect mechanism gets collected on the next allocation. The strict-
+# glibc R-release runner aborts on these (`malloc(): unsorted double linked list
+# corrupted`); other runtimes silently corrupt and "pass" — so a scheduled
+# full-suite torture pass on the R-release Linux runner is the only thing that
+# reliably catches this class before a release. See docs/GCTORTURE_TESTING.md.
+#
+# Deliberately NOT on the pull_request / push matrix: the run takes 30-90 minutes
+# (~100x slowdown at step=100), far too expensive for a PR gate. Scheduled nightly
+# plus a manual workflow_dispatch trigger for on-demand verification.
+
+on:
+  # 04:00 UTC daily — a low-traffic hour, and offset from the weekly CI cron
+  # (Sat 06:00 UTC in ci.yml) so the two never contend for runner capacity.
+  schedule:
+    - cron: '0 4 * * *'
+  # Manual trigger so the sweep can be exercised on demand (e.g. to validate
+  # this workflow, or after landing SEXP-storage changes) without waiting for
+  # the nightly cron.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gctorture-full:
+    name: gctorture2 full-suite sweep / Linux R-release
+    runs-on: ubuntu-latest
+    # ~2x the r-check-linux job's 60-minute timeout: the step=100 sweep is
+    # ~100x slower than a baseline test run, and the full suite already takes
+    # the better part of an hour without torture on cold caches. 120 minutes
+    # leaves headroom for the cdylib->staticlib double-link build plus the sweep.
+    timeout-minutes: 120
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: rpkg
+          extra-packages: any::testthat
+          needs: check
+
+      - name: Install autoconf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rpkg/src/rust -> target
+          shared-key: gctorture-nightly-r-release
+          cache-on-failure: true
+
+      - name: Configure Linux
+        run: |
+          echo "LD_LIBRARY_PATH=$(R -s -e 'cat(R.home(\"lib\"))')" >> "$GITHUB_ENV"
+
+      # Install cargo-revendor so `just configure` (a dep of gctorture-full)
+      # can sync the workspace siblings into rpkg/vendor/ in dev-monorepo mode.
+      # We deliberately do NOT run `just vendor` / seal a tarball here: this job
+      # does a plain `R CMD INSTALL rpkg` in SOURCE mode (framework crates
+      # resolve from the workspace via [patch."git+url"]), not an offline
+      # tarball install. A leaked inst/vendor.tar.xz would flip configure into
+      # tarball mode and trip gctorture-full's _assert-no-vendor-leak guard.
+      - name: Install cargo-revendor
+        run: cargo install --path cargo-revendor
+
+      # The sweep is driven directly via Rscript (not `R CMD check`), so the only
+      # thing that can abort it from underneath us is the job timeout-minutes
+      # (set to 2x the r-check-linux budget above) — the harness also calls
+      # setTimeLimit(Inf)/options(timeout=Inf) defensively.
+      - name: Run gctorture2 full-suite sweep
+        id: sweep
+        run: |
+          set -o pipefail
+          # `just gctorture-full` installs rpkg into a throwaway library, then
+          # runs scripts/gctorture-full-sweep.R at step=100: it loads the package
+          # FIRST, pre-attaches lazy helpers, enables
+          # gctorture2(step=100, wait=0, inhibit_release=FALSE), then test_dir()s
+          # the whole rpkg suite (docs/GCTORTURE_TESTING.md harness ordering).
+          just gctorture-full 2>&1 | tee "$RUNNER_TEMP/gctorture.log"
+
+      # Surface the offending test file/context in the job summary on failure.
+      # The harness prints an "Offending test files:" block and exits non-zero;
+      # a strict-allocator abort (no R-level traceback) instead leaves the last
+      # printed ProgressReporter context as the culprit, so we surface both.
+      - name: Surface failures in job summary
+        if: failure()
+        run: |
+          {
+            echo "## gctorture2 full-suite sweep FAILED"
+            echo ""
+            echo "The nightly step=100 torture sweep surfaced a likely SEXP-protection bug."
+            echo "See docs/GCTORTURE_TESTING.md for how to reproduce and interpret."
+            echo ""
+            if [ -f "$RUNNER_TEMP/gctorture.log" ]; then
+              if grep -q "Offending test files:" "$RUNNER_TEMP/gctorture.log"; then
+                echo "### Offending test files"
+                echo '```'
+                sed -n '/Offending test files:/,$p' "$RUNNER_TEMP/gctorture.log"
+                echo '```'
+              else
+                echo "### Probable strict-allocator abort (no R-level traceback)"
+                echo "The script likely SIGSEGV'd / aborted mid-sweep — the last"
+                echo "ProgressReporter context below is the most likely culprit."
+                echo '```'
+                tail -n 60 "$RUNNER_TEMP/gctorture.log"
+                echo '```'
+              fi
+            else
+              echo "No sweep log captured — the job likely failed before the sweep ran."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sweep log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gctorture-nightly-log
+          path: ${{ runner.temp }}/gctorture.log
+          retention-days: 14
+          if-no-files-found: ignore

--- a/docs/GCTORTURE_TESTING.md
+++ b/docs/GCTORTURE_TESTING.md
@@ -133,6 +133,18 @@ For a tighter feedback loop while bisecting:
 
 ## Adding to CI
 
-A nightly `gctorture-nightly` job invoking the full-suite recipe at `step = 100` would
-catch this class of bug before it reaches a release. **Not yet wired up** — the Linux
-release runner needs ~2× current timeout. Tracked at TODO (file an issue when adding).
+A nightly `gctorture nightly` job invokes the full-suite recipe at `step = 100` on the
+Linux R-release runner, catching this class of bug before it reaches a release. It is
+**wired up** at `.github/workflows/gctorture-nightly.yml` (#1024):
+
+- Scheduled at 04:00 UTC daily, plus `workflow_dispatch` for on-demand runs. It is
+  deliberately **not** on the `pull_request` / `push` matrix — the sweep takes 30–90
+  minutes, too expensive for a PR gate.
+- `timeout-minutes: 120` — ~2× the `r-check-linux` job's 60-minute budget, since the
+  step=100 sweep is ~100× slower than a baseline test run. The harness also calls
+  `setTimeLimit(Inf)` / `options(timeout = Inf)` so R's own wall-clock limits never
+  abort the (deliberately slow) run.
+- The torture logic lives in `just gctorture-full` (→ `scripts/gctorture-full-sweep.R`),
+  so it is testable locally: `just gctorture-full` runs the same sweep, and
+  `just gctorture-full step=10` is the faster bisect mode. On failure the workflow
+  surfaces the offending test file(s) in the GitHub job summary.

--- a/justfile
+++ b/justfile
@@ -589,6 +589,31 @@ test-bootstrap-vendor:
     bash tests/vendor-loud-fail.sh
     bash tests/vendor-cross-surface-rename.sh
 
+# Full-suite gctorture2 sweep over rpkg's testthat suite (slow — nightly CI).
+#
+# Catches the long-tail use-after-free class the fast per-function
+# gctorture(TRUE) sweep misses: any SEXP reachable through Rust state but not
+# rooted in R's protect mechanism. The strict-glibc R-release runner aborts on
+# these; other runtimes silently corrupt and "pass". See docs/GCTORTURE_TESTING.md.
+#
+# Installs rpkg into a throwaway library (the harness does `library(miniextendr)`
+# — devtools::load_all is unsafe under gctorture per the doc's pitfall #1), then
+# runs scripts/gctorture-full-sweep.R at step=100. Expect 30-90 minutes locally,
+# longer in CI; wire it as a scheduled job, not a PR gate
+# (.github/workflows/gctorture-nightly.yml).
+#
+# Override step with the STEP arg (step=10 for a faster bisect, step=1 = full
+# gctorture(TRUE)). Exits non-zero and lists the offending test files on failure.
+#
+# Full-suite gctorture2 sweep over rpkg tests (slow; nightly CI)
+[script("bash")]
+gctorture-full STEP="100": _assert-no-vendor-leak configure
+    set -euo pipefail
+    libdir="$(mktemp -d)"
+    trap 'rm -rf "$libdir"' EXIT
+    R CMD INSTALL --library="$libdir" rpkg
+    R_LIBS_USER="$libdir" Rscript scripts/gctorture-full-sweep.R rpkg/tests/testthat {{STEP}}
+
 # Load and test rpkg with devtools
 devtools-test FILTER="": _assert-no-vendor-leak devtools-document
     if [ -z "{{FILTER}}" ]; then \

--- a/scripts/gctorture-full-sweep.R
+++ b/scripts/gctorture-full-sweep.R
@@ -1,0 +1,111 @@
+#!/usr/bin/env Rscript
+
+# Full-suite gctorture2 sweep over rpkg's testthat suite.
+#
+# Surfaces the long-tail use-after-free class that the fast per-function
+# gctorture(TRUE) sweep misses: any SEXP reachable through Rust state but not
+# rooted in R's protect mechanism gets collected on the next allocation. The
+# strict-glibc R-release runner aborts on these (`malloc(): unsorted double
+# linked list corrupted`); other runtimes silently corrupt and "pass".
+#
+# Honors the harness ordering documented in docs/GCTORTURE_TESTING.md:
+#   1. library(miniextendr) FIRST (loading under gctorture crashes on unrelated
+#      CRAN-package .onLoad hooks).
+#   2. Pre-attach the lazy-loaded helpers test_dir() would otherwise attach
+#      mid-run (each .onLoad is a gctorture-amplified hazard — journal
+#      2026-05-08-gctorture-uaf-audit.md).
+#   3. gctorture2(step = 100, wait = 0, inhibit_release = FALSE).
+#   4. testthat::test_dir(...) over rpkg/tests/testthat.
+#
+# Intended to run on a scheduled CI job (.github/workflows/gctorture-nightly.yml)
+# and locally for bisects. Expect 30-90 minutes locally; longer in CI.
+#
+# Usage:
+#   Rscript scripts/gctorture-full-sweep.R [tests_dir] [step]
+# Defaults: tests_dir = rpkg/tests/testthat, step = 100.
+
+args <- commandArgs(trailingOnly = TRUE)
+tests_dir <- if (length(args) >= 1L && nzchar(args[[1L]])) args[[1L]] else "rpkg/tests/testthat"
+step <- if (length(args) >= 2L && nzchar(args[[2L]])) as.integer(args[[2L]]) else 100L
+
+if (!dir.exists(tests_dir)) {
+  stop(sprintf("tests dir not found: %s (run from repo root)", tests_dir))
+}
+
+# --- 1. Load the package FIRST, before any gctorture. --------------------------
+library(miniextendr)
+library(testthat)
+
+# --- 2. Pre-attach lazy helpers test_dir() would otherwise load mid-sweep. -----
+# Each .onLoad under gctorture is a torture-amplified hazard in an unrelated
+# CRAN package; attach them now so the sweep only stresses our own code paths.
+for (pkg in c("rlang", "withr", "lifecycle", "cli", "vctrs", "jsonlite")) {
+  suppressWarnings(suppressMessages(
+    tryCatch(
+      requireNamespace(pkg, quietly = TRUE),
+      error = function(e) FALSE
+    )
+  ))
+}
+
+# Don't let R's wall-clock limits abort the (deliberately) slow run.
+setTimeLimit(Inf, Inf, transient = FALSE)
+options(timeout = max(unlist(options("timeout")), 1e9))
+
+cat(sprintf(
+  "gctorture-full-sweep: step=%d over %s (miniextendr %s)\n",
+  step, tests_dir, as.character(utils::packageVersion("miniextendr"))
+))
+
+# --- 3. Enable full-suite torture. ---------------------------------------------
+gctorture2(step = step, wait = 0L, inhibit_release = FALSE)
+
+# --- 4. Run the whole suite; never stop on first failure (collect everything). -
+res <- tryCatch(
+  testthat::test_dir(
+    tests_dir,
+    reporter = testthat::ProgressReporter,
+    stop_on_failure = FALSE
+  ),
+  error = function(e) e
+)
+
+# Disable torture before we do any reporting allocations.
+gctorture2(step = 0L)
+
+if (inherits(res, "condition")) {
+  cat("gctorture-full-sweep: test_dir() itself errored:\n")
+  cat(conditionMessage(res), "\n")
+  quit(status = 1L, save = "no")
+}
+
+df <- as.data.frame(res)
+failed <- df[df$failed > 0L | df$error, , drop = FALSE]
+
+n_failed <- sum(df$failed)
+n_error <- sum(df$error)
+
+cat("\n========================================\n")
+cat(sprintf(
+  "gctorture-full-sweep summary: %d files, %d failed assertions, %d errored files\n",
+  nrow(df), n_failed, sum(df$error)
+))
+cat("========================================\n")
+
+if (nrow(failed) > 0L) {
+  cat("\nOffending test files:\n")
+  for (i in seq_len(nrow(failed))) {
+    cat(sprintf(
+      "  - %s :: %s (failed=%d error=%s)\n",
+      failed$file[[i]], failed$context[[i]],
+      failed$failed[[i]], as.character(failed$error[[i]])
+    ))
+  }
+}
+
+if (n_failed > 0L || n_error > 0L) {
+  quit(status = 1L, save = "no")
+}
+
+cat("gctorture-full-sweep: clean — 0 failures, 0 errors.\n")
+quit(status = 0L, save = "no")


### PR DESCRIPTION
Closes #1024.

Wires up the long-promised nightly full-suite `gctorture2` sweep. The per-function `gctorture(TRUE)` sweep catches the easy cases, but the full-suite `gctorture2(step=N)` pass that catches the long-tail use-after-free class before a release was still only a "file an issue when adding" TODO.

<details>
<summary>AI-authored details (Claude Opus 4.8)</summary>

## What & why

`docs/GCTORTURE_TESTING.md:136-138` recommended a nightly `gctorture2(step=100)` job on the strict-glibc Linux R-release runner — the one runtime that *aborts* on these bugs (`malloc(): unsorted double linked list corrupted`) instead of silently corrupting and "passing". It was marked **Not yet wired up**. This PR wires it.

## Cron schedule + manual trigger

```yaml
on:
  schedule:
    - cron: '0 4 * * *'   # 04:00 UTC daily — low-traffic, offset from ci.yml's weekly Sat 06:00 UTC
  workflow_dispatch:       # on-demand verification (this PR can't exercise the sweep itself)
```

Deliberately **not** on the `pull_request` / `push` matrix — the sweep is ~100x slower (30–90 min) and far too expensive for a PR gate.

## Runner

Single `ubuntu-latest` job pinned to `r-version: release` — mirrors the existing `r-check-linux` release job (same toolchain bootstrap: `setup-r`, `setup-r-dependencies`, autoconf, `dtolnay/rust-toolchain`, sccache, `Swatinem/rust-cache`). cargo-revendor is installed so `just configure` resolves the framework crates from workspace siblings in **source mode** (a plain `R CMD INSTALL rpkg`, not an offline tarball — no `just vendor`, so the `_assert-no-vendor-leak` latch guard stays happy).

## Torture invocation

`scripts/gctorture-full-sweep.R` follows the doc's harness ordering verbatim. Quoting `docs/GCTORTURE_TESTING.md`:

> **Always** load the package first, then flip gctorture on
> `test_dir` may attach extra packages (rlang, withr, dplyr, …) the first time it runs. Each `.onLoad` hook is a gctorture-amplified hazard

and the §83-103 full-suite recipe:

> ```r
> gctorture2(step = 100, wait = 0, inhibit_release = FALSE)
> res <- test_dir("rpkg/tests/testthat", reporter = ProgressReporter, stop_on_failure = FALSE)
> gctorture2(step = 0)  # disable
> ```

So the script: (1) `library(miniextendr)` + `library(testthat)` FIRST; (2) pre-attaches `rlang/withr/lifecycle/cli/vctrs/jsonlite`; (3) `gctorture2(step = 100, wait = 0, inhibit_release = FALSE)`; (4) `test_dir(..., stop_on_failure = FALSE)`. Encapsulated behind `just gctorture-full STEP="100"` so the logic is testable locally (`step=10` for faster bisects) and the workflow stays thin.

## Timeout doubling

`timeout-minutes: 120` — ~2x the `r-check-linux` job's `timeout-minutes: 60`. The step=100 sweep is ~100x slower than a baseline test run, and the full suite already takes the better part of an hour without torture on cold caches. The harness also calls `setTimeLimit(Inf)` / `options(timeout = Inf)` so R's own wall-clock limits never abort the run.

## Failure surfacing

`tee` the sweep to a log; on `failure()` write to `$GITHUB_STEP_SUMMARY`. The harness prints an `Offending test files:` block (parsed via `sed`) and exits non-zero; if it instead hard-aborts under the strict allocator (no R-level traceback), the step surfaces the last 60 log lines (the last `ProgressReporter` context is the most likely culprit). Log uploaded as an artifact.

## Docs

`docs/GCTORTURE_TESTING.md` "Adding to CI" updated — the TODO is resolved and now points at the wired-up job.

## Validation

- `actionlint .github/workflows/gctorture-nightly.yml` — pass.
- `python3 -c "import yaml; yaml.safe_load(...)"` — pass.
- `just --list` shows `gctorture-full`; `just -n gctorture-full` parses; full `just --summary` parses.
- `Rscript -e 'parse(...)'` on the harness — pass.
- Cross-checked the testthat results data.frame columns (`failed` int, `error` logical, `file`, `context`) against the testthat source — the pass/fail logic matches testthat's own `all_passed()`.
- Confirmed the job is NOT on any `pull_request`/`push` trigger (the only mention is a comment explaining its exclusion).

The sweep can't run in the PR pipeline — it first executes on the next nightly cron or via manual `workflow_dispatch`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)