### PR TITLE
docs: drop stale ColumnarDataFrame references

### DIFF
--- a/docs/COLUMNAR_OPTION_NONE.md
+++ b/docs/COLUMNAR_OPTION_NONE.md
@@ -1,8 +1,8 @@
-# ColumnarDataFrame: all-None Option columns
+# Columnar data.frame: all-None Option columns
 
 ## The old failure
 
-`ColumnarDataFrame::from_rows` discovers column types by probing runtime values.
+`vec_to_dataframe` discovers column types by probing runtime values.
 When every row has `None` for an `Option<T>` field the probe never sees a `Some`,
 the column stays `ColumnBuffer::Generic`, and R received `list(NULL, NULL, …)`
 instead of an atomic vector with `NA`. Tibble and dplyr treat `list(NULL, …)` as

--- a/docs/DATAFRAME.md
+++ b/docs/DATAFRAME.md
@@ -566,7 +566,7 @@ The redundant public types below were **removed** (#781) — there is no backwar
 | `RDataFrameBuilder::new(n)` | `DataFrame::builder(n)` |
 | four conversion error types | one `DataFrameError` |
 
-The companion type that `#[derive(DataFrameRow)]` generates (`{Name}DataFrame`, with `to_dataframe` / `from_rows` / `from_rows_par` / `from_dataframe` and `IntoIterator`) still exists as the engine the façade verbs delegate to. The serde columnar assembler (`serde::ColumnarDataFrame`) is still present as a serde-internal representation; converging its naming with the façade is tracked in #783.
+The companion type that `#[derive(DataFrameRow)]` generates (`{Name}DataFrame`, with `to_dataframe` / `from_rows` / `from_rows_par` / `from_dataframe` and `IntoIterator`) still exists as the engine the façade verbs delegate to. The serde columnar path (`serde::vec_to_dataframe` and friends) produces the same unified `DataFrame` — there is no separate `ColumnarDataFrame` type; the naming convergence was completed in #783.
 
 ## Feature flags
 


### PR DESCRIPTION
<TODO: your framing paragraph>

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- The serde columnar assembler type `ColumnarDataFrame` was unified into the single owned `DataFrame` type (#786); the naming-convergence work it tracked was completed and closed in #783. Two docs still cited the dead type.
- `docs/COLUMNAR_OPTION_NONE.md`: retitled, and `ColumnarDataFrame::from_rows` updated to the current `vec_to_dataframe` entry point.
- `docs/DATAFRAME.md`: corrected the "`serde::ColumnarDataFrame` is still present" sentence to state the serde path produces the unified `DataFrame`.

## Test plan
- [ ] Docs-only; `grep -rn ColumnarDataFrame docs/` returns nothing after this and the sibling satellite PR merge.

## Notes
- The matching stale reference in `docs/SERDE_R.md` rides in the satellite-harness PR (that PR also edits the same file), so no file is touched by both PRs.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>