### PR TITLE
feat(api): add IntoR for Box<str>

### DIFF
--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -555,6 +555,28 @@ impl IntoR for String {
     }
 }
 
+impl IntoR for Box<str> {
+    type Error = crate::into_r_error::IntoRError;
+    #[inline]
+    fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
+        // `String::from(Box<str>)` is O(1) (reuses the allocation); the produced
+        // SEXP is identical to the `String` impl's — a `character(1)` STRSXP.
+        String::from(self).try_into_sexp()
+    }
+    #[inline]
+    unsafe fn try_into_sexp_unchecked(self) -> Result<crate::SEXP, Self::Error> {
+        Ok(unsafe { self.into_sexp_unchecked() })
+    }
+    #[inline]
+    fn into_sexp(self) -> crate::SEXP {
+        String::from(self).into_sexp()
+    }
+    #[inline]
+    unsafe fn into_sexp_unchecked(self) -> crate::SEXP {
+        unsafe { String::from(self).into_sexp_unchecked() }
+    }
+}
+
 impl IntoR for char {
     type Error = std::convert::Infallible;
     #[inline]


### PR DESCRIPTION
## Gap

`miniextendr-api` had `IntoR` for `String`, `&str`, and a blanket `Box<[T]>`, but **not** for `Box<str>`. A `#[miniextendr]` function returning `Box<str>` therefore failed to compile.

(`Box<str>` is a fat pointer over an unsized `str`, so it is a distinct concrete type from `Box<T>` for sized `T` — adding it does not conflict with the `IntoExternalPtr` blanket impl that blocks a generic `impl<T> IntoR for Box<T>`, per the note at `into_r.rs:798`.)

## Fix

Add `impl IntoR for Box<str>` next to the `String`/`&str` impls in `miniextendr-api/src/into_r/large_integers.rs`, delegating to the existing `String` path via `String::from(self)`. That conversion is **O(1)** for `Box<str>` — it reuses the existing allocation, no reallocation — then calls `String`'s `IntoR`. All four trait methods (`try_into_sexp`, `into_sexp`, and the `_unchecked` variants) mirror the `String` impl's shape.

## R-visible output

Identical to the existing `String` impl: a `character(1)` STRSXP, by construction (it routes through the same `String` code path). `large_integers.rs` has no unit tests for `String`/`&str`, so no test was added rather than introducing a test harness for a one-line delegation.

Scope is strictly `IntoR for Box<str>`; `TryFromSexp for Box<str>` is intentionally out of scope for this finding.

Source: `audit/into_r.md` issue #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)