### PR TITLE
docs(api): fix broken/ambiguous rustdoc intra-doc links

### DIFF
--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -3,7 +3,7 @@
 //! [`DataFrame`] is **the** data-frame type: a single owned wrapper around a built
 //! `data.frame` SEXP that serves every direction —
 //!
-//! - **build** (Rust → R): [`IntoDataFrame::into_dataframe`] / [`into_dataframe_par`](IntoDataFrame::into_dataframe_par),
+//! - **build** (Rust → R): [`IntoDataFrame::into_dataframe`] / `into_dataframe_par` (`feature = "rayon"`),
 //! - **read** (R → Rust): [`DataFrame::column`] / [`FromDataFrame::from_dataframe`],
 //! - **edit** (post-assembly): [`DataFrame::rename`] / [`DataFrame::drop`] / [`DataFrame::select`] / …
 //!
@@ -123,7 +123,7 @@ impl From<crate::serde::RSerdeError> for DataFrameError {
 /// let df: DataFrame = rows.into_dataframe()?;
 /// ```
 ///
-/// or the closure-fill [`DataFrame::builder`] for heterogeneous parallel column fill
+/// or the closure-fill `DataFrame::builder` for heterogeneous parallel column fill
 /// (`feature = "rayon"`).
 ///
 /// # Reading
@@ -585,7 +585,7 @@ impl IntoR for DataFrame {
 ///
 /// # Parallel fast path
 ///
-/// [`into_dataframe_par`](IntoDataFrame::into_dataframe_par) (present only with
+/// `into_dataframe_par` (present only with
 /// `feature = "rayon"`) produces the **same** [`DataFrame`] as
 /// [`into_dataframe`](IntoDataFrame::into_dataframe). It defaults to the sequential path, so
 /// every implementor gets a correct `_par` for free; `#[derive(DataFrameRow)]` row types
@@ -612,7 +612,7 @@ pub trait IntoDataFrame: Sized {
 ///
 /// # Parallel fast path
 ///
-/// [`from_dataframe_par`](FromDataFrame::from_dataframe_par) (`feature = "rayon"`) reads the
+/// `from_dataframe_par` (`feature = "rayon"`) reads the
 /// same rows as [`from_dataframe`](FromDataFrame::from_dataframe), defaulting to the
 /// sequential reader; the derive overrides it with the #765 off-main-thread row assembly.
 pub trait FromDataFrame: Sized {

--- a/miniextendr-api/src/gc_protect.rs
+++ b/miniextendr-api/src/gc_protect.rs
@@ -898,7 +898,7 @@ impl ProtectScope {
     /// Create an external pointer SEXP, and immediately protect it.
     ///
     /// This is an escape-hatch tier wrapper around `R_MakeExternalPtr`. In most
-    /// cases you should use [`ExternalPtr<T>`](crate::ExternalPtr) instead — it
+    /// cases you should use [`ExternalPtr<T>`](struct@crate::ExternalPtr) instead — it
     /// provides typed safety, finalizer registration, and correct rooting (#841).
     /// Use this wrapper only when you need raw `EXTPTRSXP` construction that
     /// `ExternalPtr<T>` cannot express.


### PR DESCRIPTION
Fixes the 5 pre-existing rustdoc warnings from `cargo doc --no-deps -p miniextendr-api` (default features), per the project "fix warnings you see — no known issues" rule in `CLAUDE.md`.

<details>
<summary>🤖 Generated by Claude Opus 4.8 — details</summary>

### Warnings fixed

Reproduced with `cargo doc --no-deps -p miniextendr-api 2>&1` (default features). All 5 fired; all 5 are resolved.

**Broken links to `feature = "rayon"`-gated items** (the linked methods/fn are `#[cfg(feature = "rayon")]`, so the intra-doc link cannot resolve when `rayon` is off). Demoted to plain code spans — valid in both feature configs, still labelled `feature = "rayon"`-only in the prose:

| File:line | Before | After |
|---|---|---|
| `miniextendr-api/src/dataframe.rs:6` | `` [`into_dataframe_par`](IntoDataFrame::into_dataframe_par) `` | `` `into_dataframe_par` `` |
| `miniextendr-api/src/dataframe.rs:126` | `` [`DataFrame::builder`] `` | `` `DataFrame::builder` `` |
| `miniextendr-api/src/dataframe.rs:588` | `` [`into_dataframe_par`](IntoDataFrame::into_dataframe_par) `` | `` `into_dataframe_par` `` |
| `miniextendr-api/src/dataframe.rs:615` | `` [`from_dataframe_par`](FromDataFrame::from_dataframe_par) `` | `` `from_dataframe_par` `` |

**Ambiguous link** (`ExternalPtr` is both a struct and a derive macro). Disambiguated with the `struct@` prefix that rustdoc itself suggested:

| File:line | Before | After |
|---|---|---|
| `miniextendr-api/src/gc_protect.rs:901` | `` [`ExternalPtr<T>`](crate::ExternalPtr) `` | `` [`ExternalPtr<T>`](struct@crate::ExternalPtr) `` |

### Verification

- `cargo doc --no-deps -p miniextendr-api` — warning-free (default features).
- `cargo doc --no-deps -p miniextendr-api --features rayon` — warning-free.
- `cargo check -p miniextendr-api` — clean.
- `cargo fmt --all` — applied.

Doc-comment-only; no code or behavior changes. **R-visible output change: no.**

</details>