### PR TITLE
feat(lint): MXL303 — trait-impl vtable-symbol collision detection (TRAIT_AS_R M3)

### DIFF
--- a/docs/TRAIT_AS_R.md
+++ b/docs/TRAIT_AS_R.md
@@ -47,7 +47,7 @@ The trait ABI enables:
 | Future Lints | Purpose |
 |--------------|---------|
 | `missing_vtable` | `impl Trait for Type` without `#[miniextendr]` on the impl |
-| `tag_collision` | Duplicate `mx_tag` values across traits |
+| `tag_collision` (MXL303) | Duplicate vtable symbols across trait impls (case-fold collapse) |
 | `unused_trait_impl` | Vtable generated but type not exposed via ExternalPtr |
 
 ### C (example package)
@@ -169,7 +169,7 @@ pub struct mx_erased {
 - [x] Documentation (TRAIT_AS_R.md updated with usage examples)
 - [x] Error diagnostics (improved runtime error messages for type mismatches)
 - [x] miniextendr-lint: missing `impl Trait for Type;` registration detection
-- [ ] miniextendr-lint: tag collision detection (future)
+- [x] miniextendr-lint: tag collision detection (MXL303 — vtable-symbol case-fold collision across trait impls)
 - [x] R tests for trait method `.Call` wrappers (`rpkg/tests/testthat/test-trait-abi.R`)
 
 ## Design Decisions

--- a/miniextendr-lint/CLAUDE.md
+++ b/miniextendr-lint/CLAUDE.md
@@ -23,6 +23,7 @@ Build-time static analysis. Runs from a downstream crate's `build.rs` (via the `
 - **MXL300** — direct `Rf_error`/`Rf_errorcall` → replace with `panic!()` (framework converts to R error via tagged-SEXP transport).
 - **MXL301** — `_unchecked` FFI outside known-safe contexts (ALTREP callbacks, `with_r_unwind_protect`, `with_r_thread`).
 - **MXL302** — `into_sexp()`/`into_sexp_unchecked()` inside a `vec!`/`&[…]` literal (the use-after-free idiom, #307/#1025) → wrap each element in `__scope.protect_raw(…)` via a `ProtectScope`, or prefer the `IntoList`/`DataFrameRow` derives. Raw-text scanner: tracks `vec!`/`&[` bracket depth and flags `into_sexp(` while inside; the safe `vec![…].into_sexp()` whole-vec form is not flagged. Escape hatch: `// mxl::allow(MXL302)`.
+- **MXL303** — two `#[miniextendr]` trait impls collapse to the same vtable symbol (`__VTABLE_{TRAIT}_FOR_{TYPE}`) after the macro's case-folding (`trait.to_uppercase()` + `type.to_uppercase()`). Crate-wide; mirrors `miniextendr-macros/src/miniextendr_impl_trait/vtable.rs`. Distinct-only renderings count (Rust coherence forbids a verbatim duplicate), so a hit always means a case-fold collapse (`impl Counter for Foo` vs `impl counter for Foo`). Severity Error — the duplicate `#[no_mangle]` static would otherwise fail at link time with a message divorced from the source. Escape hatch: `// mxl::allow(MXL303)` on or above either impl.
 
 ## Adding a rule
 - New file under `rules/`, register in `rules.rs`, add code to `lint_code.rs`.

--- a/miniextendr-lint/src/crate_index.rs
+++ b/miniextendr-lint/src/crate_index.rs
@@ -152,6 +152,10 @@ pub struct AttributedTraitImpl {
     pub trait_name: String,
     pub class_system: Option<String>,
     pub line: usize,
+    /// True when the impl carries a `// mxl::allow(MXL303)` escape-hatch comment
+    /// on (or directly above) its line. Computed at parse time because the
+    /// look-behind needs the raw source split, which only `parse_file` holds.
+    pub suppressed_mxl303: bool,
 }
 // endregion
 
@@ -459,6 +463,15 @@ fn parse_file(path: &Path) -> Result<FileData, String> {
     scan_ffi_unchecked_calls(&lines, &mut data);
     scan_vec_into_sexp_calls(&lines, &mut data);
 
+    // MXL303 escape hatch: resolve the `// mxl::allow(MXL303)` look-behind for each
+    // attributed trait impl now, while the raw source split is in scope. The impl's
+    // recorded line points at the `self_ty` (e.g. `impl Trait for Type`), so the
+    // allow comment sits above one or more `#[…]` attribute lines — scan upward past
+    // attributes and blank lines to find it.
+    for ati in &mut data.attributed_trait_impls {
+        ati.suppressed_mxl303 = allow_above_attrs(&lines, ati.line, "MXL303");
+    }
+
     Ok(data)
 }
 
@@ -598,6 +611,7 @@ fn collect_items_recursive(items: &[Item], data: &mut FileData) {
                                         trait_name,
                                         class_system: impl_attrs.class_system.clone(),
                                         line,
+                                        suppressed_mxl303: false,
                                     });
                                 }
                             } else {
@@ -708,6 +722,33 @@ fn is_suppressed(lines: &[&str], line_idx: usize, code: &str) -> bool {
     }
     if line_idx > 0 && line_has_allow(lines[line_idx - 1], code) {
         return true;
+    }
+    false
+}
+
+/// Check for `// mxl::allow(<code>)` on the impl line itself, or on the nearest
+/// non-attribute / non-blank line above it.
+///
+/// `line` is 1-based and points at the impl's `self_ty`. Scans upward across
+/// `#[…]` attribute lines and blank lines (the macro attribute and any doc
+/// comments sit between the allow comment and the recorded line).
+fn allow_above_attrs(lines: &[&str], line: usize, code: &str) -> bool {
+    if line == 0 || line > lines.len() {
+        return false;
+    }
+    // The impl line itself.
+    if line_has_allow(lines[line - 1], code) {
+        return true;
+    }
+    // Walk upward over attribute/blank lines until the first "real" line.
+    let mut idx = line - 1;
+    while idx > 0 {
+        idx -= 1;
+        let trimmed = lines[idx].trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("#[") || trimmed.starts_with("#!") {
+            continue;
+        }
+        return line_has_allow(lines[idx], code);
     }
     false
 }

--- a/miniextendr-lint/src/lint_code.rs
+++ b/miniextendr-lint/src/lint_code.rs
@@ -46,6 +46,9 @@ pub enum LintCode {
     MXL301,
     /// `into_sexp()` call inside a `vec!`/array literal — unprotected SEXP across allocations (UAF).
     MXL302,
+    /// Two `#[miniextendr]` trait impls collapse to the same vtable symbol
+    /// (`__VTABLE_{TRAIT}_FOR_{TYPE}`) after the macro's case-folding.
+    MXL303,
     // endregion
 }
 
@@ -70,6 +73,10 @@ impl LintCode {
             // Runtime-breaking: vctrs constructors returning Self produce EXTPTRSXP
             // which vctrs::new_vctr() rejects; instance-method receivers panic at runtime.
             Self::MXL120 => Severity::Error,
+
+            // Build-breaking: colliding trait impls emit duplicate `#[no_mangle]`
+            // vtable statics → cryptic linker error divorced from the source.
+            Self::MXL303 => Severity::Error,
 
             // Everything else is a warning.
             Self::MXL106

--- a/miniextendr-lint/src/rules.rs
+++ b/miniextendr-lint/src/rules.rs
@@ -12,6 +12,7 @@ pub mod lifetime_param;
 pub mod r_reserved_params;
 pub mod rf_error;
 pub mod s4_method_prefix;
+pub mod trait_tag_collision;
 pub mod vctrs_self_ctor;
 pub mod vec_into_sexp;
 
@@ -51,6 +52,9 @@ pub fn run_all_rules(index: &CrateIndex) -> Vec<Diagnostic> {
 
     // Per-file: vctrs ctor returns Self / instance receiver on vctrs impl (MXL120)
     vctrs_self_ctor::check(index, &mut diagnostics);
+
+    // Crate-wide: trait-impl vtable-symbol collisions via case-folding (MXL303)
+    trait_tag_collision::check(index, &mut diagnostics);
 
     // Sort by path and line for deterministic output
     diagnostics.sort_by(|a, b| {

--- a/miniextendr-lint/src/rules/trait_tag_collision.rs
+++ b/miniextendr-lint/src/rules/trait_tag_collision.rs
@@ -1,0 +1,148 @@
+//! MXL303: trait-impl vtable-symbol collision detection.
+//!
+//! Each `#[miniextendr] impl Trait for Type` emits a vtable static named
+//! `__VTABLE_{TRAIT}_FOR_{TYPE}` (see
+//! `miniextendr-macros/src/miniextendr_impl_trait/vtable.rs`), where the trait
+//! name is `trait_ident.to_uppercase()` and the type name is the last path
+//! segment uppercased (`type_to_uppercase_name`). The static is emitted with
+//! `#[unsafe(no_mangle)]`, so two impls whose `(TRAIT, TYPE)` pair collapses to
+//! the same uppercased symbol produce **duplicate `no_mangle` symbols** — a hard
+//! linker failure whose message is divorced from the source.
+//!
+//! Rust's coherence rules already forbid the *same* trait implemented twice for
+//! the *same* type, so the only way two distinct impls collide is via the
+//! macro's **case-folding**: e.g. `impl Counter for Foo` and `impl counter for
+//! Foo`, or `impl Trait for Foo` and `impl Trait for foo`, all collapse to the
+//! same `__VTABLE_…` symbol. This rule catches that before the linker does.
+//!
+//! Scope: crate-wide. The two colliding impls may live in different files, so
+//! the check aggregates across the whole [`CrateIndex`] rather than per-file.
+//!
+//! Escape hatch: `// mxl::allow(MXL303)` on (or directly above) either impl
+//! line suppresses the diagnostic for that impl. `MINIEXTENDR_LINT=0` disables
+//! all rules.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::crate_index::CrateIndex;
+use crate::diagnostic::Diagnostic;
+use crate::lint_code::LintCode;
+
+/// A single occurrence of a trait impl, used for collision reporting.
+struct Occurrence {
+    path: PathBuf,
+    line: usize,
+    /// Original (case-preserving) `impl Trait for Type` rendering.
+    rendered: String,
+    suppressed: bool,
+}
+
+pub fn check(index: &CrateIndex, diagnostics: &mut Vec<Diagnostic>) {
+    // Group every attributed trait impl by the case-folded vtable symbol the
+    // macro would emit. A bucket with >1 distinct rendering is a collision.
+    let mut buckets: HashMap<String, Vec<Occurrence>> = HashMap::new();
+
+    for (path, data) in &index.file_data {
+        for ati in &data.attributed_trait_impls {
+            let symbol = vtable_symbol(&ati.trait_name, &ati.type_name);
+            buckets.entry(symbol).or_default().push(Occurrence {
+                path: path.clone(),
+                line: ati.line,
+                rendered: format!("impl {} for {}", ati.trait_name, ati.type_name),
+                suppressed: ati.suppressed_mxl303,
+            });
+        }
+    }
+
+    for (symbol, mut occurrences) in buckets {
+        // Distinct source renderings only — Rust coherence forbids a verbatim
+        // duplicate, so >1 here always means a case-fold collapse.
+        let distinct: std::collections::BTreeSet<&str> =
+            occurrences.iter().map(|o| o.rendered.as_str()).collect();
+        if distinct.len() < 2 {
+            continue;
+        }
+
+        // Deterministic ordering for stable diagnostics.
+        occurrences.sort_by(|a, b| a.path.cmp(&b.path).then(a.line.cmp(&b.line)));
+
+        let all_renderings = occurrences
+            .iter()
+            .map(|o| format!("`{}` ({}:{})", o.rendered, o.path.display(), o.line))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        for occ in &occurrences {
+            if occ.suppressed {
+                continue;
+            }
+            diagnostics.push(
+                Diagnostic::new(
+                    LintCode::MXL303,
+                    &occ.path,
+                    occ.line,
+                    format!(
+                        "trait impl `{}` collides on the generated vtable symbol \
+                         `{}` with another impl. The macro upper-cases the trait \
+                         and type names when naming the `#[no_mangle]` vtable \
+                         static, so these distinct impls emit duplicate symbols \
+                         and the build fails at link time. Colliding impls: {}.",
+                        occ.rendered, symbol, all_renderings,
+                    ),
+                )
+                .with_help(
+                    "rename one of the colliding trait or type identifiers so the \
+                     upper-cased names differ, or suppress with \
+                     `// mxl::allow(MXL303)` if the collision is intentional",
+                ),
+            );
+        }
+    }
+}
+
+/// Reconstruct the vtable static symbol the macro emits for `impl Trait for Type`.
+///
+/// Mirrors `miniextendr-macros/src/miniextendr_impl_trait/vtable.rs`:
+/// `__VTABLE_{trait.to_uppercase()}_FOR_{type.to_uppercase()}` for the
+/// non-generic path. The lint only sees the bare type ident (no generic args),
+/// so it folds case the same way the macro's `type_to_uppercase_name` does for
+/// plain (non-generic) types.
+fn vtable_symbol(trait_name: &str, type_name: &str) -> String {
+    format!(
+        "__VTABLE_{}_FOR_{}",
+        trait_name.to_uppercase(),
+        type_name.to_uppercase()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::vtable_symbol;
+
+    #[test]
+    fn case_fold_collapses_to_same_symbol() {
+        // Distinct traits differing only in case → same symbol.
+        assert_eq!(
+            vtable_symbol("Counter", "Foo"),
+            vtable_symbol("counter", "Foo")
+        );
+        // Distinct types differing only in case → same symbol.
+        assert_eq!(
+            vtable_symbol("Counter", "Foo"),
+            vtable_symbol("Counter", "foo")
+        );
+    }
+
+    #[test]
+    fn distinct_names_distinct_symbols() {
+        assert_ne!(
+            vtable_symbol("Counter", "Foo"),
+            vtable_symbol("Resettable", "Foo")
+        );
+        assert_ne!(
+            vtable_symbol("Counter", "Foo"),
+            vtable_symbol("Counter", "Bar")
+        );
+    }
+}

--- a/miniextendr-lint/tests/tests.rs
+++ b/miniextendr-lint/tests/tests.rs
@@ -866,6 +866,127 @@ fn mxl120_no_false_positive_for_consuming_self_on_vctrs() {
     );
 }
 
+#[test]
+fn mxl303_case_fold_vtable_collision() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Two distinct traits differing only in case both upper-case to `COUNTER`,
+    // so both emit `__VTABLE_COUNTER_FOR_FOO` → duplicate #[no_mangle] symbol.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        impl Counter for Foo {
+            fn value(&self) -> i32 { 0 }
+        }
+
+        #[miniextendr]
+        impl counter for Foo {
+            fn value(&self) -> i32 { 0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    let hits: Vec<_> = report
+        .diagnostics
+        .iter()
+        .filter(|d| format!("{}", d.code) == "MXL303")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        2,
+        "expected MXL303 to fire on both colliding impls, got: {:?}",
+        report.diagnostics
+    );
+    assert!(
+        hits.iter()
+            .any(|d| d.message.contains("__VTABLE_COUNTER_FOR_FOO")),
+        "expected the collided vtable symbol in the message, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl303_no_collision_for_distinct_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Distinct trait names and distinct type names → distinct vtable symbols.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        impl Counter for Foo {
+            fn value(&self) -> i32 { 0 }
+        }
+
+        #[miniextendr]
+        impl Resettable for Foo {
+            fn reset(&mut self) {}
+        }
+
+        #[miniextendr]
+        impl Counter for Bar {
+            fn value(&self) -> i32 { 0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .all(|d| format!("{}", d.code) != "MXL303"),
+        "MXL303 must not fire on distinct trait/type names, got: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
+fn mxl303_suppressed_by_allow_comment() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+
+    // Same collision as the positive case, but the second impl carries the
+    // escape-hatch comment, so only the first impl reports.
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+        #[miniextendr]
+        impl Counter for Foo {
+            fn value(&self) -> i32 { 0 }
+        }
+
+        // mxl::allow(MXL303)
+        #[miniextendr]
+        impl counter for Foo {
+            fn value(&self) -> i32 { 0 }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let report = run(dir.path()).expect("lint should succeed");
+    let hits = report
+        .diagnostics
+        .iter()
+        .filter(|d| format!("{}", d.code) == "MXL303")
+        .count();
+    assert_eq!(
+        hits, 1,
+        "the allow-comment should suppress one of the two colliding impls, got: {:?}",
+        report.diagnostics
+    );
+}
+
 // endregion
 
 // region: MXL302 — into_sexp() inside a vec!/array literal (use-after-free idiom)


### PR DESCRIPTION
Closes #1028. This wires up the last unchecked box in the TRAIT_AS_R M3 "Polish" list: a build-time lint that catches colliding trait impls before they blow up at link time.

<details>
<summary><h4>AI-written details</h4></summary>

## Confirmed collision surface

I traced the trait-ABI codegen before writing anything (per the issue's request). Each `#[miniextendr] impl Trait for Type` emits, in `miniextendr-macros/src/miniextendr_impl_trait/vtable.rs`:

- A vtable static named **`__VTABLE_{TRAIT}_FOR_{TYPE}`**, emitted with `#[unsafe(no_mangle)]`. The trait name is `trait_ident.to_uppercase()`; the type name is the last path segment upper-cased (`type_to_uppercase_name`).
- C-callable `.Call` symbols `C_{Type}__{Trait}__{method}` — these use **verbatim** idents, so they only collide when type+trait+method match verbatim.

**What collides, and the consequence:** the vtable static. Because the macro upper-cases both names, two *distinct* impls can collapse to the same `no_mangle` symbol — e.g. `impl Counter for Foo` vs `impl counter for Foo`, or `… for Foo` vs `… for foo`. Rust's coherence rules already forbid the *same* trait twice for the *same* type, so the **only** way two distinct impls collide is via this case-folding. The runtime/build consequence is a **duplicate `#[no_mangle]` static → hard linker failure** whose message is divorced from the source. The lint surfaces it at `cargo check` time with both producers named.

This is genuinely fireable (not structurally impossible), so a rule is warranted. It is distinct from #991 (S7 shortcut vs. sidecar-accessor write-time collision — a different namespace).

## The rule — MXL303

- PR #1031 takes MXL302, so this is **MXL303** (verified against `miniextendr-lint/CLAUDE.md`).
- **Heuristic:** aggregate all attributed trait impls crate-wide (they may live in different files), bucket by the reconstructed `__VTABLE_{TRAIT_UPPER}_FOR_{TYPE_UPPER}` symbol, and report any bucket with >1 *distinct* `impl Trait for Type` rendering. Distinct-only because coherence forbids a verbatim duplicate, so a multi-entry bucket always means a case-fold collapse.
- **Severity Error** — matches the build/runtime-breaking source-side rules; the alternative is a cryptic linker error.
- **Escape hatch:** `// mxl::allow(MXL303)` on or directly above either impl (resolved at parse time, scanning upward past `#[…]` attribute lines). `MINIEXTENDR_LINT=0` disables all rules.
- **Limits:** the lint sees the bare type ident only, so it folds case for the non-generic vtable-name path; it does not reconstruct the generic-monomorphisation hash suffix (`MYTYPE_<hash>`). Generic-arg-only collisions are out of scope and tracked as a follow-up (#1036).

## Verification

- `cargo test -p miniextendr-lint` — **35 passed** (2 unit tests on `vtable_symbol`, 3 integration tests: positive case-fold collision fires on both impls, negative distinct-names case is clean, allow-comment suppresses one).
- `cargo clippy -p miniextendr-lint --all-targets --locked -- -D warnings` — **clean**.
- `cargo fmt --all` — clean.
- **Corpus false-positive check:** ran the lint's `run()` over `miniextendr-api`, `miniextendr-macros`, `rpkg/src/rust`, `tests/cross-package/producer.pkg/src/rust`, and `tests/cross-package/consumer.pkg/src/rust` (a throwaway example, since removed). MXL303 fired **0 times** on all five — the real `impl Counter for SimpleCounter` / `impl Resettable for SimpleCounter` / `impl Counter for StatefulCounter` / `impl Counter for DoubleCounter` impls are all distinct `(trait, type)` pairs and do not collide. The 56 diagnostics on `miniextendr-api` are pre-existing rules (MXL300 etc.), none MXL303.

## Docs

`docs/TRAIT_AS_R.md:172` box is now checked, and the "Future Lints" `tag_collision` row is annotated with MXL303.

## Follow-up filed

- #1036 — extend MXL303 to generic-monomorphisation hash-suffix collisions (deferred scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
