### PR TITLE
fix(minirextendr): fall back to rpkg when Cargo.toml is only in an ancestor

### DIFF
--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -344,8 +344,25 @@ use_miniextendr <- function(path = ".",
   # Auto-detect template type if requested
   if (template_type == "auto") {
     detected <- detect_project_type()
+    proj_dir <- usethis::proj_get()
     if (is.null(detected)) {
       cli::cli_alert_info("Could not auto-detect project type, defaulting to 'rpkg'")
+      template_type <- "rpkg"
+    } else if (detected == "monorepo" &&
+               !file.exists(file.path(proj_dir, "Cargo.toml"))) {
+      # detect_project_type() reports "monorepo" both when the project dir is
+      # itself a Rust crate and when a DESCRIPTION-bearing R package merely sits
+      # *inside* a Rust repo (Cargo.toml in an ancestor, not the project dir).
+      # The monorepo scaffold branch below reads the crate name from Cargo.toml
+      # at the project root, so the ancestor-only case would abort opaquely.
+      # Scaffold as a standalone rpkg into this directory instead.
+      rust_root <- find_rust_root(proj_dir)
+      cli::cli_alert_info(
+        "Found a Rust project at {.path {rust_root}}, but {.path {proj_dir}} has no {.file Cargo.toml} of its own — scaffolding as a standalone {.val rpkg}."
+      )
+      cli::cli_alert_info(
+        "To create a monorepo layout instead, run {.fn use_miniextendr} from the Rust workspace root."
+      )
       template_type <- "rpkg"
     } else {
       template_type <- detected

--- a/minirextendr/R/utils.R
+++ b/minirextendr/R/utils.R
@@ -509,7 +509,11 @@ to_rust_name <- function(name) {
 #' @noRd
 get_package_name_from_cargo <- function(cargo_path = file.path(usethis::proj_get(), "Cargo.toml")) {
   if (!file.exists(cargo_path)) {
-    cli::cli_abort("Cargo.toml not found")
+    cli::cli_abort(c(
+      "No {.file Cargo.toml} found at {.path {cargo_path}}.",
+      "i" = "The {.val monorepo} template reads the crate name from a Rust workspace {.file Cargo.toml} at the project root.",
+      "i" = "For a standalone R package, pass {.code template_type = \"rpkg\"}."
+    ))
   }
 
   lines <- readLines(cargo_path, warn = FALSE)

--- a/minirextendr/tests/testthat/test-monorepo-gaps.R
+++ b/minirextendr/tests/testthat/test-monorepo-gaps.R
@@ -388,3 +388,61 @@ test_that("B3: patched workflow parses as YAML with working-directory on each co
 })
 
 # endregion ---------------------------------------------------------------
+
+# region: B4 — use_miniextendr() auto-detect fallback -------------------
+# detect_project_type() returns "monorepo" both when the project dir is a Rust
+# crate and when a DESCRIPTION-only R package sits *inside* a Rust repo
+# (Cargo.toml in an ancestor). The monorepo scaffold branch reads the crate name
+# from Cargo.toml at the project root, so the ancestor-only case used to abort
+# with an opaque "Cargo.toml not found". use_miniextendr() must instead fall back
+# to a standalone rpkg. These tests short-circuit the heavy scaffold steps with a
+# sentinel and assert which branch the auto-detect logic selects.
+
+test_that("B4: auto-detect falls back to rpkg for an R package nested in a Rust repo", {
+  tmp <- withr::local_tempdir()
+  # Rust workspace root; the R package lives in a subdir with only a DESCRIPTION.
+  writeLines("[workspace]", file.path(tmp, "Cargo.toml"))
+  pkg <- file.path(tmp, "pkg")
+  dir.create(pkg)
+  writeLines(c("Package: testpkg", "Version: 0.0.1"), file.path(pkg, "DESCRIPTION"))
+
+  local_mocked_bindings(
+    check_rust = function() invisible(),
+    # First real step of each branch — used as a sentinel to observe the choice.
+    create_rpkg_subdirectory = function(...) stop("BRANCH:monorepo"),
+    use_miniextendr_description = function(...) stop("BRANCH:rpkg"),
+    .package = "minirextendr"
+  )
+
+  # With the fix the standalone (rpkg) branch runs; before it, the monorepo
+  # branch aborted at get_package_name_from_cargo() with "Cargo.toml".
+  expect_error(
+    suppressMessages(suppressWarnings(
+      use_miniextendr(path = pkg, template_type = "auto", claude_skills = FALSE)
+    )),
+    "BRANCH:rpkg"
+  )
+})
+
+test_that("B4: auto-detect stays monorepo when the project dir has its own Cargo.toml", {
+  tmp <- withr::local_tempdir()
+  # Rust workspace root that IS the project dir — a real monorepo entry point.
+  writeLines(c("[package]", 'name = "my-crate"', 'version = "0.1.0"'),
+             file.path(tmp, "Cargo.toml"))
+
+  local_mocked_bindings(
+    check_rust = function() invisible(),
+    create_rpkg_subdirectory = function(...) stop("BRANCH:monorepo"),
+    use_miniextendr_description = function(...) stop("BRANCH:rpkg"),
+    .package = "minirextendr"
+  )
+
+  expect_error(
+    suppressMessages(suppressWarnings(
+      use_miniextendr(path = tmp, template_type = "auto", claude_skills = FALSE)
+    )),
+    "BRANCH:monorepo"
+  )
+})
+
+# endregion ---------------------------------------------------------------

--- a/minirextendr/tests/testthat/test-utils.R
+++ b/minirextendr/tests/testthat/test-utils.R
@@ -132,3 +132,21 @@ test_that("detect_project_type identifies rpkg inside monorepo (workspace)", {
   usethis::proj_set(file.path(tmp, "rpkg"), force = TRUE)
   expect_equal(minirextendr:::detect_project_type(file.path(tmp, "rpkg")), "monorepo")
 })
+
+test_that("get_package_name_from_cargo() abort names the path and suggests rpkg", {
+  tmp <- withr::local_tempdir()
+  missing <- file.path(tmp, "Cargo.toml")
+
+  err <- tryCatch(
+    minirextendr:::get_package_name_from_cargo(missing),
+    error = function(e) e
+  )
+  expect_s3_class(err, "rlang_error")
+
+  msg <- conditionMessage(err)
+  # Names the exact path it looked at (so the user knows where it expected one).
+  expect_match(msg, basename(tmp), fixed = TRUE)
+  expect_match(msg, "Cargo.toml", fixed = TRUE)
+  # Points at the correct escape hatch for a standalone package.
+  expect_match(msg, "rpkg", fixed = TRUE)
+})


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `minirextendr::use_miniextendr(template_type = "auto")` aborted with an opaque `Cargo.toml not found` when run inside a `DESCRIPTION`-bearing R package that merely sits somewhere under a Rust repo. `detect_project_type()` (`minirextendr/R/utils.R`) returns `"monorepo"` when any ancestor has a `Cargo.toml`, but the monorepo scaffold branch (`minirextendr/R/create.R`) calls `get_package_name_from_cargo()`, which requires `Cargo.toml` in the project dir itself, so the ancestor-only case always crashed.
- The auto-detect branch now accepts `"monorepo"` only when the project root has its own `Cargo.toml`. Otherwise it emits an informative `cli_alert_info` naming the ancestor Rust root and the reason, then scaffolds a standalone `rpkg` into the current directory.
- `get_package_name_from_cargo()`'s abort now names the exact path it looked at and suggests `template_type = "rpkg"`, which also covers explicit `template_type = "monorepo"` misuse from a directory without a `Cargo.toml`.
- `detect_project_type()` itself is left unchanged on purpose: its ancestor-walking branch is load-bearing for `upgrade.R` and `use_release_workflow()` (an rpkg inside its own monorepo).
- Adds behavioral regression tests (no source-grep assertions): the auto-detect branch decision in both directions (nested package falls back to rpkg, project-root `Cargo.toml` stays monorepo) via a sentinel that short-circuits the heavy scaffold steps, plus the improved abort message.

## Test plan
- [x] `just minirextendr-test` — `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 626 ]`
- [x] The three new tests execute and pass (`test-utils.R` abort-message test; `test-monorepo-gaps.R` B4 fallback + B4 monorepo-preserved).

## Notes
- Pure R change; no `rpkg/` or template edits, so no `patches/templates.patch` churn.
- No scope was deferred; the plan's three steps are all implemented, so no follow-up issue was filed.

---
_Drafted by Claude. Reviewed by the author._

</details>