### PR TITLE
docs: add patches/templates.patch to the rebase-conflict regenerate rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@ configure.ac eol=lf
 cleanup      eol=lf
 cleanup.ucrt eol=lf
 *.sh         eol=lf
+
+# Generated diff — never 3-way merge (produces diff-of-a-diff garbage on rebase).
+# On conflict, pick a side and regenerate with `just templates-approve`. See CLAUDE.md.
+patches/templates.patch -merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,9 @@ Some agent sandboxes block compilation. For any compiling command (`just force-d
 - If agent didn't commit, commit in the worktree first.
 - Don't delete a worktree until its branch is pushed or merged.
 - **Clean up after push**: `git worktree remove -f -f <agent-worktree-path>` + `git worktree prune`. Each worktree holds a full `target/` (2–3 GB/agent).
-- **Rebase conflicts**: plain `git rebase origin/main`. NEVER `-X theirs` blanket — drops main's changes to shared files (justfile, lockfiles, etc.). Only use `git checkout --theirs rpkg/inst/vendor.tar.xz && git add` for the binary tarball. Resolve everything else by hand. Regenerate tarball with `just vendor` and amend into the vendor-refresh commit.
+- **Rebase conflicts**: plain `git rebase origin/main`. NEVER `-X theirs` blanket — drops main's changes to shared files (justfile, lockfiles, etc.). Resolve everything by hand **except regenerated artifacts** — never hand-merge their hunks; take either side (`git checkout --theirs` / `git add`) then regenerate:
+  - `rpkg/inst/vendor.tar.xz` (binary tarball) → `just vendor`, amended into the vendor-refresh commit.
+  - `patches/templates.patch` (rpkg→templates delta, a generated diff) → `just templates-approve`, then verify with `just templates-check`.
 
 ## Sync Checks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,7 +464,9 @@ Claude Code sandbox blocks compilation. For any compiling command
 - If agent didn't commit, commit in the worktree first.
 - Don't delete a worktree until its branch is pushed or merged.
 - **Clean up after push**: `git worktree remove -f -f .claude/worktrees/<name>` + `git worktree prune`. Each worktree holds a full `target/` (2–3 GB/agent).
-- **Rebase conflicts**: plain `git rebase origin/main`. NEVER `-X theirs` blanket — drops main's changes to shared files (justfile, lockfiles, etc.). Only use `git checkout --theirs rpkg/inst/vendor.tar.xz && git add` for the binary tarball. Resolve everything else by hand. Regenerate tarball with `just vendor` and amend into the vendor-refresh commit.
+- **Rebase conflicts**: plain `git rebase origin/main`. NEVER `-X theirs` blanket — drops main's changes to shared files (justfile, lockfiles, etc.). Resolve everything by hand **except regenerated artifacts** — never hand-merge their hunks; take either side (`git checkout --theirs` / `git add`) then regenerate:
+  - `rpkg/inst/vendor.tar.xz` (binary tarball) → `just vendor`, amended into the vendor-refresh commit.
+  - `patches/templates.patch` (rpkg→templates delta, a generated diff) → `just templates-approve`, then verify with `just templates-check`.
 
 ### Using Codex for reviews
 


### PR DESCRIPTION
Adds `patches/templates.patch` to the "regenerated artifacts" carve-out in the rebase-conflict rule (CLAUDE.md + AGENTS.md).

<details>
<summary><h3>AI-written details</h3></summary>

`patches/templates.patch` is a generated diff (the rpkg→templates delta). On rebase its hunks conflict, and hand-merging a diff-of-a-diff produces garbage — exactly what just happened rebasing #1089, where all three commits conflicted only on this file. The correct fix is to take either side and regenerate, not to reconcile hunks.

The rule already documented this for the binary vendor tarball (`rpkg/inst/vendor.tar.xz` → `just vendor`). This restructures that one bullet into a shared "regenerated artifacts — never hand-merge their hunks" carve-out and adds `patches/templates.patch` → `just templates-approve` (verified by `just templates-check`).

Docs-only; mirrored verbatim in both CLAUDE.md and AGENTS.md per the project rule to keep them in sync.

---
_Drafted by Claude (claude-opus-4-8)._

</details>