### PR TITLE
fix(minirextendr): run git in the resolved project dir, not getwd()

### DIFF
--- a/minirextendr/R/cargo.R
+++ b/minirextendr/R/cargo.R
@@ -1078,11 +1078,13 @@ cargo_new <- function(path = ".",
 find_workspace_root <- function(path) {
   path <- normalizePath(path, mustWork = FALSE)
 
-  # Try git first — fast and handles deeply nested paths
+  # Try git first — fast and handles deeply nested paths. Run git *in* `path`
+  # (not getwd()): callers pass the resolved project dir, and probing getwd()
+  # instead can resolve an unrelated workspace and register the new crate in
+  # that workspace's Cargo.toml.
   git_root <- tryCatch({
-    out <- system2("git", c("rev-parse", "--show-toplevel"),
-                   stdout = TRUE, stderr = TRUE)
-    if (!is.null(attr(out, "status"))) NULL else trimws(out)
+    out <- run_command("git", c("rev-parse", "--show-toplevel"), wd = path)
+    if (!is.null(attr(out, "status"))) NULL else trimws(paste(out, collapse = "\n"))
   }, error = function(e) NULL, warning = function(w) NULL)
 
   if (!is.null(git_root) && nzchar(git_root)) {

--- a/minirextendr/R/upgrade.R
+++ b/minirextendr/R/upgrade.R
@@ -77,7 +77,7 @@ upgrade_miniextendr_package <- function(path = ".",
 
   # --- Dirty check ---
   if (!allow_dirty) {
-    check_scaffolding_clean()
+    check_scaffolding_clean(resolved_path)
   }
 
   # --- Build system templates ---
@@ -165,15 +165,23 @@ find_rpkg_subdir <- function(path) {
 #' Uses `git status --porcelain` to inspect build system files that will be
 #' overwritten during upgrade. Aborts if any have uncommitted changes.
 #'
+#' Every git invocation runs *in* `proj_dir` (via `run_command(wd = )`), not the
+#' caller's working directory. `with_project()` activates the usethis project
+#' without changing the working directory (`setwd = FALSE`), so probing git in
+#' `getwd()` would inspect an unrelated repo -- or no repo at all, which would
+#' silently skip this guard and let the upgrade overwrite the target's
+#' uncommitted files.
+#'
+#' @param proj_dir Package directory to inspect (default `usethis::proj_get()`).
+#'   The relative `scaffolding_files` pathspecs are interpreted against it.
 #' @noRd
-check_scaffolding_clean <- function() {
+check_scaffolding_clean <- function(proj_dir = usethis::proj_get()) {
   # Bail out if git is not available
   if (!nzchar(Sys.which("git"))) return(invisible())
 
   # Bail out if not in a git repo
   repo <- tryCatch({
-    out <- system2("git", c("rev-parse", "--show-toplevel"),
-                   stdout = TRUE, stderr = TRUE)
+    out <- run_command("git", c("rev-parse", "--show-toplevel"), wd = proj_dir)
     if (!is.null(attr(out, "status"))) NULL else out
   }, error = function(e) NULL)
   if (is.null(repo)) return(invisible())
@@ -198,8 +206,8 @@ check_scaffolding_clean <- function() {
     ".gitignore"
   )
 
-  out <- system2("git", c("status", "--porcelain", "--", scaffolding_files),
-                 stdout = TRUE, stderr = TRUE)
+  out <- run_command("git", c("status", "--porcelain", "--", scaffolding_files),
+                     wd = proj_dir)
   if (is.null(out) || length(out) == 0) return(invisible())
 
   cli::cli_abort(c(

--- a/minirextendr/tests/testthat/test-git-cwd.R
+++ b/minirextendr/tests/testthat/test-git-cwd.R
@@ -1,0 +1,98 @@
+# Git calls must run in the resolved project dir, not getwd()
+# (audit 2026-07-06 finding #2). `with_project()` activates the usethis project
+# without changing the working directory (setwd = FALSE), so a git call with no
+# working-dir argument inspects the caller's cwd -- an unrelated repo, or none.
+
+# Initialise a git repo at `dir` with a single committed file at `rel_path`.
+init_repo_with_committed_file <- function(dir, rel_path, contents = "clean") {
+  target <- file.path(dir, rel_path)
+  dir.create(dirname(target), recursive = TRUE, showWarnings = FALSE)
+  writeLines(contents, target)
+  git <- function(...) {
+    system2("git", c("-C", dir, ...), stdout = TRUE, stderr = TRUE)
+  }
+  git("init", "-q")
+  git("config", "user.email", "test@example.com")
+  git("config", "user.name", "minirextendr test")
+  git("config", "commit.gpgsign", "false")
+  git("add", "-A")
+  git("commit", "-q", "-m", "init")
+  invisible(dir)
+}
+
+# Initialise a git repo whose Cargo.toml declares a `[workspace]`.
+init_workspace_repo <- function(dir) {
+  writeLines(c("[workspace]", "members = []"), file.path(dir, "Cargo.toml"))
+  system2("git", c("-C", dir, "init", "-q"), stdout = TRUE, stderr = TRUE)
+  invisible(dir)
+}
+
+test_that("check_scaffolding_clean guards the active project, not getwd()", {
+  # This is the guard-bypass regression: with the active usethis project set to
+  # a dirty package but the working directory pointing elsewhere, the dirty
+  # check must still fire. On the unfixed code the no-arg call probes getwd()
+  # (a non-repo dir), silently returns early, and lets the upgrade overwrite the
+  # target's uncommitted files.
+  skip_if(!nzchar(Sys.which("git")), "git not available")
+
+  pkg <- withr::local_tempdir()
+  init_repo_with_committed_file(pkg, "src/stub.c")
+  writeLines("dirty", file.path(pkg, "src", "stub.c"))
+
+  usethis::local_project(pkg, force = TRUE, setwd = FALSE)
+
+  # Working directory is neither the target nor a git repo.
+  foreign <- withr::local_tempdir()
+  withr::local_dir(foreign)
+
+  expect_error(
+    minirextendr:::check_scaffolding_clean(),
+    "uncommitted changes"
+  )
+})
+
+test_that("check_scaffolding_clean(proj_dir) inspects the given dir from any cwd", {
+  skip_if(!nzchar(Sys.which("git")), "git not available")
+
+  pkg <- withr::local_tempdir()
+  init_repo_with_committed_file(pkg, "src/stub.c")
+  writeLines("dirty", file.path(pkg, "src", "stub.c"))
+
+  foreign <- withr::local_tempdir()
+  withr::local_dir(foreign)
+
+  expect_error(
+    minirextendr:::check_scaffolding_clean(pkg),
+    "uncommitted changes"
+  )
+})
+
+test_that("check_scaffolding_clean passes a clean repo from a foreign cwd", {
+  skip_if(!nzchar(Sys.which("git")), "git not available")
+
+  pkg <- withr::local_tempdir()
+  init_repo_with_committed_file(pkg, "src/stub.c")
+
+  foreign <- withr::local_tempdir()
+  withr::local_dir(foreign)
+
+  expect_no_error(minirextendr:::check_scaffolding_clean(pkg))
+})
+
+test_that("find_workspace_root resolves its path argument, not getwd()", {
+  skip_if(!nzchar(Sys.which("git")), "git not available")
+
+  target <- withr::local_tempdir()
+  init_workspace_repo(target)
+
+  # A *different* workspace repo used as the foreign cwd. On the unfixed code
+  # the git probe runs here and returns this root instead of `target`.
+  foreign <- withr::local_tempdir()
+  init_workspace_repo(foreign)
+  withr::local_dir(foreign)
+
+  expect_identical(
+    minirextendr:::find_workspace_root(target),
+    normalizePath(target)
+  )
+})


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `check_scaffolding_clean()` (`minirextendr/R/upgrade.R`) and `find_workspace_root()` (`minirextendr/R/cargo.R`) shelled out to git with no working-dir argument, so they inspected `getwd()` instead of the resolved usethis project — `with_project()` deliberately does not change the working directory (`setwd = FALSE`).
- Consequence 1 (silent data loss): `upgrade_miniextendr_package("/path")` from a non-repo cwd made `git rev-parse` fail, the `allow_dirty = FALSE` guard returned early, and the upgrade overwrote the target's uncommitted scaffolding files (`use_template()` deletes before writing). From a *different* repo's cwd, the dirty check reported that repo's state for the relative pathspecs instead of the target's.
- Consequence 2: `find_workspace_root()` ignored its `path` argument in the git branch, so `cargo_new()` could register the new crate in an unrelated workspace's `Cargo.toml`.
- Both now run git via `run_command(..., wd = ...)`, the pattern `use_miniextendr()` already used in `create.R`. `check_scaffolding_clean()` gains an explicit `proj_dir` parameter (default `usethis::proj_get()`). A sweep found no other no-`wd` git invocations in `minirextendr/R`.
- Behavioral regression tests: guard fires from a foreign non-repo cwd (fails on the previous code), fires with an explicit dir, passes on a clean repo from a foreign cwd, and `find_workspace_root()` resolves its argument while the cwd sits inside a different workspace repo.

Audit reference: `audit/2026-07-06-minirextendr-audit.md` finding #2.

## Test plan
- [x] `just minirextendr-test` — `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 624 ]`
- [x] New `test-git-cwd.R` cases pass (4 tests, including the guard-bypass regression that fails on main).

## Notes
- Pure `minirextendr/R` change; no template or `rpkg/` edits.
- No deferred scope.

---
_Drafted by Claude. Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)