### PR TITLE
refactor(minirextendr): adopt choices-vector + match.arg() for string-enum args

### DIFF
--- a/minirextendr/R/cargo.R
+++ b/minirextendr/R/cargo.R
@@ -980,10 +980,11 @@ cargo_new <- function(path = ".",
                       name,
                       lib = TRUE,
                       edition = "2024",
-                      vcs = "none",
+                      vcs = c("none", "git", "hg", "pijul", "fossil"),
                       add_to_workspace = TRUE,
                       quiet = FALSE) {
   with_project(path)
+  vcs <- match.arg(vcs)
   check_rust()
 
   # Validate inputs
@@ -1006,9 +1007,6 @@ cargo_new <- function(path = ".",
     cli::cli_abort("edition must be a single string.")
   }
   edition <- trimws(edition)
-
-  vcs <- match.arg(vcs, c("git", "hg", "pijul", "fossil", "none"))
-
 
   # Determine where to run cargo new from
   # If in a workspace, run from workspace root

--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -288,9 +288,9 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
 #' `devtools::document()` populates it from your roxygen comments.
 #'
 #' @param path Path to the R package root, or `"."` to use the current directory.
-#' @param template_type Template type: "auto" (detect from directory structure),
-#'   "rpkg" for standalone R package, or "monorepo" for Rust workspace.
-#'   Default is "auto" which auto-detects based on whether Cargo.toml or DESCRIPTION exists.
+#' @param template_type Template type. One of `"auto"` (the default; detect
+#'   from directory structure based on whether Cargo.toml or DESCRIPTION exists),
+#'   `"rpkg"` for a standalone R package, or `"monorepo"` for a Rust workspace.
 #' @param rpkg_name Name of the R package subdirectory for monorepo template
 #'   (default: derived from package name). Only used when template_type is "monorepo".
 #' @param miniextendr_version Version of miniextendr to vendor (default: "main").
@@ -305,9 +305,11 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
 #' @return Invisibly returns TRUE
 #' @export
 use_miniextendr <- function(path = ".",
-                            template_type = "auto", rpkg_name = NULL,
+                            template_type = c("auto", "rpkg", "monorepo"),
+                            rpkg_name = NULL,
                             miniextendr_version = "main", local_path = NULL,
                             claude_skills = TRUE) {
+  template_type <- match.arg(template_type)
   with_project(path)
   # Warn if the package directory being scaffolded is not at a git workspace
   # root. Resolve everything from the *project* directory, not getwd():

--- a/minirextendr/man/cargo_new.Rd
+++ b/minirextendr/man/cargo_new.Rd
@@ -9,7 +9,7 @@ cargo_new(
   name,
   lib = TRUE,
   edition = "2024",
-  vcs = "none",
+  vcs = c("none", "git", "hg", "pijul", "fossil"),
   add_to_workspace = TRUE,
   quiet = FALSE
 )

--- a/minirextendr/man/use_miniextendr.Rd
+++ b/minirextendr/man/use_miniextendr.Rd
@@ -6,7 +6,7 @@
 \usage{
 use_miniextendr(
   path = ".",
-  template_type = "auto",
+  template_type = c("auto", "rpkg", "monorepo"),
   rpkg_name = NULL,
   miniextendr_version = "main",
   local_path = NULL,
@@ -16,9 +16,9 @@ use_miniextendr(
 \arguments{
 \item{path}{Path to the R package root, or \code{"."} to use the current directory.}
 
-\item{template_type}{Template type: "auto" (detect from directory structure),
-"rpkg" for standalone R package, or "monorepo" for Rust workspace.
-Default is "auto" which auto-detects based on whether Cargo.toml or DESCRIPTION exists.}
+\item{template_type}{Template type. One of \code{"auto"} (the default; detect
+from directory structure based on whether Cargo.toml or DESCRIPTION exists),
+\code{"rpkg"} for a standalone R package, or \code{"monorepo"} for a Rust workspace.}
 
 \item{rpkg_name}{Name of the R package subdirectory for monorepo template
 (default: derived from package name). Only used when template_type is "monorepo".}

--- a/minirextendr/tests/testthat/test-cargo.R
+++ b/minirextendr/tests/testthat/test-cargo.R
@@ -1,0 +1,17 @@
+# Tests for cargo wrapper functions
+
+test_that("cargo_new validates vcs against its choices", {
+  tmp <- tempfile("bad-vcs-")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  # An unknown vcs errors immediately: match.arg(vcs) runs before check_rust(),
+  # so the diagnostic does not depend on the Rust toolchain being installed.
+  expect_error(
+    cargo_new(path = tmp, name = "mycrate", vcs = "svn"),
+    "should be one of"
+  )
+
+  # The default (a missing arg) still resolves to "none": the choices vector
+  # lists it first, so match.arg() picks it unchanged.
+  expect_identical(eval(formals(cargo_new)$vcs)[[1]], "none")
+})

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -466,6 +466,22 @@ test_that("create_miniextendr_package rejects invalid R package names", {
   expect_error(create_miniextendr_package(file.path(tmp, "1badname"), open = FALSE))
 })
 
+test_that("use_miniextendr validates template_type against its choices", {
+  tmp <- tempfile("bad-template-type-")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  # An unknown template_type errors immediately (match.arg is the first
+  # statement in the body), before any scaffolding side effects occur.
+  expect_error(
+    use_miniextendr(path = tmp, template_type = "banana"),
+    "should be one of"
+  )
+
+  # The default (a missing arg) still resolves to "auto": the choices vector
+  # lists it first, so match.arg() picks it unchanged.
+  expect_identical(eval(formals(use_miniextendr)$template_type)[[1]], "auto")
+})
+
 # -----------------------------------------------------------------------------
 # Monorepo end-to-end
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
Adopt R's idiomatic enum-argument pattern for string-enum arguments in `minirextendr`: declare the valid choices in the function signature (current default listed first, so defaults are unchanged) and resolve with `match.arg()` as the first use of the argument. Invalid values now fail immediately with a standard `'arg' should be one of ...` error instead of sailing past into a downstream failure.

Converted:
- **`use_miniextendr(template_type=)`** (`R/create.R`): `template_type = c("auto", "rpkg", "monorepo")`, with `template_type <- match.arg(template_type)` as the first statement in the body. Default stays `"auto"`.
- **`cargo_new(vcs=)`** (`R/cargo.R`): choices moved from the `match.arg()` call into the signature (`vcs = c("none", "git", "hg", "pijul", "fossil")`), and `match.arg(vcs)` moved ahead of `check_rust()` so an invalid `vcs` is reported without requiring the Rust toolchain. Default stays `"none"`.

Roxygen `@param` docs updated to enumerate choices and name the default; `man/use_miniextendr.Rd` and `man/cargo_new.Rd` regenerated. Added `test-cargo.R` and a case in `test-templates.R`: each asserts an invalid value errors with "should be one of" and that the default resolves to the first choice.

Already idiomatic, verified and left unchanged: `set_template_type(type=)` (`R/utils.R`), `miniextendr_sync(mode=, stage=)` (`R/sync.R`), `use_miniextendr_rmarkdown(format=)` (`R/use-feature.R`) — all already declare choices in the signature and call `match.arg()`.

Deliberately skipped (with reasons):
- **`miniextendr_check_static(error_on=)` / `use_release_workflow(error_on=)`** — thin passthroughs to `rcmdcheck::rcmdcheck()`, which already validates `error_on` via its own `match.arg()`. Its accepted set includes `"never"`, which our roxygen omits; adding a local `match.arg` here would risk dropping `"never"` and drifting from the upstream choices.
- **`mode` in `R/use-native.R`** — internal computed bindgen state (`"c"` / `"cpp"` / `"cpp14"`), not a user-facing signature argument.
- **`mode` in `R/knitr.R`** — a knitr chunk option (`options$mode`), forwarded to `miniextendr_sync()` which already validates.
- **`class_system` in `R/config.R`** — a default value inside `miniextendr_config_defaults()` (config-file data), not a function argument. Value-level validation of `miniextendr.yml` is a separate concern, out of scope here.

No `several.ok` was introduced anywhere. Partial matching (`template_type = "mono"` -> `"monorepo"`) is now legal, which is the intended idiom.

## Test plan
- [x] `just minirextendr-test` -> `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 624 ]`
- [x] Focused `just minirextendr-test cargo` -> `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 2 ]`
- [x] `just minirextendr-document` regenerated only the two affected `.Rd` files

## Notes
- Expected small merge conflict: branch `fix/minirextendr-project-type` (separate in-flight PR) edits `use_miniextendr()`'s auto-detect branch in `R/create.R` (around the `template_type == "auto"` block). This PR only touches that function's signature and adds the `match.arg()` line at the top; it does not reimplement the auto-detect logic. Resolve by keeping both changes.
- `cargo_new()` now validates `vcs` before `check_rust()`. This is a minor error-path ordering change: a bad `vcs` on a machine without the Rust toolchain now reports the `vcs` error instead of the missing-toolchain error. For valid inputs, behaviour is identical.

---
_Drafted by Claude. Reviewed by the author._

</details>
