### PR TITLE
test(rpkg): self-registering gc_stress sweep + R-side backfill; fix the three bugs they caught (audit A8)

### DIFF
--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -764,11 +764,22 @@ impl<T: DataFrameRowConvert> IntoDataFrame for Vec<T> {
 
 impl<T: DataFrameRowConvert> FromDataFrame for Vec<T> {
     fn from_dataframe(df: &DataFrame) -> Result<Self, DataFrameError> {
+        // Root the input across the read. A `.Call` caller gets this from R's
+        // argument frame, but a Rust caller may hand in a freshly-built,
+        // unprotected frame (`into_dataframe` returns an unrooted SEXP wrapper);
+        // reader-internal allocations would reclaim it mid-read under
+        // `gctorture(TRUE)` (caught by gc_stress_reader_nested_flatten).
+        // Mirrors the guard in serde's `dataframe_to_vec` — see
+        // reviews/2026-05-29-serde-deserialize-fixture-gctorture-input-protect.md.
+        // SAFETY: reader entry runs on the R main thread; `df` wraps a valid SEXP.
+        let _input = unsafe { crate::OwnedProtect::new(df.as_sexp()) };
         T::rows_from_dataframe(df).unwrap_or_else(|| Err(no_reader_error()))
     }
 
     #[cfg(feature = "rayon")]
     fn from_dataframe_par(df: &DataFrame) -> Result<Self, DataFrameError> {
+        // SAFETY: as in `from_dataframe` above.
+        let _input = unsafe { crate::OwnedProtect::new(df.as_sexp()) };
         T::rows_from_dataframe_par(df).unwrap_or_else(|| Err(no_reader_error()))
     }
 }

--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -1022,7 +1022,17 @@ where
     }
 
     let ok_df = ok_builder.finish()?;
+    // Root the finished frame across `err_builder.finish()` below: `DataFrame`
+    // is an unrooted SEXP wrapper and the second finish allocates, so under
+    // `gctorture(TRUE)` the collector reclaims `ok_df` mid-assembly otherwise
+    // (caught by gc_stress_dispatch_to_dataframes; same bug class as
+    // reviews/2026-05-29-serde-deserialize-fixture-gctorture-input-protect.md).
+    // SAFETY: R main thread (SerdeRowBuilder invariant); `ok_df` is a valid SEXP.
+    let _ok_guard = unsafe { crate::OwnedProtect::new(ok_df.as_sexp()) };
     let err_df = err_builder.finish()?;
+    // SAFETY: as above. Guards drop LIFO after the list below is assembled;
+    // both frames are additionally rooted by the builder's scope once pushed.
+    let _err_guard = unsafe { crate::OwnedProtect::new(err_df.as_sexp()) };
 
     Ok(NamedDataFrameListBuilder::with_capacity(2)
         .push(names.ok, ok_df)

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1306,17 +1306,10 @@ pub fn miniextendr(
         precondition_output.static_checks.join("\n  ")
     };
 
-    // Generate Missing<T> prelude: `if (missing(param)) param <- quote(expr=)`
-    let missing_prelude = {
-        let lines = r_wrapper_builder::build_missing_prelude(inputs, &parsed.param_defaults());
-        if lines.is_empty() {
-            String::new()
-        } else {
-            lines.join("\n  ")
-        }
-    };
-
-    // Combine all preludes: r_entry, on.exit, missing defaults, lifecycle, static preconditions, match.arg, choices, r_post_checks
+    // Combine all preludes: r_entry, on.exit, lifecycle, static preconditions, match.arg, choices, r_post_checks
+    // (Missing<T> forwarding lives inline in the `.Call()` args — see
+    // `build_call_args_vec` — because a prelude binding of the missing
+    // sentinel errors on lookup.)
     let on_exit_str = r_on_exit.as_ref().map(|oe| oe.to_r_code());
     let combined_prelude = {
         let mut parts = Vec::new();
@@ -1325,9 +1318,6 @@ pub fn miniextendr(
         }
         if let Some(ref s) = on_exit_str {
             parts.push(s.as_str());
-        }
-        if !missing_prelude.is_empty() {
-            parts.push(missing_prelude.as_str());
         }
         if let Some(ref lc) = lifecycle_prelude {
             parts.push(lc.as_str());

--- a/miniextendr-macros/src/miniextendr_impl/env_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/env_class.rs
@@ -73,9 +73,6 @@ pub fn generate_env_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.extend(method_doc.build());
         }
         lines.push(format!("{}$new <- function({}) {{", class_name, ctx.params));
-        for line in ctx.missing_prelude() {
-            lines.push(format!("  {}", line));
-        }
         for check in ctx.precondition_checks() {
             lines.push(format!("  {}", check));
         }

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -173,7 +173,6 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
         let ctor_preconditions = ctx.precondition_checks();
 
         // Missing param prelude for constructor
-        let ctor_missing = ctx.missing_prelude();
 
         let ctor_match_arg = ctx.match_arg_prelude();
 
@@ -184,15 +183,9 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
                 format!("{}, .ptr = NULL", ctx.params)
             };
             lines.push(format!("    initialize = function({}) {{", full_params));
-            // Missing defaults + preconditions + match.arg only when not using .ptr shortcut
-            if !ctor_missing.is_empty()
-                || !ctor_preconditions.is_empty()
-                || !ctor_match_arg.is_empty()
-            {
+            // Preconditions + match.arg only when not using .ptr shortcut
+            if !ctor_preconditions.is_empty() || !ctor_match_arg.is_empty() {
                 lines.push("      if (is.null(.ptr)) {".to_string());
-                for line in &ctor_missing {
-                    lines.push(format!("        {}", line));
-                }
                 for check in &ctor_preconditions {
                     lines.push(format!("        {}", check));
                 }
@@ -214,9 +207,6 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.push(format!("    }}{}", comma));
         } else {
             lines.push(format!("    initialize = function({}) {{", ctx.params));
-            for line in &ctor_missing {
-                lines.push(format!("      {}", line));
-            }
             for check in &ctor_preconditions {
                 lines.push(format!("      {}", check));
             }
@@ -354,9 +344,6 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.push(format!("      {}", on_exit.to_r_code()));
         }
         // Inject missing param defaults
-        for line in ctx.missing_prelude() {
-            lines.push(format!("      {}", line));
-        }
         // Inject match.arg validation for match_arg/choices params
         for line in ctx.match_arg_prelude() {
             lines.push(format!("      {}", line));

--- a/miniextendr-macros/src/miniextendr_impl/s3_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s3_class.rs
@@ -74,9 +74,6 @@ pub fn generate_s3_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.insert(insert_pos, format!("#' {}", lc_import));
         }
         lines.push(format!("{} <- function({}) {{", ctor_name, ctx.params));
-        for line in ctx.missing_prelude() {
-            lines.push(format!("  {}", line));
-        }
         for check in ctx.precondition_checks() {
             lines.push(format!("  {}", check));
         }

--- a/miniextendr-macros/src/miniextendr_impl/s4_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s4_class.rs
@@ -95,9 +95,6 @@ pub fn generate_s4_r_wrapper(parsed_impl: &ParsedImpl) -> String {
         }
 
         lines.push(format!("{} <- function({}) {{", class_name, ctx.params));
-        for line in ctx.missing_prelude() {
-            lines.push(format!("  {}", line));
-        }
         for check in ctx.precondition_checks() {
             lines.push(format!("  {}", check));
         }

--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -657,7 +657,6 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
     if let Some(ctx) = parsed_impl.constructor_context() {
         let ctor_preconditions = ctx.precondition_checks();
-        let ctor_missing = ctx.missing_prelude();
         let ctor_match_arg = ctx.match_arg_prelude();
         if has_self_returning_methods {
             let params_with_ptr = if ctx.params.is_empty() {
@@ -666,15 +665,9 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
                 format!("{}, .ptr = NULL", ctx.params)
             };
             lines.push(format!("  constructor = function({}) {{", params_with_ptr));
-            // Missing defaults + preconditions + match.arg only when not using .ptr shortcut
-            if !ctor_missing.is_empty()
-                || !ctor_preconditions.is_empty()
-                || !ctor_match_arg.is_empty()
-            {
+            // Preconditions + match.arg only when not using .ptr shortcut
+            if !ctor_preconditions.is_empty() || !ctor_match_arg.is_empty() {
                 lines.push("    if (is.null(.ptr)) {".to_string());
-                for line in &ctor_missing {
-                    lines.push(format!("      {}", line));
-                }
                 for check in &ctor_preconditions {
                     lines.push(format!("      {}", check));
                 }
@@ -695,9 +688,6 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             lines.push("  }".to_string());
         } else {
             lines.push(format!("  constructor = function({}) {{", ctx.params));
-            for line in &ctor_missing {
-                lines.push(format!("    {}", line));
-            }
             for check in &ctor_preconditions {
                 lines.push(format!("    {}", check));
             }

--- a/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/vctrs_class.rs
@@ -73,9 +73,6 @@ pub fn generate_vctrs_r_wrapper(parsed_impl: &ParsedImpl) -> String {
 
         // Generate constructor body based on vctrs kind
         lines.push(format!("{} <- function({}) {{", ctor_name, ctx.params));
-        for line in ctx.missing_prelude() {
-            lines.push(format!("  {}", line));
-        }
         for check in ctx.precondition_checks() {
             lines.push(format!("  {}", check));
         }

--- a/miniextendr-macros/src/r_class_formatter.rs
+++ b/miniextendr-macros/src/r_class_formatter.rs
@@ -397,18 +397,21 @@ impl<'a> MethodContext<'a> {
         .static_checks
     }
 
-    /// Emit the 7-step method prelude into `lines`, each line prefixed with `indent`.
+    /// Emit the 6-step method prelude into `lines`, each line prefixed with `indent`.
     ///
     /// The prelude is the standardised sequence that appears at the top of every
     /// generated R method body, in order:
     ///
     /// 1. `r_entry` — user code injected before any checks
     /// 2. `r_on_exit` — `on.exit(...)` cleanup
-    /// 3. `missing_prelude` — `if (missing(param)) param <- quote(expr=)` for `Missing<T>`
-    /// 4. `lifecycle_prelude` — deprecation/superseded banner (class-system-specific label)
-    /// 5. `precondition_checks` — `stopifnot(is.*(param))` for typed params
-    /// 6. `match_arg_prelude` — `base::match.arg(param)` validation
-    /// 7. `r_post_checks` — user code after all checks, before `.Call()`
+    /// 3. `lifecycle_prelude` — deprecation/superseded banner (class-system-specific label)
+    /// 4. `precondition_checks` — `stopifnot(is.*(param))` for typed params
+    /// 5. `match_arg_prelude` — `base::match.arg(param)` validation
+    /// 6. `r_post_checks` — user code after all checks, before `.Call()`
+    ///
+    /// (`Missing<T>` forwarding is not a prelude step: it lives inline in the
+    /// `.Call()` args — see `build_call_args_vec` — because a binding of the
+    /// missing sentinel errors on lookup.)
     ///
     /// `what` is the human-readable method label passed to `lifecycle_prelude`
     /// (e.g., `"Type.method"` for S3/S4, `"Type$method"` for Env/R6/S7).
@@ -422,9 +425,6 @@ impl<'a> MethodContext<'a> {
         }
         if let Some(ref on_exit) = m.method_attrs.r_on_exit {
             lines.push(format!("{}{}", indent, on_exit.to_r_code()));
-        }
-        for line in self.missing_prelude() {
-            lines.push(format!("{}{}", indent, line));
         }
         if let Some(prelude) = m.lifecycle_prelude(what) {
             lines.push(format!("{}{}", indent, prelude));
@@ -440,16 +440,6 @@ impl<'a> MethodContext<'a> {
                 lines.push(format!("{}{}", indent, line));
             }
         }
-    }
-
-    /// Build `if (missing(param)) param <- quote(expr=)` prelude lines for `Missing<T>` parameters.
-    ///
-    /// Skips params that have a user-specified default (they get the default in formals instead).
-    pub fn missing_prelude(&self) -> Vec<String> {
-        crate::r_wrapper_builder::build_missing_prelude(
-            &self.method.sig.inputs,
-            &self.method.param_defaults,
-        )
     }
 }
 

--- a/miniextendr-macros/src/r_wrapper_builder.rs
+++ b/miniextendr-macros/src/r_wrapper_builder.rs
@@ -226,6 +226,21 @@ impl<'a> RArgumentBuilder<'a> {
                 _ => continue,
             };
 
+            // `Missing<T>`: forward true missingness as the `R_MissingArg`
+            // sentinel, produced *at the argument position*. A binding holding
+            // the sentinel errors on symbol lookup ("argument is missing, with
+            // no default"), so the former `if (missing(x)) x <- quote(expr=)`
+            // prelude broke every truly-missing call. (`Missing<T>` + user
+            // default is rejected at macro parse time, so no default-shadowing
+            // concern here.)
+            if is_missing_type(pat_type.ty.as_ref()) {
+                call_args.push(format!(
+                    "if (missing({p})) quote(expr=) else {p}",
+                    p = arg_ident
+                ));
+                continue;
+            }
+
             call_args.push(arg_ident.to_string());
         }
 
@@ -237,7 +252,8 @@ impl<'a> RArgumentBuilder<'a> {
 ///
 /// Automatically skips `self`/`&self` receivers. `Missing<T>` parameters without
 /// user-provided defaults appear as bare formals (no default value); the
-/// `if (missing())` prelude is generated separately via [`build_missing_prelude`].
+/// `R_MissingArg` sentinel forwarding is emitted inline in the `.Call()` args
+/// (see [`RArgumentBuilder::build_call_args_vec`]).
 ///
 /// Returns a comma-separated string of R formals, e.g., `"x, y = NULL, ..."`.
 pub(crate) fn build_r_formals_from_sig(
@@ -317,54 +333,6 @@ pub(crate) fn is_missing_type(ty: &syn::Type) -> bool {
     }
 }
 
-/// Collect parameter names that have `Missing<T>` types.
-///
-/// These parameters need an automatic R default of `quote(expr=)` which
-/// evaluates to `R_MissingArg` (the "missing argument" sentinel).
-/// Names are normalized via [`normalize_r_arg_ident`].
-///
-/// Returns normalized parameter names in declaration order.
-pub fn collect_missing_params(
-    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
-) -> Vec<String> {
-    let mut missing_params = Vec::new();
-
-    for arg in inputs.iter() {
-        let syn::FnArg::Typed(pt) = arg else {
-            continue;
-        };
-        let syn::Pat::Ident(pat_ident) = pt.pat.as_ref() else {
-            continue;
-        };
-
-        if is_missing_type(pt.ty.as_ref()) {
-            missing_params.push(normalize_r_arg_ident(&pat_ident.ident).to_string());
-        }
-    }
-
-    missing_params
-}
-
-/// Build `if (missing(param)) param <- quote(expr=)` prelude lines for `Missing<T>` parameters.
-///
-/// These lines go in the R function body BEFORE the `.Call()`, keeping the R function
-/// signature clean (no `quote(expr=)` in formals) while still passing the
-/// `R_MissingArg` sentinel through to Rust when the caller omits the argument.
-///
-/// Note: `Missing<T>` + `default` is a compile error (checked in `miniextendr_fn.rs`
-/// and `miniextendr_impl.rs`), so the `user_defaults` filter is a safety net only.
-///
-/// Returns a vector of R code lines, one per `Missing<T>` parameter.
-pub fn build_missing_prelude(
-    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
-    user_defaults: &std::collections::HashMap<String, String>,
-) -> Vec<String> {
-    collect_missing_params(inputs)
-        .into_iter()
-        .filter(|param| !user_defaults.contains_key(param))
-        .map(|param| format!("if (missing({p})) {p} <- quote(expr=)", p = param))
-        .collect()
-}
 // endregion
 
 // region: DotCallBuilder - .Call() invocation formatting

--- a/miniextendr-macros/src/r_wrapper_builder/snapshots/miniextendr_macros__r_wrapper_builder__tests__snapshot_formals_and_call_args.snap
+++ b/miniextendr-macros/src/r_wrapper_builder/snapshots/miniextendr_macros__r_wrapper_builder__tests__snapshot_formals_and_call_args.snap
@@ -1,5 +1,6 @@
 ---
 source: miniextendr-macros/src/r_wrapper_builder/tests.rs
+assertion_line: 395
 expression: output
 ---
 # Basic scalars
@@ -24,5 +25,4 @@ call_args: x, step, verbose
 
 # Missing<T> clean formals
 formals: x, y, z
-call_args: x, y, z
-missing_prelude: if (missing(y)) y <- quote(expr=); if (missing(z)) z <- quote(expr=)
+call_args: x, if (missing(y)) quote(expr=) else y, if (missing(z)) quote(expr=) else z

--- a/miniextendr-macros/src/r_wrapper_builder/tests.rs
+++ b/miniextendr-macros/src/r_wrapper_builder/tests.rs
@@ -232,38 +232,25 @@ fn test_is_not_missing_type() {
 }
 
 #[test]
-fn test_collect_missing_params() {
+fn test_missing_type_call_args_inline_sentinel() {
+    // The R_MissingArg sentinel must be produced at the argument position —
+    // a prelude binding of the sentinel errors on symbol lookup.
     let inputs = parse_inputs("x: i32, y: Missing<f64>, z: String");
-    let missing = collect_missing_params(&inputs);
-    assert_eq!(missing, vec!["y"]);
+    let builder = RArgumentBuilder::new(&inputs);
+    assert_eq!(
+        builder.build_call_args(),
+        "x, if (missing(y)) quote(expr=) else y, z"
+    );
 }
 
 #[test]
-fn test_collect_multiple_missing_params() {
+fn test_multiple_missing_type_call_args() {
     let inputs = parse_inputs("a: Missing<i32>, b: f64, c: Missing<String>");
-    let missing = collect_missing_params(&inputs);
-    assert_eq!(missing, vec!["a", "c"]);
-}
-
-#[test]
-fn test_build_missing_prelude() {
-    let inputs = parse_inputs("x: i32, y: Missing<f64>, z: String");
-    let user_defaults = std::collections::HashMap::new();
-    let prelude = build_missing_prelude(&inputs, &user_defaults);
-
-    assert_eq!(prelude, vec!["if (missing(y)) y <- quote(expr=)"]);
-}
-
-#[test]
-fn test_build_missing_prelude_skips_user_defaults() {
-    let inputs = parse_inputs("x: i32, y: Missing<f64>, z: Missing<String>");
-    let mut user_defaults = std::collections::HashMap::new();
-    user_defaults.insert("y".to_string(), "0.0".to_string());
-
-    let prelude = build_missing_prelude(&inputs, &user_defaults);
-
-    // y has a user default, so only z gets the prelude
-    assert_eq!(prelude, vec!["if (missing(z)) z <- quote(expr=)"]);
+    let builder = RArgumentBuilder::new(&inputs);
+    assert_eq!(
+        builder.build_call_args(),
+        "if (missing(a)) quote(expr=) else a, b, if (missing(c)) quote(expr=) else c"
+    );
 }
 
 #[test]
@@ -397,14 +384,13 @@ fn snapshot_formals_and_call_args() {
     output.push_str(&format!("formals: {}\n", builder.build_formals()));
     output.push_str(&format!("call_args: {}\n", builder.build_call_args()));
 
-    // Missing<T> - clean formals (no quote(expr=) in signature)
+    // Missing<T> - clean formals (no quote(expr=) in signature); the sentinel
+    // forwarding is inline in call_args
     output.push_str("\n# Missing<T> clean formals\n");
     let inputs = parse_inputs("x: i32, y: Missing<f64>, z: Missing<String>");
     let builder = RArgumentBuilder::new(&inputs);
     output.push_str(&format!("formals: {}\n", builder.build_formals()));
     output.push_str(&format!("call_args: {}\n", builder.build_call_args()));
-    let prelude = build_missing_prelude(&inputs, &std::collections::HashMap::new());
-    output.push_str(&format!("missing_prelude: {}\n", prelude.join("; ")));
 
     insta::assert_snapshot!(output);
 }

--- a/reviews/2026-07-03-gc-sweep-unrooted-dataframe.md
+++ b/reviews/2026-07-03-gc-sweep-unrooted-dataframe.md
@@ -1,0 +1,70 @@
+# The gc_stress dynamic sweep's first catch: unrooted `DataFrame` across allocations
+
+Date: 2026-07-03. Context: plan 06 (`plans/2026-07-01-gc-stress-sweep-r-backfill.md`,
+audit A8) added a self-registering testthat sweep that runs every exported
+no-arg `gc_stress_*` fixture under `gctorture(TRUE)`. 26 of the 56 fixtures had
+never had a committed runner. The sweep's first full pass found two live bugs.
+
+## What was attempted
+
+`just devtools-test` with the new sweep in `test-gc-stress-fixtures.R`
+(5 iterations per fixture under gctorture).
+
+## What went wrong
+
+1. **Segfault** (address 0x10, "invalid permissions", `*** recursive gc
+   invocation` spam) in `gc_stress_dispatch_to_dataframes` — R aborts, whole
+   suite dies.
+2. **Intermittent R error** in `gc_stress_reader_nested_flatten`:
+   `"DataFrame always carries a names attribute"` (the `.expect` in
+   `DataFrame::named_list`, dataframe.rs) on ~2 of 5 iterations.
+3. `gc_stress_with_r_thread_stop` "failed" every iteration — false positive:
+   that fixture *raises by design* (its point is the raw `Rf_error` longjmp
+   path; `test-worker-longjmp.R` asserts the error). The sweep now excludes it
+   with a comment.
+
+## Root cause (bugs 1 and 2 are the same class)
+
+`DataFrame` (miniextendr-api/src/dataframe.rs) is a `#[derive(Clone, Copy)]`
+wrapper over a **bare, unrooted SEXP**. `SerdeRowBuilder::finish()` /
+`into_dataframe()` assemble the frame inside a `ProtectScope`, drop the scope,
+and return the unrooted wrapper. Any R allocation while Rust still holds that
+wrapper lets the GC reclaim the frame:
+
+- `dispatch_to_dataframes` held `ok_df` unrooted across `err_builder.finish()`
+  (which allocates the entire err frame) → freed node → segfault when the
+  named-list builder touched it.
+- The derive reader path (`FromDataFrame for Vec<T>` →
+  `rows_from_dataframe`) read from a Rust-built frame with no GC root;
+  reader-internal allocations reclaimed it mid-read → the names attribute
+  vanished → expect fired. Intermittent because a freed node's payload stays
+  intact until the allocator reuses it — **the sibling reader fixtures that
+  "passed" were reading freed-but-intact memory.**
+
+This is the same bug class as
+`reviews/2026-05-29-serde-deserialize-fixture-gctorture-input-protect.md`;
+serde's `dataframe_to_vec` already carries the input-rooting guard, which is
+why the serde-path fixtures were genuinely safe while the derive-reader path
+was not.
+
+## Fix
+
+- `dispatch_to_dataframes` (serde/columnar.rs): `OwnedProtect` both finished
+  frames until the output list is assembled (guards drop LIFO).
+- Blanket `FromDataFrame for Vec<T>` (dataframe.rs), both `from_dataframe`
+  and `from_dataframe_par`: root the input frame for the duration of the
+  read, mirroring `dataframe_to_vec`.
+- Sweep: documented exclusion for the one raises-by-design fixture.
+
+## Lessons
+
+- A fixture without a runner is dead weight — both bugs were in *fixtures'
+  production paths* that had existed for weeks; the fixtures were exported but
+  never called by any committed test (audit A8's exact complaint).
+- "Passed under gctorture" is necessary, not sufficient: freed-but-intact
+  reads pass silently. When one variant of a family fails intermittently,
+  audit the whole family's protection story, not just the failing member.
+- `DataFrame`'s unrooted-`Copy`-wrapper design makes every
+  hold-across-allocation site a latent UAF; the targeted guards fix the known
+  compositions, the design-level fix is tracked in a follow-up issue
+  (see PR body).

--- a/reviews/2026-07-03-missing-arg-sentinel-prelude.md
+++ b/reviews/2026-07-03-missing-arg-sentinel-prelude.md
@@ -1,0 +1,58 @@
+# `Missing<T>` was never callable with an absent argument
+
+Date: 2026-07-03. Context: plan 06's R-side test backfill (audit A8/B6 —
+"`Missing<T>` has NO R-side tests") added `test-missing.R` covering the four
+`missing_test_*` exports. Every truly-missing call errored.
+
+## What was attempted
+
+`missing_test_f64()` (argument genuinely absent) — per `Missing<T>`'s
+documented semantics this should map to `Missing::Absent`.
+
+## What went wrong
+
+```
+Error in `missing_test_f64()`: argument "x" is missing, with no default
+```
+
+for all four fixtures. Present-argument calls worked, so nothing looked wrong
+anywhere else — the *entire absent path*, the feature's whole point, was dead
+in every generated wrapper (standalone fns and all six class systems).
+
+## Root cause
+
+The wrapper codegen emitted a prelude statement:
+
+```r
+if (missing(x)) x <- quote(expr=)
+.Call(C_f, .call = match.call(), x)
+```
+
+Rebinding `x` to the empty symbol makes the binding hold `R_MissingArg` — and
+R raises "argument is missing, with no default" on **symbol lookup** of any
+binding holding that sentinel. So the `.Call`'s evaluation of `x` threw before
+Rust ever saw the argument. No statement-form workaround exists
+(`delayedAssign`, renamed bindings — all end in a lookup); the sentinel must
+be *produced at the argument position*, where it passes as a value:
+
+```r
+.Call(C_f, .call = match.call(), if (missing(x)) quote(expr=) else x)
+```
+
+## Fix
+
+`RArgumentBuilder::build_call_args_vec` (r_wrapper_builder.rs) now emits the
+inline conditional for `Missing<T>` params; `build_missing_prelude` /
+`collect_missing_params` and the prelude plumbing in `lib.rs`,
+`r_class_formatter.rs`, and all six class generators are deleted. Both
+codegen paths route through the same args builder, so one emission site fixes
+standalone fns and methods alike.
+
+## Lessons
+
+- An untested export can hide a **100%-broken** feature, not just edge-case
+  drift — the wrapper looked plausible and the C side was correct; only an
+  actual absent-argument call could catch it.
+- R's missing-argument sentinel is value-passable but not binding-passable.
+  Any codegen that needs to forward missingness must do it in expression
+  position at the call site.

--- a/rpkg/tests/testthat/test-altrep-sexp.R
+++ b/rpkg/tests/testthat/test-altrep-sexp.R
@@ -12,6 +12,18 @@ test_that("AltrepSexp materializes compact integer", {
   expect_equal(altrep_sexp_materialize_int(x), 1:10)
 })
 
+test_that("AltrepSexp materializes compact real", {
+  # Coercing a compact integer sequence yields an ALTREP compact real
+  # sequence (compact_intseq_Coerce in R's altclasses.c).
+  x <- as.numeric(1:10)
+  expect_true(unsafe_C_altrep_sexp_is_altrep(x))
+  expect_equal(altrep_sexp_materialize_real(x), as.numeric(1:10))
+})
+
+test_that("materialize_real errors on wrong SEXPTYPE", {
+  expect_error(altrep_sexp_materialize_real(1:10), "expected REALSXP")
+})
+
 test_that("AltrepSexp detects ALTREP string (as.character(1:10))", {
   y <- as.character(1:10)
   expect_true(unsafe_C_altrep_sexp_is_altrep(y))

--- a/rpkg/tests/testthat/test-arrow-na.R
+++ b/rpkg/tests/testthat/test-arrow-na.R
@@ -52,6 +52,17 @@ test_that("f64 null positions reported correctly", {
   expect_equal(positions, c(FALSE, TRUE, FALSE, TRUE, FALSE))
 })
 
+test_that("f64 inspect_arrow reports null_count and per-element null flags", {
+  v <- c(1.0, NA, 3.0)
+  # layout: [null_count, value_0, is_null_0, value_1, is_null_1, value_2, is_null_2]
+  res <- arrow_na_f64_inspect_arrow(v)
+  expect_length(res, 7L)
+  expect_equal(res[1], 1) # null_count
+  expect_equal(res[c(2, 6)], c(1.0, 3.0)) # non-null values
+  expect_equal(res[c(3, 5, 7)], c(0, 1, 0)) # is_null flags
+  expect_true(is.nan(res[4])) # null represented as NaN by the fixture
+})
+
 test_that("f64 compact (remove NAs) works", {
   v <- c(1.0, NA, 3.0, NA, 5.0)
   result <- arrow_na_f64_compact(v)

--- a/rpkg/tests/testthat/test-basic.R
+++ b/rpkg/tests/testthat/test-basic.R
@@ -71,3 +71,7 @@ test_that("doc_attr_basic doubles its input", {
 test_that("doc_attr_no_params returns expected string", {
   expect_equal(doc_attr_no_params(), "hello from doc_attr")
 })
+
+test_that("docs_demo_three_paras multi-paragraph roxygen fixture is callable", {
+  expect_identical(docs_demo_three_paras(), 0L)
+})

--- a/rpkg/tests/testthat/test-class-system-matrix.R
+++ b/rpkg/tests/testthat/test-class-system-matrix.R
@@ -54,6 +54,12 @@ test_that("CounterTraitS3 direct trait helpers exist", {
   expect_equal(custom_get.CounterTraitS3(counter), 7L)
 })
 
+test_that("new_countertraits3 snake_case constructor alias works", {
+  counter <- new_countertraits3(5L)
+  expect_true(inherits(counter, "CounterTraitS3"))
+  expect_equal(get_value(counter), 5L)
+})
+
 # =============================================================================
 # S4 trait impl (CounterTraitS4)
 # =============================================================================

--- a/rpkg/tests/testthat/test-class-systems.R
+++ b/rpkg/tests/testthat/test-class-systems.R
@@ -101,6 +101,15 @@ test_that("r6_standalone_add sums", {
   expect_equal(r6_standalone_add(2L, 3L), 5L)
 })
 
+test_that("R6Rectangle methods and active bindings work", {
+  r <- R6Rectangle$new(3, 4)
+  expect_equal(r$get_width(), 3)
+  expect_equal(r$get_height(), 4)
+  # active bindings — computed property access, no parentheses
+  expect_equal(r$area, 12)
+  expect_equal(r$perimeter, 14)
+})
+
 test_that("R6Temperature active binding getters work", {
   t <- R6Temperature$new(100)  # Boiling point in Celsius
   expect_equal(t$celsius, 100)

--- a/rpkg/tests/testthat/test-conditions-comprehensive.R
+++ b/rpkg/tests/testthat/test-conditions-comprehensive.R
@@ -469,6 +469,23 @@ test_that("standalone fn consuming sidecar panics with rust_error", {
   expect_true(grepl("sidecar_consumer_panic", deparse(cl)[[1]]))
 })
 
+test_that("raw sidecar accessors read and write the doom field", {
+  # PanickingSidecar_get_doom / _set_doom are the hand-rolled sidecar C
+  # wrappers (no __miniextendr_call slot — see the region comment above).
+  # Drive them directly with the bare ExternalPtr; the R6 active binding
+  # routes through these same entry points.
+  ptr <- panicking_sidecar_new("original")
+  expect_equal(PanickingSidecar_get_doom(ptr), "original")
+  PanickingSidecar_set_doom(ptr, "rewritten")
+  expect_equal(PanickingSidecar_get_doom(ptr), "rewritten")
+})
+
+test_that("raw sidecar accessor on a non-externalptr errors, not crashes", {
+  # The panic inside the accessor (failed downcast) must surface as an R
+  # error through the call-slot-less wrapper path.
+  expect_error(PanickingSidecar_get_doom(42L))
+})
+
 # endregion
 
 # region: edge cases — withRestarts / e$class slot / message conditionCall

--- a/rpkg/tests/testthat/test-conversions.R
+++ b/rpkg/tests/testthat/test-conversions.R
@@ -635,6 +635,33 @@ test_that("extension traits (.as_named_vector / .as_named_list) work", {
   expect_equal(list_res$two, 2L)
 })
 
+# ── NamedList (O(1) lookup wrapper) ──────────────────────────────────────────
+
+test_that("NamedList get retrieves entries by name", {
+  expect_equal(conv_named_list_get(list(width = 3L, height = 4L)), 12L)
+  # missing entries fall back to the Rust-side unwrap_or default (0)
+  expect_equal(conv_named_list_get(list(width = 3L)), 0L)
+})
+
+test_that("NamedList contains checks name existence", {
+  expect_equal(
+    conv_named_list_contains(list(a = 1L, b = 2L)),
+    c(TRUE, TRUE, FALSE)
+  )
+})
+
+test_that("NamedList len counts total and named elements", {
+  expect_equal(conv_named_list_len(list(a = 1L, 2L, c = 3L)), c(3L, 2L))
+})
+
+test_that("NamedList round-trips back to an R list", {
+  res <- conv_named_list_roundtrip(list(a = 1L, b = "two"))
+  expect_type(res, "list")
+  expect_equal(names(res), c("a", "b"))
+  expect_equal(res$a, 1L)
+  expect_equal(res$b, "two")
+})
+
 # =============================================================================
 # Map conversion edge cases (Phase A1/A2)
 # =============================================================================

--- a/rpkg/tests/testthat/test-feature-adapters.R
+++ b/rpkg/tests/testthat/test-feature-adapters.R
@@ -1757,6 +1757,12 @@ test_that("zstd compresses repetitive data smaller than input", {
   expect_lt(length(zstd_compress(data, 3L)), length(data))
 })
 
+test_that("zstd_roundtrip returns the input unchanged", {
+  skip_if_missing_feature("zstd")
+  data <- charToRaw("round trip me")
+  expect_identical(zstd_roundtrip(data, 3L), data)
+})
+
 test_that("zstd level 0 and NA select the default level", {
   skip_if_missing_feature("zstd")
   data <- charToRaw("hello hello hello")

--- a/rpkg/tests/testthat/test-gc-stress-fixtures.R
+++ b/rpkg/tests/testthat/test-gc-stress-fixtures.R
@@ -78,3 +78,75 @@ test_that("gc_stress_str_borrow keeps zero-copy &str views intact under gctortur
 })
 
 # endregion
+
+# region: legacy-prefix gctorture fixtures (gc_protect_tests.rs, #307) --------
+
+# These two predate the gc_stress_ naming convention (#430), so the dynamic
+# sweep below does not enumerate them — exercise them explicitly, with the
+# structure assertions the sweep can't make.
+test_that("List::from_values / from_pairs string fixtures survive gctorture", {
+  gctorture(TRUE)
+  on.exit(gctorture(FALSE), add = TRUE)
+
+  for (i in seq_len(5L)) {
+    v <- test_list_from_values_strings_gctorture()
+    expect_length(v, 16L)
+    expect_equal(v[[1]], "element-0")
+
+    p <- test_list_from_pairs_strings_gctorture()
+    expect_length(p, 16L)
+    expect_equal(names(p)[[1]], "k0")
+    expect_equal(p[[1]], "v0")
+  }
+})
+
+# endregion
+
+# region: dynamic sweep — every no-arg gc_stress_* fixture --------------------
+
+# Self-registering harness (#1026): enumerate every exported no-arg
+# gc_stress_* fixture so future fixtures are exercised without editing this
+# file. The explicit tests above assert result *structure*; this sweep only
+# asserts survival under gctorture. Feature-gated fixtures self-solve: if not
+# compiled, they are not in the namespace. Iterations stay low (5) because
+# this runs in PR CI — nightly's gctorture2 sweep amplifies it.
+test_that("every no-arg gc_stress_* fixture survives gctorture", {
+  ns <- getNamespace("miniextendr")
+  fixtures <- ls(ns, pattern = "^gc_stress_")
+  fixtures <- Filter(function(f) length(formals(get(f, ns))) == 0L, fixtures)
+  # gc_stress_with_r_thread_stop raises by design (its point is the raw
+  # Rf_error longjmp path; test-worker-longjmp.R expect_error()s it). Every
+  # other fixture's contract is an error-free return.
+  fixtures <- setdiff(fixtures, "gc_stress_with_r_thread_stop")
+  expect_gt(length(fixtures), 0L)
+
+  gctorture(TRUE)
+  on.exit(gctorture(FALSE), add = TRUE)
+
+  ok <- 0L
+  fail <- character(0L)
+  for (f in fixtures) {
+    res <- "ok"
+    for (i in seq_len(5L)) {
+      res <- tryCatch(
+        { get(f, ns)(); "ok" },
+        error = function(e) conditionMessage(e)
+      )
+      if (!identical(res, "ok")) {
+        fail <- c(fail, sprintf("%s iteration %d: %s", f, i, res))
+        break
+      }
+    }
+    if (identical(res, "ok")) ok <- ok + 1L
+  }
+
+  expect_equal(
+    ok, length(fixtures),
+    info = sprintf(
+      "%d of %d fixtures survived; failures: %s",
+      ok, length(fixtures), paste(fail, collapse = "; ")
+    )
+  )
+})
+
+# endregion

--- a/rpkg/tests/testthat/test-jiff.R
+++ b/rpkg/tests/testthat/test-jiff.R
@@ -95,6 +95,11 @@ test_that("jiff: jiff_zoned_year extracts year", {
   expect_equal(yr, 2024L)
 })
 
+test_that("jiff: jiff_zoned_month extracts month (1-12)", {
+  ts <- as.POSIXct("2024-06-15 10:00:00", tz = "UTC")
+  expect_equal(jiff_zoned_month(ts), 6L)
+})
+
 test_that("jiff: Vec<Zoned> roundtrips as POSIXct vector", {
   ts1 <- as.POSIXct("2024-01-01 00:00:00", tz = "UTC")
   ts2 <- as.POSIXct("2024-06-15 12:00:00", tz = "UTC")

--- a/rpkg/tests/testthat/test-match-arg-impl.R
+++ b/rpkg/tests/testthat/test-match-arg-impl.R
@@ -119,6 +119,12 @@ test_that("S3 instance method with match_arg validates", {
   expect_equal(relabel(p, "Safe"), "alpha-Safe")
 })
 
+test_that("S3MatchArgPoint class object constructs via $new", {
+  p <- S3MatchArgPoint$new("gamma")
+  expect_true(inherits(p, "S3MatchArgPoint"))
+  expect_equal(label(p), "gamma")
+})
+
 # endregion
 
 # region: S4 — scalar match_arg on constructor + instance method (#209)

--- a/rpkg/tests/testthat/test-match-arg.R
+++ b/rpkg/tests/testthat/test-match-arg.R
@@ -255,3 +255,21 @@ test_that("foreign-type MatchArg: log::LevelFilter choices are baked into wrappe
   expect_equal(match_arg_log_level("err"), "error")
   expect_error(match_arg_log_level("loud"), "should be one of")  # match.arg's own error
 })
+
+# ============================================================================
+# Auto-doc fixtures — @param auto-injected from enum choices
+# ============================================================================
+
+test_that("match_arg_auto_doc_mode behaves like a plain match_arg param", {
+  expect_equal(match_arg_auto_doc_mode(), "Fast") # NULL default → first choice
+  expect_equal(match_arg_auto_doc_mode("Sa"), "Safe") # partial match
+  expect_error(match_arg_auto_doc_mode("nope"), "should be one of")
+})
+
+test_that("match_arg_auto_doc_modes several_ok accepts subsets", {
+  expect_equal(match_arg_auto_doc_modes("Fast"), "Fast")
+  expect_equal(match_arg_auto_doc_modes(c("Safe", "Debug")), "Safe, Debug")
+  # several.ok = TRUE + missing arg: match.arg returns the FULL choices vector
+  expect_equal(match_arg_auto_doc_modes(), "Fast, Safe, Debug")
+  expect_error(match_arg_auto_doc_modes("nope"), "should be one of")
+})

--- a/rpkg/tests/testthat/test-missing.R
+++ b/rpkg/tests/testthat/test-missing.R
@@ -1,0 +1,23 @@
+# Tests for Missing<T> — distinguishes a *missing* argument from NULL and from
+# a present value (see miniextendr-api/src/missing.rs rustdoc for semantics).
+
+test_that("Missing<f64> distinguishes absent from present", {
+  expect_equal(missing_test_f64(), "absent")
+  expect_equal(missing_test_f64(2.5), "2.5")
+})
+
+test_that("Missing<String> unwrap_or_else falls back when absent", {
+  expect_equal(missing_test_string(), "default_value")
+  expect_equal(missing_test_string("hi"), "hi")
+})
+
+test_that("Missing<i32> is_present reflects argument presence", {
+  expect_false(missing_test_present())
+  expect_true(missing_test_present(1L))
+})
+
+test_that("Missing<Option<f64>> distinguishes missing, NULL, and present", {
+  expect_equal(missing_test_option(), "missing")
+  expect_equal(missing_test_option(NULL), "null")
+  expect_equal(missing_test_option(3.5), "3.5")
+})

--- a/rpkg/tests/testthat/test-r-coerce.R
+++ b/rpkg/tests/testthat/test-r-coerce.R
@@ -132,3 +132,38 @@ test_that("len method works via S3 generic", {
 
   expect_equal(len(obj), 3L)
 })
+
+# =============================================================================
+# Exported snake_case surface (constructor aliases + underscore generics)
+# =============================================================================
+
+test_that("new_rcoercetestdata constructor alias builds a working object", {
+  obj <- new_rcoercetestdata(c("a", "b"), c(1.0, 2.0))
+  expect_true(inherits(obj, "RCoerceTestData"))
+  expect_equal(len(obj), 2L)
+})
+
+test_that("new_rcoerceerrortest constructor alias builds a working object", {
+  obj <- new_rcoerceerrortest(TRUE)
+  expect_true(inherits(obj, "RCoerceErrorTest"))
+  expect_error(as.data.frame(obj), "cannot create data.frame from empty data")
+})
+
+test_that("as_character generic dispatches like as.character", {
+  obj <- RCoerceTestData$new(c("a", "b"), c(1.0, 2.0))
+  expect_equal(as_character(obj), as.character(obj))
+  expect_error(
+    as_character(RCoerceErrorTest$new(FALSE)),
+    "intentional error for testing"
+  )
+})
+
+test_that("as_integer generic truncates values like as.integer", {
+  obj <- RCoerceTestData$new(c("a", "b", "c"), c(10.9, 20.1, 30.5))
+  expect_identical(as_integer(obj), c(10L, 20L, 30L))
+})
+
+test_that("as_data_frame generic dispatches like as.data.frame", {
+  obj <- RCoerceTestData$new(c("a", "b"), c(1.0, 2.0))
+  expect_equal(as_data_frame(obj), as.data.frame(obj))
+})

--- a/rpkg/tests/testthat/test-zero-copy.R
+++ b/rpkg/tests/testthat/test-zero-copy.R
@@ -102,6 +102,16 @@ test_that("Int32Array with NAs round-trip returns same object", {
   expect_true(zero_copy_arrow_i32_identity(x))
 })
 
+test_that("Float64Array round-trip returns the values unchanged", {
+  x <- c(1.5, NA, 3.5)
+  expect_equal(zero_copy_arrow_f64_roundtrip(x), x)
+})
+
+test_that("Int32Array round-trip returns the values unchanged", {
+  x <- c(1L, NA, 3L)
+  expect_equal(zero_copy_arrow_i32_roundtrip(x), x)
+})
+
 test_that("ALTREP compact integer (1:n) correctly falls through to copy", {
   # 1:5 creates an ALTREP compact sequence — data isn't at fixed offset
   # from SEXP header. Arrow recovery must fail gracefully, returning a copy.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Plan 06 of the 2026-07-01 dogfooding ledger (`plans/2026-07-01-gc-stress-sweep-r-backfill.md`, audit finding A8; closes the harness half of #1026, the "backfill more fixtures" half stays open there).
- **Dynamic sweep** (`test-gc-stress-fixtures.R`): enumerates every exported no-arg `gc_stress_*` fixture and runs each 5 times under `gctorture(TRUE)`. 26 of 56 fixtures previously had no committed runner; future fixtures self-register. One documented exclusion (`gc_stress_with_r_thread_stop` raises by design; `test-worker-longjmp.R` asserts that error). The two legacy-prefix `test_list_*_gctorture` fixtures (predating the #430 naming convention) get explicit structure-asserting tests.
- **Backfill**: new `test-missing.R` (`Missing<T>`: absent vs NULL vs present) plus tests in 13 existing files covering every remaining literally-untested export: the NamedList quartet, `R6Rectangle` active bindings, `S3MatchArgPoint$new`, `match_arg_auto_doc_mode(s)` (including the several_ok full-vector default), the raw `PanickingSidecar_get/set_doom` accessors, `jiff_zoned_month`, `altrep_sexp_materialize_real`, `arrow_na_f64_inspect_arrow`, both zero-copy arrow roundtrips, `zstd_roundtrip`, the r-coerce snake_case surface (`new_rcoercetestdata`, `new_rcoerceerrortest`, `as_character`, `as_integer`, `as_data_frame`, verified to be distinct generics rather than base-R shadows), `new_countertraits3`, `docs_demo_three_paras`.
- The new tests caught **three live bugs**, fixed here:
  1. `dispatch_to_dataframes` **segfaulted** under gctorture: `ok_df` (an unrooted `DataFrame`) was held across `err_builder.finish()`'s allocations. Both finished frames are now `OwnedProtect`-rooted until the output list is assembled.
  2. The derive reader path (`FromDataFrame for Vec<T>`) read Rust-built frames with **no GC root**: intermittent "DataFrame always carries a names attribute" panics; sibling fixtures passed only by reading freed-but-intact memory. The reader now roots its input, mirroring serde's `dataframe_to_vec` guard.
  3. `Missing<T>` was **never callable with an absent argument**: the generated `if (missing(x)) x <- quote(expr=)` prelude rebinds `x` to `R_MissingArg`, which errors on symbol lookup at the `.Call`. The sentinel is now produced inline at the argument position (`if (missing(x)) quote(expr=) else x`); the prelude machinery is deleted across `lib.rs`, `r_class_formatter.rs`, and all six class generators.
- Post-mortems: `reviews/2026-07-03-gc-sweep-unrooted-dataframe.md`, `reviews/2026-07-03-missing-arg-sentinel-prelude.md`.
- Deferral: the underlying `DataFrame`-is-an-unrooted-`Copy`-wrapper design footgun is #1128.

## Test plan
- [x] `just devtools-test` green: 6756 pass, 0 fail, 0 warn, 20 feature-gated skips (previous run segfaulted mid-suite via the sweep, which is how bug 1 surfaced).
- [x] The two crashing fixtures re-verified at 20/20 iterations under `gctorture(TRUE)` after the fix (previously: immediate segfault / ~40% error rate).
- [x] `Missing<T>` smoke-tested against the installed package: absent, NULL, and present all distinguish correctly.
- [x] `cargo test -p miniextendr-macros --lib` (351 pass, snapshot updated to the inline-sentinel emission) and `cargo test -p miniextendr-api` green.
- [x] All three CI clippy equivalents (default, full-codegen, full-codegen-s7) green with `-D warnings`; `cargo fmt --check` clean.
- [x] `just force-document` after the macro change: no NAMESPACE/man drift (wrapper body-only change).
- [x] NAMESPACE-vs-testthat residue re-scan: remaining untested exports are bench-only (`bench_vec_*`) plus the `gc_stress_*` fixtures the sweep covers at runtime.

## Notes
- 7 pre-existing `derive_dataframe_*` trybuild UI mismatches fail locally on rustc 1.95 (E0080 note-format drift vs the snapshots CI's newer stable recorded in #1110). Zero overlap with this diff; CI's rust-tests job is authoritative for those.
- The sweep keeps iterations low (5) for PR CI; nightly's gctorture2 sweep amplifies coverage.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>