### PR TITLE
fix(macros): doc-lint must not mistake synthesized @description for an explicit tag (#1172)

### DIFF
--- a/miniextendr-macros/src/roxygen.rs
+++ b/miniextendr-macros/src/roxygen.rs
@@ -91,6 +91,42 @@ pub(crate) fn roxygen_tags_from_attrs_for_r6_method(attrs: &[syn::Attribute]) ->
 /// `@description` tag — never `@title`. The `@title` is left to the caller
 /// (structural name); see [`leading_prose_from_attrs`] for why.
 fn roxygen_tags_from_attrs_impl(attrs: &[syn::Attribute]) -> Vec<String> {
+    let mut tags = explicit_roxygen_tags_from_attrs(attrs);
+
+    // Check which tags are present
+    let tag_names_set = tag_names(&tags);
+    let has_description = tag_names_set.contains("description");
+
+    // Promote leading prose doc comments to `@description` (all paragraphs before
+    // the first `@tag`), unless the author already wrote an explicit `@description`.
+    //
+    // The page `@title` is NOT synthesized from prose. Rustdoc summaries are markdown
+    // written for `cargo doc` — intra-doc links (`[`Foo`]`, `[x][crate::y]`) and code
+    // spans — which roxygen2's markdown parser tries to resolve as R `\link{}` topics
+    // and fails ("could not resolve link to topic" / "refers to un-installed package").
+    // Titles come from the structural name instead: the wrapper name for standalone
+    // functions (see `lib.rs`) and `@title {Name} Class` for class blocks (see
+    // `ClassDocBuilder`). Demoting prose to `@description` keeps it visible while the
+    // title stays link-free.
+    //
+    // `leading_prose_from_attrs` returns `None` for tag-led blocks (no leading prose),
+    // so `@inherit`/`@rdname`-only docs never gain a spurious description.
+    if !has_description && let Some(desc) = leading_prose_from_attrs(attrs) {
+        tags.insert(0, format!("@description {}", desc));
+    }
+
+    tags
+}
+
+/// Parse only the author-written `@tag` lines from doc attributes — no
+/// leading-prose promotion.
+///
+/// [`roxygen_tags_from_attrs_impl`] layers the leading-prose → `@description`
+/// promotion on top of this. [`doc_conflict_warnings`] must use this raw parse
+/// instead: comparing the *synthesized* description (all leading prose) against
+/// the implicit one (second paragraph) warned on every multi-paragraph doc
+/// comment that had no explicit `@description` at all (#1172).
+fn explicit_roxygen_tags_from_attrs(attrs: &[syn::Attribute]) -> Vec<String> {
     let mut tags = Vec::new();
 
     // Partition: doc attrs first (stable), non-doc attrs after.
@@ -121,30 +157,9 @@ fn roxygen_tags_from_attrs_impl(attrs: &[syn::Attribute]) -> Vec<String> {
                 last.push_str(trimmed);
             }
             // Leading prose (before any @tag) is captured separately by
-            // `leading_prose_from_attrs` and promoted to @description below.
+            // `leading_prose_from_attrs` and promoted to @description in
+            // `roxygen_tags_from_attrs_impl`.
         }
-    }
-
-    // Check which tags are present
-    let tag_names_set = tag_names(&tags);
-    let has_description = tag_names_set.contains("description");
-
-    // Promote leading prose doc comments to `@description` (all paragraphs before
-    // the first `@tag`), unless the author already wrote an explicit `@description`.
-    //
-    // The page `@title` is NOT synthesized from prose. Rustdoc summaries are markdown
-    // written for `cargo doc` — intra-doc links (`[`Foo`]`, `[x][crate::y]`) and code
-    // spans — which roxygen2's markdown parser tries to resolve as R `\link{}` topics
-    // and fails ("could not resolve link to topic" / "refers to un-installed package").
-    // Titles come from the structural name instead: the wrapper name for standalone
-    // functions (see `lib.rs`) and `@title {Name} Class` for class blocks (see
-    // `ClassDocBuilder`). Demoting prose to `@description` keeps it visible while the
-    // title stays link-free.
-    //
-    // `leading_prose_from_attrs` returns `None` for tag-led blocks (no leading prose),
-    // so `@inherit`/`@rdname`-only docs never gain a spurious description.
-    if !has_description && let Some(desc) = leading_prose_from_attrs(attrs) {
-        tags.insert(0, format!("@description {}", desc));
     }
 
     tags
@@ -555,7 +570,10 @@ pub(crate) fn doc_conflict_warnings(
 ) -> proc_macro2::TokenStream {
     use quote::quote;
 
-    let tags = roxygen_tags_from_attrs(attrs);
+    // Raw parse only: `roxygen_tags_from_attrs` synthesizes a `@description`
+    // from leading prose, which this lint must not mistake for an
+    // author-written tag (#1172).
+    let tags = explicit_roxygen_tags_from_attrs(attrs);
     let mut warnings = proc_macro2::TokenStream::new();
 
     // Check @title conflict

--- a/miniextendr-macros/src/roxygen/tests.rs
+++ b/miniextendr-macros/src/roxygen/tests.rs
@@ -129,6 +129,59 @@ mod doc_lint_tests {
             Some("Description after multiple blanks.".to_string())
         );
     }
+
+    // region: #1172 — lint must only fire on author-written @description
+
+    /// Multi-paragraph prose with no explicit tags must not warn. Before the
+    /// fix, `doc_conflict_warnings` saw the `@description` synthesized from
+    /// leading prose by `roxygen_tags_from_attrs` and compared it against the
+    /// second paragraph — a guaranteed mismatch for every multi-paragraph doc.
+    #[test]
+    fn test_no_desc_warning_for_prose_only_docs() {
+        let attrs = make_doc_attrs(&[
+            "Create a lazy integer sequence ALTREP.",
+            "",
+            "Elements are computed on demand.",
+            "@param n Length.",
+        ]);
+        let warnings = doc_conflict_warnings(&attrs, proc_macro2::Span::call_site());
+        assert!(
+            warnings.is_empty(),
+            "prose-only docs must not trigger the @description lint: {warnings}"
+        );
+    }
+
+    #[test]
+    fn test_desc_warning_fires_on_drifted_explicit_description() {
+        let attrs = make_doc_attrs(&[
+            "Title.",
+            "",
+            "Second paragraph.",
+            "@description Something entirely different.",
+        ]);
+        let warnings = doc_conflict_warnings(&attrs, proc_macro2::Span::call_site());
+        assert!(
+            warnings.to_string().contains("MINIEXTENDR_DOC_LINT_DESC"),
+            "drifted explicit @description must still warn: {warnings}"
+        );
+    }
+
+    #[test]
+    fn test_no_desc_warning_when_explicit_matches_second_paragraph() {
+        let attrs = make_doc_attrs(&[
+            "Title.",
+            "",
+            "Second paragraph.",
+            "@description Second paragraph.",
+        ]);
+        let warnings = doc_conflict_warnings(&attrs, proc_macro2::Span::call_site());
+        assert!(
+            warnings.is_empty(),
+            "matching explicit @description must not warn: {warnings}"
+        );
+    }
+
+    // endregion
 }
 // endregion
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

Fixes #1172.

## Root cause: a lint bug, not fixture drift

Issue #1172 assumed ~118 fixtures had explicit `@description` tags that drifted from their doc prose. Investigating the 125 warning sites (full rcmdinstall feature set) showed **none of them contain an explicit `@description` at all** — the 27 files carrying warnings have zero overlap with the 9 files that actually use the tag.

The real bug: `doc_conflict_warnings` (`miniextendr-macros/src/roxygen.rs`) called `roxygen_tags_from_attrs`, which since #1054/#1057 *synthesizes* a `@description` tag from all leading prose (the title-by-structural-name change). The lint then mistook its own synthesized tag for an author-written one and compared it (all prose paragraphs) against the implicit description (second paragraph only) — a guaranteed mismatch for every multi-paragraph doc comment on a `#[miniextendr]` item. The lint predates the promotion (902c3b83); the promotion (efe9d423) broke its "tags are explicit" assumption.

## Approach

- Split the raw `@tag` parse out of `roxygen_tags_from_attrs_impl` into a new `explicit_roxygen_tags_from_attrs` (no prose promotion); the public tag-extraction path layers the promotion on top exactly as before — **emitted R wrapper output is byte-identical**.
- `doc_conflict_warnings` now uses the raw parse, so `MINIEXTENDR_DOC_LINT_DESC` only fires on genuinely author-written `@description` tags (`@title` was never synthesized, so its check is unchanged).
- No fixture edits were needed: with the lint fixed, zero sites have real drift, and the lint still guards against future genuinely drifted explicit tags.

## Verification

- Before: `cargo check` in `rpkg/src/rust` with the Makevars feature set → **125** `MINIEXTENDR_DOC_LINT_DESC` warnings; after → **0** (default features: 70 → 0).
- Three new regression tests in `miniextendr-macros/src/roxygen/tests.rs`: prose-only docs don't warn; a drifted explicit `@description` still warns; a matching explicit `@description` doesn't warn.
- `cargo test -p miniextendr-macros`: 418 unit tests pass. The 7 `derive_dataframe_*` trybuild UI mismatches are the known local-rustc snapshot drift (pre-existing, CI-authoritative).
- `cargo clippy -p miniextendr-macros --all-targets -- -D warnings` clean with and without `doc-lint`.
- `just configure && just rcmdinstall && just force-document`: both green, zero doc-lint warnings anywhere in the logs, and **no NAMESPACE / `man/*.Rd` / Cargo.lock churn** — confirming the emitted roxygen is unchanged, so there is nothing regenerated to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
