### PR TITLE
docs(api): note scalar_logical cannot represent NA

### DIFF
--- a/miniextendr-api/src/sexp.rs
+++ b/miniextendr-api/src/sexp.rs
@@ -180,6 +180,10 @@ impl SEXP {
     }
 
     /// Create a length-1 logical vector.
+    ///
+    /// Produces only `TRUE` or `FALSE`; a `bool` cannot represent R's `NA`.
+    /// For an NA logical, use [`scalar_logical_raw`](Self::scalar_logical_raw)
+    /// with `NA_LOGICAL` (`i32::MIN`).
     #[inline]
     pub fn scalar_logical(x: bool) -> SEXP {
         unsafe { Rf_ScalarLogical(if x { 1 } else { 0 }) }


### PR DESCRIPTION
Doc-comment-only fix for an audit finding in `audit/sexp.md` (issue #1).

<details>
<summary>AI-written summary (Claude Opus 4.8)</summary>

**Gap:** `SEXP::scalar_logical(x: bool)` in `miniextendr-api/src/sexp.rs` can only produce `TRUE` or `FALSE` — a `bool` cannot represent R's `NA` logical. The sibling constructor `scalar_logical_raw(x: i32)` already documents that it accepts `NA_LOGICAL` (`i32::MIN`) for NA, but `scalar_logical`'s own doc said nothing about the limitation, so a caller could wrongly assume it covers all logical values.

**Fix:** Added a short note to `scalar_logical`'s `///` comment stating it produces only `TRUE`/`FALSE` and pointing to `scalar_logical_raw(i32::MIN)` for the NA case, using the file's existing intra-doc-link style.

**Scope:** Documentation comment only. No code, signature, or behavior change. R-visible output is unchanged.

**Verification:**
- `cargo fmt --all` — clean
- `cargo check -p miniextendr-api` — passes
- `cargo doc --no-deps -p miniextendr-api` — builds; the new `[scalar_logical_raw](Self::scalar_logical_raw)` intra-doc link resolves with no warning. (Pre-existing unrelated broken-link warnings in `dataframe.rs` / `gc_protect.rs` are untouched and out of scope for this finding.)
</details>