### PR TITLE
fix(api): keep disable_stack_checking_permanently durable across guard drops

### DIFF
--- a/miniextendr-api/src/thread.rs
+++ b/miniextendr-api/src/thread.rs
@@ -195,6 +195,12 @@ pub fn disable_stack_checking_permanently() {
     unsafe {
         set_r_cstack_limit(usize::MAX);
     }
+    // Pin the saved limit to `usize::MAX` so a later `StackCheckGuard` drop can't
+    // silently re-enable checking. If a guard is already active, `ORIGINAL_STACK_LIMIT`
+    // holds the real pre-disable limit, and the last guard's drop would restore it —
+    // undoing the "permanent" disable. Overwriting it with `usize::MAX` makes that
+    // restore a no-op, so the disable stays durable regardless of guard ordering.
+    ORIGINAL_STACK_LIMIT.store(usize::MAX, Ordering::SeqCst);
 }
 
 /// Execute a closure with stack checking disabled.
@@ -238,6 +244,23 @@ pub const DEFAULT_R_STACK_SIZE: usize = 8 * 1024 * 1024;
 ///
 /// Use this if your code involves very deep recursion or complex R operations.
 /// Windows R uses 64 MiB for its main thread since R 4.2.
+///
+/// # Why larger than [`DEFAULT_R_STACK_SIZE`]
+///
+/// This is 8x the [`DEFAULT_R_STACK_SIZE`] used on other platforms. Two factors
+/// motivate the larger reservation on Windows:
+///
+/// - Newly spawned Windows threads get a comparatively small *committed* stack by
+///   default, and the OS does not grow a thread stack the way `ulimit -s` allows
+///   on typical Unix configurations — so the size we ask for up front is closer to
+///   the size we actually get.
+/// - R's own choice of 64 MiB for its Windows main thread (since R 4.2) reflects
+///   that deep R evaluation consumes more C stack on this platform than the
+///   ~8 MiB Unix default comfortably covers.
+///
+/// Matching R's main-thread reservation here keeps deep R evaluation on a spawned
+/// thread from overflowing the stack. This is a conservative reservation, not a
+/// precise measurement of any single call's stack frame.
 #[cfg(windows)]
 pub const WINDOWS_R_STACK_SIZE: usize = 64 * 1024 * 1024;
 
@@ -428,9 +451,15 @@ where
 #[cfg(feature = "nonapi")]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // These tests mutate process-global state (`R_CStackLimit`, `STACK_GUARD_COUNT`,
+    // `ORIGINAL_STACK_LIMIT`), so they must not run concurrently. Serialize them.
+    static STACK_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_guard_saves_and_restores() {
+        let _serial = STACK_TEST_LOCK.lock().unwrap();
         let original = get_r_cstack_limit();
 
         {
@@ -442,6 +471,40 @@ mod tests {
 
         // After guard drops, should be restored
         assert_eq!(get_r_cstack_limit(), original);
+    }
+
+    /// Regression test for the "permanent disable silently undone by a guard drop" bug.
+    ///
+    /// Ordering (a): a `StackCheckGuard` is active (so `ORIGINAL_STACK_LIMIT` holds the
+    /// real pre-disable limit) when `disable_stack_checking_permanently()` is called.
+    /// Before the fix, the guard's `Drop` restored that saved limit, re-enabling stack
+    /// checking and undoing the "permanent" disable. After the fix,
+    /// `disable_stack_checking_permanently()` also pins `ORIGINAL_STACK_LIMIT` to
+    /// `usize::MAX`, so the drop's restore is a no-op and the limit stays at `usize::MAX`.
+    #[test]
+    fn test_permanent_disable_survives_guard_drop() {
+        let _serial = STACK_TEST_LOCK.lock().unwrap();
+        let original = get_r_cstack_limit();
+
+        {
+            // Guard active: ORIGINAL_STACK_LIMIT now holds the real pre-disable limit.
+            let _guard = StackCheckGuard::disable();
+            assert_eq!(ORIGINAL_STACK_LIMIT.load(Ordering::SeqCst), original);
+
+            // Permanent disable while the guard is still alive.
+            disable_stack_checking_permanently();
+            // The saved limit is pinned to MAX so a later restore can't re-enable checking.
+            assert_eq!(ORIGINAL_STACK_LIMIT.load(Ordering::SeqCst), usize::MAX);
+        }
+        // Guard dropped: limit must remain disabled, not bounce back to `original`.
+        assert!(is_stack_checking_disabled());
+        assert_eq!(get_r_cstack_limit(), usize::MAX);
+
+        // Restore the real limit so we don't leak the permanent disable into other tests.
+        unsafe {
+            set_r_cstack_limit(original);
+        }
+        ORIGINAL_STACK_LIMIT.store(0, Ordering::SeqCst);
     }
 }
 // endregion


### PR DESCRIPTION
Fixes a latent bug in the `nonapi` stack-check guard machinery where calling `disable_stack_checking_permanently()` while a `StackCheckGuard` is active could be silently undone by the guard's later `Drop`. Found in `audit/thread.md` (issue #2). Also closes a small doc gap (issue #4).

<details>
<summary>🤖 Generated by Claude Opus 4.8 — details</summary>

## The bug (interference between permanent-disable and ref-counted guards)

`miniextendr-api/src/thread.rs` ref-counts stack-check guards:

- `StackCheckGuard::disable()`: on the first guard (`prev count == 0`), saves the live `R_CStackLimit` into `ORIGINAL_STACK_LIMIT` and sets the limit to `usize::MAX`.
- `Drop`: on the last guard (`prev count == 1`), restores `R_CStackLimit` from `ORIGINAL_STACK_LIMIT`.
- `disable_stack_checking_permanently()`: set `R_CStackLimit = usize::MAX` — **with no count change and no `ORIGINAL_STACK_LIMIT` update.**

So if a `StackCheckGuard` was active (`count > 0`, meaning `ORIGINAL_STACK_LIMIT` holds the real pre-disable limit) when `disable_stack_checking_permanently()` was called, the later guard `Drop` restored that real limit — **silently re-enabling** stack checking and undoing the "permanent" disable.

## The fix

In `disable_stack_checking_permanently()`, also store `usize::MAX` into `ORIGINAL_STACK_LIMIT` (same `Ordering::SeqCst` as the rest of the module). Any subsequent guard `Drop` then restores `usize::MAX` — i.e. stays disabled.

## Two-ordering reasoning

- **(a) guard active first, then permanent():** `permanent()` sets `R_CStackLimit = MAX` *and* `ORIGINAL_STACK_LIMIT = MAX`. The last guard's `Drop` restores `ORIGINAL_STACK_LIMIT` = `MAX` → stays disabled. ✓
- **(b) permanent() first (count 0), then a guard:** `permanent()` sets `ORIGINAL_STACK_LIMIT = MAX`. The later `StackCheckGuard::disable()` sees `prev count == 0`, so it saves the *current* limit (already `MAX`) into `ORIGINAL_STACK_LIMIT`; its `Drop` restores `MAX` → stays disabled. ✓

## Doc addition (issue #4)

`WINDOWS_R_STACK_SIZE` is 64 MiB vs `DEFAULT_R_STACK_SIZE` 8 MiB. Added a factual rationale: newly spawned Windows threads get a comparatively small committed stack (and Windows doesn't grow a thread stack the way `ulimit -s` allows on typical Unix configs), and R itself reserves 64 MiB for its Windows main thread (since R 4.2) because deep R evaluation consumes more C stack there. This is framed as a conservative reservation, not a precise per-call measurement — no specific mechanism is fabricated.

## Test

Added `test_permanent_disable_survives_guard_drop` in the `thread::tests` module (gated `#[cfg(feature = "nonapi")]`), exercising ordering (a): guard active → `permanent()` → guard drop → assert limit stays `usize::MAX`. The existing test and the new one both mutate the same process-global state (`R_CStackLimit`, `STACK_GUARD_COUNT`, `ORIGINAL_STACK_LIMIT`), so they are now serialized under a shared `Mutex` to avoid parallel-test races.

`R_CStackLimit` is an extern static provided by libR (the crate's `build.rs` always links libR), so reading/writing it does not need a running R interpreter — the existing test already relied on this. **Verification run locally** (`--features nonapi`):

- `cargo fmt --all` — clean
- `cargo check -p miniextendr-api --features nonapi` — passes
- `cargo clippy -p miniextendr-api --features nonapi --all-targets -- -D warnings` — passes (exit 0)
- `cargo test -p miniextendr-api --features nonapi --lib thread` — both `test_guard_saves_and_restores` and `test_permanent_disable_survives_guard_drop` pass

Note: an unrelated pre-existing test, `worker::tests::with_r_thread_panics_before_init`, fails when worker tests are batched in one process (it asserts a panic when the runtime is uninitialized, but another test initializes the process-global runtime first). Verified it fails identically on a clean tree with these changes stashed, and passes in isolation — not caused by this PR.

**R-visible output change: none.** This is internal `nonapi` thread-management state; no `#[miniextendr]` surface changes.

Ref: `audit/thread.md` (issues #2 and #4).
</details>
