### PR TITLE
fix(minirextendr): precondition-check configure.ac anchor before DESCRIPTION edit in use_native_package

### DIFF
--- a/minirextendr/R/use-native.R
+++ b/minirextendr/R/use-native.R
@@ -45,6 +45,16 @@ use_native_package <- function(pkg,
     ))
   }
 
+  # Precondition (#1171): verify configure.ac can take the include-path wiring
+  # BEFORE mutating DESCRIPTION. add_native_to_configure_ac() runs after the
+  # LinkingTo/Imports edit; a hand-mangled configure.ac with no insertion
+  # anchor would otherwise be discovered too late, leaving DESCRIPTION mutated
+  # with no include-path detection wired in.
+  configure_ac <- usethis::proj_path("configure.ac")
+  if (fs::file_exists(configure_ac)) {
+    abort_if_missing_native_anchor(readLines(configure_ac, warn = FALSE))
+  }
+
   # 1. Add LinkingTo + Imports in DESCRIPTION
   add_linking_to(pkg)
 
@@ -504,6 +514,40 @@ add_linking_to <- function(pkg) {
 # configure.ac generation
 # =============================================================================
 
+#' Abort if `configure.ac` lacks an anchor for native include detection
+#'
+#' [add_native_to_configure_ac()] needs one of three insertion points, in
+#' priority order: the `MINIREXTENDR: native-pkg-cppflags` marker, an existing
+#' `AC_SUBST([NATIVE_PKG_CPPFLAGS])`, or `AC_CONFIG_SRCDIR` (the anchor for
+#' creating the whole section). A hand-mangled configure.ac with none of them
+#' used to be discovered only AFTER [use_native_package()] had edited
+#' DESCRIPTION, leaving `LinkingTo`/`Imports` mutated with no include-path
+#' wiring (#1171). Called up front, before the DESCRIPTION edit, mirroring
+#' [abort_if_missing_vendor_lib_anchors()] -- a precondition is smaller and
+#' safer than rolling back partial edits.
+#'
+#' @param lines Character vector of `configure.ac` lines
+#' @return Invisibly `TRUE` if an anchor is present; aborts otherwise
+#' @noRd
+abort_if_missing_native_anchor <- function(lines) {
+  has_anchor <-
+    any(grepl("MINIREXTENDR: native-pkg-cppflags", lines, fixed = TRUE)) ||
+    any(grepl("AC_SUBST.*NATIVE_PKG_CPPFLAGS", lines)) ||
+    any(grepl("AC_CONFIG_SRCDIR", lines))
+  if (has_anchor) {
+    return(invisible(TRUE))
+  }
+  cli::cli_abort(c(
+    "configure.ac is missing the {.code AC_CONFIG_SRCDIR} anchor",
+    "x" = paste(
+      "Editing {.file DESCRIPTION} without it would leave the package",
+      "half-configured: {.code LinkingTo}/{.code Imports} added but no",
+      "include-path detection wired into {.file configure.ac}."
+    ),
+    "i" = "Run {.run upgrade_miniextendr_package()} first to refresh the scaffolding."
+  ))
+}
+
 #' Append native package include detection to configure.ac
 #'
 #' Adds an m4 block that resolves the package's include path at configure time
@@ -550,8 +594,10 @@ add_native_to_configure_ac <- function(pkg) {
     # No NATIVE_PKG_CPPFLAGS section -- need to add one
     srcdir_idx <- grep("AC_CONFIG_SRCDIR", lines)
     if (length(srcdir_idx) == 0) {
-      cli::cli_warn("Could not find insertion point in configure.ac")
-      return(invisible())
+      # Unreachable from use_native_package() (precondition, #1171); for any
+      # direct caller a hard stop beats the old warn-and-skip that left the
+      # package half-configured.
+      abort_if_missing_native_anchor(lines)
     }
     # Add the full section before AC_CONFIG_SRCDIR
     section <- c(

--- a/minirextendr/tests/testthat/test-use-native.R
+++ b/minirextendr/tests/testthat/test-use-native.R
@@ -82,6 +82,80 @@ test_that("resolve_include_paths is recursive", {
   expect_true(eigen_found)
 })
 
+# =============================================================================
+# anchor precondition (#1171)
+# =============================================================================
+
+test_that("abort_if_missing_native_anchor accepts any of the three anchors", {
+  expect_true(minirextendr:::abort_if_missing_native_anchor(
+    "AC_CONFIG_SRCDIR([src/rust/lib.rs])"
+  ))
+  expect_true(minirextendr:::abort_if_missing_native_anchor(
+    "dnl MINIREXTENDR: native-pkg-cppflags insertion marker"
+  ))
+  expect_true(minirextendr:::abort_if_missing_native_anchor(
+    "AC_SUBST([NATIVE_PKG_CPPFLAGS])"
+  ))
+  expect_error(
+    minirextendr:::abort_if_missing_native_anchor(
+      c("AC_INIT([testpkg], [1.0])", "AC_OUTPUT")
+    ),
+    "AC_CONFIG_SRCDIR"
+  )
+})
+
+test_that("use_native_package aborts before mutating DESCRIPTION when configure.ac has no anchor (#1171)", {
+  skip_if_not_installed("cli")
+  skip_if(nchar(Sys.which("bindgen")) == 0, "bindgen not installed")
+  tmp <- withr::local_tempdir()
+  # Hand-mangled configure.ac: no AC_CONFIG_SRCDIR, no NATIVE_PKG_CPPFLAGS
+  # section, no insertion marker -- nothing to hang include detection off.
+  writeLines(c(
+    "AC_INIT([testpkg], [1.0])",
+    "AC_OUTPUT"
+  ), file.path(tmp, "configure.ac"))
+  writeLines(c(
+    "Package: testpkg",
+    "Title: Test",
+    "Version: 0.1.0"
+  ), file.path(tmp, "DESCRIPTION"))
+  desc_before <- readLines(file.path(tmp, "DESCRIPTION"), warn = FALSE)
+  withr::local_dir(tmp)
+  usethis::local_project(tmp, quiet = TRUE, force = TRUE, setwd = FALSE)
+
+  expect_error(
+    use_native_package("cli", path = tmp),
+    "AC_CONFIG_SRCDIR"
+  )
+
+  # The whole point: DESCRIPTION untouched, no half-configured package.
+  expect_identical(
+    readLines(file.path(tmp, "DESCRIPTION"), warn = FALSE),
+    desc_before
+  )
+})
+
+test_that("add_native_to_configure_ac aborts instead of warning on missing anchor (#1171)", {
+  tmp <- withr::local_tempdir()
+  writeLines(c(
+    "AC_INIT([testpkg], [1.0])",
+    "AC_OUTPUT"
+  ), file.path(tmp, "configure.ac"))
+  writeLines("Package: testpkg", file.path(tmp, "DESCRIPTION"))
+  conf_before <- readLines(file.path(tmp, "configure.ac"), warn = FALSE)
+  withr::local_dir(tmp)
+  usethis::local_project(tmp, quiet = TRUE, force = TRUE, setwd = FALSE)
+
+  expect_error(
+    minirextendr:::add_native_to_configure_ac("cli"),
+    "AC_CONFIG_SRCDIR"
+  )
+  expect_identical(
+    readLines(file.path(tmp, "configure.ac"), warn = FALSE),
+    conf_before
+  )
+})
+
 test_that("add_native_to_configure_ac appends detection block", {
   skip_if_not_installed("cli")
   tmp <- withr::local_tempdir()


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

`use_native_package()` mutated DESCRIPTION (`LinkingTo`/`Imports`) before `add_native_to_configure_ac()` verified configure.ac was editable. A hand-mangled configure.ac with no `AC_CONFIG_SRCDIR` (and no `NATIVE_PKG_CPPFLAGS` section or `MINIREXTENDR: native-pkg-cppflags` marker) hit a warn-and-skip branch — leaving DESCRIPTION mutated with no include-path wiring.

### Approach

- New `abort_if_missing_native_anchor(lines)` in `minirextendr/R/use-native.R`, mirroring `abort_if_missing_vendor_lib_anchors()` from the vendor-lib fix (audit 2026-07-06 finding #5): a precondition is smaller and safer than rolling back partial edits. It accepts any of the three insertion anchors `add_native_to_configure_ac()` can use, in priority order: the `MINIREXTENDR: native-pkg-cppflags` marker, an existing `AC_SUBST([NATIVE_PKG_CPPFLAGS])`, or `AC_CONFIG_SRCDIR` (the anchor for creating the section from scratch).
- `use_native_package()` now runs the check up front, BEFORE the DESCRIPTION edit, and aborts with a clear message pointing at `upgrade_miniextendr_package()`. A missing configure.ac stays a non-error (the wiring step already no-ops for packages without one).
- The old warn-and-skip branch inside `add_native_to_configure_ac()` now aborts through the same helper — unreachable from `use_native_package()` after the precondition, but a hard stop beats a silent half-configure for any direct caller.

### Tests

- Unit test: `abort_if_missing_native_anchor()` accepts each of the three anchors, aborts when all are absent.
- Regression (the issue scenario): hand-mangled configure.ac (no `AC_CONFIG_SRCDIR`) → `use_native_package("cli")` aborts and DESCRIPTION is byte-identical to before.
- `add_native_to_configure_ac()` aborts instead of warning, configure.ac untouched.

### Verification

`just minirextendr-test`: `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 672 ]` — the 3 skips are pre-existing (svines/Countr not installed locally). Single-file run of `test-use-native.R`: `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 30 ]` with all new tests executing (bindgen present locally, so the full-flow test did not skip). `just minirextendr-check` not run per #1154 (pre-existing pak network failure).

Fixes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>