### PR TITLE
perf(build): guard tarball-mode wrapper-gen skip with non-empty assert + cdylib fallback (#1022)

### DIFF
--- a/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/monorepo/rpkg/Makevars.in
@@ -127,25 +127,31 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
 #             the cdylib regeneration would be a no-op (write-if-changed), so
-#             skip the 10-30 s cdylib build entirely. Existence guard catches
-#             a tarball that was manually stripped of its wrappers file.
-#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#             skip the 10-30 s cdylib build entirely (#1022). The pre-commit hook
+#             guarantees the shipped wrappers match the Rust code in the tarball,
+#             so the committed file is exactly what regeneration would produce.
+#             LOAD-BEARING GUARD: skip only when R/<pkg>-wrappers.R exists AND is
+#             non-empty ([ -s ]). If it is absent or empty (a tarball stripped of
+#             its wrappers, a truncated download, etc.), FALL BACK to the full
+#             cdylib wrapper-gen path rather than installing a wrapper-less,
+#             silently-broken package. The same condition gates $(CARGO_CDYLIB)
+#             below, so the cdylib is built exactly when this recipe needs to load
+#             it. Set MINIEXTENDR_FORCE_WRAPPER_GEN to force regeneration even when
+#             the shipped wrappers are valid (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@set -e; \
 	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
 	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
 	  touch '$(WRAPPERS_R)'; \
-	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
-	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
-	  if [ ! -f '$(WRAPPERS_R)' ]; then \
-	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	    exit 1; \
-	  fi; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R (skipping cdylib wrapper-gen, #1022)"; \
 	  touch '$(WRAPPERS_R)'; \
 	else \
-	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -n "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
 	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  elif [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "tarball install: pre-shipped R/$(PACKAGE_NAME)-wrappers.R absent or empty — falling back to full cdylib wrapper-gen (#1022 guard)..." >&2; \
 	  else \
 	    echo "Generating R wrappers + wasm_registry.rs..."; \
 	  fi; \
@@ -164,11 +170,15 @@ $(WRAPPERS_R): $(CARGO_CDYLIB)
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
-# modes reuse the committed wrappers and never need a cdylib.
+# No-op in wasm32 / tarball installs that reuse the committed wrappers (the guard
+# exits early): those modes never need a cdylib. The tarball-skip condition here
+# MUST match the $(WRAPPERS_R) recipe above — skip only when tarball mode, no
+# MINIEXTENDR_FORCE_WRAPPER_GEN, AND R/<pkg>-wrappers.R is present and non-empty
+# ([ -s ]). If the shipped wrappers are missing/empty, this recipe builds the
+# cdylib so the wrapper-gen fallback (#1022 guard) has something to load.
 $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
-	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \

--- a/minirextendr/inst/templates/rpkg/Makevars.in
+++ b/minirextendr/inst/templates/rpkg/Makevars.in
@@ -127,25 +127,31 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
 #             the cdylib regeneration would be a no-op (write-if-changed), so
-#             skip the 10-30 s cdylib build entirely. Existence guard catches
-#             a tarball that was manually stripped of its wrappers file.
-#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#             skip the 10-30 s cdylib build entirely (#1022). The pre-commit hook
+#             guarantees the shipped wrappers match the Rust code in the tarball,
+#             so the committed file is exactly what regeneration would produce.
+#             LOAD-BEARING GUARD: skip only when R/<pkg>-wrappers.R exists AND is
+#             non-empty ([ -s ]). If it is absent or empty (a tarball stripped of
+#             its wrappers, a truncated download, etc.), FALL BACK to the full
+#             cdylib wrapper-gen path rather than installing a wrapper-less,
+#             silently-broken package. The same condition gates $(CARGO_CDYLIB)
+#             below, so the cdylib is built exactly when this recipe needs to load
+#             it. Set MINIEXTENDR_FORCE_WRAPPER_GEN to force regeneration even when
+#             the shipped wrappers are valid (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@set -e; \
 	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
 	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
 	  touch '$(WRAPPERS_R)'; \
-	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
-	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
-	  if [ ! -f '$(WRAPPERS_R)' ]; then \
-	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	    exit 1; \
-	  fi; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R (skipping cdylib wrapper-gen, #1022)"; \
 	  touch '$(WRAPPERS_R)'; \
 	else \
-	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -n "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
 	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  elif [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "tarball install: pre-shipped R/$(PACKAGE_NAME)-wrappers.R absent or empty — falling back to full cdylib wrapper-gen (#1022 guard)..." >&2; \
 	  else \
 	    echo "Generating R wrappers + wasm_registry.rs..."; \
 	  fi; \
@@ -164,11 +170,15 @@ $(WRAPPERS_R): $(CARGO_CDYLIB)
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
-# modes reuse the committed wrappers and never need a cdylib.
+# No-op in wasm32 / tarball installs that reuse the committed wrappers (the guard
+# exits early): those modes never need a cdylib. The tarball-skip condition here
+# MUST match the $(WRAPPERS_R) recipe above — skip only when tarball mode, no
+# MINIEXTENDR_FORCE_WRAPPER_GEN, AND R/<pkg>-wrappers.R is present and non-empty
+# ([ -s ]). If the shipped wrappers are missing/empty, this recipe builds the
+# cdylib so the wrapper-gen fallback (#1022 guard) has something to load.
 $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
-	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \

--- a/rpkg/src/Makevars.in
+++ b/rpkg/src/Makevars.in
@@ -127,25 +127,31 @@ $(CARGO_AR): FORCE_CARGO $(OBJECTS)
 #             expects pre-generated files from the host devtools::document() pass.
 #   tarball : R/<pkg>-wrappers.R is already committed and ships in the tarball;
 #             the cdylib regeneration would be a no-op (write-if-changed), so
-#             skip the 10-30 s cdylib build entirely. Existence guard catches
-#             a tarball that was manually stripped of its wrappers file.
-#             Set MINIEXTENDR_FORCE_WRAPPER_GEN to override (debugging only).
+#             skip the 10-30 s cdylib build entirely (#1022). The pre-commit hook
+#             guarantees the shipped wrappers match the Rust code in the tarball,
+#             so the committed file is exactly what regeneration would produce.
+#             LOAD-BEARING GUARD: skip only when R/<pkg>-wrappers.R exists AND is
+#             non-empty ([ -s ]). If it is absent or empty (a tarball stripped of
+#             its wrappers, a truncated download, etc.), FALL BACK to the full
+#             cdylib wrapper-gen path rather than installing a wrapper-less,
+#             silently-broken package. The same condition gates $(CARGO_CDYLIB)
+#             below, so the cdylib is built exactly when this recipe needs to load
+#             it. Set MINIEXTENDR_FORCE_WRAPPER_GEN to force regeneration even when
+#             the shipped wrappers are valid (debugging only).
 #   dev     : full cdylib build + wrapper generation (normal dev/CI flow).
 $(WRAPPERS_R): $(CARGO_CDYLIB)
 	@set -e; \
 	if [ "$(IS_WASM_INSTALL)" = "true" ]; then \
 	  echo "wasm32 install: skipping wrapper-gen (pre-generated R/$(PACKAGE_NAME)-wrappers.R + src/rust/wasm_registry.rs expected)"; \
 	  touch '$(WRAPPERS_R)'; \
-	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
-	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R"; \
-	  if [ ! -f '$(WRAPPERS_R)' ]; then \
-	    echo "ERROR: tarball is missing pre-generated $(WRAPPERS_R)" >&2; \
-	    exit 1; \
-	  fi; \
+	elif [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; then \
+	  echo "tarball install: using pre-shipped R/$(PACKAGE_NAME)-wrappers.R (skipping cdylib wrapper-gen, #1022)"; \
 	  touch '$(WRAPPERS_R)'; \
 	else \
-	  if [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	  if [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -n "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; then \
 	    echo "MINIEXTENDR_FORCE_WRAPPER_GEN set: regenerating wrappers from cdylib (tarball mode override)..."; \
+	  elif [ "$(IS_TARBALL_INSTALL)" = "true" ]; then \
+	    echo "tarball install: pre-shipped R/$(PACKAGE_NAME)-wrappers.R absent or empty — falling back to full cdylib wrapper-gen (#1022 guard)..." >&2; \
 	  else \
 	    echo "Generating R wrappers + wasm_registry.rs..."; \
 	  fi; \
@@ -164,11 +170,15 @@ $(WRAPPERS_R): $(CARGO_CDYLIB)
 
 # Build cdylib for wrapper generation.
 # Runs after staticlib (via `all` ordering), so the incremental cache is warm.
-# No-op in wasm32 / tarball-without-FORCE installs (the guard exits early): those
-# modes reuse the committed wrappers and never need a cdylib.
+# No-op in wasm32 / tarball installs that reuse the committed wrappers (the guard
+# exits early): those modes never need a cdylib. The tarball-skip condition here
+# MUST match the $(WRAPPERS_R) recipe above — skip only when tarball mode, no
+# MINIEXTENDR_FORCE_WRAPPER_GEN, AND R/<pkg>-wrappers.R is present and non-empty
+# ([ -s ]). If the shipped wrappers are missing/empty, this recipe builds the
+# cdylib so the wrapper-gen fallback (#1022 guard) has something to load.
 $(CARGO_CDYLIB): FORCE_CARGO $(OBJECTS) $(CARGO_AR)
 	@set -e; \
-	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ]; }; then exit 0; fi; \
+	if [ "$(IS_WASM_INSTALL)" = "true" ] || { [ "$(IS_TARBALL_INSTALL)" = "true" ] && [ -z "$$MINIEXTENDR_FORCE_WRAPPER_GEN" ] && [ -s '$(WRAPPERS_R)' ]; }; then exit 0; fi; \
 	TARGET_OPT=""; \
 	CDYLIB_LINK_ARGS=""; \
 	for obj in $(OBJECTS); do CDYLIB_LINK_ARGS="$$CDYLIB_LINK_ARGS -C link-arg=$(ABS_RPKG_SRCDIR)/$$obj"; done; \


### PR DESCRIPTION
Hardens the tarball-mode wrapper-gen skip from #522 with the load-bearing guard #1022 asks for: skip only when the shipped `wrappers.R` exists *and* is non-empty, otherwise fall back to the full cdylib path instead of hard-failing or installing a wrapper-less package.

<details>
<summary>Details (AI-written)</summary>

## What changed

The cdylib wrapper-gen skip in tarball mode already existed (#522), but its guard checked only `[ ! -f ]` (existence) and `exit 1`-ed on a miss — hard-failing the install. #1022 wants the guard to *fall back* to regeneration, not fail. Three files, identical diff each:

- `rpkg/src/Makevars.in`
- `minirextendr/inst/templates/rpkg/Makevars.in`
- `minirextendr/inst/templates/monorepo/rpkg/Makevars.in`

**`$(WRAPPERS_R)` recipe** — the tarball-skip branch condition gained `&& [ -s '$(WRAPPERS_R)' ]` (exists AND non-empty). The else-branch now distinguishes three sub-cases: `MINIEXTENDR_FORCE_WRAPPER_GEN` override, tarball-mode fallback (logs `…absent or empty — falling back to full cdylib wrapper-gen (#1022 guard)…` to stderr), and normal source/dev gen. The old `exit 1` on missing wrappers is gone — it now regenerates.

**`$(CARGO_CDYLIB)` recipe** — its no-op gate gained the same `&& [ -s '$(WRAPPERS_R)' ]`, so the cdylib is built exactly when the wrapper-gen recipe needs to load it. The two conditions are kept verbatim-identical so they can never disagree.

No `configure.ac` change: `IS_TARBALL_INSTALL` is already substituted into `Makevars`, and the guard is pure Makevars/`[ -s ]` logic. `just templates-check` stays green (identical edits preserve the recorded delta).

## Guard logic (isolated 6-branch unit test)

| mode | wrappers.R | FORCE | `$(WRAPPERS_R)` | `$(CARGO_CDYLIB)` |
|---|---|---|---|---|
| tarball | good | — | SKIP | no-op |
| tarball | empty | — | fallback gen | build |
| tarball | missing | — | fallback gen | build |
| tarball | good | set | force gen | build |
| source | good | — | gen | build |
| wasm | good | — | skip | no-op |

All six matched expectations.

## Verification (darwin, R 4.6, arm64)

- **Skip fires in tarball mode**: `just r-cmd-build` → `R CMD INSTALL miniextendr_0.1.0.tar.gz`. Log shows `tarball install: using pre-shipped … (skipping cdylib wrapper-gen, #1022)` and **no** `Generating R wrappers` / `crate-type cdylib` / `miniextendr_write_wrappers` / `Removing cdylib`. Package loads (3990 ns symbols); `conv_vec_f32_ret()` returns `1.5 2.5 -0.5` — installed `.so` wrappers work, no drift.
- **Skip does NOT fire in source mode**: `just rcmdinstall` (dev source tree). Log shows `Generating R wrappers + wasm_registry.rs...` + `Removing cdylib...` + `* DONE` — full cdylib path, unchanged.
- **Guard fallback**: extracted the built tarball, truncated `R/miniextendr-wrappers.R` to 0 bytes, repacked (`tar --no-mac-metadata --no-xattrs`), installed to a temp library. Log shows `…absent or empty — falling back to full cdylib wrapper-gen (#1022 guard)…` + `Removing cdylib...` + `* DONE` — install **succeeded** by regenerating, did **not** hard-fail or install broken.

## Time saved

The skip eliminates the cdylib rustc relink + R-process startup + `dyn.load` round-trip in tarball mode (the ~10–30 s the issue cites). It does **not** speed up the unavoidable staticlib compile (the observed tarball install still spent ~6 min compiling `libminiextendr.a` cold — that work is required regardless). A precise A/B on this machine was not isolated because the dominant cost is the staticlib build; the saving is the cdylib pass, which this change confirms is fully skipped in the tarball-mode log.

## Latch hygiene

`inst/vendor.tar.xz` is gitignored and trap-cleaned by the producer recipes; `git status` is clean of it at the end. The dev-pin `Cargo.lock` drift (framework-crate `source` hash bump from `just vendor`) was discarded per the dev-drift convention. No `vendor.tar.xz` committed.

_Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-8)._

</details>

Closes #1022