### PR TITLE
fix(gc): root the synthetic data.frame container in gc_stress_typed_dataframe

### DIFF
--- a/reviews/2026-07-05-gc-typed-dataframe-unrooted-container.md
+++ b/reviews/2026-07-05-gc-typed-dataframe-unrooted-container.md
@@ -1,0 +1,64 @@
+# 2026-07-05 — gc_stress_typed_dataframe: unrooted container UAF flaking unrelated PRs
+
+## What was attempted
+
+Post-sweep CI verification of the rebased open PRs (all had been force-pushed
+onto current main during the 2026-07-04/05 review sweep).
+
+## What went wrong
+
+Three unrelated branches went red on the same rerun wave:
+
+- #1043 and #1044: `gc_stress_typed_dataframe` failed the gctorture sweep with
+  `DataFrame always carries a names attribute` (iterations 3 and 5
+  respectively). Neither PR touches typed dataframes.
+- #1134 (minirextendr-only diff): rpkg testthat segfaulted on the R-devel
+  check job with `*** recursive gc invocation` spam — plausibly the same bug
+  surfacing as a crash instead of a clean panic.
+
+Main's own CI was green throughout.
+
+## Root cause
+
+`List::from_raw_pairs` PROTECTs its list and names vectors only *during*
+construction — the `OwnedProtect` guards drop on return, so the returned
+`List` wraps an unprotected VECSXP. `gc_stress_typed_dataframe` (added with
+the #1129 sweep) then called `as_data_frame()` on it, which allocates the
+class STRSXP and row.names INTSXP, and drove `TheophDf::try_from_sexp` over
+the result. Under gctorture the container node is reaped at the first of
+those allocations.
+
+The read-after-free is **silent until R reuses the node**. That is why:
+- main's CI passed (schedule happened not to reuse the node in the window),
+- unrelated PRs failed stochastically (their extra fixtures/tests shifted the
+  allocation schedule),
+- the failure iteration differed per branch (3 vs 5),
+- one branch got a segfault instead of the panic (whatever reused the node
+  determined the failure mode).
+
+This is the #1128 hazard class verbatim: `DataFrame`/`List` are unrooted Copy
+SEXP wrappers; "freed-but-intact reads pass tests silently."
+
+## Fix
+
+PR #1145: root the container into the fixture's existing `ProtectScope`
+immediately after `from_raw_pairs`, before `as_data_frame()` allocates —
+both halves of the fixture. Verified 100/100 gctorture iterations post-fix.
+
+Production callers are unaffected (their input SEXP arrives from R rooted in
+the call frame); only the fixture synthesises an unrooted container.
+
+## Lessons
+
+- A gc_stress fixture that *itself* violates PROTECT discipline produces
+  flaky red CI on innocent branches — the failure lands wherever the
+  allocation schedule shifts, not where the bug lives. When an unrelated PR
+  trips a gc_stress fixture, first suspect the fixture's own rooting.
+- `from_raw_pairs` (and friends) protecting "during construction only" is an
+  API trap: every synthetic-container caller must remember to root the result
+  before the next allocation. The #1128 redesign discussion is the durable
+  fix; until then, grep new fixtures for `from_raw_pairs` → allocation
+  sequences.
+- The same UAF can present as a clean panic, a wrong-value assert, or a
+  segfault ("recursive gc invocation") — do not treat those as three bugs
+  before checking for one unrooted SEXP.

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -1456,6 +1456,12 @@ pub fn gc_stress_typed_dataframe() {
         ("time", time_sexp),
         ("conc", conc_sexp),
     ]);
+    // Root the container: from_raw_pairs' internal guards drop on return, so
+    // the fresh VECSXP is unprotected while as_data_frame() allocates its
+    // class / row.names attributes and TryFromSexp validates. Without this,
+    // gctorture reaps the container and the names attribute reads back nil
+    // once the cell is reused ("DataFrame always carries a names attribute").
+    unsafe { scope.protect_raw(list.as_sexp()) };
     let df = list
         .as_data_frame()
         .expect("synthetic data.frame promotion should succeed");
@@ -1511,6 +1517,8 @@ pub fn gc_stress_typed_dataframe() {
         ("conc", conc2_sexp),
         ("flag", flag2_sexp),
     ]);
+    // Same rooting as above: the container outlives from_raw_pairs' guards.
+    unsafe { scope2.protect_raw(list2.as_sexp()) };
     let df2 = list2
         .as_data_frame()
         .expect("synthetic data.frame promotion should succeed");


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h4>AI-written details</h4></summary>

## The bug

`gc_stress_typed_dataframe` failed on the CI reruns of two unrelated PRs (#1043 at iteration 3, #1044 at iteration 5) with `DataFrame always carries a names attribute`, while passing on main's own CI.

`List::from_raw_pairs` protects its list and names vectors only *during* construction; the `OwnedProtect` guards drop on return. The fixture then called `as_data_frame()` on the unprotected container, which allocates the `data.frame` class STRSXP and `row.names` INTSXP, and then drove `TheophDf::try_from_sexp` over it. Under `gctorture(TRUE)` the container node is reaped at the first of those allocations. The read-after-free is silent until R reuses the node, at which point the `names` attribute reads back nil and `DataFrame::named_list()`'s expect fires.

The node-reuse dependence is why it was invisible on main and stochastic on branches: extra fixtures/tests shift the allocation schedule. Both halves of the fixture (with and without the optional `flag` column) had the pattern; both are now rooted into the existing `ProtectScope` before `as_data_frame()` runs.

Production callers are unaffected: real `#[miniextendr]` entry points receive their SEXP from R, already rooted in the call frame. Only the fixture synthesises the container itself. The neighbouring fixtures were audited for the same shape: `gc_stress_as_named_list_deferred` does an allocation-free readback (safe by design), and `gc_stress_factor_labels` consumes its container immediately by intent.

## Verification

- 100/100 iterations of `gc_stress_typed_dataframe()` under `gctorture(TRUE)` post-fix (the pre-fix failures hit by CI at iterations 3 and 5).
- `cargo fmt --check` clean.

## Impact

This unblocks the CI reruns on #1043 and #1044 (their only R-side failure is this fixture) and removes a stochastic red-CI source for every future PR.

_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
