### PR TITLE
fix(macros): wrap Result<Self, E> static returns as class objects like $new() (audit A4)

### DIFF
--- a/miniextendr-macros/src/c_wrapper_builder.rs
+++ b/miniextendr-macros/src/c_wrapper_builder.rs
@@ -90,6 +90,14 @@ pub enum ReturnHandling {
     /// Returns `Result<T, ()>` -- maps `Err(())` to `Err(NullOnErr)` then converts via `IntoR`.
     /// `None`/`Err` maps to R `NULL` (unit error is a deliberate sentinel, not a Rust failure).
     ResultNullOnErr,
+    /// Returns `Result<Self, E>` -- a fallible constructor-shaped method (e.g. `from_r`,
+    /// `try_new`). Raises an error on `Err` (same as [`ResultIntoR`](Self::ResultIntoR)), but
+    /// wraps `Ok(Self)` in an `ExternalPtr` via `ExternalPtr::new` (same as
+    /// [`ExternalPtr`](Self::ExternalPtr)) instead of routing it through `IntoR` (which `Self`
+    /// generally does not implement). The R-side wrapper mirrors this: a successful return is
+    /// treated exactly like a bare `Self` return (wrapped class object via
+    /// `ReturnStrategy::for_method` — see `ParsedMethod::returns_result_self`).
+    ResultExternalPtr,
     /// Returns `T` where `T: IntoList` -- wraps in `AsList(result)` then calls `IntoR::into_sexp`.
     ///
     /// Produced when `#[miniextendr(prefer = "list")]` is used on a function returning `T: IntoList`.
@@ -710,6 +718,22 @@ impl CWrapperContext {
                     }
                 }
             }
+            // Result<Self, E>: raise on Err like ResultIntoR, but wrap Ok(Self) in an
+            // ExternalPtr like the bare-Self path rather than routing through IntoR.
+            ReturnHandling::ResultExternalPtr => {
+                quote! {
+                    let __result = #call_expr;
+                    let __result = match __result {
+                        Ok(v) => v,
+                        Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                            &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
+                        ),
+                    };
+                    ::miniextendr_api::into_r::IntoR::into_sexp(
+                        ::miniextendr_api::externalptr::ExternalPtr::new(__result)
+                    )
+                }
+            }
             ReturnHandling::AsListOf => {
                 quote! {
                     let __result = #call_expr;
@@ -922,6 +946,26 @@ impl CWrapperContext {
                     match __miniextendr_result {
                         Ok(#result_ident) => #unwind_fn(|| #conversion, None),
                         Err(()) => ::miniextendr_api::SEXP::nil(),
+                    }
+                };
+                (worker, convert)
+            }
+            // Result<Self, E>: raise on Err like ResultIntoR, but wrap Ok(Self) in an
+            // ExternalPtr like the bare-Self path rather than routing through IntoR.
+            ReturnHandling::ResultExternalPtr => {
+                let worker = quote! { #call_expr };
+                let unwind_fn = self.worker_conversion_unwind_fn();
+                let convert = quote! {
+                    match __miniextendr_result {
+                        Ok(v) => #unwind_fn(
+                            || ::miniextendr_api::into_r::IntoR::into_sexp(
+                                ::miniextendr_api::externalptr::ExternalPtr::new(v)
+                            ),
+                            None,
+                        ),
+                        Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                            &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
+                        ),
                     }
                 };
                 (worker, convert)
@@ -1446,7 +1490,8 @@ pub fn detect_return_handling_standalone_fn(output: &syn::ReturnType) -> ReturnH
 /// - `Self` -> [`ExternalPtr`](ReturnHandling::ExternalPtr)
 /// - `SEXP` -> [`RawSexp`](ReturnHandling::RawSexp)
 /// - `Option<T>` -> recurses into `T` for `OptionUnit`, `OptionSexp`, or `OptionIntoRUnwrap`
-/// - `Result<T, E>` -> recurses into `T` for `ResultUnit`, `ResultSexp`, or `ResultIntoR`
+/// - `Result<T, E>` -> recurses into `T` for `ResultUnit`, `ResultSexp`, `ResultExternalPtr`
+///   (`T = Self`), or `ResultIntoR`
 /// - Anything else -> [`IntoR`](ReturnHandling::IntoR)
 ///
 /// Note: The default for `Option<T>` (non-unit, non-SEXP) is `OptionIntoRUnwrap` (unwrap
@@ -1536,6 +1581,19 @@ fn detect_return_handling_from_type(ty: &syn::Type) -> ReturnHandling {
                             .unwrap_or(false) =>
                     {
                         ReturnHandling::ResultSexp
+                    }
+                    // Result<Self, E>: a fallible constructor-shaped method. Wrap
+                    // `Ok(Self)` in an ExternalPtr like the bare-`Self` path, rather
+                    // than routing it through `IntoR` (which `Self` generally lacks).
+                    syn::Type::Path(ip)
+                        if ip
+                            .path
+                            .segments
+                            .last()
+                            .map(|s| s.ident == "Self")
+                            .unwrap_or(false) =>
+                    {
+                        ReturnHandling::ResultExternalPtr
                     }
                     _ => ReturnHandling::ResultIntoR,
                 }

--- a/miniextendr-macros/src/c_wrapper_builder/tests.rs
+++ b/miniextendr-macros/src/c_wrapper_builder/tests.rs
@@ -71,4 +71,12 @@ fn return_handling_detection() {
         detect_return_handling(&result_unit_unit_ty),
         ReturnHandling::ResultNullOnErr
     ));
+
+    // -> Result<Self, E> -> ResultExternalPtr (audit A4: fallible constructor-shaped
+    // methods like `from_r` wrap `Ok(Self)` in an ExternalPtr, not `IntoR`).
+    let result_self_ty: syn::ReturnType = syn::parse_quote!(-> Result<Self, E>);
+    assert!(matches!(
+        detect_return_handling(&result_self_ty),
+        ReturnHandling::ResultExternalPtr
+    ));
 }

--- a/miniextendr-macros/src/method_return_builder.rs
+++ b/miniextendr-macros/src/method_return_builder.rs
@@ -93,7 +93,11 @@ pub enum ReturnStrategy {
 impl ReturnStrategy {
     /// Determine the return strategy for a parsed method.
     ///
-    /// - Methods that return `Self` use `ReturnSelf`
+    /// - Methods that return `Self` or `Result<Self, E>` use `ReturnSelf`. For the
+    ///   latter, the C wrapper already raised on `Err` (see
+    ///   [`crate::c_wrapper_builder::ReturnHandling::ResultExternalPtr`]), so a
+    ///   successful `.val` is a bare ExternalPtr — identical in shape to the
+    ///   bare-`Self` case — and gets the same class-wrapping tail.
     /// - In-place builders (`&mut self -> &mut Self` / `&self -> Self`) and
     ///   `&mut self -> ()` methods use `ChainableMutation`. Both return the
     ///   receiver object (`x` / `invisible(self)`) so the call composes under
@@ -106,7 +110,7 @@ impl ReturnStrategy {
         // `&mut self -> ()` mutators both return the receiver object.
         let is_self_ref_builder = method.returns_self_ref() && method.env.is_instance();
         let is_unit_mutator = method.env.is_mut() && method.returns_unit();
-        if method.returns_self() {
+        if method.returns_self() || method.returns_result_self() {
             ReturnStrategy::ReturnSelf
         } else if is_self_ref_builder || is_unit_mutator {
             ReturnStrategy::ChainableMutation

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -2065,6 +2065,35 @@ impl ParsedMethod {
                 if p.path.segments.last().map(|s| s.ident == "Self").unwrap_or(false)))
     }
 
+    /// Returns true if this method returns `Result<Self, E>` — a fallible
+    /// constructor-shaped method (e.g. `from_r`, `try_new`). On the R side this
+    /// is treated exactly like a bare `Self` return (wrapped class object via
+    /// [`crate::ReturnStrategy::for_method`]); the C wrapper still raises on
+    /// `Err` via the normal `Result` error path (see
+    /// [`crate::c_wrapper_builder::ReturnHandling::ResultExternalPtr`]).
+    pub fn returns_result_self(&self) -> bool {
+        let syn::ReturnType::Type(_, ty) = &self.sig.output else {
+            return false;
+        };
+        let syn::Type::Path(p) = ty.as_ref() else {
+            return false;
+        };
+        let Some(seg) = p.path.segments.last() else {
+            return false;
+        };
+        if seg.ident != "Result" {
+            return false;
+        }
+        let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
+            return false;
+        };
+        let Some(syn::GenericArgument::Type(ok_ty)) = ab.args.first() else {
+            return false;
+        };
+        matches!(ok_ty, syn::Type::Path(ip)
+            if ip.path.segments.last().map(|s| s.ident == "Self").unwrap_or(false))
+    }
+
     /// Returns true if this method returns a reference to `Self` (`&Self` or
     /// `&mut Self`) — the idiomatic Rust in-place builder signature.
     ///

--- a/miniextendr-macros/src/miniextendr_impl/tests.rs
+++ b/miniextendr-macros/src/miniextendr_impl/tests.rs
@@ -908,6 +908,62 @@ fn self_ref_builder_uses_self_handle_return() {
     let _ = ReturnHandling::SelfHandle;
 }
 
+/// Audit A4: a static returning `Result<Self, E>` (e.g. `from_r`) must wrap its
+/// successful return exactly like a bare-`Self`-returning constructor (e.g.
+/// `new`) — a usable class object, not a bare `ExternalPtr`. The C wrapper still
+/// raises on `Err` via the normal `Result` error path.
+#[test]
+fn result_self_static_wraps_like_constructor() {
+    use crate::c_wrapper_builder::ReturnHandling;
+
+    let item_impl: syn::ItemImpl = syn::parse_quote! {
+        impl SerdeRPoint {
+            pub fn new(x: f64, y: f64) -> Self { unimplemented!() }
+            pub fn from_r(sexp: SEXP) -> Result<Self, String> { unimplemented!() }
+        }
+    };
+
+    let parsed = parse_impl(ClassSystem::Env, item_impl);
+    let from_r = parsed.methods.iter().find(|m| m.ident == "from_r").unwrap();
+
+    // Detected as a `Result<Self, E>` return, not a bare `Self` return.
+    assert!(from_r.returns_result_self());
+    assert!(!from_r.returns_self());
+
+    // C-wrapper return handling wraps `Ok(Self)` in an ExternalPtr, distinct
+    // from the plain `Result<T, E> -> IntoR` path.
+    assert!(matches!(
+        crate::c_wrapper_builder::detect_return_handling(&from_r.sig.output),
+        ReturnHandling::ResultExternalPtr
+    ));
+
+    // R-side strategy matches the bare-Self constructor path.
+    let new_method = parsed.methods.iter().find(|m| m.ident == "new").unwrap();
+    assert_eq!(
+        crate::ReturnStrategy::for_method(from_r),
+        crate::ReturnStrategy::for_method(new_method)
+    );
+    assert_eq!(
+        crate::ReturnStrategy::for_method(from_r),
+        crate::ReturnStrategy::ReturnSelf
+    );
+
+    // The generated Env wrapper wraps the successful result in the class,
+    // exactly like `$new()`.
+    let wrapper = generate_env_r_wrapper(&parsed);
+    let from_r_body = wrapper
+        .split("SerdeRPoint$from_r <- function(sexp) {")
+        .nth(1)
+        .expect("from_r method body")
+        .split("\n}")
+        .next()
+        .expect("from_r method body");
+    assert!(
+        from_r_body.contains("class(.val) <- \"SerdeRPoint\""),
+        "from_r should wrap its successful return like a class constructor, got:\n{from_r_body}"
+    );
+}
+
 #[test]
 fn returns_unit_method_in_r6() {
     let item_impl: syn::ItemImpl = syn::parse_quote! {

--- a/rpkg/tests/testthat/test-serde_r.R
+++ b/rpkg/tests/testthat/test-serde_r.R
@@ -132,16 +132,15 @@ test_that("SerdeRPoint serializes to named list", {
 })
 
 test_that("SerdeRPoint deserializes from named list", {
-  # Note: from_r returns a raw ExternalPtr, not a proper S3 object
-  # This is a limitation of static methods returning Result<Self, String>
-  # The actual deserialization is tested via serde_r_roundtrip_point()
+  # from_r wraps its Result<Self, String> exactly like $new() does — the
+  # returned object is a usable SerdeRPoint, not a bare ExternalPtr.
   data <- list(x = 3.0, y = 4.0)
   p <- SerdeRPoint$from_r(data)
 
-  # Returns an ExternalPtr (not S3 wrapped)
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), data)
 
-  # Full roundtrip works at Rust level
+  # Also confirmed at the Rust level
   expect_true(serde_r_roundtrip_point(3.0, 4.0))
 })
 
@@ -175,8 +174,7 @@ test_that("Rectangle serializes nested Points", {
 })
 
 test_that("Rectangle deserializes from nested list", {
-  # Note: from_r returns raw ExternalPtr, not S3 wrapped
-  # Roundtrip tested via serde_r_roundtrip_rectangle()
+  # from_r wraps its Result<Self, String> exactly like $new() does.
   data <- list(
     top_left = list(x = 1.0, y = 2.0),
     bottom_right = list(x = 5.0, y = 6.0),
@@ -184,9 +182,10 @@ test_that("Rectangle deserializes from nested list", {
   )
   r <- Rectangle$from_r(data)
 
-  expect_type(r, "externalptr")
+  expect_s3_class(r, "Rectangle")
+  expect_equal(r$to_r(), data)
 
-  # Test roundtrip at Rust level
+  # Also confirmed at the Rust level
   expect_true(serde_r_roundtrip_rectangle(0.0, 0.0, 10.0, 10.0))
 })
 
@@ -310,15 +309,15 @@ test_that("WithOptionals roundtrip with all None values", {
 })
 
 test_that("SerdeRPoint$to_r() -> SerdeRPoint$from_r() roundtrip", {
-  # from_r returns raw externalptr, so we test the Rust-level roundtrip
   original <- SerdeRPoint$new(42.0, 24.0)
   data <- original$to_r()
   restored <- SerdeRPoint$from_r(data)
 
-  # Verify from_r worked (returns externalptr)
-  expect_type(restored, "externalptr")
+  # restored is a usable SerdeRPoint, comparable directly with $new()'s output
+  expect_s3_class(restored, "SerdeRPoint")
+  expect_equal(restored$to_r(), original$to_r())
 
-  # Full roundtrip works at Rust level
+  # Also confirmed at the Rust level
   expect_true(serde_r_roundtrip_point(42.0, 24.0))
 })
 
@@ -473,21 +472,24 @@ test_that("Deserialization missing field returns error", {
 # =============================================================================
 
 test_that("serde_r deserializes from named list", {
-  # Named lists are the primary input format for serde_r deserialization
+  # Named lists are the primary input format for serde_r deserialization.
+  # from_r wraps its Result<Self, String> exactly like $new() does.
   p <- SerdeRPoint$from_r(list(x = 1.0, y = 2.0))
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), list(x = 1.0, y = 2.0))
 })
 
 test_that("serde_r handles R lists created various ways", {
   # list()
   p1 <- SerdeRPoint$from_r(list(x = 1.0, y = 2.0))
-  expect_type(p1, "externalptr")
+  expect_s3_class(p1, "SerdeRPoint")
+  expect_equal(p1$to_r(), list(x = 1.0, y = 2.0))
 
   # as.list()
   vec <- c(x = 1.0, y = 2.0)
   p2 <- SerdeRPoint$from_r(as.list(vec))
-  expect_type(p2, "externalptr")
+  expect_s3_class(p2, "SerdeRPoint")
+  expect_equal(p2$to_r(), list(x = 1.0, y = 2.0))
 })
 
 test_that("serde_r handles environment-to-list conversion", {
@@ -498,7 +500,8 @@ test_that("serde_r handles environment-to-list conversion", {
 
   data <- as.list(e)
   p <- SerdeRPoint$from_r(data)
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), list(x = 5.0, y = 10.0))
 })
 
 test_that("serde_r works with R6 class data", {
@@ -522,8 +525,8 @@ test_that("serde_r works with R6 class data", {
   obj <- TestClass$new(3.0, 4.0)
   data <- obj$to_list()
   p <- SerdeRPoint$from_r(data)
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), list(x = 3.0, y = 4.0))
 })
 
 test_that("serde_r works with S4 class slots as list", {
@@ -534,8 +537,8 @@ test_that("serde_r works with S4 class slots as list", {
   # Extract slots as list
   data <- list(x = s4obj@x, y = s4obj@y)
   p <- SerdeRPoint$from_r(data)
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), list(x = 7.0, y = 8.0))
 
   # Cleanup
   removeClass("S4Point")
@@ -557,8 +560,8 @@ test_that("serde_r works with S7 class data", {
   # Extract properties as list
   data <- list(x = S7::prop(s7obj, "x"), y = S7::prop(s7obj, "y"))
   p <- SerdeRPoint$from_r(data)
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(p, "externalptr")
+  expect_s3_class(p, "SerdeRPoint")
+  expect_equal(p$to_r(), list(x = 9.0, y = 10.0))
 })
 
 # =============================================================================
@@ -607,10 +610,10 @@ test_that("serde_r handles deeply nested list from R", {
   )
 
   dn <- DeepNest$from_r(deep)
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(dn, "externalptr")
+  expect_s3_class(dn, "DeepNest")
+  expect_equal(dn$to_r(), deep)
 
-  # Verify roundtrip works at Rust level
+  # Also confirmed at the Rust level
   expect_true(serde_r_roundtrip_deep_nest())
 })
 
@@ -661,10 +664,10 @@ test_that("WithOptionals deserializes with NULL fields", {
   )
 
   opt <- WithOptionals$from_r(data)
-  # from_r returns raw ExternalPtr, not S3 object
-  expect_type(opt, "externalptr")
+  expect_s3_class(opt, "WithOptionals")
+  expect_equal(opt$to_r(), data)
 
-  # Verify roundtrip works at Rust level
+  # Also confirmed at the Rust level
   expect_true(serde_r_roundtrip_optionals_none())
 })
 


### PR DESCRIPTION
`SerdeRPoint$from_r(data)` and its siblings handed R a bare `externalptr` — you could deserialize but couldn't call a single method on the result, and every test in `test-serde_r.R` carried the same apology while re-verifying through Rust-side roundtrip helpers. Root cause: `returns_self()` only matched a bare `Self` return, so `Result<Self, E>` statics never got the constructor-shaped class wrapping that `$new()` gets. This teaches both codegen layers (C wrapper + all six R class-system generators) to treat `Result<Self, E>` as a fallible constructor: raise on `Err`, wrap `Ok(Self)` like `$new()`. Fixes finding #2 of `audit/2026-07-03-api-sense-runtime-vctrs-misc.md`; deferred `Option<Self>` symmetry is tracked in #1164.

<details><summary><h3>AI-written details</h3></summary>

## Summary

- `ParsedMethod::returns_result_self()` (`miniextendr-macros/src/miniextendr_impl.rs`): detects `Result<Self, E>` returns (last path segment `Result`, first generic arg `Self`), mirroring `returns_self()`.
- New `ReturnHandling::ResultExternalPtr` (`miniextendr-macros/src/c_wrapper_builder.rs`): raises on `Err` via the normal tagged-condition path (identical to `ResultIntoR`), but wraps `Ok(Self)` in an `ExternalPtr` via `ExternalPtr::new` (identical to the bare-`Self` `ExternalPtr` variant) instead of routing through `IntoR` (which `Self` generally does not implement). Emitted by `detect_return_handling` for `Result<Self, E>`, with arms in both the main-thread and worker-thread return-handling emitters.
- `ReturnStrategy::for_method` (`miniextendr-macros/src/method_return_builder.rs`) now routes `returns_result_self()` to `ReturnSelf`, so **all six class-system generators** wrap the successful return exactly like a `Self`-returning constructor, each with its idiomatic tail:
  - Env: `class(.val) <- "Type"`
  - R6: `Type$new(.ptr = .val)`
  - S3: `structure(.val, class = "Type")`
  - S4: `methods::new("Type", ptr = .val)`
  - S7: `Type(.ptr = .val)`
  - Vctrs: `structure(.val, class = "Type")` (via the shared S3 body)
- Every wrapper already used the error-checked `.val <- .Call(...)` + condition-guard pattern; the successful `.val` (a bare ExternalPtr, same shape as the bare-`Self` case) now gets the class tail instead of being returned raw.
- **Instance methods** returning `Result<Self, E>` fall out of the same two paths naturally (both the C-wrapper `detect_return_handling` fallback and `ReturnStrategy::for_method` are receiver-agnostic), so they are included — they mint a new class object, consistent with bare-`Self` instance methods.
- **Err path R-side**: unchanged and verified — `SerdeRPoint$from_r(list(x = "not a number", y = 1))` raises a regular R error (`type mismatch: expected numeric(1) or integer(1), got character`) through the `rust_condition_value` re-raise machinery.

### Tests

- `c_wrapper_builder/tests.rs`: `detect_return_handling` case pinning `Result<Self, E>` → `ResultExternalPtr`.
- `miniextendr_impl/tests.rs::result_self_static_wraps_like_constructor`: end-to-end macro test asserting `from_r` gets the same `ReturnStrategy` as `new`, the C wrapper resolves to `ResultExternalPtr`, and the generated Env wrapper emits `class(.val) <- "SerdeRPoint"`.
- `rpkg/tests/testthat/test-serde_r.R`: removed all ten "from_r returns a raw ExternalPtr" apologies. Each now asserts `expect_s3_class(p, "<Type>")` and exercises a method on the returned object (`p$to_r()` compared against the input / against `$new()` output) — covering `SerdeRPoint`, `Rectangle`, `DeepNest`, and `WithOptionals` (all the `from_r` fixtures in `serde_r_tests.rs`; `SerdeRPoint3D`, `Collections`, `Maps`, `WithEnums` share the identical generated path). Rust-side `serde_r_roundtrip_*()` assertions that still add value are kept; none of the fixtures changed.

No new SEXP storage is introduced (the wrapping is R-side string codegen), so no new `gc_stress` fixture is required per the reviewer checklist.

## Test plan

- [x] `just check` — clean across all workspaces (root, cross-package producer/consumer, rpkg, cargo-revendor)
- [x] `just test` — all green except the 7 known `derive_dataframe_*` trybuild snapshot mismatches (documented local-rustc drift vs CI stable; not overwritten)
- [x] `just clippy` + all three CI clippy variants (`clippy_default`, `clippy_all` with the `full-codegen` integration list, `clippy_all_s7`) with `-D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `just configure && just rcmdinstall && just force-document` — regenerated wrappers verified: `SerdeRPoint$from_r` / `Maps$from_r` now emit the class tail; NAMESPACE and `man/` unchanged (no export-surface change)
- [x] Manual R verification: `from_r` returns usable class objects for `SerdeRPoint`, `Rectangle`, `DeepNest`, `WithOptionals`; `identical(p$to_r(), data)` holds; `Err` path raises a proper R error
- [x] `just devtools-test` — `[ FAIL 6 | WARN 0 | SKIP 20 | PASS 6861 ]`; all 6 failures were `test-encoding.R` callr children hitting the documented "no package called 'miniextendr'" transient — foreground reruns pass clean: `test-serde_r.R` `[ FAIL 0 | PASS 187 ]`, `serde_r|encoding` filter `[ FAIL 0 | PASS 206 ]`, `trait-abi|class-example|r6|s7|s4-|env|vctrs` filter `[ FAIL 0 | SKIP 2 | PASS 257 ]`

## Deferred

- `Option<Self>` statics still return an unwrapped value with no class wrapping — tracked in #1164 (not named by the audit; no fixture currently uses the shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>