### PR TITLE
fix(api): protect self.sexp across CHARSXP alloc in DataFrame::rename/strip_prefix

### DIFF
--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -272,6 +272,9 @@ impl DataFrame {
     /// Rename a column. No-op if `from` doesn't match any column name.
     pub fn rename(self, from: &str, to: &str) -> Self {
         unsafe {
+            // Root `self.sexp` so its `names` attribute survives the
+            // `SEXP::charsxp` (Rf_mkCharLenCE) allocation below, which can GC.
+            let _guard = crate::OwnedProtect::new(self.sexp);
             let names_sexp = self.sexp.get_names();
             if names_sexp == SEXP::nil() {
                 return self;
@@ -290,6 +293,9 @@ impl DataFrame {
     /// Strip a prefix from all column names that start with it.
     pub fn strip_prefix(self, prefix: &str) -> Self {
         unsafe {
+            // Root `self.sexp` so its `names` attribute survives the
+            // `SEXP::charsxp` (Rf_mkCharLenCE) allocation below, which can GC.
+            let _guard = crate::OwnedProtect::new(self.sexp);
             let names_sexp = self.sexp.get_names();
             if names_sexp == SEXP::nil() {
                 return self;


### PR DESCRIPTION
Hardens GC discipline in two `DataFrame` editing methods to match the rest of the file. From `audit/dataframe.md`.

<details>
<summary>🤖 Generated by Claude Opus 4.8 — details</summary>

**Finding.** `miniextendr-api/src/dataframe.rs` — `DataFrame::rename` and `DataFrame::strip_prefix` allocate a CHARSXP via `SEXP::charsxp(...)` while `self.sexp` is not GC-protected.

**Root cause.** `SEXP::charsxp` calls `Rf_mkCharLenCE`, which can allocate and trigger R's GC. `self.sexp` lives only on the Rust stack (R's GC does not scan it), so it — and the `names` attribute we mutate, reached through it — could be collected mid-operation. The sibling editing methods `drop`/`select` already guard with `crate::OwnedProtect`; these two did not.

**Fix.** Root `self.sexp` for the duration of each `unsafe` block with `let _guard = crate::OwnedProtect::new(self.sexp);`, placed before `self.sexp.get_names()`. Rooting `self.sexp` keeps its `names` attribute reachable across the `SEXP::charsxp` allocation. Mirrors the idiom already used in `drop`/`select` in the same file. Diff is limited to these two functions.

**Impact.** No R-visible output change; internal GC-discipline hardening only.

**Verification.** `cargo fmt --all`, `cargo check -p miniextendr-api`, and `cargo clippy -p miniextendr-api --all-targets -- -D warnings` all pass.

This came from `audit/dataframe.md`.
</details>