### PR TITLE
fix(build): drop dead should_emit_rpath() gate, emit libR rpath unconditionally

### DIFF
--- a/miniextendr-api/build.rs
+++ b/miniextendr-api/build.rs
@@ -109,9 +109,10 @@ fn link_to_r() {
     println!("cargo:rustc-link-search=native={}", r_libdir);
     println!("cargo:rustc-link-lib=R");
 
-    // Mirror `R CMD LINK` behavior: add runtime search path for libR.
-    // Only emit rpath for non-library targets (bins/tests/benches/examples).
-    if target_os != "windows" && should_emit_rpath() {
+    // Mirror `R CMD LINK` behavior: add a runtime search path for libR so this
+    // crate's own test/bin/example binaries find it. No-op for the R-package
+    // staticlib build (staticlibs don't link) and skipped on Windows (no rpath).
+    if target_os != "windows" {
         println!("cargo:rustc-link-arg=-Wl,-rpath,{}", r_libdir);
     }
 }
@@ -138,22 +139,4 @@ fn r_libdir(r_home: &str, target_os: &str) -> String {
     } else {
         format!("{}/lib{}", r_home, r_arch)
     }
-}
-
-fn should_emit_rpath() -> bool {
-    // These env vars are set for specific target types.
-    if env::var_os("CARGO_BIN_NAME").is_some()
-        || env::var_os("CARGO_TEST_NAME").is_some()
-        || env::var_os("CARGO_BENCH_NAME").is_some()
-        || env::var_os("CARGO_EXAMPLE_NAME").is_some()
-    {
-        return true;
-    }
-
-    // Fallback to crate-type check if available.
-    if let Ok(crate_types) = env::var("CARGO_CRATE_TYPE") {
-        return crate_types.split(',').any(|t| t.trim() == "bin");
-    }
-
-    false
 }

--- a/miniextendr-engine/build.rs
+++ b/miniextendr-engine/build.rs
@@ -67,9 +67,10 @@ fn link_to_r() {
     println!("cargo:rustc-link-search=native={}", r_libdir);
     println!("cargo:rustc-link-lib=R");
 
-    // Mirror `R CMD LINK` behavior: add runtime search path for libR.
-    // Only emit rpath for non-library targets (bins/tests/benches/examples).
-    if target_os != "windows" && should_emit_rpath() {
+    // Mirror `R CMD LINK` behavior: add a runtime search path for libR so this
+    // crate's own test/bin/example binaries find it. No-op for the R-package
+    // staticlib build (staticlibs don't link) and skipped on Windows (no rpath).
+    if target_os != "windows" {
         println!("cargo:rustc-link-arg=-Wl,-rpath,{}", r_libdir);
     }
 }
@@ -96,23 +97,4 @@ fn r_libdir(r_home: &str, target_os: &str) -> String {
     } else {
         format!("{}/lib{}", r_home, r_arch)
     }
-}
-
-/// Returns whether this target kind should receive an `rpath` entry.
-fn should_emit_rpath() -> bool {
-    // These env vars are set for specific target types.
-    if env::var_os("CARGO_BIN_NAME").is_some()
-        || env::var_os("CARGO_TEST_NAME").is_some()
-        || env::var_os("CARGO_BENCH_NAME").is_some()
-        || env::var_os("CARGO_EXAMPLE_NAME").is_some()
-    {
-        return true;
-    }
-
-    // Fallback to crate-type check if available.
-    if let Ok(crate_types) = env::var("CARGO_CRATE_TYPE") {
-        return crate_types.split(',').any(|t| t.trim() == "bin");
-    }
-
-    false
 }


### PR DESCRIPTION
Removes a dead code path in the `miniextendr-api` and `miniextendr-engine` build scripts.

<details>
<summary>🤖 Details (AI-written)</summary>

`should_emit_rpath()` decided whether to emit the libR `rpath` link-arg by reading `CARGO_BIN_NAME` / `CARGO_TEST_NAME` / `CARGO_BENCH_NAME` / `CARGO_EXAMPLE_NAME` / `CARGO_CRATE_TYPE`. **None of these are set in a build-script environment** — Cargo sets them for the *crate compilation* (accessible via `env!` in crate source), not for `build.rs`. Verified empirically: a probe build script prints all five as empty under both `cargo build` and `cargo test`.

So the function always returned `false`, and the rpath was **never** emitted from either build script.

This PR removes the gate and emits the rpath unconditionally:

- **Fulfills the original intent** — the api/engine crates' own `cargo test` / bin / example binaries now get an `rpath` to R's libdir so they find `libR` at runtime.
- **No-op for the R package** — the installed `.so` is linked by R from a `--crate-type staticlib` build, which performs no linking, so the `rustc-link-arg` is inert there.
- **Skipped on Windows** — no rpath concept (guard retained).

Net −35 lines across the two files. No behavior change for the R package build; the only observable effect is that api/engine test/bin/example binaries now carry the intended rpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>