### PR TITLE
ci(features): lint s7-default side, repair check-features, kill dead all_features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,16 +311,32 @@ jobs:
         # `full-codegen` aggregate (#677) so it can't drift from the Cargo.toml
         # definition — adding a new `*-default` / nonapi / connections selector
         # there updates CI automatically. `full-codegen` picks the `r6-default`
-        # side of the r6/s7 mutex; `s7-default` is linted by clippy_default's
-        # rpkg path. We still can't use `--features full` directly: it adds
-        # heavy deps (arrow, datafusion, log) we don't need here. So we pass
-        # `full-codegen` plus a curated integration list (the lighter crates) —
-        # the latter is the only part still hand-maintained, and CI signal
-        # matches what rpkg actually enables.
+        # side of the r6/s7 mutex; the `s7-default` side gets its own step
+        # below (nothing else compiles it — the `--workspace` steps never
+        # reach rpkg/src/rust, a standalone workspace, and rpkg's
+        # tools/detect-features.R denylists `s7-default` anyway). We still
+        # can't use `--features full` directly: it adds heavy deps (arrow,
+        # datafusion, log) we don't need here. So we pass `full-codegen` plus
+        # a curated integration list (the lighter crates) — the latter is the
+        # only part still hand-maintained, and CI signal matches what rpkg
+        # actually enables.
         run: >-
           cargo clippy --workspace --all-targets --locked
           --features full-codegen,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all.log"
+        shell: bash
+
+      - name: Clippy (all features, s7-default)
+        id: clippy_all_s7
+        continue-on-error: true
+        # Same integration list as clippy_all with the r6/s7 mutex flipped via
+        # the `full-codegen-s7` aggregate — the only compile gate anywhere for
+        # the s7 side of the mutex. Keep the integration list identical to the
+        # step above; only the aggregate differs.
+        run: >-
+          cargo clippy --workspace --all-targets --locked
+          --features full-codegen-s7,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd
+          -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all_s7.log"
         shell: bash
 
       # cargo-revendor is a standalone workspace excluded from the root
@@ -350,12 +366,14 @@ jobs:
           rustfmt="${{ steps.rustfmt.outcome }}"
           clippy_default="${{ steps.clippy_default.outcome }}"
           clippy_all="${{ steps.clippy_all.outcome }}"
+          clippy_all_s7="${{ steps.clippy_all_s7.outcome }}"
           clippy_revendor="${{ steps.clippy_revendor.outcome }}"
           doc_revendor="${{ steps.doc_revendor.outcome }}"
 
           echo "rustfmt:          $rustfmt"
           echo "clippy_default:   $clippy_default"
           echo "clippy_all:       $clippy_all"
+          echo "clippy_all_s7:    $clippy_all_s7"
           echo "clippy_revendor:  $clippy_revendor"
           echo "doc_revendor:     $doc_revendor"
           echo
@@ -377,6 +395,7 @@ jobs:
           dump_failed rustfmt          "$rustfmt"
           dump_failed clippy_default   "$clippy_default"
           dump_failed clippy_all       "$clippy_all"
+          dump_failed clippy_all_s7    "$clippy_all_s7"
           dump_failed clippy_revendor  "$clippy_revendor"
           dump_failed doc_revendor     "$doc_revendor"
 
@@ -437,6 +456,47 @@ jobs:
       # workspace, so the `--workspace` step above never reaches it (#778).
       - name: Tests (cargo-revendor)
         run: cargo test --manifest-path cargo-revendor/Cargo.toml --locked --no-fail-fast
+
+  # ===========================================================================
+  # Feature-combination compile check (scheduled only)
+  # ===========================================================================
+  # Runs `just check-features` so the recipe can't silently rot when a feature
+  # is added/removed (it once carried a deleted feature for months — audit A3).
+  # Weekly-only: the final combo pulls full-integrations (arrow + datafusion),
+  # which is too heavy for a per-PR gate.
+  check-features:
+    name: Feature combos
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event_name == 'schedule'
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same trick as rust-lint: cargo check never links libR, so a dummy
+      # R_HOME satisfies build.rs without installing R.
+      - name: Set dummy R_HOME
+        run: echo "R_HOME=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check-features
+          cache-on-failure: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Check feature combinations
+        run: just check-features
 
   # ===========================================================================
   # R Package: R CMD check on Linux

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,12 +130,13 @@ Build sequence: `Makevars` → `cargo rustc --crate-type cdylib` → `dyn.load` 
 
 ### Reproducing CI clippy before PR
 
-`just clippy` ≠ CI. Two CI jobs must both pass `-D warnings`:
+`just clippy` ≠ CI. Three CI clippy steps must all pass `-D warnings`:
 
 - `clippy_default`: `cargo clippy --workspace --all-targets --locked -- -D warnings`
-- `clippy_all`: same + `--features rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi,strict-default,coerce-default,r6-default,worker-default`
+- `clippy_all`: same + `full-codegen` and a curated integration feature list — read the list from `.github/workflows/ci.yml` (`clippy_all` step); hard-coding it here drifts (it already has)
+- `clippy_all_s7`: same list with `full-codegen-s7` (the `s7-default` mutex side) instead of `full-codegen`
 
-`--all-features` fails (`r6-default` and `s7-default` are mutually exclusive). CI runs a newer toolchain, so lints like `collapsible_match`, `manual_checked_ops` can fire on CI with green local. Reproduce both before pushing.
+`--all-features` fails (`r6-default` and `s7-default` are mutually exclusive). CI runs a newer toolchain, so lints like `collapsible_match`, `manual_checked_ops` can fire on CI with green local. Reproduce all three before pushing.
 
 ### sccache + `[profile.dev] incremental`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,17 +305,19 @@ fixture exercising it?" See #430.
 
 ### Reproducing CI clippy before PR
 
-`just clippy` ≠ CI. Two CI jobs must both pass `-D warnings`:
+`just clippy` ≠ CI. Three CI clippy steps must all pass `-D warnings`:
 
 - `clippy_default`: `cargo clippy --workspace --all-targets --locked -- -D warnings`
-- `clippy_all`: same + a long curated feature list
+- `clippy_all`: same + `full-codegen` and a long curated integration feature list
+- `clippy_all_s7`: same list with `full-codegen-s7` (the `s7-default` side of
+  the r6/s7 mutex) instead of `full-codegen`
 
 **The feature list is maintained in `.github/workflows/ci.yml` (`clippy_all`
 step) — read it from there.** Hard-coding the list here drifts (it already
 has). `--all-features` does NOT work — `r6-default` and `s7-default` are
 mutually exclusive. CI runs a newer toolchain, so lints like
 `collapsible_match`, `manual_checked_ops` can fire on CI with green local.
-Reproduce both before pushing.
+Reproduce all three before pushing.
 
 ### UI test snapshots
 

--- a/justfile
+++ b/justfile
@@ -75,10 +75,6 @@ export PATH := if os() == "windows" {
     env("PATH", "")
 }
 
-# All optional features for testing (excluding nonapi which causes CRAN warnings).
-# This mirrors the default CARGO_FEATURES list in rpkg/configure.ac.
-all_features := "worker-thread,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,tinyvec,raw_conversions,vctrs,borsh,log"
-
 # Directory for devtools::check output (preserved for investigation)
 check_output_dir := justfile_directory() / "rpkg-check-output"
 
@@ -137,17 +133,27 @@ check-features:
         # defaults combos
         "strict-default,coerce-default,r6-default"
         "strict-default,s7-default,worker-default"
-        # diagnostic features
-        "growth-debug,materialization-tracking"
-        # all features together
-        "rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,connections,nonapi"
+        # diagnostic features (macro-coverage does NOT compile alone — it
+        # needs worker-thread; this combo is its only compile gate)
+        "growth-debug,worker-thread,macro-coverage"
+        # newer integrations (no standalone datafusion combo — heavy; it
+        # rides in once via full-integrations in the final combo)
+        "jiff"
+        "blake3,md5,sha2"
+        "globset,zstd"
+        "arrow"
+        # all features together — derived from the Cargo.toml aggregate so
+        # the list can't drift again (includes arrow/datafusion/log)
+        "full-integrations,connections,nonapi"
     )
     total=${#combos[@]}
     passed=0
     for combo in "${combos[@]}"; do
         echo "--- Checking: $combo ---"
         if cargo check --manifest-path="$manifest" --features "$combo" 2>&1; then
-            ((passed++))
+            # NOT ((passed++)): under set -e that aborts the recipe when
+            # passed is 0 — post-increment returns the old value's status.
+            passed=$((passed + 1))
         else
             echo "FAILED: $combo"
             exit 1

--- a/miniextendr-api/Cargo.toml
+++ b/miniextendr-api/Cargo.toml
@@ -144,10 +144,12 @@ refcount-fast-hash = ["dep:ahash"]
 # MUTEX CONSTRAINT: `r6-default` and `s7-default` are mutually exclusive — a
 # `compile_error!` in miniextendr-macros fires if both are enabled (#676/#710).
 # This is exactly why `--all-features` can't be used. `full-codegen` therefore
-# picks exactly ONE side of that pair (`r6-default`); to lint the `s7-default`
-# side, run a second invocation swapping the two. (`strict-default` and
-# `coerce-default` are NOT a mutex pair — they're orthogonal, see
-# docs/FEATURE_DEFAULTS.md — so both live in `full-codegen` together.)
+# picks exactly ONE side of that pair (`r6-default`); `full-codegen-s7` is the
+# identical set with the mutex flipped to `s7-default`, so CI can lint both
+# sides. Keep the two lists in lock-step — they must differ ONLY in the mutex
+# member. (`strict-default` and `coerce-default` are NOT a mutex pair —
+# they're orthogonal, see docs/FEATURE_DEFAULTS.md — so both live in
+# `full-codegen` together.)
 
 ## Every optional integration crate (the "dep:" features). Heavy deps like
 ## arrow/datafusion/log live here; CI's `clippy_all` enables a curated subset.
@@ -168,6 +170,16 @@ full-integrations = [
 ## the unit CI's `clippy_all` derives.
 full-codegen = [
     "strict-default", "coerce-default", "r6-default", "worker-default",
+    "nonapi", "connections", "indicatif", "refcount-fast-hash",
+]
+
+## `full-codegen` with the r6/s7 mutex flipped: `s7-default` instead of
+## `r6-default`. CI's `clippy_all_s7` step derives from this — it is the only
+## compile gate anywhere for the s7 side of the mutex (rpkg's
+## tools/detect-features.R denylists `s7-default`, and the root-workspace
+## clippy steps never reach rpkg/src/rust).
+full-codegen-s7 = [
+    "strict-default", "coerce-default", "s7-default", "worker-default",
     "nonapi", "connections", "indicatif", "refcount-fast-hash",
 ]
 

--- a/reviews/2026-07-01-check-features-set-e-increment.md
+++ b/reviews/2026-07-01-check-features-set-e-increment.md
@@ -1,0 +1,43 @@
+# `just check-features` died at combo 1 — `((passed++))` under `set -e`
+
+## What was attempted
+
+Audit A3 (2026-07-01) flagged `just check-features` as broken because combo
+`"growth-debug,materialization-tracking"` references a feature deleted in
+3ea3525b. While repairing the combo list, the first full local run of the
+recipe failed **after the first combo succeeded**, before ever reaching the
+dead combo.
+
+## What went wrong
+
+```
+--- Checking: serde,ndarray ---
+    Finished `dev` profile ... in 6.70s
+error: Recipe `check-features` failed with exit code 1
+```
+
+No cargo error — the combo compiled fine, then the recipe aborted.
+
+## Root cause
+
+The recipe runs under `set -euo pipefail` and counted successes with
+`((passed++))`. Bash arithmetic commands return exit status 1 when the
+expression evaluates to 0 — and post-increment evaluates to the *old* value.
+So with `passed=0`, the first `((passed++))` returns status 1 and `set -e`
+kills the script. The recipe has been incapable of passing since the counter
+was introduced, independent of the dead-feature combo the audit blamed.
+(The audit's inference was reasonable — cargo does hard-error on unknown
+features — but the recipe never got that far.)
+
+## Fix
+
+`passed=$((passed + 1))` — arithmetic *expansion* in an assignment always
+exits 0. Landed with the feature-matrix-hygiene PR alongside the combo-list
+repair; the recipe now completes 20/20 combos and runs weekly in CI
+(scheduled-only `check-features` job) so it can't silently rot again.
+
+## Lesson
+
+`((var++))`, `((var--))`, and any `((expr))` that can evaluate to zero are
+`set -e` landmines. In strict-mode scripts use `var=$((var + 1))`, or
+`((var++)) || true` if the command form is unavoidable.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Implements `plans/2026-07-01-feature-matrix-hygiene.md` (audit findings A2, A3, A4, C4).

- **A2/C4 — `s7-default` was compiled by nothing.** The ci.yml comment claimed clippy_default's "rpkg path" linted it, but clippy_default is `--workspace` from the repo root and never reaches `rpkg/src/rust` (a standalone workspace), and rpkg's `tools/detect-features.R` denylists `s7-default` anyway. Added a `full-codegen-s7` aggregate to `miniextendr-api/Cargo.toml` (identical to `full-codegen` with the r6/s7 mutex flipped) and a `clippy_all_s7` step in the rust-lint job that derives from it, wired into the job's failure reporting like the other steps. The comment now describes reality.
- **A3 — `just check-features` was broken twice over.** The known break: the `growth-debug,materialization-tracking` combo references a feature deleted in 3ea3525b, and cargo hard-errors on unknown features. The surprise found while repairing it: `((passed++))` under `set -euo pipefail` returns exit status 1 when `passed` is 0, so the recipe aborted after its *first successful combo* and could never have completed since the counter was introduced. Both fixed; the dead combo is now `growth-debug,worker-thread,macro-coverage` (also giving `macro-coverage` its first compile gate anywhere, it does not compile without `worker-thread`). The all-features combo is derived from the `full-integrations` aggregate so it cannot drift again, and combos were added for features that postdate the recipe (`jiff`, `blake3,md5,sha2`, `globset,zstd`, `arrow`; no standalone `datafusion` combo, it rides in once via `full-integrations`). Post-mortem: `reviews/2026-07-01-check-features-set-e-increment.md`.
- **A4 — dead `all_features` variable deleted.** Zero consumers, and its comment ("mirrors the default CARGO_FEATURES list in rpkg/configure.ac") was 8 features stale.
- **Plan item 4 — scheduled CI wiring.** New `check-features` job gated on `github.event_name == 'schedule'` (the existing Saturday 06:00 UTC cron), so the recipe cannot silently rot again. Weekly-only because the final combo pulls arrow + datafusion.
- Updated the clippy-reproduction sections in `CLAUDE.md` and `AGENTS.md` (three clippy steps now; AGENTS.md's hard-coded feature list had already drifted and now points at ci.yml instead).

## Test plan

- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen-s7,<clippy_all integration list> -- -D warnings` green locally (first-ever lint of the s7-default codegen side, zero warnings surfaced)
- [x] `just check-features` completes locally: 20/20 combos pass (~28 min, dominated by datafusion)
- [x] `grep -n all_features justfile` returns no hits
- [x] justfile parses (`just --list`) and ci.yml parses (yaml.safe_load, 15 jobs)
- [ ] CI green including the new `clippy_all_s7` step
- [ ] Weekly scheduled run executes the new `check-features` job (next: Saturday 06:00 UTC)

## Notes

- Merge order per the ledger collision map: this is plan 02 of the ci.yml group (01 → 02 → 03). Plan 01 (`ci-cargo-test-job`) is in flight and should merge first; this branch touches different regions of ci.yml so the rebase should be clean.
- Local runtime for the full recipe was ~28 min cold. The scheduled job has `timeout-minutes: 60` plus sccache with its own cache key; if the first scheduled run overruns, the fallback per the plan is to drop the job and track it as an issue instead.
- `full-codegen-s7` and `full-codegen` must stay in lock-step (differ only in the mutex member); both Cargo.toml comments say so explicitly.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>