### PR TITLE
docs: one-screen contract for what None/Err becomes in R, by return category (audit A1)

### DIFF
--- a/docs/COLUMNAR_OPTION_NONE.md
+++ b/docs/COLUMNAR_OPTION_NONE.md
@@ -1,5 +1,11 @@
 # Columnar data.frame: all-None Option columns
 
+This page covers a **column** of `Option<T>` values in a columnar/
+`DataFrameRow` context. For what a **bare scalar** `Option<T>` / `Result<T,
+E>` return becomes in R (NA vs NULL vs a raised error, by return-type
+category), see the absence-contract table in
+[CONVERSION_MATRIX.md](CONVERSION_MATRIX.md#the-absence-contract-what-none-becomes-in-r).
+
 ## The old failure
 
 `vec_to_dataframe` discovers column types by probing runtime values.

--- a/docs/CONVERSION_MATRIX.md
+++ b/docs/CONVERSION_MATRIX.md
@@ -159,18 +159,30 @@ With `#[miniextendr(strict)]`, large integer types **panic** instead of falling 
 | `Vec<i64>` | All elements fit | INTSXP vector |
 | `Vec<i64>` | Any element outside range | **Panic** (R error) |
 
-### Option Types (NA Mapping)
+### The Absence Contract: What `None` Becomes in R
 
-| Rust Type | `Some(val)` | `None` |
-|-----------|-------------|--------|
-| `Option<i32>` | INTSXP scalar | NA_integer_ |
-| `Option<f64>` | REALSXP scalar | NA_real_ |
-| `Option<bool>` | LGLSXP scalar | NA_logical |
-| `Option<Rboolean>` | LGLSXP scalar | NA_logical |
-| `Option<String>` | STRSXP scalar | NA_character_ |
-| `Option<&str>` | STRSXP scalar | NA_character_ |
-| `Option<Vec<T>>` | R vector | NULL (R_NilValue) |
-| `Option<HashMap<...>>` | Named list | NULL (R_NilValue) |
+`None` does not map to one universal R value — it depends on the *shape* of
+the return type, and the divergence is easy to trip over: changing a Rust
+return type from `Option<i32>` to `Option<&i32>`, or from `Option<i32>` to
+`Option<Vec<i32>>`, silently flips the R-visible absence value from
+`NA_integer_` to `NULL`. There is no compiler warning and no macro
+diagnostic. R code written as `is.na(x)` against the old contract will error
+("argument is of length zero") the moment it sees `NULL` instead.
+
+| Rust Return Type | `None` becomes | Test with | Why |
+|-------------------|-----------------|-----------|-----|
+| `Option<i32>` / `Option<f64>` / `Option<bool>` / `Option<Rboolean>` / `Option<RLogical>` / `Option<Rcomplex>` / `Option<String>` / coerced scalars (`i8`, `i16`, `u16`, `u32`, `f32`, `i64`, `u64`, `isize`, `usize`) | `NA_<type>_` | `is.na(x)` | Owned scalar — R has a native NA sentinel for each of these types |
+| `Option<PathBuf>` / `Option<OsString>` | `NA_character_` | `is.na(x)` | Lossy-string family; follows the same convention as owned scalars |
+| `Option<&str>` | `NA_character_` | `is.na(x)` | **Exception** to the `Option<&T>` row below: `str` is unsized, so it cannot use the generic `Copy`-bounded blanket impl. It has a hand-written impl instead that deliberately mirrors `Option<String>`. |
+| `Option<&T>` where `T: Copy` (e.g. `Option<&i32>`, `Option<&f64>`, `Option<&bool>`) | `NULL` | `is.null(x)` | A borrowed reference has nothing to copy on `None` — there is no NA representation for "no reference" |
+| `Option<Vec<T>>` / `Option<Vec<String>>` / `Option<HashMap<String, V>>` / `Option<BTreeMap<String, V>>` / `Option<HashSet<T>>` / `Option<BTreeSet<T>>` | `NULL` | `is.null(x)` | No container type has a native R NA sentinel |
+| `Option<SEXP>` | `NULL` (`R_NilValue`) | `is.null(x)` | Handled directly by the `#[miniextendr]` macro (`return_type_analysis.rs`), not by an `IntoR` impl |
+| `Option<()>` | **Not a value at all** — `None` raises a tagged `rust_*` R condition | `tryCatch(f(), error = \(e) ...)` | The macro special-cases `Option<()>` as an error boundary rather than an absence value — see [Result and Error Types](#result-and-error-types) below for the analogous `Result` behavior |
+
+See also [COLUMNAR_OPTION_NONE.md](COLUMNAR_OPTION_NONE.md) for how an
+all-`None` `Option<T>` **column** in a `DataFrameRow`/columnar context (as
+opposed to a bare scalar return covered above) is downgraded to a typed NA
+vector rather than a `list(NULL, NULL, ...)`.
 
 ### Vector Types
 
@@ -259,11 +271,33 @@ Notes:
 
 ### Result and Error Types
 
+This is the `Result` half of the absence contract — `Err` follows a
+completely different rule depending on the error type and the
+`unwrap_in_r` attribute:
+
 | Rust Type | `Ok(val)` | `Err(e)` |
 |-----------|-----------|----------|
-| `Result<T, E: Debug>` (default) | `T::into_sexp()` | **Panic** -> R error |
-| `Result<T, E: Display>` (`unwrap_in_r`) | `T::into_sexp()` | `list(error = msg)` |
-| `Result<T, ()>` | `T::into_sexp()` | NULL (R_NilValue) |
+| `Result<T, E>` (default, `E != ()`) | `T::into_sexp()` | **Not a value** — raises a tagged `rust_*` R condition (`E: Debug`-formatted message); catch with `tryCatch` |
+| `Result<(), E>` (default, `E != ()`) | `NULL`, invisibly | Same as above — raises |
+| `Result<SEXP, E>` (default, `E != ()`) | The `SEXP` directly | Same as above — raises |
+| `Result<T, E: Display>` (`#[miniextendr(unwrap_in_r)]`, `E != ()`) | `T::into_sexp()` | `list(error = e.to_string())` — **not** `NULL`, **not** `NA`; test with `!is.null(x$error)` |
+| `Result<T, ()>` (any `T`, with or without `unwrap_in_r`) | `T::into_sexp()` | `NULL` (`R_NilValue`); test with `is.null(x)` |
+| `Result<(), ()>` | `NULL`, invisibly | `NULL`, invisibly (indistinguishable from `Ok`) |
+
+`Result<T, ()>` is the *only* `Result` shape whose `Err` reaches R as a
+plain value — the macro rewrites `Err(())` to `Err(NullOnErr)`
+(`miniextendr_api::into_r::NullOnErr`) specifically because a unit error
+carries no message worth reporting. Every other `E` follows the default
+error-boundary path (tagged-condition transport is the framework's only
+error path, see `miniextendr-api/CLAUDE.md`) *unless* `unwrap_in_r` is set,
+in which case `Err` becomes data (`list(error = ...)`) instead of a raised
+condition.
+
+Audit note: `rpkg/tests/testthat/test-conversions.R:290`
+(`expect_true(is.null(conv_result_i32_err()))`) exercises the
+`Result<i32, ()>` shape specifically. It is easy to over-generalize this
+into "`Result::Err` becomes `NULL`" — that only holds for the `()` error
+type. Any other error type raises instead of returning a value.
 
 ### Intentional Asymmetries (argument-only / return-only)
 

--- a/docs/TYPE_CONVERSIONS.md
+++ b/docs/TYPE_CONVERSIONS.md
@@ -59,6 +59,13 @@ Use `Option<T>` to handle NA safely on both input and output.
 Note: `i32` rejects `NA_integer_` (= `i32::MIN`) on input; you must use `Option<i32>` to receive integer NA.
 Note: `bool` rejects logical NA on input; use `Option<bool>` to receive logical NA.
 
+**This table covers owned scalars only.** A reference return
+(`Option<&i32>`) or a container return (`Option<Vec<T>>`,
+`Option<HashMap<...>>`) maps `None` to `NULL` instead of NA — same for
+`Result::Err` in most shapes. See the full "Absence Contract" table in
+[CONVERSION_MATRIX.md](CONVERSION_MATRIX.md#the-absence-contract-what-none-becomes-in-r)
+for every return-type category, including the `Result` side.
+
 ### ALTREP-Aware Types
 
 R frequently passes ALTREP vectors (e.g., `1:10`, `seq_len(N)`) to Rust. All

--- a/miniextendr-api/src/dataframe.rs
+++ b/miniextendr-api/src/dataframe.rs
@@ -947,7 +947,7 @@ impl List {
 /// rather than folding into the `DataFrame::builder` vocabulary. Its inputs
 /// are [`DataFrame`]s (from any producer: [`IntoDataFrame`], the serde
 /// `vec_to_dataframe`, or [`GroupedDataFrame::frames`]); its output is a
-/// [`List`](crate::list::List).
+/// [`List`].
 ///
 /// Each [`push`](NamedDataFrameListBuilder::push) protects the input
 /// data.frame's SEXP via an internal [`ProtectScope`](crate::ProtectScope);
@@ -1041,7 +1041,7 @@ impl NamedDataFrameListBuilder {
         self.pairs.is_empty()
     }
 
-    /// Consume the builder and return the assembled named [`List`](crate::list::List).
+    /// Consume the builder and return the assembled named [`List`].
     ///
     /// The returned `List`'s SEXP is *not* separately protected on return — the
     /// caller takes responsibility for protection (typically by immediately

--- a/miniextendr-api/src/into_r.rs
+++ b/miniextendr-api/src/into_r.rs
@@ -40,6 +40,31 @@
 //! - Inside ALTREP callbacks
 //! - Inside standalone `#[miniextendr]` functions (they run on the main thread)
 //! - Inside `extern "C-unwind"` functions called directly by R
+//!
+//! # The absence contract: what `None` becomes in R
+//!
+//! `None` does **not** map to one universal R value — it depends on the
+//! shape of `T` in `Option<T>`:
+//!
+//! - Owned scalars (`Option<i32>`, `Option<f64>`, `Option<bool>`,
+//!   `Option<String>`, and friends in [`large_integers`]) → the matching
+//!   `NA_<type>_`. R has a native NA sentinel for each of these.
+//! - `Option<&T>` where `T: Copy` (e.g. `Option<&i32>`) → `NULL`. A
+//!   reference has nothing to copy on `None`, so there is no NA to
+//!   produce. See the impl doc on `Option<&T>` in [`large_integers`].
+//! - `Option<&str>` is the one exception to the previous rule: it returns
+//!   `NA_character_`, matching `Option<String>`, because `str` is unsized
+//!   and can't use the generic `Copy`-bounded blanket impl — it has its
+//!   own hand-written impl instead.
+//! - Containers (`Option<Vec<T>>`, `Option<HashMap<..>>`, `Option<HashSet<..>>`,
+//!   `Option<BTreeMap<..>>`, `Option<BTreeSet<..>>`) → `NULL`. No container
+//!   type has a native R NA sentinel either.
+//!
+//! Changing a return type from `Option<i32>` to `Option<&i32>` or
+//! `Option<Vec<i32>>` therefore silently flips the R-visible absence value
+//! from `NA_integer_` to `NULL`, with no compiler warning. See
+//! [`result`] for the analogous (and differently-shaped) contract on
+//! `Result::Err`.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;

--- a/miniextendr-api/src/into_r/large_integers.rs
+++ b/miniextendr-api/src/into_r/large_integers.rs
@@ -627,6 +627,15 @@ impl IntoR for &str {
     }
 }
 
+/// Convert `Option<&str>` to R: `Some(s)` → character, `None` → `NA_character_`.
+///
+/// This is a deliberate **exception** to the generic `Option<&T> where T:
+/// Copy` blanket impl below (which returns `NULL` for `None`, not NA).
+/// `str` is unsized, so it can't satisfy that impl's `Copy` bound —
+/// `&str` gets its own hand-written impl here instead, and it's written to
+/// mirror `Option<String>`'s NA semantics rather than the reference-type
+/// NULL semantics. See the module-level "absence contract" doc on
+/// [`crate::into_r`] for the full return-category table.
 impl IntoR for Option<&str> {
     type Error = crate::into_r_error::IntoRError;
     #[inline]
@@ -691,6 +700,10 @@ impl IntoR for Option<String> {
 ///
 /// Note: This returns NULL for None, not NA, since there's no reference to return.
 /// Use `Option<T>` directly if you want NA semantics for scalar types.
+///
+/// `T: Copy` excludes `str` (unsized), so `Option<&str>` does **not** go
+/// through this impl — see the dedicated `Option<&str>` impl above, which
+/// returns `NA_character_` instead of `NULL`.
 impl<T> IntoR for Option<&T>
 where
     T: Copy + IntoR,


### PR DESCRIPTION
Audit A1 flagged that our absence handling (`None`/`Err` -> R) is real and consistent under the hood, but was never written down as a single contract: NA for owned scalars, NULL for references and containers, and a raised condition (or `list(error=...)`) for most `Result::Err` shapes. That divergence was only discoverable by reading scattered test assertions, and changing a return type from `Option<i32>` to `Option<&i32>` or `Option<Vec<i32>>` silently flips the R-visible value with no warning. This adds the one-screen table plus matching rustdoc so people don't have to reverse-engineer it.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Replaced the incomplete "Option Types (NA Mapping)" table in `docs/CONVERSION_MATRIX.md` with a full "Absence Contract" table covering owned scalars, `Option<&str>` (the exception), `Option<&T>` references, containers, `Option<SEXP>`, and `Option<()>` (which is actually an error boundary, not an absence value).
- Expanded the "Result and Error Types" table in the same file to distinguish the default error-boundary path (raises, does not return a value), `unwrap_in_r` (`Err` becomes `list(error=...)`), and `Result<T, ()>` (the only shape where `Err` reaches R as plain `NULL`) — the audit's own example (`conv_result_i32_err()`) exercises the `Result<T, ()>` special case specifically, not the general rule.
- Cross-linked `docs/TYPE_CONVERSIONS.md` and `docs/COLUMNAR_OPTION_NONE.md` to the new table instead of duplicating it.
- Added a module-level "absence contract" rustdoc section to `miniextendr-api/src/into_r.rs`, plus doc comments on the `Option<&str>` and `Option<&T>` impls in `miniextendr-api/src/into_r/large_integers.rs` explaining why `&str` is the exception to the reference-type rule.
- Fixed two pre-existing (unrelated) redundant-link rustdoc warnings in `miniextendr-api/src/dataframe.rs`, found while confirming `cargo doc` was clean.
- Filed #1156 for a genuine doc/behavior mismatch found while verifying this: `into_r/result.rs`'s module doc says its impls "only fire under `unwrap_in_r`", but the `NullOnErr` impl (`Result<T, ()>`) actually fires whenever the error type is `()`, independent of that attribute. Left unfixed here since the fix belongs in that file's own doc wording, not in this table-adding PR.

## Test plan
- [x] `just check` — clean, no new warnings.
- [x] `cargo doc -p miniextendr-api --no-deps` — zero warnings (after fixing the two pre-existing ones above).
- [x] `cargo fmt --all` — no changes needed.
- [x] Cross-checked every table row against the actual `IntoR` impls in `miniextendr-api/src/into_r.rs`, `miniextendr-api/src/into_r/large_integers.rs`, and `miniextendr-api/src/into_r/result.rs`, and against the macro's return-type handling in `miniextendr-macros/src/return_type_analysis.rs` — not against test comments, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>