### PR TITLE
fix(minirextendr): record missing-Rust issue in validate; honor documented path semantics

### DIFF
--- a/minirextendr/R/config.R
+++ b/minirextendr/R/config.R
@@ -28,11 +28,15 @@
 #' If unsure: leave it where [use_miniextendr()] scaffolded it, or
 #' delete it — both are safe.
 #'
-#' @param path Path to the project root (default: current directory).
+#' @param path Path to the project root (default: the active project, like
+#'   every other `miniextendr_*()` helper).
 #' @return A list of configuration values.
 #' @export
 miniextendr_config <- function(path = ".") {
-  config_path <- file.path(path, "miniextendr.yml")
+  # Resolve like the sibling helpers (doctor, use_*): "." means the active
+  # usethis project, not getwd() (audit 2026-07-06 #7).
+  with_project(path)
+  config_path <- usethis::proj_path("miniextendr.yml")
   defaults <- miniextendr_config_defaults()
 
   if (!file.exists(config_path)) {

--- a/minirextendr/R/status.R
+++ b/minirextendr/R/status.R
@@ -191,19 +191,26 @@ miniextendr_validate <- function(path = ".") {
     }
   }
 
-  # Check Rust toolchain
+  # Check Rust toolchain. The tryCatch returns a flag appended to `issues` in
+  # this frame -- assigning inside the error handler only creates a local
+  # binding, which is how a missing toolchain used to print "Rust not found"
+  # and then report "All checks passed!" (audit 2026-07-06 #4).
   cli::cli_h2("Rust toolchain")
-  tryCatch(
+  rust_ok <- tryCatch(
     {
       check_rust()
       rustc_version <- run_command("rustc", "--version")
       cli::cli_alert_success("Rust installed: {rustc_version}")
+      TRUE
     },
     error = function(e) {
-      issues <- c(issues, "Rust not found")
       cli::cli_alert_danger("Rust not found")
+      FALSE
     }
   )
+  if (!rust_ok) {
+    issues <- c(issues, "Rust not found")
+  }
 
   # Check Cargo.toml declares miniextendr-api
   cli::cli_h2("Cargo.toml")

--- a/minirextendr/R/utils.R
+++ b/minirextendr/R/utils.R
@@ -18,7 +18,11 @@
 #' @return Called for its side effect; returns `NULL` invisibly.
 #' @noRd
 with_project <- function(path, .local_envir = parent.frame()) {
-  if (identical(path, ".")) {
+  # NULL is documented as "use the active project" on several exported
+  # signatures; usethis::local_project(NULL) would instead UNSET the active
+  # project, so treat NULL exactly like "." (audit 2026-07-06 #7).
+  if (is.null(path) || identical(path, ".")) {
+    path <- "."
     active <- tryCatch(usethis::proj_get(), error = function(e) NULL)
     if (!is.null(active)) {
       path <- active

--- a/minirextendr/man/miniextendr_config.Rd
+++ b/minirextendr/man/miniextendr_config.Rd
@@ -7,7 +7,8 @@
 miniextendr_config(path = ".")
 }
 \arguments{
-\item{path}{Path to the project root (default: current directory).}
+\item{path}{Path to the project root (default: the active project, like
+every other \verb{miniextendr_*()} helper).}
 }
 \value{
 A list of configuration values.

--- a/minirextendr/tests/testthat/test-config.R
+++ b/minirextendr/tests/testthat/test-config.R
@@ -78,3 +78,20 @@ test_that("miniextendr_config() handles malformed yaml gracefully", {
   )
   expect_equal(config, miniextendr_config_defaults())
 })
+
+test_that("miniextendr_config resolves '.' and NULL to the active project, not getwd()", {
+  skip_if_not_installed("yaml")
+
+  # audit 2026-07-06 #7: miniextendr_config() read file.path(path, ...) against
+  # getwd(), unlike every sibling helper; and with_project(NULL) UNSET the
+  # active project instead of using it as documented.
+  tmp <- withr::local_tempdir()
+  writeLines("class_system: r6", file.path(tmp, "miniextendr.yml"))
+  usethis::local_project(tmp, force = TRUE, setwd = FALSE)
+
+  foreign <- withr::local_tempdir()
+  withr::local_dir(foreign)
+
+  expect_equal(miniextendr_config()$class_system, "r6")
+  expect_equal(miniextendr_config(path = NULL)$class_system, "r6")
+})

--- a/minirextendr/tests/testthat/test-status-coverage.R
+++ b/minirextendr/tests/testthat/test-status-coverage.R
@@ -262,3 +262,33 @@ test_that("miniextendr_validate warns on AC_INIT mismatch", {
   expect_type(result, "logical")
 })
 
+
+test_that("miniextendr_validate records a missing Rust toolchain as an issue", {
+  # audit 2026-07-06 #4: the tryCatch error handler assigned `issues` locally
+  # (no <<-), so a missing toolchain printed "Rust not found" (danger) and the
+  # summary still reported "All checks passed!" and returned TRUE.
+  tmp <- tempfile("validate-norust-")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  dir.create(tmp)
+
+  # Everything else valid, so Rust is the ONLY issue.
+  writeLines(paste0(
+    "Package: testpkg\nTitle: Test\nVersion: 0.0.1\n",
+    "Config/build/bootstrap: TRUE\n",
+    "SystemRequirements: Rust (>= 1.85)\n"
+  ), file.path(tmp, "DESCRIPTION"))
+  writeLines("AC_INIT([testpkg], [0.0.1])\nCARGO_FEATURES=\n",
+    file.path(tmp, "configure.ac"))
+  dir.create(file.path(tmp, "src", "rust"), recursive = TRUE)
+  writeLines(c(
+    '[package]', 'name = "testpkg"', '',
+    '[dependencies]', 'miniextendr-api = "*"'
+  ), file.path(tmp, "src", "rust", "Cargo.toml"))
+
+  local_mocked_bindings(check_rust = function() cli::cli_abort("no rust toolchain"))
+
+  msgs <- capture_messages(result <- miniextendr_validate(tmp))
+  expect_false(result)
+  expect_true(any(grepl("Rust not found", msgs)))
+  expect_false(any(grepl("All checks passed", msgs)))
+})


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
Two small independent fixes bundled (audit findings #4 and #7):

- **#4 — `miniextendr_validate()` contradicted itself**: with no Rust toolchain it printed "Rust not found" (danger) and then "All checks passed!", returning `TRUE`. The `tryCatch` error handler assigned `issues` locally (no `<<-`), so the outer vector never recorded the failure. The check now returns a `rust_ok` flag consumed in the validate frame. This branch had zero test coverage — which is exactly how the bug survived — and is now driven via `local_mocked_bindings(check_rust = abort)` on a fixture where Rust is the *only* problem (returns `TRUE` on main, `FALSE` after the fix).
- **#7 — documented `path` semantics now hold**:
  - `miniextendr_autoconf()` / `miniextendr_configure()` document `path = NULL` as "use the active project", but `usethis::local_project(NULL)` **unsets** the project. `with_project()` now treats `NULL` exactly like `"."` — one conditional makes the existing roxygen true for every caller, with no doc churn.
  - `miniextendr_config()` resolved `file.path(path, "miniextendr.yml")` against `getwd()`, unlike every sibling helper; it now goes through `with_project()` + `proj_path()`. The internal `compute_source_hash()` caller passes an absolute path and is unaffected; `@param path` doc updated accordingly.

Audit reference: `audit/2026-07-06-minirextendr-audit.md` findings #4 and #7.

## Test plan
- [x] `just minirextendr-document` — `man/miniextendr_config.Rd` regenerated, committed.
- [x] `just minirextendr-test` — `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 625 ]`
- [x] New regression tests: validate records the missing toolchain (FALSE + "Rust not found", no "All checks passed"); config resolves `"."` and `NULL` to the active project from a foreign cwd.

## Notes
- Pure `minirextendr/R` change; no template or `rpkg/` edits.
- No deferred scope.

---
_Drafted by Claude. Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)