### PR TITLE
refactor(api): try_from_sexp_via_str_parse! — dedupe string-parse TryFromSexp across uuid/url/regex/num_bigint

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -1784,4 +1784,127 @@ macro_rules! impl_vec_option_try_from_sexp_list {
         }
     };
 }
+
+/// Implement the four string-parse `TryFromSexp` impls (`T`, `Option<T>`,
+/// `Vec<T>`, `Vec<Option<T>>`) for a type parsed from an R character vector.
+///
+/// Sibling of [`into_r_infallible!`](crate::into_r) for the reverse direction:
+/// every "parse a scalar type out of an R string" integration (uuid, url,
+/// regex, num-bigint) used to hand-write these four impls — some reinventing
+/// the STRSXP validation `String`'s own `TryFromSexp` already performs.
+/// This macro delegates to `Option<String>` / `Vec<Option<String>>`, so type,
+/// length, and NA checks live in exactly one place.
+///
+/// Semantics:
+/// - `T`: `NA_character_` / `NULL` → `SexpError::Na`; parse failure →
+///   `InvalidValue("invalid <label>: <err>")`.
+/// - `Option<T>`: `NA_character_` / `NULL` → `None`.
+/// - `Vec<T>`: any NA element →
+///   `InvalidValue("NA at index <i> not allowed for Vec<T>")`; parse failure →
+///   `InvalidValue("invalid <label> at index <i>: <err>")`.
+/// - `Vec<Option<T>>`: NA elements → `None`; parse failures error with index.
+///
+/// The parse body is a closure-style `|s| expr` where `s: &str`, returning
+/// `Result<T, E>` with `E: Display`.
+///
+/// ```ignore
+/// try_from_sexp_via_str_parse!(Uuid, "UUID", |s| Uuid::parse_str(s));
+/// ```
+#[macro_export]
+macro_rules! try_from_sexp_via_str_parse {
+    ($ty:ty, $label:literal, |$s:ident| $parse:expr) => {
+        impl $crate::from_r::TryFromSexp for $ty {
+            type Error = $crate::from_r::SexpError;
+
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                let opt: Option<String> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
+                let s = opt.ok_or($crate::from_r::SexpError::Na($crate::from_r::SexpNaError {
+                    sexp_type: $crate::SEXPTYPE::STRSXP,
+                }))?;
+                let $s: &str = &s;
+                ($parse).map_err(|e| {
+                    $crate::from_r::SexpError::InvalidValue(format!(
+                        concat!("invalid ", $label, ": {}"),
+                        e
+                    ))
+                })
+            }
+        }
+
+        impl $crate::from_r::TryFromSexp for Option<$ty> {
+            type Error = $crate::from_r::SexpError;
+
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                let opt: Option<String> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
+                match opt {
+                    None => Ok(None),
+                    Some(s) => {
+                        let $s: &str = &s;
+                        ($parse).map(Some).map_err(|e| {
+                            $crate::from_r::SexpError::InvalidValue(format!(
+                                concat!("invalid ", $label, ": {}"),
+                                e
+                            ))
+                        })
+                    }
+                }
+            }
+        }
+
+        impl $crate::from_r::TryFromSexp for Vec<$ty> {
+            type Error = $crate::from_r::SexpError;
+
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                let values: Vec<Option<String>> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
+                values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, opt)| {
+                        let s = opt.ok_or_else(|| {
+                            $crate::from_r::SexpError::InvalidValue(format!(
+                                concat!(
+                                    "NA at index {} not allowed for Vec<",
+                                    stringify!($ty),
+                                    ">"
+                                ),
+                                i
+                            ))
+                        })?;
+                        let $s: &str = &s;
+                        ($parse).map_err(|e| {
+                            $crate::from_r::SexpError::InvalidValue(format!(
+                                concat!("invalid ", $label, " at index {}: {}"),
+                                i, e
+                            ))
+                        })
+                    })
+                    .collect()
+            }
+        }
+
+        impl $crate::from_r::TryFromSexp for Vec<Option<$ty>> {
+            type Error = $crate::from_r::SexpError;
+
+            fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
+                let values: Vec<Option<String>> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
+                values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, opt)| match opt {
+                        None => Ok(None),
+                        Some(s) => {
+                            let $s: &str = &s;
+                            ($parse).map(Some).map_err(|e| {
+                                $crate::from_r::SexpError::InvalidValue(format!(
+                                    concat!("invalid ", $label, " at index {}: {}"),
+                                    i, e
+                                ))
+                            })
+                        }
+                    })
+                    .collect()
+            }
+        }
+    };
+}
 // endregion

--- a/miniextendr-api/src/optionals/num_bigint_impl.rs
+++ b/miniextendr-api/src/optionals/num_bigint_impl.rs
@@ -14,9 +14,8 @@
 pub use num_bigint::{BigInt, BigUint};
 
 use crate::coerce::{Coerce, CoerceError, TryCoerce};
-use crate::from_r::{SexpError, SexpNaError, TryFromSexp};
 use crate::into_r::into_r_infallible;
-use crate::{SEXP, SEXPTYPE};
+use crate::try_from_sexp_via_str_parse;
 use std::str::FromStr;
 
 // region: Coerce/TryCoerce impls for BigInt and BigUint
@@ -191,125 +190,8 @@ impl TryCoerce<f64> for BigInt {
     }
 }
 
-fn parse_bigint(s: &str) -> Result<BigInt, SexpError> {
-    BigInt::from_str(s).map_err(|e| SexpError::InvalidValue(e.to_string()))
-}
-
-fn parse_biguint(s: &str) -> Result<BigUint, SexpError> {
-    BigUint::from_str(s).map_err(|e| SexpError::InvalidValue(e.to_string()))
-}
-
-impl TryFromSexp for BigInt {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let s: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        let s = s.ok_or(SexpError::Na(SexpNaError {
-            sexp_type: SEXPTYPE::STRSXP,
-        }))?;
-        parse_bigint(&s)
-    }
-}
-
-impl TryFromSexp for BigUint {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let s: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        let s = s.ok_or(SexpError::Na(SexpNaError {
-            sexp_type: SEXPTYPE::STRSXP,
-        }))?;
-        parse_biguint(&s)
-    }
-}
-
-impl TryFromSexp for Option<BigInt> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let s: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        match s {
-            Some(s) => parse_bigint(&s).map(Some),
-            None => Ok(None),
-        }
-    }
-}
-
-impl TryFromSexp for Option<BigUint> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let s: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        match s {
-            Some(s) => parse_biguint(&s).map(Some),
-            None => Ok(None),
-        }
-    }
-}
-
-impl TryFromSexp for Vec<BigInt> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let values: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        values
-            .into_iter()
-            .map(|opt| {
-                let s = opt.ok_or(SexpError::Na(SexpNaError {
-                    sexp_type: SEXPTYPE::STRSXP,
-                }))?;
-                parse_bigint(&s)
-            })
-            .collect()
-    }
-}
-
-impl TryFromSexp for Vec<BigUint> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let values: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        values
-            .into_iter()
-            .map(|opt| {
-                let s = opt.ok_or(SexpError::Na(SexpNaError {
-                    sexp_type: SEXPTYPE::STRSXP,
-                }))?;
-                parse_biguint(&s)
-            })
-            .collect()
-    }
-}
-
-impl TryFromSexp for Vec<Option<BigInt>> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let values: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        values
-            .into_iter()
-            .map(|opt| match opt {
-                Some(s) => parse_bigint(&s).map(Some),
-                None => Ok(None),
-            })
-            .collect()
-    }
-}
-
-impl TryFromSexp for Vec<Option<BigUint>> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let values: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        values
-            .into_iter()
-            .map(|opt| match opt {
-                Some(s) => parse_biguint(&s).map(Some),
-                None => Ok(None),
-            })
-            .collect()
-    }
-}
+try_from_sexp_via_str_parse!(BigInt, "BigInt", |s| BigInt::from_str(s));
+try_from_sexp_via_str_parse!(BigUint, "BigUint", |s| BigUint::from_str(s));
 
 into_r_infallible!(BigInt, |this| this.to_string().into_sexp());
 into_r_infallible!(BigUint, |this| this.to_string().into_sexp());

--- a/miniextendr-api/src/optionals/regex_impl.rs
+++ b/miniextendr-api/src/optionals/regex_impl.rs
@@ -60,79 +60,15 @@
 
 pub use regex::Regex;
 
-use crate::SEXP;
-use crate::from_r::{SexpError, TryFromSexp};
+use crate::try_from_sexp_via_str_parse;
 
-// region: Scalar conversions
+// region: TryFromSexp conversions
 
-impl TryFromSexp for Regex {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let pattern: String = TryFromSexp::try_from_sexp(sexp)?;
-        Regex::new(&pattern)
-            .map_err(|e| SexpError::InvalidValue(format!("invalid regex pattern: {}", e)))
-    }
-}
+try_from_sexp_via_str_parse!(Regex, "regex pattern", |s| Regex::new(s));
 
 // Note: IntoR is intentionally not implemented for Regex.
 // A compiled regex cannot be meaningfully converted back to R.
 // If you need the pattern, keep the original String.
-// endregion
-
-// region: Option conversions (NA support)
-
-impl TryFromSexp for Option<Regex> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let opt: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        match opt {
-            None => Ok(None),
-            Some(pattern) => Regex::new(&pattern)
-                .map(Some)
-                .map_err(|e| SexpError::InvalidValue(format!("invalid regex pattern: {}", e))),
-        }
-    }
-}
-// endregion
-
-// region: Vec conversions
-
-impl TryFromSexp for Vec<Regex> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let patterns: Vec<String> = TryFromSexp::try_from_sexp(sexp)?;
-        patterns
-            .into_iter()
-            .enumerate()
-            .map(|(i, pattern)| {
-                Regex::new(&pattern).map_err(|e| {
-                    SexpError::InvalidValue(format!("invalid regex pattern at index {}: {}", i, e))
-                })
-            })
-            .collect()
-    }
-}
-
-impl TryFromSexp for Vec<Option<Regex>> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let patterns: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        patterns
-            .into_iter()
-            .enumerate()
-            .map(|(i, opt)| match opt {
-                None => Ok(None),
-                Some(pattern) => Regex::new(&pattern).map(Some).map_err(|e| {
-                    SexpError::InvalidValue(format!("invalid regex pattern at index {}: {}", i, e))
-                }),
-            })
-            .collect()
-    }
-}
 // endregion
 
 // region: Helper functions

--- a/miniextendr-api/src/optionals/url_impl.rs
+++ b/miniextendr-api/src/optionals/url_impl.rs
@@ -40,186 +40,24 @@
 
 pub use url::Url;
 
-use crate::from_r::{
-    SexpError, SexpLengthError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str,
-};
 use crate::into_r::into_r_infallible;
-use crate::{SEXP, SEXPTYPE, SexpExt};
+use crate::try_from_sexp_via_str_parse;
 
-// region: Scalar conversions
+// region: TryFromSexp / IntoR conversions
 
-impl TryFromSexp for Url {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpError::Length(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }));
-        }
-
-        let charsxp = sexp.string_elt(0);
-        if charsxp == SEXP::na_string() {
-            return Err(SexpError::Na(SexpNaError {
-                sexp_type: SEXPTYPE::STRSXP,
-            }));
-        }
-
-        let s = unsafe { charsxp_to_str(charsxp) };
-        Url::parse(s).map_err(|e| SexpError::InvalidValue(format!("invalid URL: {}", e)))
-    }
-}
+try_from_sexp_via_str_parse!(Url, "URL", |s| Url::parse(s));
 
 into_r_infallible!(Url, |this| this.as_str().into_sexp());
-// endregion
-
-// region: Option conversions (NA support)
-
-impl TryFromSexp for Option<Url> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        // NULL -> None
-        if actual == SEXPTYPE::NILSXP {
-            return Ok(None);
-        }
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpError::Length(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }));
-        }
-
-        let charsxp = sexp.string_elt(0);
-        if charsxp == SEXP::na_string() {
-            return Ok(None);
-        }
-
-        let s = unsafe { charsxp_to_str(charsxp) };
-        match Url::parse(s) {
-            Ok(url) => Ok(Some(url)),
-            Err(e) => Err(SexpError::InvalidValue(format!("invalid URL: {}", e))),
-        }
-    }
-}
-
 // Leverage Option<String>'s IntoR which handles NA correctly.
 into_r_infallible!(Option<Url>, |this| this
     .map(|u| u.as_str().to_string())
     .into_sexp());
-// endregion
-
-// region: Vector conversions
-
-impl TryFromSexp for Vec<Url> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
-            if charsxp == SEXP::na_string() {
-                return Err(SexpError::InvalidValue(format!(
-                    "NA at index {} not allowed for Vec<Url>",
-                    i
-                )));
-            }
-            let s = unsafe { charsxp_to_str(charsxp) };
-            match Url::parse(s) {
-                Ok(url) => result.push(url),
-                Err(e) => {
-                    return Err(SexpError::InvalidValue(format!(
-                        "invalid URL at index {}: {}",
-                        i, e
-                    )));
-                }
-            }
-        }
-
-        Ok(result)
-    }
-}
-
 // Convert to Vec<String> and use its IntoR.
 into_r_infallible!(Vec<Url>, |this| this
     .into_iter()
     .map(|u| u.as_str().to_string())
     .collect::<Vec<String>>()
     .into_sexp());
-// endregion
-
-// region: Vec<Option<Url>> conversions (NA-aware vectors)
-
-impl TryFromSexp for Vec<Option<Url>> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
-            if charsxp == SEXP::na_string() {
-                result.push(None);
-            } else {
-                let s = unsafe { charsxp_to_str(charsxp) };
-                match Url::parse(s) {
-                    Ok(url) => result.push(Some(url)),
-                    Err(e) => {
-                        return Err(SexpError::InvalidValue(format!(
-                            "invalid URL at index {}: {}",
-                            i, e
-                        )));
-                    }
-                }
-            }
-        }
-
-        Ok(result)
-    }
-}
-
 // Convert to Vec<Option<String>> and use its IntoR.
 into_r_infallible!(Vec<Option<Url>>, |this| this
     .into_iter()

--- a/miniextendr-api/src/optionals/uuid_impl.rs
+++ b/miniextendr-api/src/optionals/uuid_impl.rs
@@ -35,113 +35,20 @@
 
 pub use uuid::Uuid;
 
-use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::into_r_infallible;
-use crate::{SEXP, SEXPTYPE, SexpExt};
+use crate::try_from_sexp_via_str_parse;
 
-// region: Scalar conversions
+// region: TryFromSexp / IntoR conversions
 
-impl TryFromSexp for Uuid {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let s: String = TryFromSexp::try_from_sexp(sexp)?;
-        Uuid::parse_str(&s).map_err(|e| SexpError::InvalidValue(format!("invalid UUID: {}", e)))
-    }
-}
+try_from_sexp_via_str_parse!(Uuid, "UUID", |s| Uuid::parse_str(s));
 
 into_r_infallible!(Uuid, |this| this.to_string().into_sexp());
-// endregion
-
-// region: Option conversions (NA support)
-
-impl TryFromSexp for Option<Uuid> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let opt: Option<String> = TryFromSexp::try_from_sexp(sexp)?;
-        match opt {
-            None => Ok(None),
-            Some(s) => Uuid::parse_str(&s)
-                .map(Some)
-                .map_err(|e| SexpError::InvalidValue(format!("invalid UUID: {}", e))),
-        }
-    }
-}
-
 into_r_infallible!(Option<Uuid>, |this| this.map(|u| u.to_string()).into_sexp());
-// endregion
-
-// region: Vector conversions
-
-impl TryFromSexp for Vec<Uuid> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        use crate::from_r::charsxp_to_str;
-
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
-
-            // Check for NA
-            if charsxp == SEXP::na_string() {
-                return Err(SexpError::InvalidValue(format!(
-                    "NA at index {} not allowed for Vec<Uuid>",
-                    i
-                )));
-            }
-
-            let s = unsafe { charsxp_to_str(charsxp) };
-
-            let uuid = Uuid::parse_str(s).map_err(|e| {
-                SexpError::InvalidValue(format!("invalid UUID at index {}: {}", i, e))
-            })?;
-            result.push(uuid);
-        }
-
-        Ok(result)
-    }
-}
-
 into_r_infallible!(Vec<Uuid>, |this| this
     .into_iter()
     .map(|u| u.to_string())
     .collect::<Vec<_>>()
     .into_sexp());
-// endregion
-
-// region: Vec<Option<Uuid>> conversions (NA-aware vectors)
-
-impl TryFromSexp for Vec<Option<Uuid>> {
-    type Error = SexpError;
-
-    fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let strings: Vec<Option<String>> = TryFromSexp::try_from_sexp(sexp)?;
-        strings
-            .into_iter()
-            .enumerate()
-            .map(|(i, opt)| match opt {
-                None => Ok(None),
-                Some(s) => Uuid::parse_str(&s).map(Some).map_err(|e| {
-                    SexpError::InvalidValue(format!("invalid UUID at index {}: {}", i, e))
-                }),
-            })
-            .collect()
-    }
-}
-
 into_r_infallible!(Vec<Option<Uuid>>, |this| this
     .into_iter()
     .map(|opt| opt.map(|u| u.to_string()))

--- a/miniextendr-api/tests/str_parse.rs
+++ b/miniextendr-api/tests/str_parse.rs
@@ -1,0 +1,111 @@
+//! Tests for the `try_from_sexp_via_str_parse!` string-parse conversions
+//! (uuid / url / regex / num-bigint), including the NA-policy standardization:
+//! scalar NA errors (`SexpError::Na`), `Option` NA maps to `None`, `Vec<T>`
+//! rejects NA with an indexed error, `Vec<Option<T>>` maps NA to `None`.
+
+mod r_test_utils;
+
+#[cfg(any(feature = "uuid", feature = "regex"))]
+use miniextendr_api::from_r::{SexpError, TryFromSexp};
+#[cfg(any(feature = "uuid", feature = "regex"))]
+use miniextendr_api::into_r::IntoR;
+
+#[cfg(feature = "uuid")]
+use miniextendr_api::Uuid;
+
+#[cfg(feature = "uuid")]
+const VALID_UUID: &str = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_scalar_valid_and_invalid() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = VALID_UUID.to_string().into_sexp();
+        let u: Uuid = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(u.to_string(), VALID_UUID);
+
+        let bad = "not-a-uuid".to_string().into_sexp();
+        let err = <Uuid as TryFromSexp>::try_from_sexp(bad).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid UUID"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_scalar_na_is_na_error_not_parse_error() {
+    r_test_utils::with_r_thread(|| {
+        let na = Option::<String>::None.into_sexp();
+        let err = <Uuid as TryFromSexp>::try_from_sexp(na).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "got: {err:?}");
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_option_na_is_none() {
+    r_test_utils::with_r_thread(|| {
+        let na = Option::<String>::None.into_sexp();
+        let opt: Option<Uuid> = TryFromSexp::try_from_sexp(na).unwrap();
+        assert!(opt.is_none());
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_rejects_na_with_index() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![Some(VALID_UUID.to_string()), None].into_sexp();
+        let err = <Vec<Uuid> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NA at index 1 not allowed for Vec<Uuid>"),
+            "got: {msg}"
+        );
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_parse_error_carries_index() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![VALID_UUID.to_string(), "nope".to_string()].into_sexp();
+        let err = <Vec<Uuid> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid UUID at index 1"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_option_na_is_none() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![Some(VALID_UUID.to_string()), None].into_sexp();
+        let v: Vec<Option<Uuid>> = TryFromSexp::try_from_sexp(sexp).unwrap();
+        assert_eq!(v.len(), 2);
+        assert!(v[0].is_some());
+        assert!(v[1].is_none());
+    });
+}
+
+// NA regression: `NA_character_` used to flow through `String`'s NA -> ""
+// mapping and silently compile as an empty regex (which matches everything).
+// It must now be rejected as a missing value.
+#[cfg(feature = "regex")]
+#[test]
+fn regex_na_rejected_not_silently_empty_pattern() {
+    use miniextendr_api::Regex;
+    r_test_utils::with_r_thread(|| {
+        let na = Option::<String>::None.into_sexp();
+        let err = <Regex as TryFromSexp>::try_from_sexp(na).unwrap_err();
+        assert!(matches!(err, SexpError::Na(_)), "got: {err:?}");
+
+        let sexp = vec![Some("^a+$".to_string()), None].into_sexp();
+        let err = <Vec<Regex> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("NA at index 1 not allowed for Vec<Regex>"),
+            "got: {err}"
+        );
+    });
+}


### PR DESCRIPTION
Audit D4 (`audit/_worklist-2026-07-03.md`, evidence `audit/2026-07-03-dogfooding-optionals-integrations.md` finding #1): the "parse a scalar type out of an R string vector" `TryFromSexp` set was copy-pasted ~20× across uuid/url/regex/num_bigint — with url and uuid hand-rolling the STRSXP validation `String`'s own impl already performs — while the mirror-image `IntoR` direction has had `into_r_infallible!` all along. This adds the missing counterpart macro and migrates all four modules onto it.

## What changed

- **New `try_from_sexp_via_str_parse!(Type, "label", |s| parse(s))`** in `miniextendr-api/src/from_r.rs` (helper-macros region), expanding to the four delegating impls (`T` / `Option<T>` / `Vec<T>` / `Vec<Option<T>>`) over `Option<String>` / `Vec<Option<String>>` — type, length, and NA checks live in exactly one place.
- **Migrated:** uuid (4 impls → 1 invocation), url (4 → 1, deleting ~140 lines of hand-rolled `unsafe` STRSXP loops), regex (4 → 1), num_bigint (8 → 2, deleting the now-unused `parse_bigint`/`parse_biguint` helpers). Net **−314 LoC** in the four modules; `IntoR` sides untouched.

## NA-policy standardization (deliberate behavior changes)

Previously each module had its own NA story; now uniform:

| Shape | Policy |
|---|---|
| `T` | NA / NULL → `SexpError::Na` |
| `Option<T>` | NA / NULL → `None` (unchanged everywhere) |
| `Vec<T>` | NA → `InvalidValue("NA at index {i} not allowed for Vec<T>")` |
| `Vec<Option<T>>` | NA → `None`; parse failures error with index (unchanged) |

Concretely:
- **regex NA bug fixed:** `NA_character_` used to flow through `String`'s NA→`""` mapping and *silently compile as an empty pattern that matches everything* (scalar and `Vec<Regex>`). Now rejected as a missing value. Regression test included.
- uuid scalar NA: was a confusing `"invalid UUID: invalid length…"` parse error → now `SexpError::Na`.
- url scalar NULL: was `SexpTypeError` → now `SexpError::Na` (consistent "missing value" story).
- num_bigint `Vec<T>` NA: was un-indexed `SexpNaError` → now the indexed `InvalidValue` message (matches what uuid/url already said, preserved verbatim via `stringify!`).
- BigInt/BigUint parse errors gain the type label ("invalid BigInt: …") and, in vectors, the index. The only testthat message-grep on these paths (`test-feature-adapters.R:61`, `"invalid UUID"`) is unaffected; `test-conditions.R`'s `"invalid digit"` grep targets a different fixture and remains a substring regardless.

## Scope notes

- ordered_float / rust_decimal / num_complex / jiff / bytes are **not** migrated — their conversions are numeric/other shapes, not string-parse (per the audit finding).
- Vector conversions keep the pre-existing bail-on-first-failure shape; batched diagnostics (CLAUDE.md "collect all errors in vectorized ops") tracked in #1143 — now a one-site change instead of eight.

## Test plan

- [x] New integration test `miniextendr-api/tests/str_parse.rs` (7 tests): valid/invalid parse with label+index assertions, scalar NA → `Na` error, `Option` NA → `None`, `Vec<T>` NA rejection with index, `Vec<Option<T>>` NA → `None`, and the regex empty-pattern NA regression. Integration test (separate process) rather than `--lib` unit test to avoid the `R_MAIN_THREAD_ID` test-isolation hazard (#1139).
- [x] Existing `tests/{uuid,regex,num_bigint}.rs` — 29 tests pass unmodified.
- [x] `just check`, `just clippy` clean; `just test` passes everywhere except the known pre-existing `derive_dataframe_*` trybuild drift (local rustc 1.95 vs CI stable; untouched by this diff).
- [x] `cargo fmt --all --check` clean; all three CI clippy variants (`default` / `full-codegen`+integrations / `full-codegen-s7`+integrations) clean with `-D warnings`.
- [ ] rpkg testthat suite: cargo-only session (shared install slot held elsewhere) — coordinator runs the R-side suite at review checkpoint; uuid/url/regex/num-bigint are all in the auto-detected default feature set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
