### PR TITLE
fix(api): RHash returns a hex String (R-native); doc alloc_array 2-slot protect cost

### DIFF
--- a/miniextendr-api/src/adapter_traits.rs
+++ b/miniextendr-api/src/adapter_traits.rs
@@ -112,20 +112,19 @@ impl<T: Display> RDisplay for T {
 ///
 /// # Methods
 ///
-/// - `hash()` - Returns a 64-bit hash as i64
+/// - `hash()` - Returns the 64-bit hash as a 16-character hex string
 ///
 /// # Note
 ///
 /// Hash values are deterministic within a single R session but may vary
 /// between sessions due to Rust's hasher implementation.
 ///
-/// Returned hashes may be **negative**. `DefaultHasher::finish()` yields a
-/// `u64`, which this trait returns as `i64` (R has no unsigned 64-bit type).
-/// The cast reinterprets the bit pattern, so any hash in `[2^63, 2^64)`
-/// surfaces in R as a negative integer. This is expected, not an error —
-/// the full 64-bit value is preserved; only the sign is a side effect of the
-/// reinterpretation. The sign bit is deliberately not masked off, as that
-/// would discard a bit of entropy.
+/// The hash is returned as a hex `String` (e.g. `"a1b2c3d4e5f60718"`), not a
+/// number. R has no faithful 64-bit integer type, so returning the `u64` as a
+/// numeric would round away its low bits above `2^53` — distinct Rust values
+/// would collide in R — and surface half the range as negative. A hex string
+/// preserves all 64 bits, is directly usable as an R environment key, and
+/// works with `duplicated()` / `match()` for deduplication.
 ///
 /// # Example
 ///
@@ -140,20 +139,19 @@ impl<T: Display> RDisplay for T {
 pub trait RHash {
     /// Compute a hash of this value.
     ///
-    /// The returned `i64` is the `u64` output of [`DefaultHasher`]
-    /// reinterpreted bit-for-bit, so hashes in `[2^63, 2^64)` come back
-    /// negative in R. See the trait-level docs for the full rationale.
-    fn hash(&self) -> i64;
+    /// Returns the [`DefaultHasher`] `u64` output as a 16-character lowercase
+    /// hex string. See the trait-level docs for why a string rather than a
+    /// number.
+    fn hash(&self) -> String;
 }
 
 impl<T: Hash> RHash for T {
-    fn hash(&self) -> i64 {
+    fn hash(&self) -> String {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
-        // `finish()` is a `u64`; the `as i64` reinterprets the bit pattern
-        // (R has no unsigned 64-bit type). Hashes >= 2^63 therefore become
-        // negative i64. Intentional: masking the sign bit would lose entropy.
-        hasher.finish() as i64
+        // R has no faithful 64-bit integer; hex-encode the full u64 so every
+        // bit survives the trip to R (a numeric would round above 2^53).
+        format!("{:016x}", hasher.finish())
     }
 }
 

--- a/miniextendr-api/src/adapter_traits.rs
+++ b/miniextendr-api/src/adapter_traits.rs
@@ -119,6 +119,14 @@ impl<T: Display> RDisplay for T {
 /// Hash values are deterministic within a single R session but may vary
 /// between sessions due to Rust's hasher implementation.
 ///
+/// Returned hashes may be **negative**. `DefaultHasher::finish()` yields a
+/// `u64`, which this trait returns as `i64` (R has no unsigned 64-bit type).
+/// The cast reinterprets the bit pattern, so any hash in `[2^63, 2^64)`
+/// surfaces in R as a negative integer. This is expected, not an error —
+/// the full 64-bit value is preserved; only the sign is a side effect of the
+/// reinterpretation. The sign bit is deliberately not masked off, as that
+/// would discard a bit of entropy.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -131,6 +139,10 @@ impl<T: Display> RDisplay for T {
 #[miniextendr]
 pub trait RHash {
     /// Compute a hash of this value.
+    ///
+    /// The returned `i64` is the `u64` output of [`DefaultHasher`]
+    /// reinterpreted bit-for-bit, so hashes in `[2^63, 2^64)` come back
+    /// negative in R. See the trait-level docs for the full rationale.
     fn hash(&self) -> i64;
 }
 
@@ -138,6 +150,9 @@ impl<T: Hash> RHash for T {
     fn hash(&self) -> i64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
+        // `finish()` is a `u64`; the `as i64` reinterprets the bit pattern
+        // (R has no unsigned 64-bit type). Hashes >= 2^63 therefore become
+        // negative i64. Intentional: masking the sign bit would lose entropy.
         hasher.finish() as i64
     }
 }

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -754,6 +754,15 @@ impl ProtectScope {
     /// (consuming one protect slot) to satisfy `Rf_allocArray`'s SEXP-dims contract.
     /// The resulting array SEXP consumes a second protect slot.
     ///
+    /// # Protect-stack budget
+    ///
+    /// This helper consumes **two** protect slots — one for the dims vector and
+    /// one for the array — yet returns a single [`Root`] (for the array). The
+    /// dims INTSXP has no accessible handle: it stays protected until the scope
+    /// drops. Consequently [`count()`](Self::count) increases by 2 even though
+    /// the caller sees only one `Root`. Callers budgeting protect-stack depth
+    /// must account for both slots, not just the returned handle.
+    ///
     /// # Safety
     ///
     /// Must be called from the R main thread. `dims` must be non-empty.

--- a/rpkg/tests/testthat/test-adapter-traits.R
+++ b/rpkg/tests/testthat/test-adapter-traits.R
@@ -33,7 +33,7 @@ test_that("Point - RHash works", {
   h2 <- p2$hash()
   h3 <- p3$hash()
 
-  expect_true(is.numeric(h1))
+  expect_true(is.character(h1))
   expect_equal(h1, h2)
   # Different values should (very likely) produce different hash
   # Note: collision is theoretically possible but extremely unlikely


### PR DESCRIPTION
This started life as a doc-only PR noting that `RHash::hash()` can come back negative. Auditing that turned up the real problem: `i64` isn't faithfully representable in R at all, so the value was silently *lossy*, not just sign-flipped. So I've turned finding 1 into a fix — `hash()` now returns a hex `String` — rather than documenting a wart. The `alloc_array` 2-slot protect note (finding 2) is genuinely doc-only and rides along unchanged.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- **Finding 1 — `RHash` now returns a hex `String` (was `i64`).** `hash() -> i64` routed through the lax `IntoR` path; a `DefaultHasher` output is almost always `> i32::MAX`, so it landed in R as an `f64` (REALSXP). An f64 has a 52-bit mantissa, so the low ~11 bits of a 64-bit hash were rounded away crossing into R — distinct Rust values **collide** in R, breaking the trait's stated jobs (dedup, environment keys). The negative-sign behavior the first revision documented was the harmless symptom of the same root cause (R has no unsigned/64-bit integer).
- Fix: `format!("{:016x}", hasher.finish())` — a 16-char lowercase hex string. All 64 bits survive, it's directly usable as an R environment key (env keys must be character anyway), and it works with `duplicated()` / `match()`. Hex over base64: marginal size difference for 8 bytes, and hex is the universal R hash idiom (`digest`, `rlang::hash`, `openssl`) with zero deps.
- **Finding 2 — `alloc_array` consumes two protect slots.** Unchanged from the first revision: `ProtectScope::alloc_array` allocates a dims INTSXP (1 slot) and the array (a second slot) but returns only the array's `Root`, so `scope.count()` rises by 2 while the caller sees one handle. Added a `# Protect-stack budget` doc section. Doc-only.

## Test plan
- [x] `cargo fmt --all` / `cargo check -p miniextendr-api` / `cargo clippy -p miniextendr-api --all-targets -- -D warnings` — clean
- [x] `cargo test -p miniextendr-api --lib test_rhash` — passes
- [x] `just rcmdinstall && just force-document` — succeeds; `NAMESPACE` and `man/` unchanged (only generated reference is the `Point$RHash$hash` alias)
- [x] `just devtools-test adapter-traits` — FAIL 0 | PASS 93

## Notes
- Updated the rpkg testthat expectation from `is.numeric` to `is.character`.
- Session-instability of `DefaultHasher` (random per-session seed) is inherent and orthogonal to representation; separately fixable by pinning a fixed-seed hasher if cross-session stability is ever wanted.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>