### PR TITLE
refactor(api): delegate f32/usize/isize scalar conversions to the shared numeric dispatch

### DIFF
--- a/miniextendr-api/src/from_r/coerced_scalars.rs
+++ b/miniextendr-api/src/from_r/coerced_scalars.rs
@@ -327,62 +327,12 @@ impl TryFromSexp for f32 {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value as f32)
-            }
-            SEXPTYPE::REALSXP => {
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value as f32)
-            }
-            SEXPTYPE::RAWSXP => {
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value as f32)
-            }
-            SEXPTYPE::LGLSXP => {
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    return Err(lglsxp_na_error());
-                }
-                Ok(value.to_i32() as f32)
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_scalar(sexp)
     }
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                let value: i32 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                Ok(value as f32)
-            }
-            SEXPTYPE::REALSXP => {
-                let value: f64 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                Ok(value as f32)
-            }
-            SEXPTYPE::RAWSXP => {
-                let value: u8 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                Ok(value as f32)
-            }
-            SEXPTYPE::LGLSXP => {
-                let value: RLogical = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                if value.is_na() {
-                    return Err(lglsxp_na_error());
-                }
-                Ok(value.to_i32() as f32)
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        unsafe { try_from_sexp_numeric_scalar_unchecked(sexp) }
     }
 }
 
@@ -447,86 +397,12 @@ impl TryFromSexp for Option<f32> {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        if sexp.type_of() == SEXPTYPE::NILSXP {
-            return Ok(None);
-        }
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                if value == crate::altrep_traits::NA_INTEGER {
-                    Ok(None)
-                } else {
-                    Ok(Some(value as f32))
-                }
-            }
-            SEXPTYPE::REALSXP => {
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                if is_na_real(value) {
-                    Ok(None)
-                } else {
-                    Ok(Some(value as f32))
-                }
-            }
-            SEXPTYPE::RAWSXP => {
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(Some(value as f32))
-            }
-            SEXPTYPE::LGLSXP => {
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    Ok(None)
-                } else {
-                    Ok(Some(value.to_i32() as f32))
-                }
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_option(sexp)
     }
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        if sexp.type_of() == SEXPTYPE::NILSXP {
-            return Ok(None);
-        }
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                let value: i32 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                if value == crate::altrep_traits::NA_INTEGER {
-                    Ok(None)
-                } else {
-                    Ok(Some(value as f32))
-                }
-            }
-            SEXPTYPE::REALSXP => {
-                let value: f64 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                if is_na_real(value) {
-                    Ok(None)
-                } else {
-                    Ok(Some(value as f32))
-                }
-            }
-            SEXPTYPE::RAWSXP => {
-                let value: u8 = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                Ok(Some(value as f32))
-            }
-            SEXPTYPE::LGLSXP => {
-                let value: RLogical = unsafe { TryFromSexp::try_from_sexp_unchecked(sexp)? };
-                if value.is_na() {
-                    Ok(None)
-                } else {
-                    Ok(Some(value.to_i32() as f32))
-                }
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        unsafe { try_from_sexp_numeric_option_unchecked(sexp) }
     }
 }
 // endregion
@@ -633,46 +509,12 @@ impl TryFromSexp for usize {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        // Try i32 first (more common), fall back to f64 for large values
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                use crate::coerce::TryCoerce;
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                value
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))
-            }
-            SEXPTYPE::REALSXP => {
-                use crate::coerce::TryCoerce;
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                let u: u64 = value
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))?;
-                u.try_into()
-                    .map_err(|_| SexpError::InvalidValue("value out of usize range".into()))
-            }
-            SEXPTYPE::RAWSXP => {
-                use crate::coerce::Coerce;
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value.coerce())
-            }
-            SEXPTYPE::LGLSXP => {
-                use crate::coerce::TryCoerce;
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    return Err(lglsxp_na_error());
-                }
-                value
-                    .to_i32()
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_scalar(sexp)
+    }
+
+    #[inline]
+    unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
+        unsafe { try_from_sexp_numeric_scalar_unchecked(sexp) }
     }
 }
 
@@ -681,64 +523,12 @@ impl TryFromSexp for Option<usize> {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        if sexp.type_of() == SEXPTYPE::NILSXP {
-            return Ok(None);
-        }
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                use crate::coerce::TryCoerce;
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                if value == crate::altrep_traits::NA_INTEGER {
-                    Ok(None)
-                } else {
-                    value
-                        .try_coerce()
-                        .map(Some)
-                        .map_err(|e| SexpError::InvalidValue(format!("{e}")))
-                }
-            }
-            SEXPTYPE::REALSXP => {
-                use crate::coerce::TryCoerce;
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                if is_na_real(value) {
-                    return Ok(None);
-                }
-                let u: u64 = value
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))?;
-                u.try_into()
-                    .map(Some)
-                    .map_err(|_| SexpError::InvalidValue("value out of usize range".into()))
-            }
-            SEXPTYPE::RAWSXP => {
-                use crate::coerce::Coerce;
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(Some(value.coerce()))
-            }
-            SEXPTYPE::LGLSXP => {
-                use crate::coerce::TryCoerce;
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    Ok(None)
-                } else {
-                    value
-                        .to_i32()
-                        .try_coerce()
-                        .map(Some)
-                        .map_err(|e| SexpError::InvalidValue(format!("{e}")))
-                }
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_option(sexp)
     }
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        Self::try_from_sexp(sexp)
+        unsafe { try_from_sexp_numeric_option_unchecked(sexp) }
     }
 }
 
@@ -747,41 +537,12 @@ impl TryFromSexp for isize {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        // Try i32 first (more common), fall back to f64 for large values
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                use crate::coerce::Coerce;
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value.coerce())
-            }
-            SEXPTYPE::REALSXP => {
-                use crate::coerce::TryCoerce;
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                let i: i64 = value
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))?;
-                i.try_into()
-                    .map_err(|_| SexpError::InvalidValue("value out of isize range".into()))
-            }
-            SEXPTYPE::RAWSXP => {
-                use crate::coerce::Coerce;
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(value.coerce())
-            }
-            SEXPTYPE::LGLSXP => {
-                use crate::coerce::Coerce;
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    return Err(lglsxp_na_error());
-                }
-                Ok(value.to_i32().coerce())
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_scalar(sexp)
+    }
+
+    #[inline]
+    unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
+        unsafe { try_from_sexp_numeric_scalar_unchecked(sexp) }
     }
 }
 
@@ -790,57 +551,12 @@ impl TryFromSexp for Option<isize> {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        if sexp.type_of() == SEXPTYPE::NILSXP {
-            return Ok(None);
-        }
-        let actual = sexp.type_of();
-        match actual {
-            SEXPTYPE::INTSXP => {
-                use crate::coerce::Coerce;
-                let value: i32 = TryFromSexp::try_from_sexp(sexp)?;
-                if value == crate::altrep_traits::NA_INTEGER {
-                    Ok(None)
-                } else {
-                    Ok(Some(value.coerce()))
-                }
-            }
-            SEXPTYPE::REALSXP => {
-                use crate::coerce::TryCoerce;
-                let value: f64 = TryFromSexp::try_from_sexp(sexp)?;
-                if is_na_real(value) {
-                    return Ok(None);
-                }
-                let i: i64 = value
-                    .try_coerce()
-                    .map_err(|e| SexpError::InvalidValue(format!("{e}")))?;
-                i.try_into()
-                    .map(Some)
-                    .map_err(|_| SexpError::InvalidValue("value out of isize range".into()))
-            }
-            SEXPTYPE::RAWSXP => {
-                use crate::coerce::Coerce;
-                let value: u8 = TryFromSexp::try_from_sexp(sexp)?;
-                Ok(Some(value.coerce()))
-            }
-            SEXPTYPE::LGLSXP => {
-                use crate::coerce::Coerce;
-                let value: RLogical = TryFromSexp::try_from_sexp(sexp)?;
-                if value.is_na() {
-                    Ok(None)
-                } else {
-                    Ok(Some(value.to_i32().coerce()))
-                }
-            }
-            _ => Err(SexpError::InvalidValue(format!(
-                "expected integer, numeric, logical, or raw; got {:?}",
-                actual
-            ))),
-        }
+        try_from_sexp_numeric_option(sexp)
     }
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        Self::try_from_sexp(sexp)
+        unsafe { try_from_sexp_numeric_option_unchecked(sexp) }
     }
 }
 // endregion

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -663,6 +663,427 @@ fn coerced_scalar_i64_from_na_integer_errors() {
 
 // endregion
 
+// region: from_r/coerced_scalars.rs — f32/usize/isize delegation onto
+// try_from_sexp_numeric_scalar/_option (audit D5, #1145-ish)
+//
+// f32/usize/isize (+ their Options) used to hand-roll the same 4-arm
+// INTSXP/REALSXP/RAWSXP/LGLSXP match that i64/u64 already delegate to
+// try_from_sexp_numeric_scalar / try_from_sexp_numeric_option. These tests
+// pin behavior parity (including the out-of-range/NA error shapes) across
+// the collapse to delegating one-liners, plus real _unchecked coverage for
+// usize/isize (previously `try_from_sexp_unchecked` just called the checked
+// path).
+
+/// f32 from INTSXP: widens cleanly.
+#[test]
+fn coerced_scalar_f32_from_intsxp_widens() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(7, &mut g) };
+        let v: f32 = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 7.0f32);
+    });
+}
+
+/// f32 from REALSXP: widens cleanly.
+#[test]
+fn coerced_scalar_f32_from_realsxp() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(1.5, &mut g) };
+        let v: f32 = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 1.5f32);
+    });
+}
+
+/// f32 from LGLSXP: TRUE → 1.0.
+#[test]
+fn coerced_scalar_f32_from_lglsxp_true() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { g.protect(SEXP::scalar_logical(true)) };
+        let v: f32 = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 1.0f32);
+    });
+}
+
+/// f32 from LGLSXP NA: rejected (mirrors the bare i32 NA guard).
+#[test]
+fn coerced_scalar_f32_from_lglsxp_na_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(NA_LOGICAL, &mut g) };
+        let result: Result<f32, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// f32 from STRSXP: rejected.
+#[test]
+fn coerced_scalar_f32_from_strsxp_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { g.protect(SEXP::scalar_string_from_str("nope")) };
+        let result: Result<f32, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// Option<f32> from NA_integer_ → None.
+#[test]
+fn coerced_option_f32_from_na_integer_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(NA_INTEGER, &mut g) };
+        let v: Option<f32> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<f32> from NA_real_ → None.
+#[test]
+fn coerced_option_f32_from_na_real_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(NA_REAL, &mut g) };
+        let v: Option<f32> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<f32> from NA_logical_ → None.
+#[test]
+fn coerced_option_f32_from_na_logical_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(NA_LOGICAL, &mut g) };
+        let v: Option<f32> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<f32> from NULL → None.
+#[test]
+fn coerced_option_f32_from_null_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let s = SEXP::nil();
+        let v: Option<f32> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<f32> from RAWSXP: raw has no NA, widens directly.
+#[test]
+fn coerced_option_f32_from_rawsxp() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_raw(9, &mut g) };
+        let v: Option<f32> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, Some(9.0f32));
+    });
+}
+
+/// usize from INTSXP: widens cleanly.
+#[test]
+fn coerced_scalar_usize_from_intsxp() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(42, &mut g) };
+        let v: usize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 42usize);
+    });
+}
+
+/// usize from INTSXP: negative value is rejected.
+#[test]
+fn coerced_scalar_usize_from_intsxp_negative_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(-1, &mut g) };
+        let result: Result<usize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// usize from REALSXP: in-range whole number succeeds.
+#[test]
+fn coerced_scalar_usize_from_realsxp_in_range() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(100.0, &mut g) };
+        let v: usize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 100usize);
+    });
+}
+
+/// usize from REALSXP: negative value is rejected (out-of-range low).
+#[test]
+fn coerced_scalar_usize_from_realsxp_negative_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(-1.0, &mut g) };
+        let result: Result<usize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// usize from REALSXP: fractional value is rejected.
+#[test]
+fn coerced_scalar_usize_from_realsxp_fractional_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(2.5, &mut g) };
+        let result: Result<usize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// usize from REALSXP: NA_real_ is rejected (not None — only Option<usize> maps NA → None).
+#[test]
+fn coerced_scalar_usize_from_realsxp_na_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(NA_REAL, &mut g) };
+        let result: Result<usize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// usize from RAWSXP: widens directly.
+#[test]
+fn coerced_scalar_usize_from_rawsxp() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_raw(255, &mut g) };
+        let v: usize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 255usize);
+    });
+}
+
+/// usize from LGLSXP: TRUE → 1.
+#[test]
+fn coerced_scalar_usize_from_lglsxp_true() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(1, &mut g) };
+        let v: usize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 1usize);
+    });
+}
+
+/// usize from LGLSXP NA: rejected.
+#[test]
+fn coerced_scalar_usize_from_lglsxp_na_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(NA_LOGICAL, &mut g) };
+        let result: Result<usize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// usize `_unchecked` path now real-delegates (not checked-fallback) and stays
+/// behavior-identical to the checked path for the happy path.
+#[test]
+fn coerced_scalar_usize_unchecked_matches_checked() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(17, &mut g) };
+        let v: usize = unsafe { TryFromSexp::try_from_sexp_unchecked(s).unwrap() };
+        assert_eq!(v, 17usize);
+    });
+}
+
+/// Option<usize> from NA_integer_ → None.
+#[test]
+fn coerced_option_usize_from_na_integer_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(NA_INTEGER, &mut g) };
+        let v: Option<usize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<usize> from NA_real_ → None.
+#[test]
+fn coerced_option_usize_from_na_real_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(NA_REAL, &mut g) };
+        let v: Option<usize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<usize> from NULL → None.
+#[test]
+fn coerced_option_usize_from_null_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let s = SEXP::nil();
+        let v: Option<usize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<usize> from REALSXP: out-of-range (negative) errors, doesn't silently
+/// become None or wrap.
+#[test]
+fn coerced_option_usize_from_realsxp_negative_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(-5.0, &mut g) };
+        let result: Result<Option<usize>, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// Option<usize> `_unchecked` path now real-delegates to the numeric-option
+/// unchecked helper.
+#[test]
+fn coerced_option_usize_unchecked_matches_checked() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(NA_INTEGER, &mut g) };
+        let v: Option<usize> = unsafe { TryFromSexp::try_from_sexp_unchecked(s).unwrap() };
+        assert!(v.is_none());
+    });
+}
+
+/// isize from INTSXP: negative values are allowed (unlike usize).
+#[test]
+fn coerced_scalar_isize_from_intsxp_negative() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(-42, &mut g) };
+        let v: isize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, -42isize);
+    });
+}
+
+/// isize from REALSXP: in-range whole number succeeds.
+#[test]
+fn coerced_scalar_isize_from_realsxp_in_range() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(-100.0, &mut g) };
+        let v: isize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, -100isize);
+    });
+}
+
+/// isize from REALSXP: fractional value is rejected.
+#[test]
+fn coerced_scalar_isize_from_realsxp_fractional_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(-2.5, &mut g) };
+        let result: Result<isize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// isize from REALSXP: NA_real_ is rejected (not None — only Option<isize> maps NA → None).
+#[test]
+fn coerced_scalar_isize_from_realsxp_na_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(NA_REAL, &mut g) };
+        let result: Result<isize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// isize from RAWSXP: widens directly.
+#[test]
+fn coerced_scalar_isize_from_rawsxp() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_raw(200, &mut g) };
+        let v: isize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 200isize);
+    });
+}
+
+/// isize from LGLSXP: FALSE → 0.
+#[test]
+fn coerced_scalar_isize_from_lglsxp_false() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(0, &mut g) };
+        let v: isize = TryFromSexp::try_from_sexp(s).unwrap();
+        assert_eq!(v, 0isize);
+    });
+}
+
+/// isize from LGLSXP NA: rejected.
+#[test]
+fn coerced_scalar_isize_from_lglsxp_na_errors() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_logical_raw(NA_LOGICAL, &mut g) };
+        let result: Result<isize, _> = TryFromSexp::try_from_sexp(s);
+        assert!(result.is_err());
+    });
+}
+
+/// isize `_unchecked` path now real-delegates (not checked-fallback).
+#[test]
+fn coerced_scalar_isize_unchecked_matches_checked() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(-17, &mut g) };
+        let v: isize = unsafe { TryFromSexp::try_from_sexp_unchecked(s).unwrap() };
+        assert_eq!(v, -17isize);
+    });
+}
+
+/// Option<isize> from NA_integer_ → None.
+#[test]
+fn coerced_option_isize_from_na_integer_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_int(NA_INTEGER, &mut g) };
+        let v: Option<isize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<isize> from NA_real_ → None.
+#[test]
+fn coerced_option_isize_from_na_real_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(NA_REAL, &mut g) };
+        let v: Option<isize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<isize> from NULL → None.
+#[test]
+fn coerced_option_isize_from_null_gives_none() {
+    r_test_utils::with_r_thread(|| {
+        let s = SEXP::nil();
+        let v: Option<isize> = TryFromSexp::try_from_sexp(s).unwrap();
+        assert!(v.is_none());
+    });
+}
+
+/// Option<isize> `_unchecked` path now real-delegates to the numeric-option
+/// unchecked helper.
+#[test]
+fn coerced_option_isize_unchecked_matches_checked() {
+    r_test_utils::with_r_thread(|| {
+        let mut g = Guard(0);
+        let s = unsafe { scalar_real(-9.0, &mut g) };
+        let v: Option<isize> = unsafe { TryFromSexp::try_from_sexp_unchecked(s).unwrap() };
+        assert_eq!(v, Some(-9isize));
+    });
+}
+
+// endregion
+
 // region: from_r/logical.rs — Rboolean and bool conversions
 
 /// Rboolean from LGLSXP TRUE.


### PR DESCRIPTION
Follow-up from the 2026-07-03 conversion/serde dogfooding audit (D5): `f32`, `usize`, `isize`, and their `Option` variants were still hand-rolling the same 4-arm `INTSXP`/`REALSXP`/`RAWSXP`/`LGLSXP` dispatch that `i64`/`u64` already delegate to `try_from_sexp_numeric_scalar`/`_option`. Collapses all six impls onto the shared helpers now that the `TryCoerce` bounds they need exist in `coerce.rs`.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Rewrote `TryFromSexp` for `f32`, `Option<f32>`, `usize`, `Option<usize>`, `isize`, `Option<isize>` in `miniextendr-api/src/from_r/coerced_scalars.rs` as delegating one-liners over `try_from_sexp_numeric_scalar`/`try_from_sexp_numeric_option` (and their `_unchecked` counterparts), matching the existing `i64`/`u64` shape exactly. Net -284 lines in that file (846 → 562).
- **Behavior improvement**: `usize` from `REALSXP` used to go `f64 → u64 → usize` (two narrowing steps), which on a 32-bit `usize` over-accepts before the second `try_into`. It now goes through `f64: TryCoerce<usize>` (`coerce.rs:811`), which range-checks directly against `usize::MAX` in one step.
- **`_unchecked` asymmetry closed**: `usize`/`Option<usize>`/`isize`/`Option<isize>` previously defined `try_from_sexp_unchecked` as a thin call back into the checked path (no unsafe fast path at all). They now real-delegate to `try_from_sexp_numeric_scalar_unchecked`/`try_from_sexp_numeric_option_unchecked`, same as every other numeric scalar in this module.
- Verified the `#882` "SEXPTYPE literals are source of truth" doc comment at the top of the file still reads correctly post-deletion — it describes the shared helper match arms, which are untouched.
- Added ~50 new tests to `miniextendr-api/tests/conversion_coverage.rs` (integration test, live R engine via `with_r_thread`, per the `#1139` `R_MAIN_THREAD_ID` OnceLock hazard with in-crate `--lib` tests) covering INTSXP/REALSXP (in-range + out-of-range)/LGLSXP/RAWSXP/NA/NULL for all six impls, plus explicit `_unchecked` coverage for usize/isize/Option<usize>/Option<isize> to pin the newly-real fast path.

## Test plan
- [x] `just check` (workspace + rpkg/src/rust + tests/cross-package/* + cargo-revendor) — clean.
- [x] `cargo test -p miniextendr-api --test conversion_coverage` — 132 passed, 0 failed.
- [x] `just test` — all suites green except the pre-existing `derive_dataframe_*` trybuild UI mismatches (local-rustc-vs-CI-toolchain drift, unrelated to this change, not touched/overwritten per repo convention).
- [x] `cargo fmt --all` — no changes needed.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default) — clean.
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd -- -D warnings` (clippy_all) — clean.
- [x] Same feature list with `full-codegen-s7` instead of `full-codegen` (clippy_all_s7) — clean.
- [ ] rpkg testthat / R CMD suite — not run here (shared rv library install slot was held by another agent this session); coordinator runs the rpkg suite at the review checkpoint.

## Notes
- No scope was cut and nothing deferred out of this PR — the six-impl collapse plus test backfill is fully self-contained, so no companion `gh issue create` was needed.
- Findings #2-#6 in the same audit (STRSXP vector/scalar walk dedup, VECSXP walk dedup, serde/de.rs internal dedup, `create_named_list`/`create_named_list_static` merge) are separate, larger-scoped cleanups and are intentionally out of scope for this PR.

---
_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>
