### PR TITLE
refactor(api): map_strsxp_with / map_vecsxp_with — centralize string and list walks

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -950,48 +950,17 @@ where
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::R_xlen_t);
-            let inner: Vec<T> = Vec::<T>::try_from_sexp(elem).map_err(Into::into)?;
-            result.push(inner);
-        }
-
-        Ok(result)
+        map_vecsxp_with(sexp, |_i, elem| {
+            Vec::<T>::try_from_sexp(elem).map_err(Into::into)
+        })
     }
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
+        unsafe {
+            map_vecsxp_with_unchecked(sexp, |_i, elem| {
+                Vec::<T>::try_from_sexp_unchecked(elem).map_err(Into::into)
+            })
         }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::R_xlen_t);
-            let inner: Vec<T> =
-                unsafe { Vec::<T>::try_from_sexp_unchecked(elem).map_err(Into::into)? };
-            result.push(inner);
-        }
-
-        Ok(result)
     }
 }
 // endregion
@@ -1110,6 +1079,163 @@ where
             actual
         ))),
     }
+}
+
+/// Shared SEXP-dispatch shell for the STRSXP (character vector) walk.
+///
+/// String-side counterpart of [`from_numeric_vec_with`]: checks `STRSXP`,
+/// walks each element via `string_elt`, and applies the per-element `map`
+/// closure to the raw CHARSXP. NA/blank-string policy (`""` vs `None` vs
+/// error) and the target representation (`String` vs `&str` vs `Cow`) are
+/// entirely the caller's closure to encode — this only centralizes the type
+/// check and the walk.
+///
+/// Mirrors `from_numeric_vec_with`'s choice to route both the checked and
+/// unchecked `TryFromSexp` paths through the same (checked-FFI) walk — none
+/// of the current STRSXP vector impls define a distinct unchecked fast path
+/// (they fall back to `TryFromSexp`'s default `try_from_sexp_unchecked`, which
+/// just calls the checked version), so there is no unchecked-FFI twin here.
+#[inline]
+pub(crate) fn map_strsxp_with<U>(
+    sexp: SEXP,
+    mut map: impl FnMut(SEXP /* charsxp */, usize) -> Result<U, SexpError>,
+) -> Result<Vec<U>, SexpError> {
+    let actual = sexp.type_of();
+    if actual != SEXPTYPE::STRSXP {
+        return Err(SexpTypeError {
+            expected: SEXPTYPE::STRSXP,
+            actual,
+        }
+        .into());
+    }
+
+    let len = sexp.len();
+    let mut result = Vec::with_capacity(len);
+    for i in 0..len {
+        let charsxp = sexp.string_elt(i as crate::R_xlen_t);
+        result.push(map(charsxp, i)?);
+    }
+    Ok(result)
+}
+
+/// Shared scalar-STRSXP prologue: type-check + `len == 1` + `string_elt(0)`.
+///
+/// Returns the raw CHARSXP; NA (`SEXP::na_string()`) and blank-string
+/// (`SEXP::blank_string()`) policy stay the caller's decision — some sites
+/// error on NA, some map it to `""`, some to `None`, and `String`'s blank
+/// handling has historically differed from `&str`'s (see audit D6 finding
+/// #3), so this helper does not paper over that divergence.
+#[inline]
+pub(crate) fn scalar_charsxp(sexp: SEXP) -> Result<SEXP, SexpError> {
+    let actual = sexp.type_of();
+    if actual != SEXPTYPE::STRSXP {
+        return Err(SexpTypeError {
+            expected: SEXPTYPE::STRSXP,
+            actual,
+        }
+        .into());
+    }
+
+    let len = sexp.len();
+    if len != 1 {
+        return Err(SexpLengthError {
+            expected: 1,
+            actual: len,
+        }
+        .into());
+    }
+
+    Ok(sexp.string_elt(0))
+}
+
+/// Unchecked-FFI variant of [`scalar_charsxp`] — uses `len_unchecked` /
+/// `string_elt_unchecked`.
+///
+/// # Safety
+///
+/// Must be called from R's main thread (same contract as
+/// [`TryFromSexp::try_from_sexp_unchecked`]).
+#[inline]
+pub(crate) unsafe fn scalar_charsxp_unchecked(sexp: SEXP) -> Result<SEXP, SexpError> {
+    let actual = sexp.type_of();
+    if actual != SEXPTYPE::STRSXP {
+        return Err(SexpTypeError {
+            expected: SEXPTYPE::STRSXP,
+            actual,
+        }
+        .into());
+    }
+
+    let len = unsafe { sexp.len_unchecked() };
+    if len != 1 {
+        return Err(SexpLengthError {
+            expected: 1,
+            actual: len,
+        }
+        .into());
+    }
+
+    Ok(unsafe { sexp.string_elt_unchecked(0) })
+}
+
+/// Shared SEXP-dispatch shell for the VECSXP (list) walk.
+///
+/// List-side counterpart of [`from_numeric_vec_with`] / [`map_strsxp_with`]:
+/// checks `VECSXP`, walks each element via `vector_elt`, and applies the
+/// per-element `map` closure (which receives the element's index and SEXP).
+/// Per-element policy (recursion, `NILSXP` → `None`, duplicate-pointer
+/// aliasing checks, …) lives entirely in the closure.
+#[inline]
+pub(crate) fn map_vecsxp_with<U>(
+    sexp: SEXP,
+    mut map: impl FnMut(usize, SEXP) -> Result<U, SexpError>,
+) -> Result<Vec<U>, SexpError> {
+    let actual = sexp.type_of();
+    if actual != SEXPTYPE::VECSXP {
+        return Err(SexpTypeError {
+            expected: SEXPTYPE::VECSXP,
+            actual,
+        }
+        .into());
+    }
+
+    let len = sexp.len();
+    let mut result = Vec::with_capacity(len);
+    for i in 0..len {
+        let elem = sexp.vector_elt(i as crate::R_xlen_t);
+        result.push(map(i, elem)?);
+    }
+    Ok(result)
+}
+
+/// Unchecked-FFI variant of [`map_vecsxp_with`] — uses `len_unchecked` /
+/// `vector_elt_unchecked` for the type-check and walk.
+///
+/// # Safety
+///
+/// Must be called from R's main thread (same contract as
+/// [`TryFromSexp::try_from_sexp_unchecked`]).
+#[inline]
+pub(crate) unsafe fn map_vecsxp_with_unchecked<U>(
+    sexp: SEXP,
+    mut map: impl FnMut(usize, SEXP) -> Result<U, SexpError>,
+) -> Result<Vec<U>, SexpError> {
+    let actual = sexp.type_of();
+    if actual != SEXPTYPE::VECSXP {
+        return Err(SexpTypeError {
+            expected: SEXPTYPE::VECSXP,
+            actual,
+        }
+        .into());
+    }
+
+    let len = unsafe { sexp.len_unchecked() };
+    let mut result = Vec::with_capacity(len);
+    for i in 0..len {
+        let elem = unsafe { sexp.vector_elt_unchecked(i as crate::R_xlen_t) };
+        result.push(map(i, elem)?);
+    }
+    Ok(result)
 }
 
 /// Convert numeric/logical/raw vectors to `Vec<T>` with element-wise coercion.
@@ -1357,41 +1483,17 @@ impl<T: TypedExternal + Send> TryFromSexp for Vec<ExternalPtr<T>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-        for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::R_xlen_t);
-            result.push(<ExternalPtr<T> as TryFromSexp>::try_from_sexp(elem)?);
-        }
-        Ok(result)
+        map_vecsxp_with(sexp, |_i, elem| {
+            <ExternalPtr<T> as TryFromSexp>::try_from_sexp(elem)
+        })
     }
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
+        unsafe {
+            map_vecsxp_with_unchecked(sexp, |_i, elem| {
+                <ExternalPtr<T> as TryFromSexp>::try_from_sexp_unchecked(elem)
+            })
         }
-
-        let len = unsafe { sexp.len_unchecked() };
-        let mut result = Vec::with_capacity(len);
-        for i in 0..len {
-            let elem = unsafe { sexp.vector_elt_unchecked(i as crate::R_xlen_t) };
-            result.push(unsafe { <ExternalPtr<T> as TryFromSexp>::try_from_sexp_unchecked(elem)? });
-        }
-        Ok(result)
     }
 }
 
@@ -1402,45 +1504,17 @@ impl<T: TypedExternal + Send> TryFromSexp for Vec<Option<ExternalPtr<T>>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-        for i in 0..len {
-            let elem = sexp.vector_elt(i as crate::R_xlen_t);
-            result.push(<Option<ExternalPtr<T>> as TryFromSexp>::try_from_sexp(
-                elem,
-            )?);
-        }
-        Ok(result)
+        map_vecsxp_with(sexp, |_i, elem| {
+            <Option<ExternalPtr<T>> as TryFromSexp>::try_from_sexp(elem)
+        })
     }
 
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::VECSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::VECSXP,
-                actual,
-            }
-            .into());
+        unsafe {
+            map_vecsxp_with_unchecked(sexp, |_i, elem| {
+                <Option<ExternalPtr<T>> as TryFromSexp>::try_from_sexp_unchecked(elem)
+            })
         }
-
-        let len = unsafe { sexp.len_unchecked() };
-        let mut result = Vec::with_capacity(len);
-        for i in 0..len {
-            let elem = unsafe { sexp.vector_elt_unchecked(i as crate::R_xlen_t) };
-            result.push(unsafe {
-                <Option<ExternalPtr<T>> as TryFromSexp>::try_from_sexp_unchecked(elem)?
-            });
-        }
-        Ok(result)
     }
 }
 // endregion

--- a/miniextendr-api/src/from_r/collections.rs
+++ b/miniextendr-api/src/from_r/collections.rs
@@ -16,7 +16,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str};
+use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_str, map_vecsxp_with};
 use crate::{RLogical, SEXP, SEXPTYPE, SexpExt};
 
 macro_rules! impl_map_try_from_sexp {
@@ -157,25 +157,7 @@ where
     M: TryFromSexp,
     M::Error: Into<SexpError>,
 {
-    let actual = sexp.type_of();
-    if actual != SEXPTYPE::VECSXP {
-        return Err(SexpTypeError {
-            expected: SEXPTYPE::VECSXP,
-            actual,
-        }
-        .into());
-    }
-
-    let len = sexp.len();
-    let mut result = Vec::with_capacity(len);
-
-    for i in 0..len {
-        let elem = sexp.vector_elt(i as crate::R_xlen_t);
-        let map = M::try_from_sexp(elem).map_err(Into::into)?;
-        result.push(map);
-    }
-
-    Ok(result)
+    map_vecsxp_with(sexp, |_i, elem| M::try_from_sexp(elem).map_err(Into::into))
 }
 
 macro_rules! impl_set_try_from_sexp_native {

--- a/miniextendr-api/src/from_r/cow_and_paths.rs
+++ b/miniextendr-api/src/from_r/cow_and_paths.rs
@@ -19,8 +19,10 @@ use std::collections::{BTreeSet, HashSet};
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use crate::from_r::{SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str};
-use crate::{SEXP, SEXPTYPE, SexpExt};
+use crate::SEXP;
+use crate::from_r::{
+    SexpError, SexpTypeError, TryFromSexp, charsxp_to_cow, charsxp_to_str, map_strsxp_with,
+};
 
 /// Blanket impl: Convert R vector to `Cow<'static, [T]>` where T: RNativeType.
 ///
@@ -85,28 +87,13 @@ impl TryFromSexp for Vec<Cow<'static, str>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
+        map_strsxp_with(sexp, |charsxp, _i| {
             if charsxp == SEXP::na_string() || charsxp == SEXP::blank_string() {
-                result.push(Cow::Borrowed(""));
+                Ok(Cow::Borrowed(""))
             } else {
-                result.push(unsafe { charsxp_to_cow(charsxp) });
+                Ok(unsafe { charsxp_to_cow(charsxp) })
             }
-        }
-
-        Ok(result)
+        })
     }
 }
 
@@ -117,29 +104,14 @@ impl TryFromSexp for Vec<Option<Cow<'static, str>>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
+        map_strsxp_with(sexp, |charsxp, _i| {
             if charsxp == SEXP::na_string() {
-                result.push(None);
+                Ok(None)
             } else {
                 // charsxp_to_cow returns Cow::Borrowed("") for R_BlankString-equivalent
-                result.push(Some(unsafe { charsxp_to_cow(charsxp) }));
+                Ok(Some(unsafe { charsxp_to_cow(charsxp) }))
             }
-        }
-
-        Ok(result)
+        })
     }
 }
 
@@ -165,29 +137,14 @@ impl TryFromSexp for Vec<String> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
+        map_strsxp_with(sexp, |charsxp, _i| {
             let s = if charsxp == SEXP::na_string() {
                 String::new()
             } else {
                 unsafe { charsxp_to_str(charsxp) }.to_owned()
             };
-            result.push(s);
-        }
-
-        Ok(result)
+            Ok(s)
+        })
     }
 }
 
@@ -198,32 +155,12 @@ impl TryFromSexp for Vec<&'static str> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
+        map_strsxp_with(sexp, |charsxp, _i| {
+            if charsxp == SEXP::na_string() || charsxp == SEXP::blank_string() {
+                return Ok("");
             }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
-            if charsxp == SEXP::na_string() {
-                result.push("");
-                continue;
-            }
-            if charsxp == SEXP::blank_string() {
-                result.push("");
-                continue;
-            }
-            result.push(unsafe { charsxp_to_str(charsxp) });
-        }
-
-        Ok(result)
+            Ok(unsafe { charsxp_to_str(charsxp) })
+        })
     }
 }
 
@@ -232,32 +169,15 @@ impl TryFromSexp for Vec<Option<&'static str>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
+        map_strsxp_with(sexp, |charsxp, _i| {
             if charsxp == SEXP::na_string() {
-                result.push(None);
-                continue;
+                return Ok(None);
             }
             if charsxp == SEXP::blank_string() {
-                result.push(Some(""));
-                continue;
+                return Ok(Some(""));
             }
-            result.push(Some(unsafe { charsxp_to_str(charsxp) }));
-        }
-
-        Ok(result)
+            Ok(Some(unsafe { charsxp_to_str(charsxp) }))
+        })
     }
 }
 

--- a/miniextendr-api/src/from_r/na_vectors.rs
+++ b/miniextendr-api/src/from_r/na_vectors.rs
@@ -26,7 +26,7 @@
 use crate::coerce::TryCoerce;
 use crate::from_r::{
     SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_str, coerce_value,
-    from_numeric_vec_with, is_na_real, r_slice,
+    from_numeric_vec_with, is_na_real, map_strsxp_with, r_slice,
 };
 use crate::{RLogical, Rboolean, SEXP, SEXPTYPE, SexpExt};
 
@@ -211,29 +211,13 @@ impl TryFromSexp for Vec<Option<String>> {
     type Error = SexpError;
 
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        let mut result = Vec::with_capacity(len);
-
-        for i in 0..len {
-            let charsxp = sexp.string_elt(i as crate::R_xlen_t);
-
+        map_strsxp_with(sexp, |charsxp, _i| {
             if charsxp == SEXP::na_string() {
-                result.push(None);
+                Ok(None)
             } else {
-                result.push(Some(unsafe { charsxp_to_str(charsxp) }.to_owned()));
+                Ok(Some(unsafe { charsxp_to_str(charsxp) }.to_owned()))
             }
-        }
-
-        Ok(result)
+        })
     }
 }
 

--- a/miniextendr-api/src/from_r/references.rs
+++ b/miniextendr-api/src/from_r/references.rs
@@ -20,7 +20,7 @@
 //! Outbound: borrowed slices have no `IntoR` impl (R owns return-value
 //! storage); see [`crate::into_r`] for the owned equivalents.
 
-use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp};
+use crate::from_r::{SexpError, SexpLengthError, SexpTypeError, TryFromSexp, map_vecsxp_with};
 use crate::{RLogical, RNativeType, SEXP, SEXPTYPE, SexpExt};
 
 macro_rules! impl_ref_conversions_for {
@@ -179,25 +179,7 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
-                    let value: &'static $t = TryFromSexp::try_from_sexp(elem)?;
-                    out.push(value);
-                }
-
-                Ok(out)
+                map_vecsxp_with(sexp, |_i, elem| TryFromSexp::try_from_sexp(elem))
             }
         }
 
@@ -205,29 +187,14 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     if elem.type_of() == SEXPTYPE::NILSXP {
-                        out.push(None);
+                        Ok(None)
                     } else {
                         let value: &'static $t = TryFromSexp::try_from_sexp(elem)?;
-                        out.push(Some(value));
+                        Ok(Some(value))
                     }
-                }
-
-                Ok(out)
+                })
             }
         }
 
@@ -235,21 +202,8 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
                 let mut ptrs: Vec<*mut $t> = Vec::new();
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     let value: &'static mut $t = TryFromSexp::try_from_sexp(elem)?;
                     let ptr = std::ptr::from_mut(value);
                     if ptrs.iter().any(|&p| p == ptr) {
@@ -259,10 +213,8 @@ macro_rules! impl_ref_conversions_for {
                         ));
                     }
                     ptrs.push(ptr);
-                    out.push(value);
-                }
-
-                Ok(out)
+                    Ok(value)
+                })
             }
         }
 
@@ -270,24 +222,10 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
                 let mut ptrs: Vec<*mut $t> = Vec::new();
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     if elem.type_of() == SEXPTYPE::NILSXP {
-                        out.push(None);
-                        continue;
+                        return Ok(None);
                     }
                     let value: &'static mut $t = TryFromSexp::try_from_sexp(elem)?;
                     let ptr = std::ptr::from_mut(value);
@@ -298,10 +236,8 @@ macro_rules! impl_ref_conversions_for {
                         ));
                     }
                     ptrs.push(ptr);
-                    out.push(Some(value));
-                }
-
-                Ok(out)
+                    Ok(Some(value))
+                })
             }
         }
 
@@ -309,26 +245,9 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
-                    let slice: &'static [$t] =
-                        TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
-                    out.push(slice);
-                }
-
-                Ok(out)
+                map_vecsxp_with(sexp, |_i, elem| {
+                    TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)
+                })
             }
         }
 
@@ -336,30 +255,15 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     if elem.type_of() == SEXPTYPE::NILSXP {
-                        out.push(None);
+                        Ok(None)
                     } else {
                         let slice: &'static [$t] =
                             TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
-                        out.push(Some(slice));
+                        Ok(Some(slice))
                     }
-                }
-
-                Ok(out)
+                })
             }
         }
 
@@ -367,21 +271,8 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
                 let mut ptrs: Vec<*mut $t> = Vec::new();
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     let slice: &'static mut [$t] =
                         TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
                     if !slice.is_empty() {
@@ -394,10 +285,8 @@ macro_rules! impl_ref_conversions_for {
                         }
                         ptrs.push(ptr);
                     }
-                    out.push(slice);
-                }
-
-                Ok(out)
+                    Ok(slice)
+                })
             }
         }
 
@@ -405,24 +294,10 @@ macro_rules! impl_ref_conversions_for {
             type Error = SexpError;
 
             fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-                let actual = sexp.type_of();
-                if actual != SEXPTYPE::VECSXP {
-                    return Err(SexpTypeError {
-                        expected: SEXPTYPE::VECSXP,
-                        actual,
-                    }
-                    .into());
-                }
-
-                let len = sexp.len();
-                let mut out = Vec::with_capacity(len);
                 let mut ptrs: Vec<*mut $t> = Vec::new();
-
-                for i in 0..len {
-                    let elem = sexp.vector_elt(i as crate::R_xlen_t);
+                map_vecsxp_with(sexp, |_i, elem| {
                     if elem.type_of() == SEXPTYPE::NILSXP {
-                        out.push(None);
-                        continue;
+                        return Ok(None);
                     }
                     let slice: &'static mut [$t] =
                         TryFromSexp::try_from_sexp(elem).map_err(SexpError::from)?;
@@ -436,10 +311,8 @@ macro_rules! impl_ref_conversions_for {
                         }
                         ptrs.push(ptr);
                     }
-                    out.push(Some(slice));
-                }
-
-                Ok(out)
+                    Ok(Some(slice))
+                })
             }
         }
     };

--- a/miniextendr-api/src/from_r/strings.rs
+++ b/miniextendr-api/src/from_r/strings.rs
@@ -22,8 +22,8 @@
 //! counterparts: `String` / `&str` impls in [`crate::into_r`].
 
 use crate::from_r::{
-    SexpError, SexpLengthError, SexpTypeError, TryFromSexp, charsxp_to_str,
-    charsxp_to_str_unchecked,
+    SexpError, TryFromSexp, charsxp_to_str, charsxp_to_str_unchecked, scalar_charsxp,
+    scalar_charsxp_unchecked,
 };
 use crate::{SEXP, SEXPTYPE, SexpExt};
 
@@ -49,26 +49,7 @@ impl TryFromSexp for &'static str {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        // Get the CHARSXP at index 0
-        let charsxp = sexp.string_elt(0);
+        let charsxp = scalar_charsxp(sexp)?;
 
         // Check for NA_STRING or R_BlankString
         if charsxp == SEXP::na_string() {
@@ -84,26 +65,7 @@ impl TryFromSexp for &'static str {
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = unsafe { sexp.len_unchecked() };
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        // Get the CHARSXP at index 0
-        let charsxp = unsafe { sexp.string_elt_unchecked(0) };
+        let charsxp = unsafe { scalar_charsxp_unchecked(sexp)? };
 
         // Check for NA_STRING or R_BlankString
         if charsxp == SEXP::na_string() {
@@ -127,25 +89,7 @@ impl TryFromSexp for Option<&'static str> {
             return Ok(None);
         }
 
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        let charsxp = sexp.string_elt(0);
+        let charsxp = scalar_charsxp(sexp)?;
         if charsxp == SEXP::na_string() {
             return Ok(None);
         }
@@ -162,25 +106,7 @@ impl TryFromSexp for Option<&'static str> {
             return Ok(None);
         }
 
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = unsafe { sexp.len_unchecked() };
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        let charsxp = unsafe { sexp.string_elt_unchecked(0) };
+        let charsxp = unsafe { scalar_charsxp_unchecked(sexp)? };
         if charsxp == SEXP::na_string() {
             return Ok(None);
         }
@@ -247,25 +173,7 @@ impl TryFromSexp for String {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        let charsxp = sexp.string_elt(0);
+        let charsxp = scalar_charsxp(sexp)?;
 
         if charsxp == SEXP::na_string() {
             return Ok(String::new());
@@ -276,25 +184,7 @@ impl TryFromSexp for String {
 
     #[inline]
     unsafe fn try_from_sexp_unchecked(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
-
-        let len = unsafe { sexp.len_unchecked() };
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        let charsxp = unsafe { sexp.string_elt_unchecked(0) };
+        let charsxp = unsafe { scalar_charsxp_unchecked(sexp)? };
 
         if charsxp == SEXP::na_string() {
             return Ok(String::new());
@@ -319,29 +209,12 @@ impl TryFromSexp for Option<String> {
 
     #[inline]
     fn try_from_sexp(sexp: SEXP) -> Result<Self, Self::Error> {
-        let actual = sexp.type_of();
         // NULL -> None
-        if actual == SEXPTYPE::NILSXP {
+        if sexp.type_of() == SEXPTYPE::NILSXP {
             return Ok(None);
         }
-        if actual != SEXPTYPE::STRSXP {
-            return Err(SexpTypeError {
-                expected: SEXPTYPE::STRSXP,
-                actual,
-            }
-            .into());
-        }
 
-        let len = sexp.len();
-        if len != 1 {
-            return Err(SexpLengthError {
-                expected: 1,
-                actual: len,
-            }
-            .into());
-        }
-
-        let charsxp = sexp.string_elt(0);
+        let charsxp = scalar_charsxp(sexp)?;
 
         // Return None for NA_STRING
         if charsxp == SEXP::na_string() {

--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -655,15 +655,11 @@ impl RDeserializer {
     }
 
     fn deserialize_str_inner(&self) -> Result<&str, RSerdeError> {
-        let sexp_type = self.sexp_type();
-        if sexp_type != SEXPTYPE::STRSXP || self.len() != 1 {
-            return Err(RSerdeError::TypeMismatch {
+        let charsxp =
+            crate::from_r::scalar_charsxp(self.sexp).map_err(|_| RSerdeError::TypeMismatch {
                 expected: "character(1)",
                 actual: self.type_name(),
-            });
-        }
-
-        let charsxp = self.sexp.string_elt(0);
+            })?;
         if charsxp == SEXP::na_string() {
             return Err(RSerdeError::UnexpectedNa);
         }

--- a/miniextendr-api/src/serde/ser.rs
+++ b/miniextendr-api/src/serde/ser.rs
@@ -526,17 +526,7 @@ fn make_tagged_list(tag: &str, value: SEXP) -> SEXP {
 
 /// Extract a string from a SEXP (must be STRSXP of length 1).
 fn sexp_to_string(sexp: SEXP) -> Result<String, RSerdeError> {
-    let sexp_type = sexp.type_of();
-    if sexp_type != SEXPTYPE::STRSXP {
-        return Err(RSerdeError::NonStringKey);
-    }
-
-    let len = sexp.xlength();
-    if len != 1 {
-        return Err(RSerdeError::NonStringKey);
-    }
-
-    let charsxp = sexp.string_elt(0);
+    let charsxp = crate::from_r::scalar_charsxp(sexp).map_err(|_| RSerdeError::NonStringKey)?;
     if charsxp == SEXP::na_string() {
         return Err(RSerdeError::NonStringKey);
     }

--- a/miniextendr-api/tests/from_r_references.rs
+++ b/miniextendr-api/tests/from_r_references.rs
@@ -60,6 +60,16 @@ unsafe fn make_str_vec(values: &[&str], guard: &mut ProtectCount) -> SEXP {
     sexp
 }
 
+/// Build a VECSXP (R list) from already-protected element SEXPs.
+unsafe fn make_list(elements: &[SEXP], guard: &mut ProtectCount) -> SEXP {
+    let len = elements.len() as R_xlen_t;
+    let sexp = unsafe { guard.protect(Rf_allocVector(SEXPTYPE::VECSXP, len)) };
+    for (i, &elem) in elements.iter().enumerate() {
+        sexp.set_vector_elt(i as isize, elem);
+    }
+    sexp
+}
+
 // region: references.rs — &T / &mut T single-element borrowed scalars
 
 #[test]
@@ -282,6 +292,109 @@ fn str_and_slice_unchecked() {
         let int_vec = make_int_vec(&[4, 5, 6], &mut guard);
         let slice: &[i32] = TryFromSexp::try_from_sexp_unchecked(int_vec).unwrap();
         assert_eq!(slice, &[4, 5, 6]);
+    }
+}
+// endregion
+
+// region: references.rs — Vec<&T> / Vec<Option<&T>> / Vec<&mut T> / Vec<&[T]>
+// list-based conversions (audit D6: these route through the shared
+// `map_vecsxp_with` VECSXP walk as of the STRSXP/VECSXP walk-dedup; had no
+// direct unit coverage before).
+
+#[test]
+fn references_vec_list_suite() {
+    r_test_utils::with_r_thread(|| {
+        vec_ref_list_ok();
+        vec_ref_list_type_mismatch();
+        vec_ref_list_empty();
+        vec_option_ref_list_null_elements();
+        vec_ref_mut_list_duplicate_detection();
+        vec_ref_slice_list_ok();
+    });
+}
+
+/// `Vec<&'static i32>` from a VECSXP of int scalars — the happy path through
+/// `impl_ref_conversions_for!`'s `Vec<&'static $t>` branch (now `map_vecsxp_with`).
+fn vec_ref_list_ok() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let a = guard.protect(SEXP::scalar_integer(1));
+        let b = guard.protect(SEXP::scalar_integer(2));
+        let c = guard.protect(SEXP::scalar_integer(3));
+        let list = make_list(&[a, b, c], &mut guard);
+
+        let refs: Vec<&'static i32> = TryFromSexp::try_from_sexp(list).unwrap();
+        assert_eq!(refs.into_iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+}
+
+/// Non-VECSXP input → `SexpError::Type` naming `VECSXP` (the type-check
+/// `map_vecsxp_with` centralizes).
+fn vec_ref_list_type_mismatch() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let int_sexp = guard.protect(SEXP::scalar_integer(1));
+        let err = <Vec<&'static i32> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::VECSXP),
+            other => panic!("expected SexpError::Type, got {other:?}"),
+        }
+    }
+}
+
+/// Empty VECSXP (`list()`) → empty `Vec`.
+fn vec_ref_list_empty() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let empty_list = guard.protect(Rf_allocVector(SEXPTYPE::VECSXP, 0));
+        let refs: Vec<&'static i32> = TryFromSexp::try_from_sexp(empty_list).unwrap();
+        assert!(refs.is_empty());
+    }
+}
+
+/// `Vec<Option<&'static i32>>`: `NULL` elements map to `None`, others to `Some`.
+fn vec_option_ref_list_null_elements() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let a = guard.protect(SEXP::scalar_integer(1));
+        let c = guard.protect(SEXP::scalar_integer(3));
+        let list = make_list(&[a, SEXP::nil(), c], &mut guard);
+
+        let opts: Vec<Option<&'static i32>> = TryFromSexp::try_from_sexp(list).unwrap();
+        assert_eq!(opts.len(), 3);
+        assert_eq!(opts[0].copied(), Some(1));
+        assert_eq!(opts[1], None);
+        assert_eq!(opts[2].copied(), Some(3));
+    }
+}
+
+/// `Vec<&'static mut i32>` rejects a list that aliases the same SEXP twice —
+/// the duplicate-pointer check the `map_vecsxp_with`-routed closure carries
+/// across iterations via a captured `ptrs` accumulator.
+fn vec_ref_mut_list_duplicate_detection() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let shared = guard.protect(SEXP::scalar_integer(1));
+        let list = make_list(&[shared, shared], &mut guard);
+
+        let err = <Vec<&'static mut i32> as TryFromSexp>::try_from_sexp(list).unwrap_err();
+        assert!(
+            matches!(err, SexpError::InvalidValue(_)),
+            "expected duplicate-element InvalidValue, got {err:?}"
+        );
+    }
+}
+
+/// `Vec<&'static [i32]>` from a list of int vectors.
+fn vec_ref_slice_list_ok() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let v1 = make_int_vec(&[1, 2], &mut guard);
+        let v2 = make_int_vec(&[3, 4, 5], &mut guard);
+        let list = make_list(&[v1, v2], &mut guard);
+
+        let slices: Vec<&'static [i32]> = TryFromSexp::try_from_sexp(list).unwrap();
+        assert_eq!(slices, vec![&[1, 2][..], &[3, 4, 5][..]]);
     }
 }
 // endregion

--- a/miniextendr-api/tests/from_r_strsxp_vecsxp_walks.rs
+++ b/miniextendr-api/tests/from_r_strsxp_vecsxp_walks.rs
@@ -1,0 +1,135 @@
+//! Edge-case coverage for the shared `map_strsxp_with` / `map_vecsxp_with`
+//! walk helpers introduced in audit D6 (STRSXP/VECSXP walk dedup).
+//!
+//! The existing conversion test suite densely covers the happy paths for the
+//! consumer impls (`Vec<String>`, `Vec<Option<String>>`, `Vec<Vec<T>>`,
+//! `Vec<HashMap<String, V>>`, …) — that density is exactly the point of a pure
+//! walk-dedup. What was missing before this refactor: dedicated coverage for
+//! the empty-vector and non-matching-SEXPTYPE edges that the two new helpers
+//! now centralize (previously duplicated, and untested, in each hand-rolled
+//! walk).
+
+mod r_test_utils;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use miniextendr_api::SEXPTYPE;
+use miniextendr_api::from_r::{SexpError, TryFromSexp};
+use miniextendr_api::prelude::SEXP;
+use miniextendr_api::sys::Rf_allocVector;
+
+#[derive(Default)]
+struct ProtectCount(i32);
+
+impl ProtectCount {
+    unsafe fn protect(&mut self, sexp: SEXP) -> SEXP {
+        unsafe { miniextendr_api::sys::Rf_protect(sexp) };
+        self.0 += 1;
+        sexp
+    }
+}
+
+impl Drop for ProtectCount {
+    fn drop(&mut self) {
+        if self.0 > 0 {
+            unsafe { miniextendr_api::sys::Rf_unprotect(self.0) };
+        }
+    }
+}
+
+#[test]
+fn strsxp_vecsxp_walk_edge_cases() {
+    r_test_utils::with_r_thread(|| {
+        empty_strsxp_vectors();
+        non_strsxp_type_error();
+        empty_vecsxp_lists();
+        non_vecsxp_type_error();
+    });
+}
+
+/// Empty STRSXP (`character(0)`) walks to an empty `Vec` for every
+/// `map_strsxp_with`-routed representation.
+fn empty_strsxp_vectors() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let empty = guard.protect(Rf_allocVector(SEXPTYPE::STRSXP, 0));
+
+        let as_string: Vec<String> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_opt_string: Vec<Option<String>> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_str: Vec<&'static str> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_opt_str: Vec<Option<&'static str>> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_cow: Vec<Cow<'static, str>> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_opt_cow: Vec<Option<Cow<'static, str>>> = TryFromSexp::try_from_sexp(empty).unwrap();
+
+        assert!(as_string.is_empty());
+        assert!(as_opt_string.is_empty());
+        assert!(as_str.is_empty());
+        assert!(as_opt_str.is_empty());
+        assert!(as_cow.is_empty());
+        assert!(as_opt_cow.is_empty());
+    }
+}
+
+/// A non-STRSXP input to a `map_strsxp_with`-routed impl is a `SexpError::Type`
+/// naming `STRSXP` (the type-check the helper centralizes).
+fn non_strsxp_type_error() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let int_sexp = guard.protect(SEXP::scalar_integer(1));
+
+        let err = <Vec<String> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::STRSXP),
+            other => panic!("Vec<String>: expected SexpError::Type, got {other:?}"),
+        }
+
+        let err = <Vec<Option<String>> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::STRSXP),
+            other => panic!("Vec<Option<String>>: expected SexpError::Type, got {other:?}"),
+        }
+
+        let err = <Vec<Cow<'static, str>> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::STRSXP),
+            other => panic!("Vec<Cow<str>>: expected SexpError::Type, got {other:?}"),
+        }
+    }
+}
+
+/// Empty VECSXP (`list()`) walks to an empty `Vec` for `map_vecsxp_with`-routed
+/// representations, including the `list_to_vec_of_maps` (collections.rs) path.
+fn empty_vecsxp_lists() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let empty = guard.protect(Rf_allocVector(SEXPTYPE::VECSXP, 0));
+
+        let as_vec_vec: Vec<Vec<i32>> = TryFromSexp::try_from_sexp(empty).unwrap();
+        let as_vec_map: Vec<HashMap<String, i32>> = TryFromSexp::try_from_sexp(empty).unwrap();
+
+        assert!(as_vec_vec.is_empty());
+        assert!(as_vec_map.is_empty());
+    }
+}
+
+/// A non-VECSXP input to a `map_vecsxp_with`-routed impl is a `SexpError::Type`
+/// naming `VECSXP`.
+fn non_vecsxp_type_error() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let int_sexp = guard.protect(SEXP::scalar_integer(1));
+
+        let err = <Vec<Vec<i32>> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::VECSXP),
+            other => panic!("Vec<Vec<i32>>: expected SexpError::Type, got {other:?}"),
+        }
+
+        let err = <Vec<HashMap<String, i32>> as TryFromSexp>::try_from_sexp(int_sexp).unwrap_err();
+        match err {
+            SexpError::Type(e) => assert_eq!(e.expected, SEXPTYPE::VECSXP),
+            other => panic!("Vec<HashMap<String, i32>>: expected SexpError::Type, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Audit D6: the numeric-vector walk has been centralized for ages (`from_numeric_vec_with`), but every STRSXP and VECSXP reader in `from_r/` re-rolled the same type-check + element loop by hand — ~30 sites' worth. This adds the missing string- and list-side counterparts and routes the drop-in sites through them, a pure walk-dedup with every call site's NA/blank/error policy preserved verbatim.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Follow-up from the 2026-07-03 conversion/serde dogfooding audit (D6), the string/list-side counterpart of D5 (#1148 — numeric scalar dispatch): `from_numeric_vec_with` already centralizes the atomic-numeric-vector walk, but the STRSXP and VECSXP walks had no equivalent and were hand-rolled at every call site. Adds three `pub(crate)` helpers to `miniextendr-api/src/from_r.rs` and routes the identified sites through them:

- **`map_strsxp_with`** (finding #2) — STRSXP type-check + `string_elt` walk, per-element mapping left to the caller's closure. Routed **6 call sites**: `na_vectors.rs`'s `Vec<Option<String>>`, and `cow_and_paths.rs`'s `Vec<Cow<str>>`, `Vec<Option<Cow<str>>>`, `Vec<String>`, `Vec<&str>`, `Vec<Option<&str>>`.
- **`scalar_charsxp` / `scalar_charsxp_unchecked`** (finding #3) — STRSXP scalar prologue (type-check + `len == 1` + `string_elt(0)`), NA/blank policy left to the caller. Routed **7 call sites** in `strings.rs` (`&str`, `Option<&str>`, `String` checked+unchecked, `Option<String>` — the `String`/`&str` blank-string handling divergence flagged in the audit is preserved as-is, not silently unified) plus **2 drop-in serde sites** (`serde/ser.rs::sexp_to_string`, `serde/de.rs::deserialize_str_inner`) adapted via `.map_err(...)` without threading serde's error type into `from_r`.
- **`map_vecsxp_with` / `map_vecsxp_with_unchecked`** (finding #4) — VECSXP type-check + `vector_elt` walk. Routed **15 source-level call sites**: `from_r.rs` top-level `Vec<Vec<T>>` / `Vec<ExternalPtr<T>>` / `Vec<Option<ExternalPtr<T>>>` (checked + unchecked, 6 sites), the `references.rs` `impl_ref_conversions_for!` macro body (8 impl bodies, expands to 40 across the 5 `RNativeType` instantiations — a single macro edit collapses all of them), and `collections.rs::list_to_vec_of_maps`.

Every routed site's exact NA policy, blank-string policy, and error type/message is unchanged — this is a pure walk-dedup. Net **-308 lines** in `miniextendr-api/src/{from_r.rs,from_r/*.rs,serde/*.rs}`.

## Policy notes (no silent fixes)

- `String`'s scalar STRSXP impl does not special-case `SEXP::blank_string()` while `&str`'s does (both map NA to `""`, but only `&str` additionally coerces `R_BlankString`-equivalent CHARSXPs — the two happen to produce the same visible result today since blank strings already round-trip as `""`, but the code paths differ). Preserved as-is per the audit note; not treated as a bug in this PR.
- The new `map_strsxp_with` / `map_vecsxp_with` use their checked FFI variants (`len()`, `string_elt()`, `vector_elt()`) even when called from a `try_from_sexp_unchecked` body that previously used `len_unchecked()` / `*_unchecked()` directly (only the 3 `from_r.rs` top-level VECSXP impls had a real unchecked fast path; STRSXP vector impls never did). This mirrors the existing precedent set by `from_numeric_vec_with`/`try_from_sexp_numeric_vec`, which already routes both checked and unchecked callers through one checked-FFI walk. `map_vecsxp_with_unchecked` exists as a true unchecked-FFI twin and is used by the 3 `from_r.rs` impls that had a real fast path, so no unchecked-FFI capability was removed — only the STRSXP side collapses onto the checked-only helper, same as the numeric precedent.
- Audit finding #4 also counted `vector_elt` sites in `serde/de.rs` (`ListSeqAccess` / `NamedListMapAccess` / `deserialize_enum`'s data-variant arm) toward the ~22 VECSXP-walk sites. On inspection these are lazy, pull-based `SeqAccess`/`MapAccess` iterators driven one element at a time by serde's `Visitor` machinery, not eager "collect the whole list" walks — structurally incompatible with `map_vecsxp_with`'s shape. Filed #1149 to track a possible future lazy-iterator-shaped helper rather than silently dropping that part of the finding.

## Test plan

- [x] `just check` (workspace + rpkg/src/rust + tests/cross-package/* + cargo-revendor) — clean.
- [x] `just test` — all suites green except the pre-existing `derive_dataframe_*` trybuild UI mismatches (local-rustc-vs-CI-toolchain drift, unrelated, not touched/overwritten per repo convention).
- [x] `cargo test -p miniextendr-api --test from_r_references --test from_r_strsxp_vecsxp_walks` — new/extended coverage, all passing: backfilled the `references.rs` `Vec<&T>`/`Vec<Option<&T>>`/`Vec<&mut T>`/`Vec<&[T]>` family (zero direct unit coverage before this PR, despite being the highest-fan-out consolidation — 8 macro bodies × 5 `RNativeType`s), plus empty-vector and non-matching-SEXPTYPE edge cases for the three new helpers across their STRSXP/VECSXP consumer types.
- [x] `cargo fmt --all` — clean.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (clippy_default) — clean.
- [x] `cargo clippy --workspace --all-targets --locked --features full-codegen,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd -- -D warnings` (clippy_all) — clean.
- [x] Same feature list with `full-codegen-s7` instead of `full-codegen` (clippy_all_s7) — clean.
- [x] rpkg loop: `just configure && just rcmdinstall` then `just devtools-test` — `[ FAIL 0 | WARN 0 | SKIP 20 | PASS 6805 ]`.

## Notes

- Deferred: #1149 (serde `de.rs` list/map lazy-iterator sites — not drop-in for `map_vecsxp_with`, see policy notes above).
- No behavior changes intended anywhere in this PR; every routed call site keeps its exact prior `Result` values, error variants, and messages.

---
_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>
