### PR TITLE
refactor(api): tighten unsafe contracts — drop ProtectScope::Default, mark RngGuard !Send+!Sync

### DIFF
--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -1016,19 +1016,6 @@ impl Drop for ProtectScope {
     }
 }
 
-impl Default for ProtectScope {
-    /// Create a new scope. Equivalent to `unsafe { ProtectScope::new() }`.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure this is called from the R main thread.
-    #[inline]
-    fn default() -> Self {
-        // SAFETY: This is a foot-gun but matches the pattern of other R interop code.
-        // Users should prefer `unsafe { ProtectScope::new() }` for clarity.
-        unsafe { Self::new() }
-    }
-}
 // endregion
 
 // region: Root
@@ -1648,7 +1635,7 @@ mod tests {
 
     #[test]
     fn protect_scope_default_count_is_zero() {
-        let scope = ProtectScope::default();
+        let scope = unsafe { ProtectScope::new() };
         assert_eq!(scope.count(), 0);
     }
 
@@ -1742,7 +1729,7 @@ mod tests {
 
     #[test]
     fn disarm_prevents_unprotect() {
-        let scope = ProtectScope::default();
+        let scope = unsafe { ProtectScope::new() };
         assert!(scope.armed.get());
 
         unsafe { scope.disarm() };
@@ -1753,7 +1740,7 @@ mod tests {
 
     #[test]
     fn rearm_restores_unprotect() {
-        let scope = ProtectScope::default();
+        let scope = unsafe { ProtectScope::new() };
 
         unsafe {
             scope.disarm();
@@ -1769,7 +1756,7 @@ mod tests {
 
     #[test]
     fn scope_counter_starts_at_zero() {
-        let scope = ProtectScope::default();
+        let scope = unsafe { ProtectScope::new() };
         assert_eq!(scope.count(), 0);
     }
 

--- a/miniextendr-api/src/rng.rs
+++ b/miniextendr-api/src/rng.rs
@@ -108,6 +108,11 @@
 //! - Scoped RNG access within a larger function
 
 use crate::sys::{GetRNGstate, PutRNGstate};
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+/// Enforces `!Send + !Sync` (R's RNG state is only valid on the R main thread).
+type NoSendSync = PhantomData<Rc<()>>;
 
 /// RAII guard for R's RNG state.
 ///
@@ -139,7 +144,8 @@ use crate::sys::{GetRNGstate, PutRNGstate};
 /// Must be used on R's main thread. The guard assumes it has exclusive
 /// access to R's RNG state while alive.
 pub struct RngGuard {
-    _private: (), // Prevent construction outside this module
+    // `!Send + !Sync` marker that also prevents construction outside this module.
+    _nosend: NoSendSync,
 }
 
 impl RngGuard {
@@ -153,7 +159,9 @@ impl RngGuard {
     #[inline]
     pub fn new() -> Self {
         unsafe { GetRNGstate() };
-        Self { _private: () }
+        Self {
+            _nosend: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Two small, theme-coherent audit findings ("tighten unsafe contracts"): both make an unsafe contract explicit at the type level rather than leaving it as an implicit foot-gun. No R-visible behaviour changes.

## 1. Remove `impl Default for ProtectScope` (`audit/gc_protect.md`)

`ProtectScope::new()` is `unsafe` (it may only be called on the R main thread), but `impl Default for ProtectScope` had body `unsafe { Self::new() }` — so the *safe* `Default` trait silently invoked unsafe code. That's a foot-gun: `mem::take`, `unwrap_or_default`, `Option::get_or_insert_default`, struct-update syntax, or any generic `T: Default` bound could construct a `ProtectScope` off the R main thread with no `unsafe` block in sight.

Because `new()` is `unsafe`, removing `Default` does **not** trip `clippy::new_without_default` (that lint only fires for a *safe* `new()` with no `Default`).

The only in-crate callers of `ProtectScope::default()` were 4 of `gc_protect.rs`'s own `#[cfg(test)]` sites; each is now `unsafe { ProtectScope::new() }`. A repo-wide grep confirmed no other call sites (ignoring `vendor/`, `tests/cross-package/*/vendor/`, and worktree copies).

## 2. Mark `RngGuard` `!Send + !Sync` (`audit/rng.md`)

R's RNG state (`GetRNGstate` / `PutRNGstate`, `.Random.seed`) is only valid on the R main thread, so an `RngGuard` must never cross a thread boundary. The previous `_private: ()` field only prevented construction outside the module — it did nothing to stop the guard being sent to another thread.

Replaced it with `_nosend: PhantomData<Rc<()>>`, reusing the same `NoSendSync` idiom already established in `gc_protect.rs`. This both keeps the struct unconstructable outside the module **and** makes it `!Send + !Sync`. `rng.rs` stays self-contained (its own local `NoSendSync` alias rather than importing across modules).

## Deferred follow-up (flagged for a maintainer decision)

Removing `Default for RngGuard` and making `RngGuard::new()` `unsafe` — the natural next step to fully mirror `ProtectScope`'s contract — is **intentionally left out of this PR**. Unlike `ProtectScope::new()`, `RngGuard::new()` is currently *safe*, so removing the `Default` impl on its own would trip `clippy::new_without_default`. The two must therefore move together as a single contract change (make `new()` unsafe + drop `Default`), which is a larger, separately-reviewable decision. Flagging it here rather than silently bundling it.

## Verification

- `cargo fmt --all` — clean (only the two touched files)
- `cargo check -p miniextendr-api` — OK
- `cargo test -p miniextendr-api --no-run` — compiles (updated test sites included); `gc_protect` lib tests: 18 passed
- `cargo clippy -p miniextendr-api --all-targets -- -D warnings` — clean; specifically **no `new_without_default`**

R-visible output change: **none**.
