### PR TITLE
refactor(api): dedupe VECSXP/STRSXP build idioms into ListBuilder & StrVecBuilder (#1023)

### DIFF
--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -168,7 +168,8 @@ use crate::sexp_types::cetype_t;
 use crate::sys::{
     R_MakeExternalPtr, R_NewEnv, R_ProtectWithIndex, R_Reprotect, Rf_alloc3DArray, Rf_allocArray,
     Rf_allocLang, Rf_allocList, Rf_allocMatrix, Rf_allocS4Object, Rf_allocSExp, Rf_allocVector,
-    Rf_cons, Rf_lcons, Rf_lengthgets, Rf_mkCharLenCE, Rf_protect, Rf_unprotect, Rf_xlengthgets,
+    Rf_allocVector_unchecked, Rf_cons, Rf_lcons, Rf_lengthgets, Rf_mkCharLenCE, Rf_protect,
+    Rf_unprotect, Rf_xlengthgets,
 };
 use crate::{R_xlen_t, RNativeType, SEXP, SEXPTYPE, SexpExt};
 use core::cell::Cell;
@@ -494,6 +495,28 @@ impl ProtectScope {
     pub unsafe fn alloc_vecsxp<'a>(&'a self, n: usize) -> Root<'a> {
         let len = R_xlen_t::try_from(n).expect("length exceeds R_xlen_t");
         unsafe { self.alloc_vector(SEXPTYPE::VECSXP, len) }
+    }
+
+    /// Allocate a VECSXP via the **unchecked** FFI path and immediately protect it.
+    ///
+    /// `_unchecked` twin of [`alloc_vecsxp`](Self::alloc_vecsxp): allocates with
+    /// `Rf_allocVector_unchecked` (bypassing the main-thread assertion / worker
+    /// round-trip) for use inside ALTREP callbacks, `with_r_unwind_protect`, or
+    /// `with_r_thread` bodies. Protection still goes through the (checked)
+    /// `Rf_protect` — matching the established `OwnedProtect`-in-unchecked-context
+    /// idiom — and is released with the rest of the scope on drop.
+    ///
+    /// # Safety
+    ///
+    /// Must be called from the R main thread, and only from a context where the
+    /// checked-FFI assertion is intentionally bypassed (see CLAUDE.md "FFI thread
+    /// checking").
+    #[inline]
+    pub unsafe fn alloc_vecsxp_unchecked<'a>(&'a self, n: usize) -> Root<'a> {
+        let len = R_xlen_t::try_from(n).expect("length exceeds R_xlen_t");
+        // SAFETY: caller guarantees R main thread in a checked-bypass context.
+        let sexp = unsafe { Rf_allocVector_unchecked(SEXPTYPE::VECSXP, len) };
+        unsafe { self.protect(sexp) }
     }
 
     // region: Typed vector allocation shortcuts

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -497,9 +497,9 @@ impl ProtectScope {
         unsafe { self.alloc_vector(SEXPTYPE::VECSXP, len) }
     }
 
-    /// Allocate a VECSXP via the **unchecked** FFI path and immediately protect it.
+    /// Allocate a vector via the **unchecked** FFI path and immediately protect it.
     ///
-    /// `_unchecked` twin of [`alloc_vecsxp`](Self::alloc_vecsxp): allocates with
+    /// `_unchecked` twin of [`alloc_vector`](Self::alloc_vector): allocates with
     /// `Rf_allocVector_unchecked` (bypassing the main-thread assertion / worker
     /// round-trip) for use inside ALTREP callbacks, `with_r_unwind_protect`, or
     /// `with_r_thread` bodies. Protection still goes through the (checked)
@@ -512,11 +512,40 @@ impl ProtectScope {
     /// checked-FFI assertion is intentionally bypassed (see CLAUDE.md "FFI thread
     /// checking").
     #[inline]
+    pub unsafe fn alloc_vector_unchecked<'a>(&'a self, ty: SEXPTYPE, n: R_xlen_t) -> Root<'a> {
+        // SAFETY: caller guarantees R main thread in a checked-bypass context.
+        let sexp = unsafe { Rf_allocVector_unchecked(ty, n) };
+        unsafe { self.protect(sexp) }
+    }
+
+    /// Allocate a VECSXP via the **unchecked** FFI path, protected.
+    ///
+    /// `_unchecked` twin of [`alloc_vecsxp`](Self::alloc_vecsxp). See
+    /// [`alloc_vector_unchecked`](Self::alloc_vector_unchecked) for the safety
+    /// contract.
+    ///
+    /// # Safety
+    ///
+    /// Same as [`alloc_vector_unchecked`](Self::alloc_vector_unchecked).
+    #[inline]
     pub unsafe fn alloc_vecsxp_unchecked<'a>(&'a self, n: usize) -> Root<'a> {
         let len = R_xlen_t::try_from(n).expect("length exceeds R_xlen_t");
-        // SAFETY: caller guarantees R main thread in a checked-bypass context.
-        let sexp = unsafe { Rf_allocVector_unchecked(SEXPTYPE::VECSXP, len) };
-        unsafe { self.protect(sexp) }
+        unsafe { self.alloc_vector_unchecked(SEXPTYPE::VECSXP, len) }
+    }
+
+    /// Allocate a STRSXP via the **unchecked** FFI path, protected.
+    ///
+    /// `_unchecked` twin of [`alloc_character`](Self::alloc_character). See
+    /// [`alloc_vector_unchecked`](Self::alloc_vector_unchecked) for the safety
+    /// contract.
+    ///
+    /// # Safety
+    ///
+    /// Same as [`alloc_vector_unchecked`](Self::alloc_vector_unchecked).
+    #[inline]
+    pub unsafe fn alloc_character_unchecked<'a>(&'a self, n: usize) -> Root<'a> {
+        let len = R_xlen_t::try_from(n).expect("length exceeds R_xlen_t");
+        unsafe { self.alloc_vector_unchecked(SEXPTYPE::STRSXP, len) }
     }
 
     // region: Typed vector allocation shortcuts

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -46,7 +46,8 @@ use std::hash::Hash;
 
 use crate::SexpExt;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
-use crate::gc_protect::OwnedProtect;
+use crate::gc_protect::{OwnedProtect, ProtectScope};
+use crate::list::ListBuilder;
 
 /// Trait for converting Rust types to R SEXP values.
 ///
@@ -1462,14 +1463,20 @@ impl IntoR for Vec<&str> {
 /// This is the shared core for the "protect a VECSXP, fill it via
 /// `SET_VECTOR_ELT`, unprotect" idiom that recurs across the `IntoR` impls for
 /// nested collections (`Vec<Vec<T>>`, `Vec<&[T]>`, tuples, `Vec<Box<[T]>>`,
-/// `Vec<[T; N]>`, `Vec<HashMap<..>>`, …). The list is protected by an
-/// [`OwnedProtect`] guard for the duration of `fill`, so any child allocations
-/// performed inside `fill` cannot collect the list; the guard's `Drop` issues
-/// the matching `UNPROTECT(1)` — the protect/unprotect count is balanced by
-/// construction (RAII), so a miscount is unrepresentable.
+/// `Vec<[T; N]>`, `Vec<HashMap<..>>`, …). It routes through [`ListBuilder`]
+/// over a local [`ProtectScope`]: the list is allocated and protected by the
+/// scope for the duration of `fill`, so any child allocations performed inside
+/// `fill` cannot collect the list; the scope's `Drop` issues the matching
+/// `UNPROTECT(1)` — the protect/unprotect count is balanced by construction
+/// (RAII), so a miscount is unrepresentable. The returned SEXP is **unprotected**
+/// (the scope has dropped); the caller must protect it before any further
+/// allocation.
 ///
 /// `fill` receives the protected list SEXP and is responsible for populating it
-/// (via the checked [`set_vector_elt`](crate::SexpExt::set_vector_elt)).
+/// (via the checked [`set_vector_elt`](crate::SexpExt::set_vector_elt)). For the
+/// homogeneous "list of converted children" case prefer [`vecsxp_from_iter`];
+/// `fill` is for heterogeneous fills (e.g. tuples, where each slot has a
+/// distinct element type).
 ///
 /// # Safety
 ///
@@ -1477,19 +1484,17 @@ impl IntoR for Vec<&str> {
 #[inline]
 unsafe fn build_vecsxp(n: usize, fill: impl FnOnce(crate::SEXP)) -> crate::SEXP {
     unsafe {
-        let list = OwnedProtect::new(crate::sys::Rf_allocVector(
-            crate::SEXPTYPE::VECSXP,
-            n as crate::R_xlen_t,
-        ));
-        fill(list.get());
-        *list
+        let scope = ProtectScope::new();
+        let builder = ListBuilder::new(&scope, n);
+        fill(builder.as_sexp());
+        builder.into_sexp()
     }
 }
 
 /// `_unchecked` twin of [`build_vecsxp`] for contexts where the checked FFI
 /// thread assertion must be bypassed (ALTREP callbacks, `with_r_unwind_protect`,
-/// `with_r_thread`). Allocates via `Rf_allocVector_unchecked`; `fill` must use
-/// the `_unchecked` setters.
+/// `with_r_thread`). Allocates via [`ListBuilder::new_unchecked`]; `fill` must
+/// use the `_unchecked` setters.
 ///
 /// # Safety
 ///
@@ -1499,22 +1504,20 @@ unsafe fn build_vecsxp(n: usize, fill: impl FnOnce(crate::SEXP)) -> crate::SEXP 
 #[inline]
 unsafe fn build_vecsxp_unchecked(n: usize, fill: impl FnOnce(crate::SEXP)) -> crate::SEXP {
     unsafe {
-        let list = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-            crate::SEXPTYPE::VECSXP,
-            n as crate::R_xlen_t,
-        ));
-        fill(list.get());
-        *list
+        let scope = ProtectScope::new();
+        let builder = ListBuilder::new_unchecked(&scope, n);
+        fill(builder.as_sexp());
+        builder.into_sexp()
     }
 }
 
 /// Build a VECSXP from an exact-size iterator of child `SEXP`s (checked).
 ///
-/// The list is protected before iteration begins; the iterator is consumed
+/// Routes through [`ListBuilder`]: the list is allocated and protected by a
+/// local [`ProtectScope`] before iteration begins, then the iterator is consumed
 /// inside the protected window so each child produced lazily (typically via a
-/// `.map(|c| c.into_sexp())` adaptor at the callsite) is inserted immediately,
-/// closing the GC gap. Collapses the dominant protect-container-fill-unprotect
-/// idiom onto [`build_vecsxp`].
+/// `.map(|c| c.into_sexp())` adaptor at the callsite) is inserted immediately
+/// via [`ListBuilder::set`], closing the GC gap.
 ///
 /// The element type is `SEXP` (not a generic `IntoR`) deliberately: the caller
 /// performs the conversion lazily in the iterator adaptor, which keeps the
@@ -1529,16 +1532,16 @@ where
     I: ExactSizeIterator<Item = crate::SEXP>,
 {
     unsafe {
-        let n = iter.len();
-        build_vecsxp(n, |list| {
-            for (i, child) in iter.enumerate() {
-                list.set_vector_elt(i as crate::R_xlen_t, child);
-            }
-        })
+        let scope = ProtectScope::new();
+        let builder = ListBuilder::new(&scope, iter.len());
+        for (i, child) in iter.enumerate() {
+            builder.set(i as isize, child);
+        }
+        builder.into_sexp()
     }
 }
 
-/// `_unchecked` twin of [`vecsxp_from_iter`] — uses the `_unchecked` setter.
+/// `_unchecked` twin of [`vecsxp_from_iter`] — uses [`ListBuilder::set_unchecked`].
 /// For ALTREP / `with_r_thread` / unwind contexts. The caller's adaptor must
 /// produce children via `into_sexp_unchecked()`.
 ///
@@ -1552,12 +1555,12 @@ where
     I: ExactSizeIterator<Item = crate::SEXP>,
 {
     unsafe {
-        let n = iter.len();
-        build_vecsxp_unchecked(n, |list| {
-            for (i, child) in iter.enumerate() {
-                list.set_vector_elt_unchecked(i as crate::R_xlen_t, child);
-            }
-        })
+        let scope = ProtectScope::new();
+        let builder = ListBuilder::new_unchecked(&scope, iter.len());
+        for (i, child) in iter.enumerate() {
+            builder.set_unchecked(i as isize, child);
+        }
+        builder.into_sexp()
     }
 }
 

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -46,8 +46,9 @@ use std::hash::Hash;
 
 use crate::SexpExt;
 use crate::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
-use crate::gc_protect::{OwnedProtect, ProtectScope};
+use crate::gc_protect::ProtectScope;
 use crate::list::ListBuilder;
+use crate::strvec::StrVecBuilder;
 
 /// Trait for converting Rust types to R SEXP values.
 ///
@@ -1222,19 +1223,19 @@ impl_option_collection_into_r!(
 );
 
 /// Helper: allocate STRSXP and fill from a string iterator (checked).
+///
+/// Routes the alloc + protect through [`StrVecBuilder`] over a local
+/// [`ProtectScope`]; the CHARSXP policy (empty-string → `R_BlankString`) stays
+/// here via [`str_to_charsxp`].
 pub(crate) fn str_iter_to_strsxp<'a>(iter: impl ExactSizeIterator<Item = &'a str>) -> crate::SEXP {
     unsafe {
-        let n: crate::R_xlen_t = iter
-            .len()
-            .try_into()
-            .expect("string vec length exceeds isize::MAX");
-        let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
+        let scope = ProtectScope::new();
+        let builder = StrVecBuilder::new(&scope, iter.len());
+        let vec = builder.as_sexp();
         for (i, s) in iter.enumerate() {
-            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-            let charsxp = str_to_charsxp(s);
-            sexp.set_string_elt(idx, charsxp);
+            vec.set_string_elt(i as isize, str_to_charsxp(s));
         }
-        *sexp
+        builder.into_sexp()
     }
 }
 
@@ -1243,20 +1244,53 @@ pub(crate) unsafe fn str_iter_to_strsxp_unchecked<'a>(
     iter: impl ExactSizeIterator<Item = &'a str>,
 ) -> crate::SEXP {
     unsafe {
-        let n: crate::R_xlen_t = iter
-            .len()
-            .try_into()
-            .expect("string vec length exceeds isize::MAX");
-        let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-            crate::SEXPTYPE::STRSXP,
-            n,
-        ));
+        let scope = ProtectScope::new();
+        let builder = StrVecBuilder::new_unchecked(&scope, iter.len());
+        let vec = builder.as_sexp();
         for (i, s) in iter.enumerate() {
-            let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-            let charsxp = str_to_charsxp_unchecked(s);
-            sexp.set_string_elt_unchecked(idx, charsxp);
+            vec.set_string_elt_unchecked(i as isize, str_to_charsxp_unchecked(s));
         }
-        *sexp
+        builder.into_sexp()
+    }
+}
+
+/// Helper: allocate STRSXP and fill from an optional-string iterator (checked).
+///
+/// `None` becomes `NA_character_`. Shared by the `Vec<Option<…str>>` impls.
+pub(crate) fn opt_str_iter_to_strsxp<'a>(
+    iter: impl ExactSizeIterator<Item = Option<&'a str>>,
+) -> crate::SEXP {
+    unsafe {
+        let scope = ProtectScope::new();
+        let builder = StrVecBuilder::new(&scope, iter.len());
+        let vec = builder.as_sexp();
+        for (i, opt_s) in iter.enumerate() {
+            let charsxp = match opt_s {
+                Some(s) => str_to_charsxp(s),
+                None => crate::SEXP::na_string(),
+            };
+            vec.set_string_elt(i as isize, charsxp);
+        }
+        builder.into_sexp()
+    }
+}
+
+/// Helper: allocate STRSXP and fill from an optional-string iterator (unchecked).
+pub(crate) unsafe fn opt_str_iter_to_strsxp_unchecked<'a>(
+    iter: impl ExactSizeIterator<Item = Option<&'a str>>,
+) -> crate::SEXP {
+    unsafe {
+        let scope = ProtectScope::new();
+        let builder = StrVecBuilder::new_unchecked(&scope, iter.len());
+        let vec = builder.as_sexp();
+        for (i, opt_s) in iter.enumerate() {
+            let charsxp = match opt_s {
+                Some(s) => str_to_charsxp_unchecked(s),
+                None => crate::SEXP::na_string(),
+            };
+            vec.set_string_elt_unchecked(i as isize, charsxp);
+        }
+        builder.into_sexp()
     }
 }
 
@@ -1343,42 +1377,11 @@ impl IntoR for Vec<Option<std::borrow::Cow<'_, str>>> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     fn into_sexp(self) -> crate::SEXP {
-        unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp(s.as_ref()),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt(idx, charsxp);
-            }
-            *sexp
-        }
+        opt_str_iter_to_strsxp(self.iter().map(|o| o.as_ref().map(|c| c.as_ref())))
     }
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
         unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::SEXPTYPE::STRSXP,
-                n,
-            ));
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp_unchecked(s.as_ref()),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt_unchecked(idx, charsxp);
-            }
-            *sexp
+            opt_str_iter_to_strsxp_unchecked(self.iter().map(|o| o.as_ref().map(|c| c.as_ref())))
         }
     }
 }
@@ -1396,43 +1399,10 @@ impl IntoR for Vec<Option<&str>> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     fn into_sexp(self) -> crate::SEXP {
-        unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp(s),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt(idx, charsxp);
-            }
-            *sexp
-        }
+        opt_str_iter_to_strsxp(self.iter().copied())
     }
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::SEXPTYPE::STRSXP,
-                n,
-            ));
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp_unchecked(s),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt_unchecked(idx, charsxp);
-            }
-            *sexp
-        }
+        unsafe { opt_str_iter_to_strsxp_unchecked(self.iter().copied()) }
     }
 }
 // endregion
@@ -1457,59 +1427,6 @@ impl IntoR for Vec<&str> {
 // endregion
 
 // region: VECSXP-from-iterator helpers
-
-/// Build a VECSXP of length `n`, protecting it across the fill, and return it.
-///
-/// This is the shared core for the "protect a VECSXP, fill it via
-/// `SET_VECTOR_ELT`, unprotect" idiom that recurs across the `IntoR` impls for
-/// nested collections (`Vec<Vec<T>>`, `Vec<&[T]>`, tuples, `Vec<Box<[T]>>`,
-/// `Vec<[T; N]>`, `Vec<HashMap<..>>`, …). It routes through [`ListBuilder`]
-/// over a local [`ProtectScope`]: the list is allocated and protected by the
-/// scope for the duration of `fill`, so any child allocations performed inside
-/// `fill` cannot collect the list; the scope's `Drop` issues the matching
-/// `UNPROTECT(1)` — the protect/unprotect count is balanced by construction
-/// (RAII), so a miscount is unrepresentable. The returned SEXP is **unprotected**
-/// (the scope has dropped); the caller must protect it before any further
-/// allocation.
-///
-/// `fill` receives the protected list SEXP and is responsible for populating it
-/// (via the checked [`set_vector_elt`](crate::SexpExt::set_vector_elt)). For the
-/// homogeneous "list of converted children" case prefer [`vecsxp_from_iter`];
-/// `fill` is for heterogeneous fills (e.g. tuples, where each slot has a
-/// distinct element type).
-///
-/// # Safety
-///
-/// Must be called from the R main thread.
-#[inline]
-unsafe fn build_vecsxp(n: usize, fill: impl FnOnce(crate::SEXP)) -> crate::SEXP {
-    unsafe {
-        let scope = ProtectScope::new();
-        let builder = ListBuilder::new(&scope, n);
-        fill(builder.as_sexp());
-        builder.into_sexp()
-    }
-}
-
-/// `_unchecked` twin of [`build_vecsxp`] for contexts where the checked FFI
-/// thread assertion must be bypassed (ALTREP callbacks, `with_r_unwind_protect`,
-/// `with_r_thread`). Allocates via [`ListBuilder::new_unchecked`]; `fill` must
-/// use the `_unchecked` setters.
-///
-/// # Safety
-///
-/// Must be called from the R main thread, and only from a context where the
-/// checked-FFI assertion is intentionally bypassed (see CLAUDE.md "FFI thread
-/// checking").
-#[inline]
-unsafe fn build_vecsxp_unchecked(n: usize, fill: impl FnOnce(crate::SEXP)) -> crate::SEXP {
-    unsafe {
-        let scope = ProtectScope::new();
-        let builder = ListBuilder::new_unchecked(&scope, n);
-        fill(builder.as_sexp());
-        builder.into_sexp()
-    }
-}
 
 /// Build a VECSXP from an exact-size iterator of child `SEXP`s (checked).
 ///
@@ -1930,48 +1847,11 @@ impl IntoR for Vec<Option<String>> {
         Ok(unsafe { self.into_sexp_unchecked() })
     }
     fn into_sexp(self) -> crate::SEXP {
-        unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
-
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp(s),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt(idx, charsxp);
-            }
-
-            *sexp
-        }
+        opt_str_iter_to_strsxp(self.iter().map(|o| o.as_deref()))
     }
 
     unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
-        unsafe {
-            let n: crate::R_xlen_t = self
-                .len()
-                .try_into()
-                .expect("vec length exceeds isize::MAX");
-            let sexp = OwnedProtect::new(crate::sys::Rf_allocVector_unchecked(
-                crate::SEXPTYPE::STRSXP,
-                n,
-            ));
-
-            for (i, opt_s) in self.iter().enumerate() {
-                let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
-                let charsxp = match opt_s {
-                    Some(s) => str_to_charsxp_unchecked(s),
-                    None => crate::SEXP::na_string(),
-                };
-                sexp.set_string_elt_unchecked(idx, charsxp);
-            }
-
-            *sexp
-        }
+        unsafe { opt_str_iter_to_strsxp_unchecked(self.iter().map(|o| o.as_deref())) }
     }
 }
 // endregion
@@ -1992,21 +1872,23 @@ macro_rules! impl_tuple_into_r {
             }
             fn into_sexp(self) -> crate::SEXP {
                 unsafe {
-                    build_vecsxp($n, |list| {
-                        $(
-                            list.set_vector_elt($idx as crate::R_xlen_t, self.$idx.into_sexp());
-                        )+
-                    })
+                    let scope = ProtectScope::new();
+                    let builder = ListBuilder::new(&scope, $n);
+                    $(
+                        builder.set($idx as isize, self.$idx.into_sexp());
+                    )+
+                    builder.into_sexp()
                 }
             }
 
             unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
                 unsafe {
-                    build_vecsxp_unchecked($n, |list| {
-                        $(
-                            list.set_vector_elt_unchecked($idx as crate::R_xlen_t, self.$idx.into_sexp_unchecked());
-                        )+
-                    })
+                    let scope = ProtectScope::new();
+                    let builder = ListBuilder::new_unchecked(&scope, $n);
+                    $(
+                        builder.set_unchecked($idx as isize, self.$idx.into_sexp_unchecked());
+                    )+
+                    builder.into_sexp()
                 }
             }
         }
@@ -2165,18 +2047,7 @@ where
 
 /// Helper: convert a Vec of IntoR items to an R list (VECSXP).
 fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::SEXP {
-    unsafe {
-        let n = items.len();
-        let list = OwnedProtect::new(crate::sys::Rf_allocVector(
-            crate::SEXPTYPE::VECSXP,
-            n as crate::R_xlen_t,
-        ));
-        for (i, item) in items.into_iter().enumerate() {
-            list.get()
-                .set_vector_elt(i as crate::R_xlen_t, item.into_sexp());
-        }
-        *list
-    }
+    unsafe { vecsxp_from_iter(items.into_iter().map(|item| item.into_sexp())) }
 }
 
 // region: Vec<Option<Collection>> conversions
@@ -2185,19 +2056,10 @@ fn vec_of_into_r_to_list<T: IntoR>(items: Vec<T>) -> crate::SEXP {
 /// `R_NilValue` (NULL) and `Some(v)` mapping to whatever `v.into_sexp()` produces.
 fn vec_option_of_into_r_to_list<T: IntoR>(items: Vec<Option<T>>) -> crate::SEXP {
     unsafe {
-        let n = items.len();
-        let list = OwnedProtect::new(crate::sys::Rf_allocVector(
-            crate::SEXPTYPE::VECSXP,
-            n as crate::R_xlen_t,
-        ));
-        for (i, item) in items.into_iter().enumerate() {
-            let elt = match item {
-                Some(v) => v.into_sexp(),
-                None => crate::SEXP::nil(),
-            };
-            list.get().set_vector_elt(i as crate::R_xlen_t, elt);
-        }
-        *list
+        vecsxp_from_iter(items.into_iter().map(|item| match item {
+            Some(v) => v.into_sexp(),
+            None => crate::SEXP::nil(),
+        }))
     }
 }
 

--- a/miniextendr-api/src/list.rs
+++ b/miniextendr-api/src/list.rs
@@ -566,6 +566,28 @@ impl<'a> ListBuilder<'a> {
         }
     }
 
+    /// Create a new list builder via the **unchecked** FFI allocation path.
+    ///
+    /// `_unchecked` twin of [`new`](Self::new): the VECSXP is allocated with
+    /// `Rf_allocVector_unchecked` (see [`ProtectScope::alloc_vecsxp_unchecked`]),
+    /// bypassing the main-thread assertion. Use inside ALTREP callbacks,
+    /// `with_r_unwind_protect`, or `with_r_thread` bodies, and pair element
+    /// insertion with [`set_unchecked`](Self::set_unchecked).
+    ///
+    /// # Safety
+    ///
+    /// Must be called from the R main thread, in a context where the checked-FFI
+    /// assertion is intentionally bypassed (see CLAUDE.md "FFI thread checking").
+    #[inline]
+    pub unsafe fn new_unchecked(scope: &'a ProtectScope, len: usize) -> Self {
+        // SAFETY: caller guarantees R main thread in a checked-bypass context.
+        let list = unsafe { scope.alloc_vecsxp_unchecked(len).into_raw() };
+        Self {
+            list,
+            _scope: scope,
+        }
+    }
+
     /// Create a builder wrapping an existing protected list.
     ///
     /// # Safety
@@ -594,6 +616,26 @@ impl<'a> ListBuilder<'a> {
         // SAFETY: caller guarantees valid and protected child
         debug_assert!(idx >= 0 && idx < self.list.xlength());
         self.list.set_vector_elt(idx, child);
+    }
+
+    /// Set an element via the **unchecked** FFI path.
+    ///
+    /// `_unchecked` twin of [`set`](Self::set): inserts with
+    /// `set_vector_elt_unchecked`, bypassing the main-thread assertion. Pair with
+    /// [`new_unchecked`](Self::new_unchecked) inside ALTREP callbacks,
+    /// `with_r_unwind_protect`, or `with_r_thread` bodies.
+    ///
+    /// # Safety
+    ///
+    /// - `child` must be a valid SEXP, already protected (typically by the same
+    ///   scope, or by being inserted into this protected parent immediately after
+    ///   allocation with no intervening allocation)
+    /// - Must be called from the R main thread, in a checked-bypass context
+    #[inline]
+    pub unsafe fn set_unchecked(&self, idx: isize, child: SEXP) {
+        // SAFETY: caller guarantees valid, protected child in a checked-bypass context.
+        debug_assert!(idx >= 0 && idx < self.list.xlength());
+        unsafe { self.list.set_vector_elt_unchecked(idx, child) };
     }
 
     /// Set an element, protecting the child within the builder's scope.

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -340,6 +340,25 @@ impl<'a> StrVecBuilder<'a> {
         Self { vec, _scope: scope }
     }
 
+    /// Create a new string vector builder via the **unchecked** FFI allocation path.
+    ///
+    /// `_unchecked` twin of [`new`](Self::new): the STRSXP is allocated with
+    /// `Rf_allocVector_unchecked` (see [`ProtectScope::alloc_character_unchecked`]),
+    /// bypassing the main-thread assertion. Use inside ALTREP callbacks,
+    /// `with_r_unwind_protect`, or `with_r_thread` bodies, and pair element
+    /// insertion with the `_unchecked` string-element setters.
+    ///
+    /// # Safety
+    ///
+    /// Must be called from the R main thread, in a context where the checked-FFI
+    /// assertion is intentionally bypassed (see CLAUDE.md "FFI thread checking").
+    #[inline]
+    pub unsafe fn new_unchecked(scope: &'a ProtectScope, len: usize) -> Self {
+        // SAFETY: caller guarantees R main thread in a checked-bypass context.
+        let vec = unsafe { scope.alloc_character_unchecked(len).into_raw() };
+        Self { vec, _scope: scope }
+    }
+
     /// Set an element from a Rust string.
     ///
     /// # Safety


### PR DESCRIPTION
Follow-up to #1047: the `build_vecsxp`/`vecsxp_from_iter` helpers (and a few sibling sites) hand-rolled the "alloc + protect + fill" idiom with a raw `OwnedProtect`, duplicating `ListBuilder` + `ProtectScope::alloc_vecsxp` (and, for strings, `StrVecBuilder`). This routes every site through the builders and adds the `_unchecked` builder variants the unchecked conversion path needs. Net ~220 lines removed.

<details>
<summary><h3>AI-written details</h3></summary>

## New `_unchecked` builder surface
- `ProtectScope::alloc_vector_unchecked` + `alloc_vecsxp_unchecked` + `alloc_character_unchecked` (`gc_protect.rs`) — unchecked `Rf_allocVector` + protect.
- `ListBuilder::new_unchecked` / `ListBuilder::set_unchecked` (`list.rs`).
- `StrVecBuilder::new_unchecked` (`strvec.rs`).

These match the established "unchecked alloc + checked protect/unprotect" idiom the merged `build_vecsxp_unchecked` already used via `OwnedProtect`; protect/unprotect stay checked and are released by the local `ProtectScope`'s `Drop`.

## VECSXP sites → `ListBuilder` / `vecsxp_from_iter`
- `vecsxp_from_iter` / `_unchecked` drive `ListBuilder::set` / `set_unchecked`.
- `build_vecsxp` / `build_vecsxp_unchecked` **removed entirely** — the only consumer was the tuple-impl macro (heterogeneous fills), which now inlines `ListBuilder` directly (`new[_unchecked]` + per-slot `set[_unchecked]`).
- `vec_of_into_r_to_list` and `vec_option_of_into_r_to_list` (were raw `OwnedProtect`) now go through `vecsxp_from_iter`.

## STRSXP sites → `StrVecBuilder`
- `str_iter_to_strsxp` / `_unchecked` now own alloc+protect via `StrVecBuilder`.
- New shared `opt_str_iter_to_strsxp` / `_unchecked`; the three near-identical `Vec<Option<{Cow,&str,String}>>` impls collapse onto it (`None` → `NA_character_`).
- The empty-string → `R_BlankString` CHARSXP policy (`str_to_charsxp`) stays at the callsite, so CHARSXP behavior is byte-for-byte unchanged.

## Semantics
Protect/unprotect behaviour is unchanged across all sites: the local `ProtectScope`'s `Drop` issues the matching `UNPROTECT`, so the count is balanced by construction (RAII) — a miscount stays unrepresentable. Returned SEXPs are unprotected (scope dropped), exactly as before; callers protect them.

No `#[miniextendr]` surface change → no generated-artifact (`wrappers.R`/`NAMESPACE`/`man`) drift. Refs #1023 (slices 2/3 of the broader raw-protect migration stay open).

## Test plan
- [x] `cargo test -p miniextendr-api` — 515 passed
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (`clippy_default`) — green
- [x] `cargo clippy` with the curated `clippy_all` feature list — green
- [x] `cargo fmt --all` — clean
- [x] `just rcmdinstall` — clean, no generated-artifact drift
- [x] `gctorture(TRUE)` over no-arg nested-list/map fixtures — 420/420 clean
- [x] `gctorture(TRUE)` over no-arg string-vector fixtures (`Vec<String>`, `Vec<Option<String>>`, sets, scalars) — 360/360 clean
- [x] `just devtools-test` — `[ FAIL 0 | WARN 0 | SKIP 19 | PASS 6531 ]`

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>