### PR TITLE
refactor(api): generic impl_alt*_from_data! — collapse ~19 hand-rolled ALTREP adaptor stacks

### DIFF
--- a/miniextendr-api/src/altrep_data/iter.rs
+++ b/miniextendr-api/src/altrep_data/iter.rs
@@ -5,8 +5,9 @@
 //!
 //! ## Submodules
 //!
-//! - [`state`]: Core `IterState<I, T>` + standard wrapper types (Int, Real, Logical, Raw, String, List, Complex)
+//! - [`state`]: Core `IterState<I, T>` + standard wrapper types (Int, Real, Logical, Raw)
 //! - [`coerce`]: Coerced variants (`IterIntCoerceData`, `IterRealCoerceData`, `IterIntFromBoolData`)
+//!   plus the String/List/Complex wrapper types (`IterStringData`, `IterListData`, `IterComplexData`)
 //! - [`sparse`]: Sparse iterators using `nth()` for skip-ahead (`SparseIterState`)
 //! - [`windowed`]: Sliding-window iterators (`WindowedIterState`)
 

--- a/miniextendr-api/src/altrep_data/iter/coerce.rs
+++ b/miniextendr-api/src/altrep_data/iter/coerce.rs
@@ -6,8 +6,7 @@
 use super::IterState;
 use crate::SEXP;
 use crate::altrep_data::{
-    AltComplexData, AltIntegerData, AltListData, AltRealData, AltStringData, AltrepLen, InferBase,
-    fill_region,
+    AltComplexData, AltIntegerData, AltListData, AltRealData, AltStringData, AltrepLen, fill_region,
 };
 
 /// Iterator-backed integer vector with coercion from any integer-like type.
@@ -101,71 +100,12 @@ where
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntCoerceData\0";
 }
 
-impl<I, T> InferBase for IterIntCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<i32> + Copy + 'static,
-{
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<I, T> crate::altrep_traits::Altrep for IterIntCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<i32> + Copy + 'static,
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I, T> crate::altrep_traits::AltVec for IterIntCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<i32> + Copy + 'static,
-{
-}
-
-impl<I, T> crate::altrep_traits::AltInteger for IterIntCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<i32> + Copy + 'static,
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+// Bridge stack (InferBase + Altrep + AltVec + AltInteger) via the generic
+// `impl_alt*_from_data!` family — see audit D1 / miniextendr-api/CLAUDE.md.
+crate::impl_altinteger_from_data_generic!(
+    {I, T} IterIntCoerceData<I, T>
+    {I: Iterator<Item = T> + 'static, T: crate::coerce::Coerce<i32> + Copy + 'static}
+);
 
 /// Iterator-backed real vector with coercion from any float-like type.
 ///
@@ -257,71 +197,10 @@ where
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRealCoerceData\0";
 }
 
-impl<I, T> InferBase for IterRealCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<f64> + Copy + 'static,
-{
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
-    }
-}
-
-impl<I, T> crate::altrep_traits::Altrep for IterRealCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<f64> + Copy + 'static,
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I, T> crate::altrep_traits::AltVec for IterRealCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<f64> + Copy + 'static,
-{
-}
-
-impl<I, T> crate::altrep_traits::AltReal for IterRealCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<f64> + Copy + 'static,
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altreal_from_data_generic!(
+    {I, T} IterRealCoerceData<I, T>
+    {I: Iterator<Item = T> + 'static, T: crate::coerce::Coerce<f64> + Copy + 'static}
+);
 
 /// Iterator-backed integer vector with coercion from bool.
 ///
@@ -396,56 +275,9 @@ impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntFromBoolData\0";
 }
 
-impl<I: Iterator<Item = bool> + 'static> InferBase for IterIntFromBoolData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for IterIntFromBoolData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltVec for IterIntFromBoolData<I> {}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltInteger
-    for IterIntFromBoolData<I>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altinteger_from_data_generic!(
+    {I} IterIntFromBoolData<I> {I: Iterator<Item = bool> + 'static}
+);
 
 /// Iterator-backed string vector.
 ///
@@ -534,45 +366,12 @@ impl<I: Iterator<Item = String> + 'static> crate::externalptr::TypedExternal for
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterStringData\0";
 }
 
-impl<I: Iterator<Item = String> + 'static> InferBase for IterStringData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::String;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altstring_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_str::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::Altrep for IterStringData<I> {
-    // String ALTREP elt calls Rf_mkCharLenCE (R API) — must use RUnwind to catch longjmps.
-    const GUARD: crate::altrep_traits::AltrepGuard = crate::altrep_traits::AltrepGuard::RUnwind;
-
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::AltVec for IterStringData<I> {}
-
-impl<I: Iterator<Item = String> + 'static> crate::altrep_traits::AltString for IterStringData<I> {
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltStringData::elt(data, i as usize)
-            .map(|s| unsafe { crate::altrep_impl::checked_mkchar(s) })
-            .unwrap_or(SEXP::na_string())
-    }
-}
+// String ALTREP elt calls Rf_mkCharLenCE (R API) — the generic macro's
+// `__impl_altrep_base!` uses RUnwind (catches R longjmps), matching the
+// hand-rolled guard this replaces.
+crate::impl_altstring_from_data_generic!(
+    {I} IterStringData<I> {I: Iterator<Item = String> + 'static}
+);
 
 /// Iterator-backed list vector.
 ///
@@ -656,40 +455,9 @@ impl<I: Iterator<Item = SEXP> + 'static> crate::externalptr::TypedExternal for I
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterListData\0";
 }
 
-impl<I: Iterator<Item = SEXP> + 'static> InferBase for IterListData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::List;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altlist_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_list::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::Altrep for IterListData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::AltVec for IterListData<I> {}
-
-impl<I: Iterator<Item = SEXP> + 'static> crate::altrep_traits::AltList for IterListData<I> {
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::SEXP {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltListData::elt(data, i as usize)
-    }
-}
+crate::impl_altlist_from_data_generic!(
+    {I} IterListData<I> {I: Iterator<Item = SEXP> + 'static}
+);
 
 /// Iterator-backed complex number vector.
 ///
@@ -772,59 +540,7 @@ impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExt
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterComplexData\0";
 }
 
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> InferBase for IterComplexData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Complex;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altcomplex_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_cplx::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::Altrep
-    for IterComplexData<I>
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltVec
-    for IterComplexData<I>
-{
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltComplex
-    for IterComplexData<I>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::Rcomplex {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [crate::Rcomplex],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altcomplex_from_data_generic!(
+    {I} IterComplexData<I> {I: Iterator<Item = crate::Rcomplex> + 'static}
+);
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/sparse.rs
+++ b/miniextendr-api/src/altrep_data/iter/sparse.rs
@@ -7,8 +7,8 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 use crate::altrep_data::{
-    AltComplexData, AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltrepLen, InferBase,
-    Logical, fill_region,
+    AltComplexData, AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltrepLen, Logical,
+    fill_region,
 };
 
 /// Core state for sparse iterator-backed ALTREP vectors.
@@ -233,54 +233,9 @@ impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal for Sp
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterIntData\0";
 }
 
-impl<I: Iterator<Item = i32> + 'static> InferBase for SparseIterIntData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for SparseIterIntData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltVec for SparseIterIntData<I> {}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for SparseIterIntData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altinteger_from_data_generic!(
+    {I} SparseIterIntData<I> {I: Iterator<Item = i32> + 'static}
+);
 
 /// Sparse iterator-backed real (f64) vector data.
 ///
@@ -336,54 +291,9 @@ impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterRealData\0";
 }
 
-impl<I: Iterator<Item = f64> + 'static> InferBase for SparseIterRealData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for SparseIterRealData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for SparseIterRealData<I> {}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for SparseIterRealData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altreal_from_data_generic!(
+    {I} SparseIterRealData<I> {I: Iterator<Item = f64> + 'static}
+);
 
 /// Sparse iterator-backed logical vector data.
 pub struct SparseIterLogicalData<I: Iterator<Item = bool>> {
@@ -435,56 +345,9 @@ impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterLogicalData\0";
 }
 
-impl<I: Iterator<Item = bool> + 'static> InferBase for SparseIterLogicalData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Logical;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altlogical_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_lgl::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for SparseIterLogicalData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltVec for SparseIterLogicalData<I> {}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical
-    for SparseIterLogicalData<I>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::elt(data, i as usize).to_r_int()
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altlogical_from_data_generic!(
+    {I} SparseIterLogicalData<I> {I: Iterator<Item = bool> + 'static}
+);
 
 /// Sparse iterator-backed raw (u8) vector data.
 pub struct SparseIterRawData<I: Iterator<Item = u8>> {
@@ -535,54 +398,9 @@ impl<I: Iterator<Item = u8> + 'static> crate::externalptr::TypedExternal for Spa
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterRawData\0";
 }
 
-impl<I: Iterator<Item = u8> + 'static> InferBase for SparseIterRawData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Raw;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altraw_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_raw::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::Altrep for SparseIterRawData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltVec for SparseIterRawData<I> {}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for SparseIterRawData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> u8 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [u8],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altraw_from_data_generic!(
+    {I} SparseIterRawData<I> {I: Iterator<Item = u8> + 'static}
+);
 
 /// Sparse iterator-backed complex number vector.
 pub struct SparseIterComplexData<I>
@@ -653,59 +471,7 @@ impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExt
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterComplexData\0";
 }
 
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> InferBase for SparseIterComplexData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Complex;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altcomplex_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_cplx::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::Altrep
-    for SparseIterComplexData<I>
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltVec
-    for SparseIterComplexData<I>
-{
-}
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::altrep_traits::AltComplex
-    for SparseIterComplexData<I>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> crate::Rcomplex {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [crate::Rcomplex],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltComplexData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altcomplex_from_data_generic!(
+    {I} SparseIterComplexData<I> {I: Iterator<Item = crate::Rcomplex> + 'static}
+);
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/state.rs
+++ b/miniextendr-api/src/altrep_data/iter/state.rs
@@ -1,16 +1,16 @@
 //! Core iterator-backed ALTREP infrastructure.
 //!
 //! Provides `IterState<I, T>` (the shared lazy-caching state machine) and
-//! wrapper types for each ALTREP family: `IterIntData`, `IterRealData`,
-//! `IterLogicalData`, `IterRawData`, `IterStringData`, `IterListData`,
-//! `IterComplexData`.
+//! wrapper types for the integer/real/logical/raw ALTREP families:
+//! `IterIntData`, `IterRealData`, `IterLogicalData`, `IterRawData`. The
+//! string/list/complex wrappers (`IterStringData`, `IterListData`,
+//! `IterComplexData`) live in `super::coerce`.
 
 use std::cell::RefCell;
 use std::sync::OnceLock;
 
 use crate::altrep_data::{
-    AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltrepLen, InferBase, Logical,
-    fill_region,
+    AltIntegerData, AltLogicalData, AltRawData, AltRealData, AltrepLen, Logical, fill_region,
 };
 
 /// Core state for iterator-backed ALTREP vectors.
@@ -279,54 +279,9 @@ impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal for It
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntData\0";
 }
 
-impl<I: Iterator<Item = i32> + 'static> InferBase for IterIntData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for IterIntData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltVec for IterIntData<I> {}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger for IterIntData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altinteger_from_data_generic!(
+    {I} IterIntData<I> {I: Iterator<Item = i32> + 'static}
+);
 
 /// Iterator-backed real (f64) vector data.
 ///
@@ -379,54 +334,9 @@ impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal for It
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRealData\0";
 }
 
-impl<I: Iterator<Item = f64> + 'static> InferBase for IterRealData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for IterRealData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for IterRealData<I> {}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for IterRealData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altreal_from_data_generic!(
+    {I} IterRealData<I> {I: Iterator<Item = f64> + 'static}
+);
 
 /// Iterator-backed logical vector data.
 ///
@@ -478,54 +388,9 @@ impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal for I
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterLogicalData\0";
 }
 
-impl<I: Iterator<Item = bool> + 'static> InferBase for IterLogicalData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Logical;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altlogical_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_lgl::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::Altrep for IterLogicalData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltVec for IterLogicalData<I> {}
-
-impl<I: Iterator<Item = bool> + 'static> crate::altrep_traits::AltLogical for IterLogicalData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::elt(data, i as usize).to_r_int()
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltLogicalData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altlogical_from_data_generic!(
+    {I} IterLogicalData<I> {I: Iterator<Item = bool> + 'static}
+);
 
 /// Iterator-backed raw (u8) vector data.
 ///
@@ -578,52 +443,7 @@ impl<I: Iterator<Item = u8> + 'static> crate::externalptr::TypedExternal for Ite
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRawData\0";
 }
 
-impl<I: Iterator<Item = u8> + 'static> InferBase for IterRawData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Raw;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altraw_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_raw::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::Altrep for IterRawData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltVec for IterRawData<I> {}
-
-impl<I: Iterator<Item = u8> + 'static> crate::altrep_traits::AltRaw for IterRawData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> u8 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [u8],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRawData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altraw_from_data_generic!(
+    {I} IterRawData<I> {I: Iterator<Item = u8> + 'static}
+);
 // endregion

--- a/miniextendr-api/src/altrep_data/iter/windowed.rs
+++ b/miniextendr-api/src/altrep_data/iter/windowed.rs
@@ -6,7 +6,7 @@
 use std::cell::RefCell;
 use std::sync::OnceLock;
 
-use crate::altrep_data::{AltIntegerData, AltRealData, AltrepLen, InferBase, fill_region};
+use crate::altrep_data::{AltIntegerData, AltRealData, AltrepLen, fill_region};
 
 /// Core state for windowed iterator-backed ALTREP vectors.
 ///
@@ -279,56 +279,9 @@ impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::WindowedIterIntData\0";
 }
 
-impl<I: Iterator<Item = i32> + 'static> InferBase for WindowedIterIntData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::Altrep for WindowedIterIntData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltVec for WindowedIterIntData<I> {}
-
-impl<I: Iterator<Item = i32> + 'static> crate::altrep_traits::AltInteger
-    for WindowedIterIntData<I>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altinteger_from_data_generic!(
+    {I} WindowedIterIntData<I> {I: Iterator<Item = i32> + 'static}
+);
 
 /// Windowed iterator-backed real (f64) vector data.
 ///
@@ -385,52 +338,7 @@ impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::WindowedIterRealData\0";
 }
 
-impl<I: Iterator<Item = f64> + 'static> InferBase for WindowedIterRealData<I> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::Altrep for WindowedIterRealData<I> {
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltVec for WindowedIterRealData<I> {}
-
-impl<I: Iterator<Item = f64> + 'static> crate::altrep_traits::AltReal for WindowedIterRealData<I> {
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altreal_from_data_generic!(
+    {I} WindowedIterRealData<I> {I: Iterator<Item = f64> + 'static}
+);
 // endregion

--- a/miniextendr-api/src/altrep_data/macros.rs
+++ b/miniextendr-api/src/altrep_data/macros.rs
@@ -14,7 +14,17 @@
 #[doc(hidden)]
 macro_rules! __impl_inferbase {
     ($ty:ty, $base:ident, $make_fn:path, $install_fn:ident) => {
-        impl $crate::altrep_data::InferBase for $ty {
+        $crate::__impl_inferbase!({} $ty {}, $base, $make_fn, $install_fn);
+    };
+    // Generic form: `{$gen} $ty {$where}, $base, $make_fn, $install_fn`. Brace
+    // delimiters (not `[]`/`()`) are deliberate — see `__impl_altrep_base!` in
+    // `altrep_impl/macros.rs` for why: `{` can never start a `$ty:ty` fragment,
+    // so the bare-`$ty:ty` arm above fails cleanly against a brace-led
+    // invocation instead of hard-erroring on a bogus type parse. The
+    // non-generic arm above forwards here with empty `{}` brackets so there
+    // is exactly one emission body.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $base:ident, $make_fn:path, $install_fn:ident) => {
+        impl<$($gen)*> $crate::altrep_data::InferBase for $ty where $($whr)* {
             const BASE: $crate::altrep::RBase = $crate::altrep::RBase::$base;
 
             unsafe fn make_class(
@@ -39,11 +49,18 @@ macro_rules! __impl_inferbase {
 }
 
 /// Implement `InferBase` for an integer ALTREP data type.
+///
+/// Accepts an optional generic form: `impl_inferbase_integer!({T} Foo<T> {T:
+/// Bound})` — see [`crate::impl_altinteger_from_data_generic!`] for the same
+/// convention at the family-macro layer.
 #[macro_export]
 macro_rules! impl_inferbase_integer {
     ($ty:ty) => {
+        $crate::impl_inferbase_integer!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             Int,
             $crate::sys::altrep::R_make_altinteger_class,
             install_int
@@ -51,12 +68,16 @@ macro_rules! impl_inferbase_integer {
     };
 }
 
-/// Implement `InferBase` for a real ALTREP data type.
+/// Implement `InferBase` for a real ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_real {
     ($ty:ty) => {
+        $crate::impl_inferbase_real!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             Real,
             $crate::sys::altrep::R_make_altreal_class,
             install_real
@@ -64,12 +85,16 @@ macro_rules! impl_inferbase_real {
     };
 }
 
-/// Implement `InferBase` for a logical ALTREP data type.
+/// Implement `InferBase` for a logical ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_logical {
     ($ty:ty) => {
+        $crate::impl_inferbase_logical!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             Logical,
             $crate::sys::altrep::R_make_altlogical_class,
             install_lgl
@@ -77,12 +102,16 @@ macro_rules! impl_inferbase_logical {
     };
 }
 
-/// Implement `InferBase` for a raw ALTREP data type.
+/// Implement `InferBase` for a raw ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_raw {
     ($ty:ty) => {
+        $crate::impl_inferbase_raw!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             Raw,
             $crate::sys::altrep::R_make_altraw_class,
             install_raw
@@ -90,12 +119,16 @@ macro_rules! impl_inferbase_raw {
     };
 }
 
-/// Implement `InferBase` for a string ALTREP data type.
+/// Implement `InferBase` for a string ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_string {
     ($ty:ty) => {
+        $crate::impl_inferbase_string!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             String,
             $crate::sys::altrep::R_make_altstring_class,
             install_str
@@ -103,12 +136,16 @@ macro_rules! impl_inferbase_string {
     };
 }
 
-/// Implement `InferBase` for a complex ALTREP data type.
+/// Implement `InferBase` for a complex ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_complex {
     ($ty:ty) => {
+        $crate::impl_inferbase_complex!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             Complex,
             $crate::sys::altrep::R_make_altcomplex_class,
             install_cplx
@@ -116,12 +153,16 @@ macro_rules! impl_inferbase_complex {
     };
 }
 
-/// Implement `InferBase` for a list ALTREP data type.
+/// Implement `InferBase` for a list ALTREP data type. See
+/// [`impl_inferbase_integer!`] for the generic calling convention.
 #[macro_export]
 macro_rules! impl_inferbase_list {
     ($ty:ty) => {
+        $crate::impl_inferbase_list!({} $ty {});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
         $crate::__impl_inferbase!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             List,
             $crate::sys::altrep::R_make_altlist_class,
             install_list

--- a/miniextendr-api/src/altrep_data/stream.rs
+++ b/miniextendr-api/src/altrep_data/stream.rs
@@ -7,7 +7,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
-use super::{AltIntegerData, AltRealData, AltrepLen, InferBase};
+use super::{AltIntegerData, AltRealData, AltrepLen};
 
 // region: StreamingRealData
 
@@ -112,61 +112,9 @@ impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::externalptr::TypedExter
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::StreamingRealData\0";
 }
 
-impl<F: Fn(usize, &mut [f64]) -> usize + 'static> InferBase for StreamingRealData<F> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Real;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altreal_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_real::<Self>(cls) };
-    }
-}
-
-impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::Altrep
-    for StreamingRealData<F>
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::AltVec
-    for StreamingRealData<F>
-{
-}
-
-impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::altrep_traits::AltReal
-    for StreamingRealData<F>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> f64 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [f64],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltRealData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altreal_from_data_generic!(
+    {F} StreamingRealData<F> {F: Fn(usize, &mut [f64]) -> usize + 'static}
+);
 // endregion
 
 // region: StreamingIntData
@@ -272,59 +220,7 @@ impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::externalptr::TypedExter
     const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::StreamingIntData\0";
 }
 
-impl<F: Fn(usize, &mut [i32]) -> usize + 'static> InferBase for StreamingIntData<F> {
-    const BASE: crate::altrep::RBase = crate::altrep::RBase::Int;
-
-    unsafe fn make_class(
-        class_name: *const i8,
-        pkg_name: *const i8,
-    ) -> crate::sys::altrep::R_altrep_class_t {
-        unsafe {
-            crate::sys::altrep::R_make_altinteger_class(class_name, pkg_name, core::ptr::null_mut())
-        }
-    }
-
-    unsafe fn install_methods(cls: crate::sys::altrep::R_altrep_class_t) {
-        unsafe { crate::altrep_bridge::install_base::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_vec::<Self>(cls) };
-        unsafe { crate::altrep_bridge::install_int::<Self>(cls) };
-    }
-}
-
-impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::Altrep
-    for StreamingIntData<F>
-{
-    fn length(x: crate::SEXP) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        data.len() as crate::R_xlen_t
-    }
-}
-
-impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::AltVec
-    for StreamingIntData<F>
-{
-}
-
-impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::altrep_traits::AltInteger
-    for StreamingIntData<F>
-{
-    const HAS_ELT: bool = true;
-
-    fn elt(x: crate::SEXP, i: crate::R_xlen_t) -> i32 {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::elt(data, i as usize)
-    }
-
-    const HAS_GET_REGION: bool = true;
-
-    fn get_region(
-        x: crate::SEXP,
-        start: crate::R_xlen_t,
-        len: crate::R_xlen_t,
-        buf: &mut [i32],
-    ) -> crate::R_xlen_t {
-        let data = unsafe { <Self as crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
-        AltIntegerData::get_region(data, start as usize, len as usize, buf) as crate::R_xlen_t
-    }
-}
+crate::impl_altinteger_from_data_generic!(
+    {F} StreamingIntData<F> {F: Fn(usize, &mut [i32]) -> usize + 'static}
+);
 // endregion

--- a/miniextendr-api/src/altrep_impl/macros.rs
+++ b/miniextendr-api/src/altrep_impl/macros.rs
@@ -11,6 +11,14 @@
 //! path — `__impl_altvec_<family>_dataptr!` provides a trivial
 //! `AltrepDataptr<T>` returning `None`, falling through to data2
 //! materialisation.
+//!
+//! Each family also has an `impl_alt<family>_from_data_generic!` sibling
+//! accepting a brace-delimited generic parameter list and where-clause
+//! (`{$gen} $ty {$where}[, $knob]*`) for adaptor types like
+//! `IterIntCoerceData<I, T>` — see `altrep_data::iter` / `altrep_data::stream`
+//! for the ~19 call sites this replaced (audit D1). The plain macros forward
+//! to their `_generic!` sibling with empty `{}` brackets, so each family has
+//! exactly one emission body regardless of which form is called.
 
 // region: Macros for generating trait implementations
 
@@ -46,8 +54,21 @@ macro_rules! impl_altinteger_from_data {
     // first DATAPTR call. Without this, R's default DATAPTR errors with
     // "cannot access data pointer". See `__impl_alt_family!` for the knob matrix.
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altinteger_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altinteger_from_data!`]: accepts an optional
+/// generic parameter list and where-clause (`{T, U} Foo<T, U> {T: Bound, ..}`)
+/// so it can target `struct Foo<T> { .. }` adaptors — e.g. iterator-backed
+/// ALTREP types — not just concrete/monomorphic types. The non-generic macro
+/// above forwards here with empty `{}` brackets so there is exactly one
+/// emission body for both call shapes.
+#[macro_export]
+macro_rules! impl_altinteger_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altinteger_methods,
             impl_inferbase_integer,
             dataptr: dataptr(i32),
@@ -87,8 +108,16 @@ macro_rules! __impl_altrep_base {
     ($ty:ty, with_serialize) => {
         $crate::__impl_altrep_base!($ty, RUnwind, with_serialize);
     };
-    ($ty:ty, $guard:ident) => {
-        impl $crate::altrep_traits::Altrep for $ty {
+    // Generic form: `{$gen} $ty {$where}, $guard[, with_serialize]`. Brace
+    // (not bracket/paren) delimiters are deliberate: `{` can never start a
+    // `$ty:ty` fragment, so a bare-`$ty:ty` arm asked to match a brace-led
+    // invocation fails cleanly instead of committing to (and hard-erroring
+    // on) a bogus type parse — `[]`/`()` are themselves valid (empty
+    // slice-like / unit) type starts and would NOT fail cleanly here. The
+    // non-generic arms above forward to this one with empty `{}` brackets so
+    // there is exactly one emission body per (guard, serialize) combination.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $guard:ident) => {
+        impl<$($gen)*> $crate::altrep_traits::Altrep for $ty where $($whr)* {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
@@ -99,8 +128,8 @@ macro_rules! __impl_altrep_base {
             }
         }
     };
-    ($ty:ty, $guard:ident, with_serialize) => {
-        impl $crate::altrep_traits::Altrep for $ty {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $guard:ident, with_serialize) => {
+        impl<$($gen)*> $crate::altrep_traits::Altrep for $ty where $($whr)* {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
@@ -148,6 +177,18 @@ macro_rules! __impl_altrep_base {
             }
         }
     };
+    // Bare-`$ty:ty` forwarders (concrete/monomorphic types) — listed AFTER
+    // the brace-generic arms above so a genuinely bare call (e.g. from the
+    // `#[derive(Altrep*)]` proc-macro, which always targets concrete types)
+    // still resolves here rather than being intercepted by the brace arms
+    // (which require a literal leading `{...}` group and so never match a
+    // bare invocation).
+    ($ty:ty, $guard:ident) => {
+        $crate::__impl_altrep_base!({} $ty {}, $guard);
+    };
+    ($ty:ty, $guard:ident, with_serialize) => {
+        $crate::__impl_altrep_base!({} $ty {}, $guard, with_serialize);
+    };
 }
 
 /// Internal macro: impl AltVec with dataptr support
@@ -161,7 +202,12 @@ macro_rules! __impl_altrep_base {
 #[doc(hidden)]
 macro_rules! __impl_altvec_dataptr {
     ($ty:ty, $elem:ty) => {
-        impl $crate::altrep_traits::AltVec for $ty {
+        $crate::__impl_altvec_dataptr!({} $ty {}, $elem);
+    };
+    // Generic form: `[$gen] $ty [$where], $elem`. See `__impl_altrep_base!`
+    // for the empty-brackets delegation pattern.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $elem:ty) => {
+        impl<$($gen)*> $crate::altrep_traits::AltVec for $ty where $($whr)* {
             const HAS_DATAPTR: bool = true;
 
             fn dataptr(x: $crate::SEXP, writable: bool) -> *mut core::ffi::c_void {
@@ -248,7 +294,11 @@ macro_rules! __impl_altvec_dataptr {
 #[doc(hidden)]
 macro_rules! __impl_altvec_string_dataptr {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltVec for $ty {
+        $crate::__impl_altvec_string_dataptr!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltVec for $ty where $($whr)* {
             const HAS_DATAPTR: bool = true;
 
             fn dataptr(x: $crate::SEXP, _writable: bool) -> *mut core::ffi::c_void {
@@ -321,12 +371,16 @@ macro_rules! __impl_altvec_string_dataptr {
 #[doc(hidden)]
 macro_rules! __impl_altvec_materializing_dataptr {
     ($ty:ty, $elem:ty) => {
-        impl $crate::altrep_data::AltrepDataptr<$elem> for $ty {
+        $crate::__impl_altvec_materializing_dataptr!({} $ty {}, $elem);
+    };
+    // Generic form: `[$gen] $ty [$where], $elem`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $elem:ty) => {
+        impl<$($gen)*> $crate::altrep_data::AltrepDataptr<$elem> for $ty where $($whr)* {
             fn dataptr(&mut self, _writable: bool) -> Option<*mut $elem> {
                 None
             }
         }
-        $crate::__impl_altvec_dataptr!($ty, $elem);
+        $crate::__impl_altvec_dataptr!({$($gen)*} $ty {$($whr)*}, $elem);
     };
 }
 
@@ -382,7 +436,11 @@ macro_rules! __impl_altvec_complex_dataptr {
 #[doc(hidden)]
 macro_rules! __impl_altvec_extract_subset {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltVec for $ty {
+        $crate::__impl_altvec_extract_subset!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltVec for $ty where $($whr)* {
             const HAS_EXTRACT_SUBSET: bool = true;
 
             fn extract_subset(
@@ -542,6 +600,19 @@ macro_rules! __impl_altvec_flavor {
     ($ty:ty, subset) => {
         $crate::__impl_altvec_extract_subset!($ty);
     };
+    // Generic form: `[$gen] $ty [$where], $flavor`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, dataptr($elem:ty)) => {
+        $crate::__impl_altvec_dataptr!({$($gen)*} $ty {$($whr)*}, $elem);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, materializing($elem:ty)) => {
+        $crate::__impl_altvec_materializing_dataptr!({$($gen)*} $ty {$($whr)*}, $elem);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, string_dataptr) => {
+        $crate::__impl_altvec_string_dataptr!({$($gen)*} $ty {$($whr)*});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, subset) => {
+        $crate::__impl_altvec_extract_subset!({$($gen)*} $ty {$($whr)*});
+    };
 }
 
 /// Internal macro: canonical ALTREP emission.
@@ -563,6 +634,19 @@ macro_rules! __impl_alt_from_data {
         $crate::__impl_altvec_flavor!($ty, $flavor $(($elem))?);
         $crate::$methods!($ty);
         $crate::$inferbase!($ty);
+    };
+    // Generic form: `[$gen] $ty [$where], $methods, $inferbase, $flavor`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident, $flavor:ident $(($elem:ty))?) => {
+        $crate::__impl_altrep_base!({$($gen)*} $ty {$($whr)*}, RUnwind);
+        $crate::__impl_altvec_flavor!({$($gen)*} $ty {$($whr)*}, $flavor $(($elem))?);
+        $crate::$methods!({$($gen)*} $ty {$($whr)*});
+        $crate::$inferbase!({$($gen)*} $ty {$($whr)*});
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident, $flavor:ident $(($elem:ty))?, serialize) => {
+        $crate::__impl_altrep_base!({$($gen)*} $ty {$($whr)*}, RUnwind, with_serialize);
+        $crate::__impl_altvec_flavor!({$($gen)*} $ty {$($whr)*}, $flavor $(($elem))?);
+        $crate::$methods!({$($gen)*} $ty {$($whr)*});
+        $crate::$inferbase!({$($gen)*} $ty {$($whr)*});
     };
 }
 
@@ -612,6 +696,31 @@ macro_rules! __impl_alt_family {
      dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, subset, serialize) => {
         $crate::__impl_alt_from_data!($ty, $methods, $inferbase, subset, serialize);
     };
+    // Generic form: `[$gen] $ty [$where], $methods, $inferbase, dataptr: .., default: ..[, knobs]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, $dff $(($dfe))?);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, dataptr) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, $dpf $(($dpe))?);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, serialize) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, $dff $(($dfe))?, serialize);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, subset) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, subset);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, dataptr, serialize) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, $dpf $(($dpe))?, serialize);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $methods:ident, $inferbase:ident,
+     dataptr: $dpf:ident $(($dpe:ty))?, default: $dff:ident $(($dfe:ty))?, subset, serialize) => {
+        $crate::__impl_alt_from_data!({$($gen)*} $ty {$($whr)*}, $methods, $inferbase, subset, serialize);
+    };
 }
 // endregion
 
@@ -622,7 +731,11 @@ macro_rules! __impl_alt_family {
 #[doc(hidden)]
 macro_rules! __impl_altinteger_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltInteger for $ty {
+        $crate::__impl_altinteger_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltInteger for $ty where $($whr)* {
             $crate::__impl_alt_elt!($ty, $crate::altrep_data::AltIntegerData, i32, i32::MIN);
             $crate::__impl_alt_get_region!($ty, $crate::altrep_data::AltIntegerData, i32);
             $crate::__impl_alt_is_sorted!($ty, $crate::altrep_data::AltIntegerData);
@@ -693,8 +806,17 @@ macro_rules! __impl_altinteger_methods {
 #[macro_export]
 macro_rules! impl_altreal_from_data {
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altreal_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altreal_from_data!`] — see
+/// [`impl_altinteger_from_data_generic!`] for the calling convention.
+#[macro_export]
+macro_rules! impl_altreal_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altreal_methods,
             impl_inferbase_real,
             dataptr: dataptr(f64),
@@ -709,7 +831,11 @@ macro_rules! impl_altreal_from_data {
 #[doc(hidden)]
 macro_rules! __impl_altreal_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltReal for $ty {
+        $crate::__impl_altreal_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltReal for $ty where $($whr)* {
             $crate::__impl_alt_elt!($ty, $crate::altrep_data::AltRealData, f64, f64::NAN);
             $crate::__impl_alt_get_region!($ty, $crate::altrep_data::AltRealData, f64);
             $crate::__impl_alt_is_sorted!($ty, $crate::altrep_data::AltRealData);
@@ -775,8 +901,17 @@ macro_rules! impl_altlogical_from_data {
     // Note the asymmetry: the `dataptr` knob is typed `i32` (R's LGLSXP storage),
     // while the materializing default goes through `RLogical` for type safety.
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altlogical_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altlogical_from_data!`] — see
+/// [`impl_altinteger_from_data_generic!`] for the calling convention.
+#[macro_export]
+macro_rules! impl_altlogical_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altlogical_methods,
             impl_inferbase_logical,
             dataptr: dataptr(i32),
@@ -791,7 +926,11 @@ macro_rules! impl_altlogical_from_data {
 #[doc(hidden)]
 macro_rules! __impl_altlogical_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltLogical for $ty {
+        $crate::__impl_altlogical_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltLogical for $ty where $($whr)* {
             // Logical elt is special: returns Logical → .to_r_int()
             const HAS_ELT: bool = true;
 
@@ -851,8 +990,17 @@ macro_rules! __impl_altlogical_methods {
 #[macro_export]
 macro_rules! impl_altraw_from_data {
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altraw_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altraw_from_data!`] — see
+/// [`impl_altinteger_from_data_generic!`] for the calling convention.
+#[macro_export]
+macro_rules! impl_altraw_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altraw_methods,
             impl_inferbase_raw,
             dataptr: dataptr(u8),
@@ -867,7 +1015,11 @@ macro_rules! impl_altraw_from_data {
 #[doc(hidden)]
 macro_rules! __impl_altraw_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltRaw for $ty {
+        $crate::__impl_altraw_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltRaw for $ty where $($whr)* {
             $crate::__impl_alt_elt!($ty, $crate::altrep_data::AltRawData, u8, 0);
             $crate::__impl_alt_get_region!($ty, $crate::altrep_data::AltRawData, u8);
         }
@@ -900,8 +1052,17 @@ macro_rules! impl_altstring_from_data {
     // String vectors have no contiguous typed pointer; the default and `dataptr`
     // knobs both route through `string_dataptr` (whole-vector STRSXP materialization).
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altstring_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altstring_from_data!`] — see
+/// [`impl_altinteger_from_data_generic!`] for the calling convention.
+#[macro_export]
+macro_rules! impl_altstring_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altstring_methods,
             impl_inferbase_string,
             dataptr: string_dataptr,
@@ -916,7 +1077,11 @@ macro_rules! impl_altstring_from_data {
 #[doc(hidden)]
 macro_rules! __impl_altstring_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltString for $ty {
+        $crate::__impl_altstring_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltString for $ty where $($whr)* {
             // String elt with lazy per-element caching in data2 STRSXP.
             //
             // On first access, allocates a STRSXP in data2 (initialized to R_NaString).
@@ -983,7 +1148,21 @@ macro_rules! impl_altlist_from_data {
         $crate::impl_altlist_from_data!($ty, RUnwind);
     };
     ($ty:ty, $guard:ident) => {
-        impl $crate::altrep_traits::Altrep for $ty {
+        $crate::impl_altlist_from_data_generic!({} $ty {}, $guard);
+    };
+}
+
+/// Generic form of [`impl_altlist_from_data!`]: accepts an optional generic
+/// parameter list and where-clause so it can target `struct Foo<T> { .. }`
+/// adaptors, not just concrete types. The non-generic macro above forwards
+/// here with empty `{}` brackets so there is exactly one emission body.
+#[macro_export]
+macro_rules! impl_altlist_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        $crate::impl_altlist_from_data_generic!({$($gen)*} $ty {$($whr)*}, RUnwind);
+    };
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}, $guard:ident) => {
+        impl<$($gen)*> $crate::altrep_traits::Altrep for $ty where $($whr)* {
             const GUARD: $crate::altrep_traits::AltrepGuard =
                 $crate::altrep_traits::AltrepGuard::$guard;
 
@@ -994,9 +1173,9 @@ macro_rules! impl_altlist_from_data {
             }
         }
 
-        impl $crate::altrep_traits::AltVec for $ty {}
+        impl<$($gen)*> $crate::altrep_traits::AltVec for $ty where $($whr)* {}
 
-        impl $crate::altrep_traits::AltList for $ty {
+        impl<$($gen)*> $crate::altrep_traits::AltList for $ty where $($whr)* {
             fn elt(x: $crate::SEXP, i: $crate::R_xlen_t) -> $crate::SEXP {
                 let data =
                     unsafe { <$ty as $crate::altrep_data::AltrepExtract>::altrep_extract_ref(x) };
@@ -1004,7 +1183,7 @@ macro_rules! impl_altlist_from_data {
             }
         }
 
-        $crate::impl_inferbase_list!($ty);
+        $crate::impl_inferbase_list!({$($gen)*} $ty {$($whr)*});
     };
 }
 
@@ -1013,7 +1192,11 @@ macro_rules! impl_altlist_from_data {
 #[doc(hidden)]
 macro_rules! __impl_altcomplex_methods {
     ($ty:ty) => {
-        impl $crate::altrep_traits::AltComplex for $ty {
+        $crate::__impl_altcomplex_methods!({} $ty {});
+    };
+    // Generic form: `[$gen] $ty [$where]`.
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*}) => {
+        impl<$($gen)*> $crate::altrep_traits::AltComplex for $ty where $($whr)* {
             $crate::__impl_alt_elt!(
                 $ty,
                 $crate::altrep_data::AltComplexData,
@@ -1041,8 +1224,17 @@ macro_rules! __impl_altcomplex_methods {
 #[macro_export]
 macro_rules! impl_altcomplex_from_data {
     ($ty:ty $(, $knob:ident)*) => {
+        $crate::impl_altcomplex_from_data_generic!({} $ty {} $(, $knob)*);
+    };
+}
+
+/// Generic form of [`impl_altcomplex_from_data!`] — see
+/// [`impl_altinteger_from_data_generic!`] for the calling convention.
+#[macro_export]
+macro_rules! impl_altcomplex_from_data_generic {
+    ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
         $crate::__impl_alt_family!(
-            $ty,
+            {$($gen)*} $ty {$($whr)*},
             __impl_altcomplex_methods,
             impl_inferbase_complex,
             dataptr: dataptr($crate::Rcomplex),

--- a/miniextendr-api/tests/altrep_from_data_matrix.rs
+++ b/miniextendr-api/tests/altrep_from_data_matrix.rs
@@ -132,6 +132,56 @@ fixture_serialize!(IntSubsetSerialize);
 miniextendr_api::impl_altinteger_from_data!(IntSubsetSerialize, subset, serialize);
 // endregion
 
+// region: Generic form — `impl_alt*_from_data_generic!` (audit D1)
+//
+// Coverage for the generic sibling that the ~19 hand-rolled iterator/stream
+// ALTREP adaptors (`altrep_data::iter::*`, `altrep_data::stream::*`) route
+// through: a type with a generic parameter and a `where` clause, mirroring
+// the shape those adaptors need (e.g. `IterIntCoerceData<I, T>`).
+
+/// Generic fixture: wraps any `T: Copy + Into<i32> + 'static` in a `Vec`.
+struct GenericIntFixture<T>(Vec<T>)
+where
+    T: Copy + Into<i32> + 'static;
+
+impl<T> AltrepLen for GenericIntFixture<T>
+where
+    T: Copy + Into<i32> + 'static,
+{
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<T> AltIntegerData for GenericIntFixture<T>
+where
+    T: Copy + Into<i32> + 'static,
+{
+    fn elt(&self, i: usize) -> i32 {
+        self.0[i].into()
+    }
+}
+
+// Manual (non-TypedExternal) `AltrepExtract`, generic over `T` — the
+// `fixture_extract!` helper above only takes a bare ident, not a generic type.
+impl<T> AltrepExtract for GenericIntFixture<T>
+where
+    T: Copy + Into<i32> + 'static,
+{
+    unsafe fn altrep_extract_ref(_x: SEXP) -> &'static Self {
+        unreachable!("compile-time fixture — never dispatched")
+    }
+
+    unsafe fn altrep_extract_mut(_x: SEXP) -> &'static mut Self {
+        unreachable!("compile-time fixture — never dispatched")
+    }
+}
+
+miniextendr_api::impl_altinteger_from_data_generic!(
+    {T} GenericIntFixture<T> {T: Copy + Into<i32> + 'static}
+);
+// endregion
+
 // region: Logical family — asymmetric element types (dataptr: i32, materializing: RLogical)
 
 struct LglBasic(Vec<bool>);
@@ -186,5 +236,10 @@ fn knob_matrix_compiles() {
         assert!(<IntSubset as AltVec>::HAS_EXTRACT_SUBSET);
         assert!(<IntSubsetSerialize as AltVec>::HAS_EXTRACT_SUBSET);
         assert!(<IntBasic as AltInteger>::HAS_ELT);
+
+        // Generic form (audit D1): same bridge stack, instantiated for a
+        // type with a generic parameter + where clause.
+        assert!(<GenericIntFixture<u8> as AltVec>::HAS_DATAPTR);
+        assert!(<GenericIntFixture<u8> as AltInteger>::HAS_ELT);
     }
 }


### PR DESCRIPTION
Collapses the ~19 hand-rolled ALTREP adaptor trait stacks flagged in audit D1 down to the same `impl_alt*_from_data!` macro family the built-in types already use, by teaching that macro family generics.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Implements audit D1 (`audit/2026-07-03-dogfooding-altrep-collections.md` finding #1): the `impl_alt*_from_data!` macro family (`miniextendr-api/src/altrep_impl/macros.rs`) only matched `$ty:ty` with no generic params or where-clause, so it couldn't target the ~19 generic iterator/stream-backed ALTREP adaptor types (`IterIntCoerceData<I, T>`, `SparseIterIntData<I>`, `StreamingRealData<F>`, etc. across `altrep_data/iter/{coerce,sparse,state,windowed}.rs` and `altrep_data/stream.rs`), which each hand-rolled the identical `TypedExternal`/`InferBase`/`Altrep`/`AltVec`/`Alt<Family>` bridge stack instead.

- Extended every layer of the macro chain (`__impl_altrep_base!`, `__impl_altvec_dataptr!`/`_string_dataptr!`/`_materializing_dataptr!`/`_extract_subset!`, `__impl_altvec_flavor!`, `__impl_alt_from_data!`, `__impl_alt_family!`, the 6 per-family `__impl_alt<family>_methods!` macros, `__impl_inferbase!`, and the 7 `impl_inferbase_<family>!` wrappers) with a brace-delimited generic form: `{$($gen:tt)*} $ty:ty {$($whr:tt)*}`. Brace delimiters are deliberate — `{` can never start a `$ty:ty` fragment, so a bare (non-generic) call cleanly falls through to the existing arm instead of the macro matcher committing to (and hard-erroring on) a bogus type parse, which is what happens with `[]`/`()` (both are themselves valid, if degenerate, type starts).
- Each existing plain macro (`impl_altinteger_from_data!`, `__impl_altrep_base!`, etc.) now forwards to a `_generic!` sibling with empty `{}` brackets, so there is exactly one emission body per macro, per the plan.
- Migrated all 19 call sites (`IterIntData`, `IterRealData`, `IterLogicalData`, `IterRawData`, `IterIntCoerceData`, `IterRealCoerceData`, `IterIntFromBoolData`, `IterStringData`, `IterListData`, `IterComplexData`, `SparseIterIntData`, `SparseIterRealData`, `SparseIterLogicalData`, `SparseIterRawData`, `SparseIterComplexData`, `WindowedIterIntData`, `WindowedIterRealData`, `StreamingIntData`, `StreamingRealData`) to a single `impl_alt<family>_from_data_generic!(...)` invocation each, deleting the hand-rolled `TypedExternal`-adjacent bridge impls. The `TypedExternal` impls themselves and the `AltrepLen`/`Alt*Data` data-trait impls (the actual per-type domain logic) are untouched.
- Added a generic-form fixture (`GenericIntFixture<T>`) + spot-check to `miniextendr-api/tests/altrep_from_data_matrix.rs` for macro-expansion coverage of the new `_generic!` path, alongside the existing knob-matrix coverage.

## Elt-clamp / index-guard reconciliation (as flagged in the audit)

Migrating through the shared macro changes behavior in three ways, all resolved in favor of the macro (the now-single source of truth):

1. **Element-index clamp**: the macro's `__impl_alt_elt!` does `i.max(0) as usize`; the hand-rolled adaptors did `i as usize`. Kept the clamp — it guards against a negative `R_xlen_t` wrapping around to a huge `usize` on cast.
2. **`get_region` bounds guard**: the macro's `__impl_alt_get_region!` early-returns `0` when `start < 0 || len <= 0`; the hand-rolled adaptors had no such guard and called `start as usize` unconditionally. Same reasoning as (1) — adopted the guard.
3. **`InferBase::make_class`**: the macro path passes the real `altrep_dll_info()` (needed for cross-session `readRDS` class lookup) and asserts the created class via `validate_altrep_class`; every hand-rolled adaptor passed `core::ptr::null_mut()` for the DLL handle and skipped validation entirely. Adopted the macro's version.

None of these are reachable via a live SEXP for the 19 migrated types today (see the "Also found" note below), so none of the three is an observable behavior change in the current codebase — but all three matter for any future type that reaches this shared bridge with a real ALTREP dispatch, and per the audit, one accidental behavioral drift per hand-rolled site is exactly the maintenance hazard this PR removes.

## Also found (filed separately, not fixed here)

While tracing how these 19 types actually get exercised at runtime, none of them implement `RegisterAltrep` (the trait that lets a type back a live ALTREP SEXP via `IntoR`) — every rpkg fixture that uses one of these types wraps it inside a separate concrete struct with its own `#[derive(Altrep*, manual)]`, and only ever calls the inner type's plain `AltrepLen`/`Alt*Data` methods directly. So the bridge stack these 19 types carry (before and after this PR) is unreachable dead code for direct instantiation, and the elt-clamp/get_region-guard code path in general has zero live-SEXP Rust test coverage for any type, built-in or adapted. Filed as #1146 with the full detail; out of scope for D1 (which is about de-duplicating the stack, not about whether it's reachable).

## Test plan

- [x] `just check` / `just test` (workspace) — clean except the 7 pre-existing `derive_dataframe_*` UI-snapshot mismatches documented in `CLAUDE.md` as local-rustc drift (all `derive_altrep_*` UI tests pass)
- [x] `just clippy`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default)
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen,<integration list> -- -D warnings` (clippy_all)
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen-s7,<integration list> -- -D warnings` (clippy_all_s7)
- [x] `cargo fmt --all`
- [x] `cargo test -p miniextendr-api --lib altrep` — 75 passed
- [x] `cargo test -p miniextendr-api --test altrep_from_data_matrix` — knob matrix + new generic fixture, passing
- [x] `just configure && just rcmdinstall && just devtools-test` — full rpkg testthat suite: `[ FAIL 0 | WARN 0 | SKIP 20 | PASS 6805 ]`, including `test-streaming-altrep.R`, `test-sparse-iter-altrep.R`, and the full `altrep*` set (1184 assertions in the targeted `altrep` filter run), which exercise the wrapper structs backed by the migrated `StreamingIntData`/`StreamingRealData`/`SparseIter*Data` types. (A first full-suite run showed 72 failures in `test-rayon.R`/`test-arrow-na.R`/`test-encoding.R`/`test-altrep-serialization-cross-session.R`, all traced to a stale partial install on the shared `rv/library` slot — 1666 vs 1673 exports in the installed NAMESPACE; a clean `rcmdinstall` and rerun produced the 0-failure result above.)

## Notes

- No new SEXP-storage path was added (pure trait-impl refactor), so no new `gc_stress_*` fixture is required per CLAUDE.md.
- LoC delta: 403 insertions / 1008 deletions, net -605 lines (see diffstat).

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
