### PR TITLE
fix(serde): clear UnexpectedNa error for NA elements in non-Option Vec<T>

### DIFF
--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -732,6 +732,41 @@ struct VectorElementDeserializer {
     index: usize,
 }
 
+impl VectorElementDeserializer {
+    /// Whether the element at `index` is NA for the vector's type.
+    ///
+    /// RAWSXP has no NA representation, so raw elements are never NA.
+    fn is_na(&self) -> bool {
+        match self.sexp_type {
+            SEXPTYPE::LGLSXP => self.sexp.logical_elt(self.index as isize) == NA_LOGICAL,
+            SEXPTYPE::INTSXP => self.sexp.integer_elt(self.index as isize) == NA_INTEGER,
+            SEXPTYPE::REALSXP => {
+                self.sexp.real_elt(self.index as isize).to_bits() == NA_REAL.to_bits()
+            }
+            SEXPTYPE::STRSXP => self.sexp.string_elt(self.index as isize) == SEXP::na_string(),
+            _ => false,
+        }
+    }
+}
+
+/// Generates the bare scalar `deserialize_*` methods for
+/// `VectorElementDeserializer`: an NA element reaching a non-`Option` scalar
+/// target is a genuine missingness error (`RSerdeError::UnexpectedNa`),
+/// matching the top-level scalar path in `RDeserializer`. Only
+/// `deserialize_option` maps NA to `None` (#1166).
+macro_rules! vector_element_scalar_na_errors {
+    ($($method:ident)*) => {
+        $(
+            fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+                if self.is_na() {
+                    return Err(RSerdeError::UnexpectedNa);
+                }
+                self.deserialize_any(visitor)
+            }
+        )*
+    };
+}
+
 impl<'de> de::Deserializer<'de> for VectorElementDeserializer {
     type Error = RSerdeError;
 
@@ -815,9 +850,31 @@ impl<'de> de::Deserializer<'de> for VectorElementDeserializer {
         self.deserialize_tuple(len, visitor)
     }
 
+    /// NA element -> `None`, everything else -> `Some(value)`.
+    ///
+    /// Parallel to `RDeserializer::deserialize_option`: only this
+    /// `Option`-driven path maps NA to `visit_none()`. The bare scalar
+    /// methods below error with `RSerdeError::UnexpectedNa` instead, so
+    /// `Vec<i32>` with an NA element reports a clear NA error rather than
+    /// leaking serde's "invalid type: Option value" internal (#1166).
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        if self.is_na() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    vector_element_scalar_na_errors! {
+        deserialize_bool
+        deserialize_i8 deserialize_i16 deserialize_i32 deserialize_i64
+        deserialize_u8 deserialize_u16 deserialize_u32 deserialize_u64
+        deserialize_f32 deserialize_f64
+        deserialize_char deserialize_str deserialize_string
+    }
+
     serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf
-        option unit unit_struct newtype_struct map struct
+        bytes byte_buf unit unit_struct newtype_struct map struct
         enum identifier ignored_any
     }
 }

--- a/miniextendr-api/tests/serde_option_na.rs
+++ b/miniextendr-api/tests/serde_option_na.rs
@@ -15,6 +15,11 @@
 //! `miniextendr-api/src`, because a real SEXP requires an initialized R
 //! runtime (see the comment in `src/strict.rs`). These integration tests use
 //! the embedded-R harness in `tests/r_test_utils.rs` instead.
+//!
+//! Also covers #1166: an NA *element* of an atomic vector must behave like
+//! the scalar path — `Vec<T>` errors with `RSerdeError::UnexpectedNa` (not a
+//! leaked serde "invalid type: Option value" internal), `Vec<Option<T>>`
+//! yields `None`.
 
 #![cfg(feature = "serde")]
 
@@ -23,8 +28,9 @@ mod r_test_utils;
 use miniextendr_api::SEXPTYPE;
 use miniextendr_api::altrep_traits::{NA_INTEGER, NA_LOGICAL, NA_REAL};
 use miniextendr_api::from_r::TryFromSexp;
+use miniextendr_api::into_r::IntoR;
 use miniextendr_api::prelude::{SEXP, SexpExt};
-use miniextendr_api::serde::from_r;
+use miniextendr_api::serde::{RSerdeError, from_r};
 use miniextendr_api::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
 use serde::Deserialize;
 
@@ -73,6 +79,9 @@ fn serde_option_na_suite() {
         bare_scalar_na_still_errors();
         struct_field_na_becomes_none_matching_null();
         struct_required_field_na_still_errors();
+        vec_na_element_errors_with_unexpected_na();
+        vec_option_na_element_becomes_none();
+        vec_without_na_still_roundtrips();
     });
 }
 
@@ -215,3 +224,77 @@ fn struct_required_field_na_still_errors() {
         );
     }
 }
+
+// region: vector-element NA handling (#1166)
+
+/// Assert an error is the clear `UnexpectedNa`, not a leaked serde internal
+/// like "invalid type: Option value, expected i32".
+#[track_caller]
+fn assert_unexpected_na(err: &RSerdeError, context: &str) {
+    assert!(
+        matches!(err, RSerdeError::UnexpectedNa),
+        "{context}: expected RSerdeError::UnexpectedNa, got: {err:?}"
+    );
+    assert_eq!(err.to_string(), "unexpected NA value");
+}
+
+/// An NA element inside a non-`Option` `Vec<T>` is still an error, but with
+/// the same clear `UnexpectedNa` message the bare-scalar path produces.
+fn vec_na_element_errors_with_unexpected_na() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let ints = guard.protect(vec![Some(1i32), None, Some(3)].into_sexp());
+        let err = from_r::<Vec<i32>>(ints).expect_err("NA element in Vec<i32> must error");
+        assert_unexpected_na(&err, "Vec<i32>");
+
+        let reals = guard.protect(vec![Some(1.5f64), None].into_sexp());
+        let err = from_r::<Vec<f64>>(reals).expect_err("NA element in Vec<f64> must error");
+        assert_unexpected_na(&err, "Vec<f64>");
+
+        let bools = guard.protect(vec![Some(true), None].into_sexp());
+        let err = from_r::<Vec<bool>>(bools).expect_err("NA element in Vec<bool> must error");
+        assert_unexpected_na(&err, "Vec<bool>");
+
+        let strs = guard.protect(vec![Some("a".to_string()), None].into_sexp());
+        let err = from_r::<Vec<String>>(strs).expect_err("NA element in Vec<String> must error");
+        assert_unexpected_na(&err, "Vec<String>");
+    }
+}
+
+/// `Vec<Option<T>>` still maps NA elements to `None` and non-NA elements to
+/// `Some` via the new `VectorElementDeserializer::deserialize_option`.
+fn vec_option_na_element_becomes_none() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let ints = guard.protect(vec![Some(1i32), None, Some(3)].into_sexp());
+        let vals: Vec<Option<i32>> = from_r(ints).expect("Vec<Option<i32>> with NA element");
+        assert_eq!(vals, vec![Some(1), None, Some(3)]);
+
+        let reals = guard.protect(vec![Some(1.5f64), None].into_sexp());
+        let vals: Vec<Option<f64>> = from_r(reals).expect("Vec<Option<f64>> with NA element");
+        assert_eq!(vals, vec![Some(1.5), None]);
+
+        let bools = guard.protect(vec![Some(true), None, Some(false)].into_sexp());
+        let vals: Vec<Option<bool>> = from_r(bools).expect("Vec<Option<bool>> with NA element");
+        assert_eq!(vals, vec![Some(true), None, Some(false)]);
+
+        let strs = guard.protect(vec![Some("a".to_string()), None].into_sexp());
+        let vals: Vec<Option<String>> = from_r(strs).expect("Vec<Option<String>> with NA element");
+        assert_eq!(vals, vec![Some("a".to_string()), None]);
+    }
+}
+
+/// NA-free vectors are unaffected for both `Vec<T>` and `Vec<Option<T>>`.
+fn vec_without_na_still_roundtrips() {
+    let mut guard = ProtectCount::default();
+    unsafe {
+        let ints = guard.protect(vec![1i32, 2, 3].into_sexp());
+        let vals: Vec<i32> = from_r(ints).expect("Vec<i32> without NA");
+        assert_eq!(vals, vec![1, 2, 3]);
+
+        let vals: Vec<Option<i32>> = from_r(ints).expect("Vec<Option<i32>> without NA");
+        assert_eq!(vals, vec![Some(1), Some(2), Some(3)]);
+    }
+}
+
+// endregion


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## Problem

`VectorElementDeserializer` (`miniextendr-api/src/serde/de.rs`) forwarded both `option` and all the bare scalar type methods (`i32`, `f64`, `bool`, `str`, ...) to `deserialize_any` via `serde::forward_to_deserialize_any!`. `deserialize_any` unconditionally maps an NA element to `visitor.visit_none()`, so for `Vec<i32>` (non-Option element type) serde's derived `i32` visitor — which has no `visit_none` override — leaked a serde internal:

```r
serde_r_deserialize_vec_i32(c(1L, NA_integer_, 3L))
#> Error: deserialize vec i32: Message("invalid type: Option value, expected i32")
```

After this change the same call reports the clear NA error the top-level bare-scalar path already produces:

```r
serde_r_deserialize_vec_i32(c(1L, NA_integer_, 3L))
#> Error: deserialize vec i32: UnexpectedNa   # Display: "unexpected NA value"
```

NA in `Vec<i32>` remains an error — only the message improves.

## Approach

- `VectorElementDeserializer` gets its own `deserialize_option` (parallel to `RDeserializer::deserialize_option`): NA element → `visit_none()`, otherwise `visit_some(self)`. Only Option-driven deserialization routes through `visit_none()` now. This also fixes the `Some` side for atomic-vector elements: previously `Vec<Option<i32>>` routed non-NA elements through `deserialize_any` → `visit_i32` on serde's `OptionVisitor`, which has no scalar visit methods.
- The bare scalar element methods (`deserialize_bool`/`i8..i64`/`u8..u64`/`f32`/`f64`/`char`/`str`/`string`, generated by a local `macro_rules!`) now check `is_na()` first and error with `RSerdeError::UnexpectedNa`, matching the top-level scalar path, then delegate to `deserialize_any` for value extraction.
- `deserialize_any` itself is unchanged (self-describing/untagged targets still see NA as none), as are the seq/tuple coalescing paths; `bytes`/`byte_buf`/`unit`/`map`/`struct`/`enum`/`identifier`/`ignored_any` stay forwarded. RAWSXP has no NA representation, so `is_na()` is always false there.

## Tests

Extended `miniextendr-api/tests/serde_option_na.rs` (embedded-R harness via `r_test_utils::with_r_thread`, same suite as the audit-A5 regression tests):

- `vec_na_element_errors_with_unexpected_na` — `Vec<i32>`/`Vec<f64>`/`Vec<bool>`/`Vec<String>` with an NA element error with `RSerdeError::UnexpectedNa` (Display: `unexpected NA value`), asserted via `matches!` so a regression back to `Message("invalid type: ...")` fails loudly.
- `vec_option_na_element_becomes_none` — `Vec<Option<T>>` for all four types still maps NA → `None` and non-NA → `Some`.
- `vec_without_na_still_roundtrips` — NA-free vectors unaffected for both `Vec<T>` and `Vec<Option<T>>`.

Ran `just test` plus CI's three clippy configurations (`clippy_default`, `clippy_all`, `clippy_all_s7`) locally. Skipped an rpkg `just rcmdinstall`/testthat repro: the shared rv library is contended by sibling agent sessions right now, and the in-crate embedded-R tests exercise the exact same `from_r` path the `serde_r_deserialize_vec_i32` fixture calls.

Fixes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
