### PR TITLE
fix(minirextendr): only NAMESPACE-export #[miniextendr] top-level fns from inline code

### DIFF
--- a/minirextendr/R/rust-source.R
+++ b/minirextendr/R/rust-source.R
@@ -210,19 +210,51 @@ inline_cache_dir <- function() {
   fs::path(tools::R_user_dir("minirextendr", "cache"), "rust_source")
 }
 
-#' Extract pub fn names from Rust code
+#' Extract exported function names from Rust code
 #'
-#' Simple regex extraction of public function names.
+#' Only *top-level* `pub fn`s annotated with `#[miniextendr]` get an R binding
+#' from the wrapper generator, so only those may be exported in the synthesized
+#' NAMESPACE -- exporting methods inside `impl` blocks or un-annotated helpers
+#' makes `library()` fail with "undefined exports" (audit 2026-07-06 #6).
+#' Line-wise scan with brace-depth tracking: a scaffolding convenience for
+#' inline snippets, not a Rust parser. Doc comments and other attributes may
+#' sit between `#[miniextendr]` and its `pub fn`.
 #'
 #' @param code Rust code string
 #' @return Character vector of function names
 #' @noRd
 extract_pub_fn_names <- function(code) {
-  matches <- regmatches(
-    code,
-    gregexpr("\\bpub\\s+fn\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(", code)
-  )[[1]]
-  sub("^pub\\s+fn\\s+", "", sub("\\s*\\($", "", matches))
+  # ponytail: brace counting ignores braces inside string literals; good
+  # enough for inline snippets, swap for real parsing if it ever bites.
+  fn_re <- "\\bpub\\s+fn\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\("
+  lines <- strsplit(code, "\n", fixed = TRUE)[[1]]
+  depth <- 0L
+  pending_attr <- FALSE
+  fn_names <- character()
+  for (raw in lines) {
+    line <- sub("//.*$", "", raw)
+    if (depth == 0L) {
+      is_attr <- grepl("^\\s*#\\s*\\[\\s*miniextendr\\b", line)
+      if (is_attr) pending_attr <- TRUE
+      if (pending_attr) {
+        m <- regmatches(line, regexec(fn_re, line))[[1]]
+        if (length(m) == 2L) {
+          fn_names <- c(fn_names, m[[2]])
+          pending_attr <- FALSE
+        } else if (!is_attr &&
+                   grepl("\\b(impl|struct|enum|trait|mod|fn)\\b", line)) {
+          # The attribute belonged to something that is not an exported free
+          # fn (e.g. `#[miniextendr] impl Foo` -- handled by
+          # extract_impl_names()).
+          pending_attr <- FALSE
+        }
+      }
+    }
+    depth <- depth +
+      lengths(regmatches(line, gregexpr("\\{", line))) -
+      lengths(regmatches(line, gregexpr("\\}", line)))
+  }
+  fn_names
 }
 
 #' Extract impl block type names from Rust code

--- a/minirextendr/tests/testthat/test-rust-source.R
+++ b/minirextendr/tests/testthat/test-rust-source.R
@@ -61,9 +61,11 @@ test_that("compute_inline_hash trims whitespace", {
 
 # ---- extract_pub_fn_names ----
 
-test_that("extract_pub_fn_names finds pub fn declarations", {
+test_that("extract_pub_fn_names finds annotated pub fn declarations", {
   code <- '
+#[miniextendr]
 pub fn add(a: f64, b: f64) -> f64 { a + b }
+#[miniextendr]
 pub fn hello(name: &str) -> String { format!("Hello, {}!", name) }
 fn private_fn() {}
 '
@@ -74,6 +76,44 @@ fn private_fn() {}
 test_that("extract_pub_fn_names returns empty for no pub fn", {
   code <- 'fn private() {}'
   expect_equal(minirextendr:::extract_pub_fn_names(code), character())
+})
+
+test_that("extract_pub_fn_names skips un-annotated helpers and impl methods", {
+  # audit 2026-07-06 #6: exporting these made library() fail with
+  # "undefined exports" -- only #[miniextendr] top-level free fns have bindings.
+  code <- '
+#[miniextendr]
+pub fn exported(x: i32) -> i32 { helper(x) }
+
+pub fn helper(x: i32) -> i32 { x + 1 }
+
+pub struct Counter { value: i32 }
+
+#[miniextendr]
+impl Counter {
+    pub fn new() -> Self { Counter { value: 0 } }
+    pub fn bump(&mut self) { self.value += 1; }
+}
+'
+  expect_equal(minirextendr:::extract_pub_fn_names(code), "exported")
+})
+
+test_that("extract_pub_fn_names handles attribute args, doc comments, one-liners", {
+  code <- '
+#[miniextendr(invisible)]
+pub fn with_args() {}
+
+#[miniextendr]
+/// doc comment between attribute and fn
+#[allow(dead_code)]
+pub fn documented() {}
+
+#[miniextendr] pub fn one_liner(x: i32) -> i32 { x }
+'
+  expect_equal(
+    minirextendr:::extract_pub_fn_names(code),
+    c("with_args", "documented", "one_liner")
+  )
 })
 
 # ---- extract_impl_names ----


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `extract_pub_fn_names()` (`minirextendr/R/rust-source.R`) matched **every** `pub fn` with a bare regex — impl-block methods and un-annotated helpers included — and `scaffold_inline_package()` wrote them all as NAMESPACE `export()`s. Only `#[miniextendr]` top-level free functions get an R binding, so `rust_source()` code containing an impl block or helper failed at `library()` with `undefined exports: <name>` — naming a symbol, not the cause (audit finding #6; the same detector-looser-than-consumer species as the project-type bug).
- The extractor is now a line-wise scan with brace-depth tracking: only depth-0 `pub fn`s preceded by `#[miniextendr]` are returned. Doc comments and other attributes may sit between the annotation and the fn; the same-line form works; `#[miniextendr] impl` blocks remain the business of `extract_impl_names()` (unchanged — those exports are backed by class-wrapper bindings). Deliberately a scaffolding convenience, not a Rust parser (commented as such, with the known string-literal-brace ceiling).
- Side effect: `rust_function()`'s existing "requires at least one `pub fn` with `#[miniextendr]`" abort now fires accurately for un-annotated code instead of letting it through to a confusing load-time failure.

Audit reference: `audit/2026-07-06-minirextendr-audit.md` finding #6.

## Test plan
- [x] `just minirextendr-test` — `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 622 ]`
- [x] Extraction-level tests (no cargo needed): impl methods and un-annotated helpers excluded; attribute-with-args, doc-comment-between, and one-liner forms all extracted.

## Notes
- Pure `minirextendr/R` change; no template or `rpkg/` edits.
- Considered deriving exports from the generated wrappers.R after install instead of source regexes — heavier restructuring of the inline pipeline for marginal gain over the tightened extractor; can be revisited if the regex ceiling ever bites.

---
_Drafted by Claude. Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)