### PR TITLE
fix(api): strict Vec<Option<T>> rejects type mismatches like Vec<T> (audit A6)

### DIFF
--- a/docs/CONVERSION_MATRIX.md
+++ b/docs/CONVERSION_MATRIX.md
@@ -104,6 +104,8 @@ Vector conversions (`Vec<T>`) follow the same source-type rules as scalars:
 | `Vec<Option<String>>` | STRSXP only | NA_character_ -> None |
 | `Vec<i64>` (strict) | INTSXP or REALSXP | Per-element checked coercion; RAWSXP/LGLSXP rejected |
 | `Vec<u64>` (strict) | INTSXP or REALSXP | Per-element checked coercion; RAWSXP/LGLSXP rejected |
+| `Vec<Option<i64>>` (strict) | INTSXP or REALSXP | Same input-type gate as `Vec<i64>` (strict); NA -> None |
+| `Vec<Option<u64>>` (strict) | INTSXP or REALSXP | Same input-type gate as `Vec<u64>` (strict); NA -> None |
 | `(A, B, ...)` (arity 2-8) | VECSXP only | Positional (names ignored); exact length required; all failing elements reported in one batched error |
 
 ---

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -303,6 +303,54 @@ pub fn checked_vec_try_from_sexp_usize(sexp: SEXP, param: &str) -> Vec<usize> {
         .collect()
 }
 
+/// Convert R SEXP to `Vec<Option<i64>>` in strict mode.
+///
+/// Applies the same input-SEXP-type gate as [`checked_vec_try_from_sexp_i64`]
+/// — only INTSXP and REALSXP are accepted; LGLSXP and RAWSXP are rejected.
+/// NA elements become `None`; type strictness and missingness are orthogonal.
+pub fn checked_vec_option_try_from_sexp_i64(sexp: SEXP, param: &str) -> Vec<Option<i64>> {
+    checked_vec_option_try_from_sexp_numeric::<i64>(sexp, param)
+}
+
+/// Convert R SEXP to `Vec<Option<u64>>` in strict mode.
+pub fn checked_vec_option_try_from_sexp_u64(sexp: SEXP, param: &str) -> Vec<Option<u64>> {
+    checked_vec_option_try_from_sexp_numeric::<u64>(sexp, param)
+}
+
+/// Convert R SEXP to `Vec<Option<isize>>` in strict mode.
+pub fn checked_vec_option_try_from_sexp_isize(sexp: SEXP, param: &str) -> Vec<Option<isize>> {
+    checked_vec_option_try_from_sexp_i64(sexp, param)
+        .into_iter()
+        .map(|opt| {
+            opt.map(|x| {
+                isize::try_from(x).unwrap_or_else(|_| {
+                    panic!(
+                        "strict conversion failed for parameter '{}': i64 value {} does not fit in isize",
+                        param, x
+                    )
+                })
+            })
+        })
+        .collect()
+}
+
+/// Convert R SEXP to `Vec<Option<usize>>` in strict mode.
+pub fn checked_vec_option_try_from_sexp_usize(sexp: SEXP, param: &str) -> Vec<Option<usize>> {
+    checked_vec_option_try_from_sexp_u64(sexp, param)
+        .into_iter()
+        .map(|opt| {
+            opt.map(|x| {
+                usize::try_from(x).unwrap_or_else(|_| {
+                    panic!(
+                        "strict conversion failed for parameter '{}': u64 value {} does not fit in usize",
+                        param, x
+                    )
+                })
+            })
+        })
+        .collect()
+}
+
 /// Generic strict scalar conversion: only INTSXP and REALSXP allowed.
 #[inline]
 fn checked_try_from_sexp_numeric_scalar<T>(sexp: SEXP, param: &str) -> T
@@ -386,6 +434,65 @@ where
                             param, e
                         )
                     })
+                })
+                .collect()
+        }
+        _ => panic!(
+            "strict conversion failed for parameter '{}': expected integer or double vector, got {:?}",
+            param, actual
+        ),
+    }
+}
+
+/// Generic strict `Vec<Option<T>>` conversion: only INTSXP and REALSXP allowed.
+///
+/// Mirrors [`checked_vec_try_from_sexp_numeric`] but maps R's NA sentinel
+/// (`NA_INTEGER` for INTSXP, `NA_REAL` for REALSXP) to `None` instead of
+/// erroring — missingness is orthogonal to the input-type gate.
+fn checked_vec_option_try_from_sexp_numeric<T>(sexp: SEXP, param: &str) -> Vec<Option<T>>
+where
+    i32: TryCoerce<T>,
+    f64: TryCoerce<T>,
+    <i32 as TryCoerce<T>>::Error: std::fmt::Debug,
+    <f64 as TryCoerce<T>>::Error: std::fmt::Debug,
+{
+    let actual = sexp.type_of();
+    match actual {
+        SEXPTYPE::INTSXP => {
+            let slice: &[i32] = unsafe { sexp.as_slice() };
+            slice
+                .iter()
+                .copied()
+                .map(|v| {
+                    if v == crate::altrep_traits::NA_INTEGER {
+                        None
+                    } else {
+                        Some(TryCoerce::<T>::try_coerce(v).unwrap_or_else(|e| {
+                            panic!(
+                                "strict conversion failed for parameter '{}': {:?}",
+                                param, e
+                            )
+                        }))
+                    }
+                })
+                .collect()
+        }
+        SEXPTYPE::REALSXP => {
+            let slice: &[f64] = unsafe { sexp.as_slice() };
+            slice
+                .iter()
+                .copied()
+                .map(|v| {
+                    if crate::from_r::is_na_real(v) {
+                        None
+                    } else {
+                        Some(TryCoerce::<T>::try_coerce(v).unwrap_or_else(|e| {
+                            panic!(
+                                "strict conversion failed for parameter '{}': {:?}",
+                                param, e
+                            )
+                        }))
+                    }
                 })
                 .collect()
         }

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -69,6 +69,40 @@ unsafe fn scalar_logical_raw(v: i32, g: &mut Guard) -> SEXP {
     unsafe { g.protect(SEXP::scalar_logical_raw(v)) }
 }
 
+unsafe fn vec_int(values: &[i32], g: &mut Guard) -> SEXP {
+    unsafe {
+        let s = g.protect(Rf_allocVector(SEXPTYPE::INTSXP, values.len() as isize));
+        s.as_mut_slice::<i32>().copy_from_slice(values);
+        s
+    }
+}
+
+unsafe fn vec_real(values: &[f64], g: &mut Guard) -> SEXP {
+    unsafe {
+        let s = g.protect(Rf_allocVector(SEXPTYPE::REALSXP, values.len() as isize));
+        s.as_mut_slice::<f64>().copy_from_slice(values);
+        s
+    }
+}
+
+unsafe fn vec_logical(values: &[i32], g: &mut Guard) -> SEXP {
+    unsafe {
+        let s = g.protect(Rf_allocVector(SEXPTYPE::LGLSXP, values.len() as isize));
+        for (i, &v) in values.iter().enumerate() {
+            s.set_logical_elt(i as isize, v);
+        }
+        s
+    }
+}
+
+unsafe fn vec_raw(values: &[u8], g: &mut Guard) -> SEXP {
+    unsafe {
+        let s = g.protect(Rf_allocVector(SEXPTYPE::RAWSXP, values.len() as isize));
+        s.as_mut_slice::<u8>().copy_from_slice(values);
+        s
+    }
+}
+
 // endregion
 
 // region: strict.rs — checked_into_sexp_* (outbound strict conversions)
@@ -231,6 +265,132 @@ fn strict_input_i64_accepts_real() {
         let s = unsafe { scalar_real(7.0, &mut g) };
         let val = checked_try_from_sexp_i64(s, "x");
         assert_eq!(val, 7i64);
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_i64` — audit A6 regression.
+/// Must apply the same input-SEXP-type gate as `checked_vec_try_from_sexp_i64`
+/// (reject LGLSXP), not silently coerce like the lax `TryFromSexp` path does.
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_i64_rejects_logical() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_i64;
+        let mut g = Guard(0);
+        let lgl = unsafe { vec_logical(&[1, 0], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_i64(lgl, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_i64` rejects RAWSXP.
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_i64_rejects_raw() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_i64;
+        let mut g = Guard(0);
+        let raw = unsafe { vec_raw(&[1, 2], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_i64(raw, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_i64` accepts INTSXP,
+/// mapping `NA_integer_` elements to `None`.
+#[test]
+fn strict_input_vec_option_i64_accepts_int_with_na() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_i64;
+        let mut g = Guard(0);
+        let s = unsafe { vec_int(&[1, NA_INTEGER, 3], &mut g) };
+        let val = checked_vec_option_try_from_sexp_i64(s, "x");
+        assert_eq!(val, vec![Some(1i64), None, Some(3i64)]);
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_i64` accepts REALSXP,
+/// mapping `NA_real_` elements to `None`.
+#[test]
+fn strict_input_vec_option_i64_accepts_real_with_na() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_i64;
+        let mut g = Guard(0);
+        let s = unsafe { vec_real(&[1.0, NA_REAL, 3.0], &mut g) };
+        let val = checked_vec_option_try_from_sexp_i64(s, "x");
+        assert_eq!(val, vec![Some(1i64), None, Some(3i64)]);
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_i64` — an out-of-range
+/// `Some` element still panics (range checking, not just the type gate).
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_i64_out_of_range_panics() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_i64;
+        let mut g = Guard(0);
+        // f64 above i64 range fails the i64-from-f64 TryCoerce step.
+        let s = unsafe { vec_real(&[1.0, 1e300], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_i64(s, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_u64` rejects LGLSXP.
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_u64_rejects_logical() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_u64;
+        let mut g = Guard(0);
+        let lgl = unsafe { vec_logical(&[1, 0], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_u64(lgl, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_isize` rejects LGLSXP.
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_isize_rejects_logical() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_isize;
+        let mut g = Guard(0);
+        let lgl = unsafe { vec_logical(&[1, 0], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_isize(lgl, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_usize` rejects LGLSXP.
+#[test]
+#[should_panic(expected = "strict conversion failed")]
+fn strict_input_vec_option_usize_rejects_logical() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_usize;
+        let mut g = Guard(0);
+        let lgl = unsafe { vec_logical(&[1, 0], &mut g) };
+        let _ = checked_vec_option_try_from_sexp_usize(lgl, "x");
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_isize` accepts INTSXP with NA.
+#[test]
+fn strict_input_vec_option_isize_accepts_int_with_na() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_isize;
+        let mut g = Guard(0);
+        let s = unsafe { vec_int(&[5, NA_INTEGER], &mut g) };
+        let val = checked_vec_option_try_from_sexp_isize(s, "x");
+        assert_eq!(val, vec![Some(5isize), None]);
+    });
+}
+
+/// Strict INPUT: `checked_vec_option_try_from_sexp_usize` accepts INTSXP with NA.
+#[test]
+fn strict_input_vec_option_usize_accepts_int_with_na() {
+    r_test_utils::with_r_thread(|| {
+        use miniextendr_api::strict::checked_vec_option_try_from_sexp_usize;
+        let mut g = Guard(0);
+        let s = unsafe { vec_int(&[5, NA_INTEGER], &mut g) };
+        let val = checked_vec_option_try_from_sexp_usize(s, "x");
+        assert_eq!(val, vec![Some(5usize), None]);
     });
 }
 

--- a/miniextendr-macros/src/return_type_analysis.rs
+++ b/miniextendr-macros/src/return_type_analysis.rs
@@ -362,8 +362,9 @@ pub(crate) fn strict_conversion_for_type(
 
 /// Try to generate a strict conversion expression for a lossy input parameter type.
 ///
-/// Returns `Some(TokenStream)` if the type is a lossy scalar or `Vec<lossy>`,
-/// otherwise `None` (falls through to standard `TryFromSexp`).
+/// Returns `Some(TokenStream)` if the type is a lossy scalar, `Vec<lossy>`,
+/// or `Vec<Option<lossy>>`, otherwise `None` (falls through to standard
+/// `TryFromSexp`).
 ///
 /// # Parameters
 /// - `ty`: The Rust parameter type to check
@@ -385,7 +386,7 @@ pub(crate) fn strict_input_conversion_for_type(
         });
     }
 
-    // Check for Vec<lossy>
+    // Check for Vec<lossy> or Vec<Option<lossy>>
     if name == "Vec"
         && let Some(inner) = first_type_arg_from_type(ty)
     {
@@ -395,6 +396,21 @@ pub(crate) fn strict_input_conversion_for_type(
             return Some(quote::quote! {
                 ::miniextendr_api::strict::#helper(#sexp_ident, #param_name)
             });
+        }
+        // Check for Vec<Option<lossy>> — must apply the same input-SEXP-type
+        // gate as Vec<lossy> (reject LGLSXP/RAWSXP), not fall through to the
+        // coercing TryFromSexp path. NA elements still become `None`.
+        if inner_name == "Option"
+            && let Some(option_inner) = first_type_arg_from_type(inner)
+        {
+            let option_inner_name = last_segment_ident(option_inner)?.to_string();
+            if LOSSY_SCALARS.contains(&option_inner_name.as_str()) {
+                let helper =
+                    quote::format_ident!("checked_vec_option_try_from_sexp_{}", option_inner_name);
+                return Some(quote::quote! {
+                    ::miniextendr_api::strict::#helper(#sexp_ident, #param_name)
+                });
+            }
         }
     }
 

--- a/rpkg/tests/testthat/test-scalar-conversions.R
+++ b/rpkg/tests/testthat/test-scalar-conversions.R
@@ -144,9 +144,14 @@ test_that("strict Vec<Option<i64>> handles all-NA input", {
   expect_equal(length(result), 2L)
 })
 
-test_that("strict Vec<Option<i64>> coerces logical input (strict only checks output range)", {
-  # Strict mode for Vec<Option<i64>> checks output values fit i32 range.
-  # Input type coercion (LGLSXP → i64) is handled by TryFromSexp, not strict.
-  result <- strict_echo_vec_option_i64(c(TRUE, FALSE))
-  expect_equal(result, c(1L, 0L))
+test_that("strict Vec<Option<i64>> rejects logical input (audit A6)", {
+  # Strict mode for Vec<Option<i64>> now applies the same input-SEXP-type gate
+  # as Vec<i64> (strict): only INTSXP/REALSXP are accepted, LGLSXP is rejected.
+  # Previously this silently coerced via the lax TryFromSexp path (audit
+  # finding #3 in audit/2026-07-03-api-sense-runtime-vctrs-misc.md).
+  expect_error(strict_echo_vec_option_i64(c(TRUE, FALSE)), "strict conversion failed")
+})
+
+test_that("strict Vec<Option<i64>> rejects raw input", {
+  expect_error(strict_echo_vec_option_i64(as.raw(c(1, 2))), "strict conversion failed")
 })


### PR DESCRIPTION
"Strict" promised input-type rejection in two of three sibling conversion paths and silently coerced in the third: `strict_echo_i64(TRUE)` and `strict_echo_vec_i64(c(TRUE, FALSE))` both error, but `strict_echo_vec_option_i64(c(TRUE, FALSE))` quietly returned `c(1L, 0L)` because the `Vec<Option<T>>` case fell through to the lax `TryFromSexp` path. Same adjective, two meanings. This makes strict `Vec<Option<T>>` apply the same input-SEXP-type gate as strict `Vec<T>` — reject LGLSXP/RAWSXP — while NA elements keep mapping to `None`, since missingness is orthogonal to type strictness.

<details>
<summary><h3>AI-written details</h3></summary>

**Source:** `audit/2026-07-03-api-sense-runtime-vctrs-misc.md` finding #3, via `plans/2026-07-06-audit-a6-strict-option-vec-consistency.md` (audit A6).

## Summary
- `miniextendr-api/src/strict.rs`: new generic `checked_vec_option_try_from_sexp_numeric<T>` — only INTSXP/REALSXP accepted (identical gate to `checked_vec_try_from_sexp_numeric`); `NA_integer_`/`NA_real_` elements become `None`; non-NA elements go through the same `TryCoerce` range checking (out-of-range still panics with the `strict conversion failed` family). Public helpers for the four lossy types: `checked_vec_option_try_from_sexp_{i64,u64,isize,usize}`.
- `miniextendr-macros/src/return_type_analysis.rs`: `strict_input_conversion_for_type` now recognizes `Vec<Option<lossy>>` and emits the checked helper instead of falling through to the coercing `TryFromSexp` path.
- `rpkg/tests/testthat/test-scalar-conversions.R`: the test that documented the divergence ("strict only checks output range") now asserts rejection; added a RAWSXP rejection case.
- `miniextendr-api/tests/conversion_coverage.rs`: 10 new integration tests (LGLSXP/RAWSXP rejection, INTSXP/REALSXP acceptance with NA→None, out-of-range panic) for all four types, using `with_r_thread` per #1139.
- `docs/CONVERSION_MATRIX.md`: two new rows for strict `Vec<Option<i64>>`/`Vec<Option<u64>>`.

Error text is the existing `strict conversion failed for parameter '<name>': expected integer or double vector, got <type>` family — same wording as the `Vec<T>` gate.

No exports added or removed; NAMESPACE/man unchanged. No new SEXP storage (element-wise reads only), so no gc_stress fixture is required.

## Test plan
- [x] `just check` / `just clippy` clean; `cargo fmt --all` clean
- [x] All three CI clippy variants (`clippy_default`, `clippy_all`, `clippy_all_s7`) with `-D warnings` — clean
- [x] `just test` — green except the 7 known `derive_dataframe_*` trybuild local-rustc drift mismatches (snapshots not overwritten; CI toolchain authoritative)
- [x] `cargo test -p miniextendr-api --test conversion_coverage` — 10 new tests pass
- [x] Full rpkg loop (`just configure && just rcmdinstall && just force-document`) then `just devtools-test`: **[ FAIL 0 | WARN 0 | SKIP 20 | PASS 6872 ]**

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
