### PR TITLE
fix: leash StrVec and RCow borrows to a lifetime (kill the `&'static`-from-R escape)

### DIFF
--- a/miniextendr-api/src/rcow.rs
+++ b/miniextendr-api/src/rcow.rs
@@ -33,8 +33,10 @@
 //! # Lifetime contract
 //!
 //! As with `Cow<[T]>`, a borrowed `RCow` is valid only for the duration of the
-//! enclosing `.Call` (R protects the argument SEXP while Rust runs). Do not send
-//! it to another thread or store it past the call return.
+//! enclosing `.Call` (R protects the argument SEXP while Rust runs). Write
+//! `RCow<'_, T>` at a `#[miniextendr]` boundary: the `'a` leashes the borrow to
+//! the call, so sending it to another thread or storing it past the call return
+//! is a *compile error*, not an honor-system pitfall.
 
 use std::ops::Deref;
 
@@ -82,13 +84,13 @@ impl<T> RBorrow<'_, T> {
 /// ```ignore
 /// // Zero-copy in *and* out: the returned SEXP is the original R vector.
 /// #[miniextendr]
-/// pub fn passthrough(x: RCow<'static, f64>) -> RCow<'static, f64> {
+/// pub fn passthrough(x: RCow<'_, f64>) -> RCow<'_, f64> {
 ///     x
 /// }
 ///
 /// // Mutating forces a copy (copy-on-write), then materializes a fresh vector.
 /// #[miniextendr]
-/// pub fn doubled(mut x: RCow<'static, f64>) -> RCow<'static, f64> {
+/// pub fn doubled(mut x: RCow<'_, f64>) -> RCow<'_, f64> {
 ///     for v in x.to_mut() {
 ///         *v *= 2.0;
 ///     }
@@ -164,11 +166,17 @@ impl<T> From<Vec<T>> for RCow<'_, T> {
 /// Reads an R vector zero-copy, remembering the source SEXP so it can be handed
 /// straight back by [`IntoR`]. Rejects a mismatched [`SEXPTYPE`](crate::SEXPTYPE)
 /// just like the `&[T]` impl it delegates to.
-impl<T: RNativeType> TryFromSexp for RCow<'static, T> {
+///
+/// The impl is generic over `'a` so a borrowed `RCow<'_, T>` argument is leashed
+/// to the enclosing `.Call` (R protects the argument SEXP for the call's
+/// duration). Storing it past the call return — in an `ExternalPtr`, a global,
+/// or another thread — is a compile error, not an honor-system hazard.
+impl<'a, T: RNativeType> TryFromSexp for RCow<'a, T> {
     type Error = SexpTypeError;
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
+        // The `&[T]` impl fabricates &'static; covariance narrows it to &'a.
         let data: &'static [T] = TryFromSexp::try_from_sexp(sexp)?;
         Ok(RCow::Borrowed(RBorrow { sexp, data }))
     }

--- a/miniextendr-api/src/strvec.rs
+++ b/miniextendr-api/src/strvec.rs
@@ -3,6 +3,7 @@
 //! Provides safe construction and element insertion for string vectors.
 
 use std::borrow::Cow;
+use std::marker::PhantomData;
 
 use crate::SEXPTYPE::STRSXP;
 use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
@@ -10,23 +11,30 @@ use crate::gc_protect::{OwnedProtect, ProtectScope, Protected};
 use crate::into_r::IntoR;
 use crate::{SEXP, SexpExt};
 
-/// Owned handle to an R character vector (`STRSXP`).
+/// Borrowed view over an R character vector (`STRSXP`).
 ///
-/// This wrapper provides safe methods for building character vectors
-/// element-by-element with proper GC protection.
+/// The `'a` lifetime leashes every `&str` this view hands out to the window in
+/// which the underlying `STRSXP` stays GC-reachable. At a `#[miniextendr]`
+/// boundary, write `StrVec<'_>`: R protects `.Call` arguments for the call's
+/// duration, so the elided lifetime is bounded by the call and the borrows
+/// cannot escape into an `ExternalPtr`, a global, or another thread — doing so
+/// is a compile error (the `&str` would have to outlive `'a`). Callers that own
+/// the rooting obligation reach for the `unsafe` `*_static` family instead.
+///
+/// `Copy` and cheap (a single `SEXP`); covariant in `'a`.
 #[derive(Clone, Copy, Debug)]
-pub struct StrVec(SEXP);
+pub struct StrVec<'a>(SEXP, PhantomData<&'a str>);
 
-impl StrVec {
+impl<'a> StrVec<'a> {
     /// Wrap an existing `STRSXP` without additional checks.
     ///
     /// # Safety
     ///
     /// Caller must ensure `sexp` is a valid character vector (`STRSXP`)
-    /// whose lifetime remains managed by R.
+    /// that stays GC-reachable for the inferred lifetime `'a`.
     #[inline]
     pub const unsafe fn from_raw(sexp: SEXP) -> Self {
-        StrVec(sexp)
+        StrVec(sexp, PhantomData)
     }
 
     /// Get the underlying `SEXP`.
@@ -58,28 +66,29 @@ impl StrVec {
         Some(self.0.string_elt(idx))
     }
 
-    /// Get the string at the given index (zero-copy).
+    /// Get the string at the given index (zero-copy), leashed to `'a`.
     ///
     /// Returns `None` if out of bounds or if the element is `NA_character_`.
     /// Panics if the CHARSXP is not valid UTF-8 (should not happen in a UTF-8 locale).
     #[inline]
-    pub fn get_str(self, idx: isize) -> Option<&'static str> {
+    pub fn get_str(self, idx: isize) -> Option<&'a str> {
         let charsxp = self.get_charsxp(idx)?;
         unsafe {
             if charsxp == SEXP::na_string() {
                 return None;
             }
+            // charsxp_to_str fabricates &'static; covariance narrows it to &'a.
             Some(charsxp_to_str(charsxp))
         }
     }
 
-    /// Get the string at the given index as `Cow<str>` (encoding-safe).
+    /// Get the string at the given index as `Cow<str>` (encoding-safe), leashed to `'a`.
     ///
     /// Returns `Cow::Borrowed` for UTF-8 strings (zero-copy), `Cow::Owned` for
     /// non-UTF-8 strings (translated via `Rf_translateCharUTF8`).
     /// Returns `None` if out of bounds or `NA_character_`.
     #[inline]
-    pub fn get_cow(self, idx: isize) -> Option<Cow<'static, str>> {
+    pub fn get_cow(self, idx: isize) -> Option<Cow<'a, str>> {
         let charsxp = self.get_charsxp(idx)?;
         unsafe {
             if charsxp == SEXP::na_string() {
@@ -89,12 +98,55 @@ impl StrVec {
         }
     }
 
-    /// Iterate over elements as `Option<&str>`.
+    /// Get the string at the given index as `&'static str` — the courageous escape.
+    ///
+    /// Unlike [`get_str`](Self::get_str), the returned reference is **not** leashed
+    /// to `'a`, so it can be stored in an `ExternalPtr`, a global, or sent across
+    /// threads. The string data lives in R's CHARSXP; it is only valid while that
+    /// `STRSXP` stays GC-reachable.
+    ///
+    /// # Safety
+    ///
+    /// The caller takes on the rooting obligation: the underlying `STRSXP` must be
+    /// kept reachable by R (e.g. via the `prot` slot of the `ExternalPtr` it is
+    /// stored in, or `R_PreserveObject`) for as long as the returned `&'static str`
+    /// is used. Letting R GC the source is use-after-free.
+    #[inline]
+    pub unsafe fn get_str_static(self, idx: isize) -> Option<&'static str> {
+        let charsxp = self.get_charsxp(idx)?;
+        unsafe {
+            if charsxp == SEXP::na_string() {
+                return None;
+            }
+            Some(charsxp_to_str(charsxp))
+        }
+    }
+
+    /// Get the string at the given index as `Cow<'static, str>` — the courageous escape.
+    ///
+    /// `Cow` analogue of [`get_str_static`](Self::get_str_static); same rooting
+    /// obligation for the borrowed (`Cow::Borrowed`) case.
+    ///
+    /// # Safety
+    ///
+    /// See [`get_str_static`](Self::get_str_static).
+    #[inline]
+    pub unsafe fn get_cow_static(self, idx: isize) -> Option<Cow<'static, str>> {
+        let charsxp = self.get_charsxp(idx)?;
+        unsafe {
+            if charsxp == SEXP::na_string() {
+                return None;
+            }
+            Some(charsxp_to_cow(charsxp))
+        }
+    }
+
+    /// Iterate over elements as `Option<&str>` (leashed to `'a`).
     ///
     /// `NA_character_` elements yield `None`, valid strings yield `Some(&str)`.
     /// Zero-copy — each `&str` borrows directly from R's CHARSXP.
     #[inline]
-    pub fn iter(self) -> StrVecIter {
+    pub fn iter(self) -> StrVecIter<'a> {
         StrVecIter {
             vec: self,
             idx: 0,
@@ -102,11 +154,11 @@ impl StrVec {
         }
     }
 
-    /// Iterate over elements as `Option<Cow<str>>` (encoding-safe).
+    /// Iterate over elements as `Option<Cow<str>>` (encoding-safe, leashed to `'a`).
     ///
     /// Like [`iter`](Self::iter) but handles non-UTF-8 CHARSXPs gracefully.
     #[inline]
-    pub fn iter_cow(self) -> StrVecCowIter {
+    pub fn iter_cow(self) -> StrVecCowIter<'a> {
         StrVecCowIter {
             vec: self,
             idx: 0,
@@ -221,18 +273,18 @@ impl StrVec {
 
 // region: StrVec iterators
 
-/// Iterator over `StrVec` elements as `Option<&str>`.
+/// Iterator over `StrVec` elements as `Option<&str>` (leashed to `'a`).
 ///
 /// Yields `None` for `NA_character_`, `Some(&str)` for valid strings.
 /// Zero-copy — each `&str` borrows directly from R's CHARSXP.
-pub struct StrVecIter {
-    vec: StrVec,
+pub struct StrVecIter<'a> {
+    vec: StrVec<'a>,
     idx: isize,
     len: isize,
 }
 
-impl Iterator for StrVecIter {
-    type Item = Option<&'static str>;
+impl<'a> Iterator for StrVecIter<'a> {
+    type Item = Option<&'a str>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -255,19 +307,19 @@ impl Iterator for StrVecIter {
     }
 }
 
-impl ExactSizeIterator for StrVecIter {}
+impl ExactSizeIterator for StrVecIter<'_> {}
 
-/// Iterator over `StrVec` elements as `Option<Cow<'static, str>>`.
+/// Iterator over `StrVec` elements as `Option<Cow<'a, str>>`.
 ///
 /// Like [`StrVecIter`] but handles non-UTF-8 CHARSXPs via `Rf_translateCharUTF8`.
-pub struct StrVecCowIter {
-    vec: StrVec,
+pub struct StrVecCowIter<'a> {
+    vec: StrVec<'a>,
     idx: isize,
     len: isize,
 }
 
-impl Iterator for StrVecCowIter {
-    type Item = Option<Cow<'static, str>>;
+impl<'a> Iterator for StrVecCowIter<'a> {
+    type Item = Option<Cow<'a, str>>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -290,11 +342,11 @@ impl Iterator for StrVecCowIter {
     }
 }
 
-impl ExactSizeIterator for StrVecCowIter {}
+impl ExactSizeIterator for StrVecCowIter<'_> {}
 
-impl IntoIterator for StrVec {
-    type Item = Option<&'static str>;
-    type IntoIter = StrVecIter;
+impl<'a> IntoIterator for StrVec<'a> {
+    type Item = Option<&'a str>;
+    type IntoIter = StrVecIter<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -402,10 +454,10 @@ impl<'a> StrVecBuilder<'a> {
         self.vec
     }
 
-    /// Convert to a `StrVec` wrapper.
+    /// Convert to a `StrVec` view, leashed to the builder's protect scope `'a`.
     #[inline]
-    pub fn into_strvec(self) -> StrVec {
-        StrVec(self.vec)
+    pub fn into_strvec(self) -> StrVec<'a> {
+        StrVec(self.vec, PhantomData)
     }
 
     /// Convert to the underlying SEXP.
@@ -430,7 +482,7 @@ impl<'a> StrVecBuilder<'a> {
 
 // region: Trait implementations
 
-impl IntoR for StrVec {
+impl IntoR for StrVec<'_> {
     type Error = std::convert::Infallible;
     fn try_into_sexp(self) -> Result<SEXP, Self::Error> {
         Ok(self.into_sexp())
@@ -444,7 +496,7 @@ impl IntoR for StrVec {
     }
 }
 
-impl TryFromSexp for StrVec {
+impl<'a> TryFromSexp for StrVec<'a> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
@@ -456,7 +508,7 @@ impl TryFromSexp for StrVec {
             }
             .into());
         }
-        Ok(StrVec(sexp))
+        Ok(StrVec(sexp, PhantomData))
     }
 }
 // endregion
@@ -466,9 +518,11 @@ impl TryFromSexp for StrVec {
 /// GC-protected view over an R character vector (`STRSXP`).
 ///
 /// Unlike [`StrVec`] (which is `Copy` and trusts the caller for GC protection),
-/// `ProtectedStrVec` wraps a [`Protected<'static, StrVec>`](crate::gc_protect::Protected) that keeps the
-/// STRSXP alive. All borrowed data (`&str`, iterators) has its lifetime tied to `&self`,
-/// not `'static` — preventing use-after-GC bugs at compile time.
+/// `ProtectedStrVec` wraps a [`Protected<'static, StrVec<'static>>`](crate::gc_protect::Protected)
+/// that keeps the STRSXP alive — the `'static` on the inner view is sound here
+/// because the protect guard *is* the rooting obligation. All borrowed data
+/// (`&str`, iterators) it hands out has its lifetime tied to `&self`, not
+/// `'static` — preventing use-after-GC bugs at compile time.
 ///
 /// # When to use
 ///
@@ -489,7 +543,7 @@ impl TryFromSexp for StrVec {
 /// }
 /// ```
 pub struct ProtectedStrVec {
-    protected: Protected<'static, StrVec>,
+    protected: Protected<'static, StrVec<'static>>,
     len: isize,
 }
 
@@ -593,9 +647,9 @@ impl ProtectedStrVec {
         self.protected.get().as_sexp()
     }
 
-    /// Get the inner `StrVec` (unprotected copy — caller assumes protection responsibility).
+    /// Get the inner `StrVec` view, leashed to `&self` (the protect guard).
     #[inline]
-    pub fn as_strvec(&self) -> StrVec {
+    pub fn as_strvec(&self) -> StrVec<'_> {
         *self.protected.get()
     }
 }

--- a/miniextendr-macros/tests/ui/view_type_lifetime_leash.rs
+++ b/miniextendr-macros/tests/ui/view_type_lifetime_leash.rs
@@ -1,0 +1,36 @@
+//! Soundness guard for the R-borrowing view types (`StrVec<'_>`, `RCow<'_, T>`).
+//!
+//! These views hand out borrows into R-owned vector/CHARSXP data. Every such
+//! borrow is leashed to the view's `'a` — the window in which R keeps the source
+//! SEXP reachable (`.Call` protects arguments for the call's duration). A borrow
+//! that escaped to `'static` (stored in an `ExternalPtr`, a global, or sent to
+//! another thread) would be a use-after-GC once R collects the source. This file
+//! must FAIL to compile: if it ever builds, the leash is broken — most likely an
+//! accessor's `&'a` return type was reverted to `&'static`, or a view's
+//! `TryFromSexp` impl was re-pinned to `'static`. See the static-str soundness work.
+
+use miniextendr_api::{RCow, StrVec};
+
+// The original use-after-GC PoC, now a compile error: a `&str` extracted from a
+// leashed `StrVec<'_>` view cannot be stowed in a `'static` field.
+struct StrKeeper {
+    s: &'static str,
+}
+
+fn keep_extracted_str(v: StrVec<'_>) -> StrKeeper {
+    StrKeeper {
+        s: v.get_str(0).unwrap(),
+    }
+}
+
+// The whole borrowed `RCow<'_, T>` view is leashed the same way: it cannot be
+// stored past the call that produced it.
+struct CowKeeper {
+    c: RCow<'static, i32>,
+}
+
+fn keep_rcow(c: RCow<'_, i32>) -> CowKeeper {
+    CowKeeper { c }
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/view_type_lifetime_leash.stderr
+++ b/miniextendr-macros/tests/ui/view_type_lifetime_leash.stderr
@@ -1,0 +1,16 @@
+error: lifetime may not live long enough
+  --> tests/ui/view_type_lifetime_leash.rs:22:12
+   |
+20 | fn keep_extracted_str(v: StrVec<'_>) -> StrKeeper {
+   |                       - has type `StrVec<'1>`
+21 |     StrKeeper {
+22 |         s: v.get_str(0).unwrap(),
+   |            ^^^^^^^^^^^^^^^^^^^^^ this usage requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> tests/ui/view_type_lifetime_leash.rs:33:17
+   |
+32 | fn keep_rcow(c: RCow<'_, i32>) -> CowKeeper {
+   |              - has type `RCow<'1, i32>`
+33 |     CowKeeper { c }
+   |                 ^ this usage requires that `'1` must outlive `'static`


### PR DESCRIPTION
## Problem

`StrVec` and `RCow`'s borrowed arm hand out references straight into R-owned CHARSXP / vector data. Both hard-coded `'static`:

- `StrVec::get_str(self) -> Option<&'static str>`
- `impl TryFromSexp for RCow<'static, T>`

That `'static` is a lie. The data lives only while R keeps the source SEXP reachable (R protects `.Call` arguments for the call's duration). A borrow stowed in an `ExternalPtr`, a global, or sent cross-thread dangles the moment R GCs the source.

**Demonstrated empirically** during investigation: `StrVec::get_str` → stored in an `ExternalPtr` → `rm() + gc()` → the recreated string lands at a different address; the original reads freed memory. No `unsafe` required.

## Fix — leash to a real `'a`

- **`StrVec` → `StrVec<'a>`** (covariant `PhantomData<&'a str>`). Safe `get_str` / `get_cow` / `iter` / `iter_cow` / `IntoIterator` return `&'a` / `Cow<'a>`. `'static` is relegated to the new `unsafe get_str_static` / `get_cow_static` escape hatch (for callers who own the rooting obligation, e.g. having stashed the source SEXP in an `ExternalPtr`'s `prot` slot). `StrVecBuilder::into_strvec` leashes to the builder's protect scope. `ProtectedStrVec` wraps `StrVec<'static>` — sound, because its protect guard *is* the rooting obligation.
- **`RCow`** — `impl TryFromSexp for RCow<'static, T>` → generic `impl<'a, T> … RCow<'a, T>`. Users write `RCow<'_, T>`; the module's honor-system "do not store past the call return" note becomes **compile-enforced**.

At a `#[miniextendr]` boundary the user writes `StrVec<'_>` / `RCow<'_, T>`. The anonymous lifetime is a fresh generic the generated wrapper cannot widen to `'static`, so storing a borrow past the call is a compile error (E0521). The C wrapper stays `SEXP`-in/out — lifetimes erase at codegen, so this needs no macro change (anonymous `<'_>` already works with the current macro; explicit `<'a>` is enabled by #1086, on which this stacks).

Sound models already in tree, left unchanged: `Factor<'a>`, `ProtectedStrVec`.

## Test

`miniextendr-macros/tests/ui/view_type_lifetime_leash.rs` (trybuild compile-fail) reproduces the original use-after-GC PoC — storing a leashed `StrVec<'_>` / `RCow<'_, _>` borrow in a `'static` field — and asserts it no longer compiles:

```
error: lifetime may not live long enough
  ... this usage requires that `'1` must outlive `'static`
```

## Scope / follow-up

The remaining `'static`-pinned **std-type** `TryFromSexp` conversions (`Cow<'static, […]>`, `Cow<'static, str>`, `Vec<&'static str>`, `Vec<&'static [T]>`, scalar `&'static T`) are the same escape class but a broad, mechanical change across ~50 generated impls. Tracked in #1087. Note the bare covariant `&[T]` / `&mut [T]` / `&str` arg forms are *already* leashed by the user fn's elided lifetime (and `&[T]`/`&mut [T]` already have generic blanket impls), so the high-value targets there are the invariant `Vec<&'static …>` / `Cow<'static, …>` families.

## Verification

- `just check` — green across all manifests (incl. rpkg fixtures + cross-package).
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- `cargo test -p miniextendr-macros --test ui` — passes (new compile-fail snapshot stable, no other UI snapshots drifted).

`clippy_all`'s feature matrix not separately re-run: the diff touches only `strvec.rs` / `rcow.rs` (always-compiled, no feature gates) plus a trybuild test, so the extra features cannot surface new lints in the changed code.

## Stacking

Based on `feat/miniextendr-accept-lifetimes` (#1086) for clean history; **no hard code dependency** on it (uses only anonymous `<'_>`). When #1086 merges, this auto-retargets to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)