### PR TITLE
refactor(cli): DCF-aware DESCRIPTION reader on ProjectContext; drop dead print_status JSON branch

### DIFF
--- a/miniextendr-cli/src/commands/config.rs
+++ b/miniextendr-cli/src/commands/config.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use crate::cli::ConfigCmd;
-use crate::output::print_status;
+use crate::output::{print_json, print_status};
 use crate::project::ProjectContext;
 
 #[derive(Serialize, Clone)]
@@ -99,18 +99,18 @@ pub fn dispatch(cmd: &ConfigCmd, ctx: &ProjectContext, _quiet: bool, json: bool)
         ConfigCmd::Show => {
             let cfg = read_config(&ctx.root);
             if json {
-                println!("{}", serde_json::to_string_pretty(&cfg)?);
+                print_json(&cfg)?;
             } else {
-                print_status(&cfg.to_string(), false);
+                print_status(&cfg.to_string());
             }
             Ok(())
         }
         ConfigCmd::Defaults => {
             let cfg = defaults();
             if json {
-                println!("{}", serde_json::to_string_pretty(&cfg)?);
+                print_json(&cfg)?;
             } else {
-                print_status(&cfg.to_string(), false);
+                print_status(&cfg.to_string());
             }
             Ok(())
         }

--- a/miniextendr-cli/src/commands/feature.rs
+++ b/miniextendr-cli/src/commands/feature.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 
 use crate::bridge::{rscript_eval, run_command};
 use crate::cli::{FeatureCmd, FeatureDetectCmd, FeatureRuleCmd};
+use crate::output::print_json;
 use crate::project::ProjectContext;
 
 pub fn dispatch(cmd: &FeatureCmd, ctx: &ProjectContext, quiet: bool, json: bool) -> Result<()> {
@@ -164,7 +165,7 @@ fn feature_list(ctx: &ProjectContext, json: bool) -> Result<()> {
         if !optional_deps.is_empty() {
             map.insert("_optional_deps".into(), serde_json::json!(optional_deps));
         }
-        println!("{}", serde_json::to_string_pretty(&map)?);
+        print_json(&map)?;
     } else {
         println!("Cargo features:");
         for (name, deps) in &features {
@@ -320,7 +321,7 @@ fn feature_rule_list(ctx: &ProjectContext, json: bool) -> Result<()> {
         .collect();
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&rules)?);
+        print_json(&rules)?;
     } else if rules.is_empty() {
         println!("No feature detection rules defined.");
     } else {
@@ -385,24 +386,21 @@ fn add_desc_field(ctx: &ProjectContext, field: &str, pkg: &str, quiet: bool) -> 
         return Ok(());
     }
 
-    let content = std::fs::read_to_string(&desc_path)?;
-    let prefix = format!("{field}:");
-
-    // Check if field exists and if pkg is already listed
-    let mut found_field = false;
-    for line in content.lines() {
-        if line.starts_with(&prefix) {
-            found_field = true;
-            if line.contains(pkg) {
-                if !quiet {
-                    println!("{pkg} already in {field}");
-                }
-                return Ok(());
-            }
+    // Check if field exists and if pkg is already listed (DCF-aware, so a
+    // value wrapped across continuation lines is still searched in full).
+    let existing = ctx.description_field(field);
+    if let Some(value) = &existing
+        && value.contains(pkg)
+    {
+        if !quiet {
+            println!("{pkg} already in {field}");
         }
+        return Ok(());
     }
 
-    let new_content = if found_field {
+    let content = std::fs::read_to_string(&desc_path)?;
+    let prefix = format!("{field}:");
+    let new_content = if existing.is_some() {
         // Append to existing field
         content.replace(&prefix.to_string(), &format!("{prefix} {pkg},"))
     } else {

--- a/miniextendr-cli/src/commands/init.rs
+++ b/miniextendr-cli/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use crate::bridge::{has_program, run_command};
 use crate::cli::InitCmd;
@@ -28,7 +28,7 @@ pub fn dispatch(cmd: &InitCmd, ctx: &ProjectContext, quiet: bool) -> Result<()> 
             rpkg_name: _,
             miniextendr_version: _,
             local_path: _,
-        } => init_use(&ctx.root, quiet),
+        } => init_use(ctx, quiet),
     }
 }
 
@@ -172,14 +172,17 @@ fn init_monorepo(
 }
 
 /// Add miniextendr scaffolding to an existing project.
-fn init_use(root: &Path, quiet: bool) -> Result<()> {
+fn init_use(ctx: &ProjectContext, quiet: bool) -> Result<()> {
+    let root = &ctx.root;
     let desc_path = root.join("DESCRIPTION");
     if !desc_path.exists() {
         bail!("No DESCRIPTION found. Is this an R package directory?");
     }
 
     // Read package name
-    let pkg_name = read_pkg_name(root)?;
+    let pkg_name = ctx
+        .package_name()
+        .context("Could not read Package field from DESCRIPTION")?;
     let crate_name = pkg_name.replace(['.', '-'], "_");
 
     if !quiet {
@@ -519,14 +522,4 @@ fn update_description_for_miniextendr(root: &Path) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn read_pkg_name(root: &Path) -> Result<String> {
-    let desc = std::fs::read_to_string(root.join("DESCRIPTION"))?;
-    for line in desc.lines() {
-        if let Some(value) = line.strip_prefix("Package:") {
-            return Ok(value.trim().to_string());
-        }
-    }
-    bail!("Could not read Package field from DESCRIPTION");
 }

--- a/miniextendr-cli/src/commands/render.rs
+++ b/miniextendr-cli/src/commands/render.rs
@@ -85,13 +85,5 @@ fn render_format(ctx: &ProjectContext, format: &str, quiet: bool) -> Result<()> 
 }
 
 fn pkg_name(ctx: &ProjectContext) -> String {
-    let desc = ctx.root.join("DESCRIPTION");
-    if let Ok(content) = std::fs::read_to_string(desc) {
-        for line in content.lines() {
-            if let Some(value) = line.strip_prefix("Package:") {
-                return value.trim().to_string();
-            }
-        }
-    }
-    "mypackage".into()
+    ctx.package_name().unwrap_or_else(|| "mypackage".into())
 }

--- a/miniextendr-cli/src/commands/status.rs
+++ b/miniextendr-cli/src/commands/status.rs
@@ -1,10 +1,9 @@
-use std::path::Path;
-
 use anyhow::Result;
 use serde::Serialize;
 
 use crate::bridge::{has_program, program_version};
 use crate::cli::StatusCmd;
+use crate::output::print_json;
 use crate::project::{MINIEXTENDR_CRATES, ProjectContext};
 
 #[derive(Serialize)]
@@ -49,7 +48,7 @@ fn status_has(ctx: &ProjectContext, json: bool) -> Result<()> {
     };
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        print_json(&result)?;
     } else {
         println!("{result}");
     }
@@ -65,7 +64,9 @@ fn status_show(ctx: &ProjectContext, json: bool) -> Result<()> {
     let root = &ctx.root;
 
     // Derive wrapper filename from DESCRIPTION
-    let pkg_name = read_description_field(root, "Package").unwrap_or_else(|| "miniextendr".into());
+    let pkg_name = ctx
+        .description_field("Package")
+        .unwrap_or_else(|| "miniextendr".into());
     let wrapper_file = format!("R/{pkg_name}-wrappers.R");
 
     let categories: &[(&str, &[&str])] = &[
@@ -213,7 +214,7 @@ fn status_show(ctx: &ProjectContext, json: bool) -> Result<()> {
             missing: all_missing,
             stale,
         };
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        print_json(&report)?;
     }
 
     Ok(())
@@ -249,7 +250,9 @@ fn status_validate(ctx: &ProjectContext, json: bool) -> Result<()> {
             println!("  [FAIL] DESCRIPTION not found");
         }
     } else {
-        let bootstrap = read_description_field(root, "Config/build/bootstrap").unwrap_or_default();
+        let bootstrap = ctx
+            .description_field("Config/build/bootstrap")
+            .unwrap_or_default();
         if bootstrap == "TRUE" {
             pass.push("Config/build/bootstrap = TRUE".into());
             if !json {
@@ -262,7 +265,9 @@ fn status_validate(ctx: &ProjectContext, json: bool) -> Result<()> {
             }
         }
 
-        let sys_req = read_description_field(root, "SystemRequirements").unwrap_or_default();
+        let sys_req = ctx
+            .description_field("SystemRequirements")
+            .unwrap_or_default();
         if sys_req.to_lowercase().contains("rust") {
             pass.push("SystemRequirements mentions Rust".into());
             if !json {
@@ -357,22 +362,8 @@ fn status_validate(ctx: &ProjectContext, json: bool) -> Result<()> {
         }
     } else {
         let report = ValidateReport { pass, warn, fail };
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        print_json(&report)?;
     }
 
     Ok(())
-}
-
-/// Read a field from DESCRIPTION (simple DCF parser).
-fn read_description_field(root: &Path, field: &str) -> Option<String> {
-    let desc_path = root.join("DESCRIPTION");
-    let content = std::fs::read_to_string(desc_path).ok()?;
-    let prefix = format!("{field}:");
-
-    for line in content.lines() {
-        if line.starts_with(&prefix) {
-            return Some(line[prefix.len()..].trim().to_string());
-        }
-    }
-    None
 }

--- a/miniextendr-cli/src/commands/vendor.rs
+++ b/miniextendr-cli/src/commands/vendor.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, bail};
 
 use crate::bridge::{bash, run_command, run_command_capture};
 use crate::cli::VendorCmd;
+use crate::output::print_json;
 use crate::project::{MINIEXTENDR_CRATES, ProjectContext, find_workspace_root};
 
 pub fn dispatch(cmd: &VendorCmd, ctx: &ProjectContext, quiet: bool, json: bool) -> Result<()> {
@@ -137,7 +138,7 @@ fn vendor_versions(quiet: bool, json: bool) -> Result<()> {
 
     if json {
         let versions: Vec<&str> = output.lines().collect();
-        println!("{}", serde_json::to_string_pretty(&versions)?);
+        print_json(&versions)?;
     } else if !quiet {
         println!("Available miniextendr versions:");
         for line in output.lines() {
@@ -312,7 +313,7 @@ fn vendor_cache_info(json: bool) -> Result<()> {
             "cache_dir": cache_dir.to_string_lossy(),
             "exists": cache_dir.exists(),
         });
-        println!("{}", serde_json::to_string_pretty(&info)?);
+        print_json(&info)?;
     } else {
         println!("Cache directory: {}", cache_dir.display());
         if cache_dir.exists() {

--- a/miniextendr-cli/src/output.rs
+++ b/miniextendr-cli/src/output.rs
@@ -1,8 +1,13 @@
+use anyhow::Result;
+use serde::Serialize;
+
 /// Print a simple status message.
-pub fn print_status(msg: &str, json: bool) {
-    if json {
-        println!("{}", serde_json::json!({ "status": msg }));
-    } else {
-        println!("{msg}");
-    }
+pub fn print_status(msg: &str) {
+    println!("{msg}");
+}
+
+/// Serialize `value` as pretty JSON and print it to stdout.
+pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
 }

--- a/miniextendr-cli/src/project.rs
+++ b/miniextendr-cli/src/project.rs
@@ -129,4 +129,95 @@ impl ProjectContext {
     pub fn has_miniextendr(&self) -> bool {
         self.cargo_manifest.is_some() && self.description.is_some()
     }
+
+    /// Read a field's value from `DESCRIPTION`, if present.
+    ///
+    /// DCF (Debian Control File, the format `DESCRIPTION` uses) allows a
+    /// field's value to continue onto following lines: a continuation line
+    /// starts with whitespace and is joined onto the value of the field it
+    /// extends, separated by a single space.
+    pub fn description_field(&self, field: &str) -> Option<String> {
+        let content = std::fs::read_to_string(self.root.join("DESCRIPTION")).ok()?;
+        parse_description_field(&content, field)
+    }
+
+    /// The `Package` field from `DESCRIPTION`, if present.
+    pub fn package_name(&self) -> Option<String> {
+        self.description_field("Package")
+    }
+}
+
+/// Parse a single field's value out of DCF-formatted `content` (the format
+/// used by `DESCRIPTION` files), joining continuation lines onto the field
+/// they extend.
+fn parse_description_field(content: &str, field: &str) -> Option<String> {
+    let prefix = format!("{field}:");
+    let mut lines = content.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Some(value) = line.strip_prefix(&prefix) else {
+            continue;
+        };
+        let mut value = value.trim().to_string();
+        while let Some(next_line) = lines.peek() {
+            if !next_line.starts_with(|c: char| c.is_whitespace()) {
+                break;
+            }
+            let cont = lines.next().unwrap().trim();
+            if !cont.is_empty() {
+                if !value.is_empty() {
+                    value.push(' ');
+                }
+                value.push_str(cont);
+            }
+        }
+        return Some(value);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_description_field;
+
+    #[test]
+    fn simple_field() {
+        let content = "Package: mypkg\nVersion: 0.1.0\n";
+        assert_eq!(
+            parse_description_field(content, "Package"),
+            Some("mypkg".to_string())
+        );
+    }
+
+    #[test]
+    fn continuation_line_field() {
+        let content = "Package: mypkg\n\
+             Description: This is a\n    long description that\n    wraps.\n\
+             Version: 0.1.0\n";
+        assert_eq!(
+            parse_description_field(content, "Description"),
+            Some("This is a long description that wraps.".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_field() {
+        let content = "Package: mypkg\nVersion: 0.1.0\n";
+        assert_eq!(parse_description_field(content, "License"), None);
+    }
+
+    #[test]
+    fn field_name_prefix_of_another() {
+        // "Packaged:" must not be mistaken for a match on "Package".
+        let content = "Packaged: 2024-01-01\nPackage: mypkg\n";
+        assert_eq!(
+            parse_description_field(content, "Package"),
+            Some("mypkg".to_string())
+        );
+        // And querying the longer name should not pick up the shorter one.
+        let content = "Package: mypkg\nPackaged: 2024-01-01\n";
+        assert_eq!(
+            parse_description_field(content, "Packaged"),
+            Some("2024-01-01".to_string())
+        );
+    }
 }


### PR DESCRIPTION
miniextendr-cli had four private copies of "read a field out of DESCRIPTION", none of which handled DCF continuation lines — so any wrapped field (a long `Suggests`, a multi-line `Description`) silently read as truncated. This puts one DCF-aware reader on `ProjectContext`, deletes the copies, and removes `print_status`'s dead JSON branch (D9 + D10 from the 2026-07-03 audit).

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- **D9** — `commands/{render,init,status,feature}.rs` each grew their own "find a field in `DESCRIPTION`" parser (3 near-identical reimplementations + one inline scan in `feature.rs::add_desc_field`). None handled DCF continuation lines (a line starting with whitespace continues the previous field's value) — a latent correctness bug for any field that wraps (e.g. long `Description:` values). Added `ProjectContext::description_field(&self, field: &str) -> Option<String>` (DCF continuation-aware, reads `DESCRIPTION` fresh from `self.root` each call) and a thin `ProjectContext::package_name(&self) -> Option<String>` wrapper, and routed all four call sites through it:
  - `render.rs::pkg_name` now delegates to `ctx.package_name()`.
  - `init.rs::init_use` now takes `&ProjectContext` (was `&Path`) and uses `ctx.package_name()`; the private `read_pkg_name` free fn is deleted.
  - `status.rs::status_show`/`status_validate` now call `ctx.description_field(...)` directly; the private `read_description_field` free fn is deleted.
  - `feature.rs::add_desc_field` now uses `ctx.description_field(field)` to check whether the field exists and whether the package is already listed (this also fixes the same continuation-line gap for `Suggests`/`Depends` checks, which previously only searched a single physical line via `line.contains(pkg)`).
- **D10** — `output::print_status`'s `json` branch was dead (both callers in `config.rs` always passed `json=false`), while every command that actually emits JSON hand-rolled `serde_json::to_string_pretty(...)`. Dropped the `json` parameter and the dead branch (no-backwards-compatibility principle), and added `output::print_json<T: Serialize>(&T) -> Result<()>` as the one shared JSON-emission helper — used at all 9 `to_string_pretty` call sites across `config.rs`, `feature.rs`, `vendor.rs`, `status.rs`.
- Added 4 unit tests on the new DCF parser: simple field, continuation-line field (join with a space), missing field, and a `Package` vs `Packaged` prefix-collision regression (guards against a future `contains`/loose-prefix regression, even though the existing `strip_prefix(field + ":")` approach was already correct).

Reader shape chosen: a plain `Option<String>` accessor keyed by field name (`description_field`), matching what `status.rs`'s pre-existing `read_description_field` already did (the audit called this "essentially the canonical version already") — no parsed-DCF struct, since none of the four call sites need more than single-field lookups.

## Test plan
- [x] `cargo test -p miniextendr-cli` — 4/4 pass (the new DCF parser tests; this crate had no prior tests).
- [x] `cargo fmt --all` — no diff.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default) — clean.
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen,<integration list> -- -D warnings` (clippy_all) — clean.
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen-s7,<integration list> -- -D warnings` (clippy_all_s7) — clean.
- [x] `cargo check --workspace --all-targets --locked` — clean.

## Notes
- Rust-only change, scoped to `miniextendr-cli`; no `rpkg` / R-side work needed.
- No deferred scope: `audit/_worklist-2026-07-03.md` already dispositions the adjacent `miniextendr-cli` finding (C3, `bridge::find_rscript` over-`pub`) as "leave as-is," so nothing from this audit pass needed a new tracking issue.
- References: `audit/2026-07-03-dogfooding-smaller-crates.md` findings C1/C2, `audit/_worklist-2026-07-03.md` D9/D10, plan `plans/2026-07-04-audit-cli-description-json.md`.

---
_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>

