### PR TITLE
docs(api): result.rs — state each IntoR impl's actual gating condition (NullOnErr fires regardless of unwrap_in_r)

### DIFF
--- a/miniextendr-api/src/into_r/result.rs
+++ b/miniextendr-api/src/into_r/result.rs
@@ -1,18 +1,26 @@
 //! `Result<T, E>` conversions to R.
 //!
-//! Used by `#[miniextendr(unwrap_in_r)]` to pass Results to R as lists
-//! with `ok` and `err` fields, instead of unwrapping in Rust.
+//! Used by `#[miniextendr(unwrap_in_r)]` to pass Results to R as values
+//! (`Err` becomes `list(error = ...)`), instead of unwrapping in Rust.
 //! Also provides `NullOnErr` for `Result<T, ()>` → NULL-on-error semantics.
 //!
 //! # Tradeoff
 //!
-//! These impls only fire under `#[miniextendr(unwrap_in_r)]` (Result-as-value).
-//! Without that attribute, a `Result<T, E>` return acts as an **error
-//! boundary**: `Err(e)` panics with `Debug`-formatted `e`, the framework's
-//! tagged-condition transport carries it to R, and the wrapper raises a
-//! classed `rust_*` condition. Failure mode of opting into `unwrap_in_r`
-//! without telling R callers: they suddenly need to inspect `$ok` / `$err`
-//! on every return value instead of using `tryCatch`.
+//! The two impls in this module have different gating conditions:
+//!
+//! - `IntoR for Result<T, E: Display>` (the `list(error = ...)` shape) fires
+//!   **only** under `#[miniextendr(unwrap_in_r)]` (Result-as-value). Without
+//!   that attribute, a `Result<T, E>` return acts as an **error boundary**:
+//!   `Err(e)` panics with `Debug`-formatted `e`, the framework's
+//!   tagged-condition transport carries it to R, and the wrapper raises a
+//!   classed `rust_*` condition. Failure mode of opting into `unwrap_in_r`
+//!   without telling R callers: they suddenly need to check `$error` on every
+//!   return value instead of using `tryCatch`.
+//! - `IntoR for Result<T, NullOnErr>` fires whenever the error type is `()`,
+//!   **independent of `unwrap_in_r`**: the macro rewrites `Result<T, ()>` to
+//!   `Result<T, NullOnErr>` before the `unwrap_in_r` check, so `Err(())`
+//!   returns `NULL` to R in both modes. A unit error is a deliberate
+//!   "no value" sentinel, not a Rust failure — it never raises an R error.
 
 use std::collections::HashMap;
 
@@ -45,6 +53,10 @@ use crate::into_r::IntoR;
 /// **With `unwrap_in_r`**: `Result<T, E>` is passed through to R:
 /// - `Ok(v)` → `v` converted to R
 /// - `Err(e)` → `list(error = e.to_string())` (requires `E: Display`)
+///
+/// **Exception**: `Result<T, ()>` never reaches this impl in either mode —
+/// the macro rewrites it to `Result<T, NullOnErr>` before the `unwrap_in_r`
+/// check, and `Err(())` returns `NULL`. See [`NullOnErr`].
 ///
 /// # Example
 ///
@@ -109,7 +121,9 @@ where
 /// ```
 ///
 /// The macro generates code that converts `Err(())` to `Err(NullOnErr)` and
-/// returns `NULL` in R.
+/// returns `NULL` in R. This rewrite fires whenever the error type is `()`,
+/// **whether or not** `#[miniextendr(unwrap_in_r)]` is set — the unit-error
+/// check runs before the `unwrap_in_r` check.
 ///
 /// # Note
 ///
@@ -123,6 +137,8 @@ pub struct NullOnErr;
 ///
 /// This is a special case for `Result<T, ()>` types where the error
 /// carries no information. Instead of raising an R error, we return NULL.
+/// Fires whenever the error type is `()`, independent of
+/// `#[miniextendr(unwrap_in_r)]`.
 impl<T: IntoR> IntoR for Result<T, NullOnErr> {
     type Error = std::convert::Infallible;
     fn try_into_sexp(self) -> Result<crate::SEXP, Self::Error> {
@@ -138,4 +154,3 @@ impl<T: IntoR> IntoR for Result<T, NullOnErr> {
         }
     }
 }
-// endregion

--- a/miniextendr-api/src/refcount_protect.rs
+++ b/miniextendr-api/src/refcount_protect.rs
@@ -654,7 +654,7 @@ thread_local! {
 ///
 /// This provides the lowest overhead for protection operations by
 /// eliminating `RefCell` borrow checking — each thread gets its own
-/// [`ThreadLocalState`] accessed through an `UnsafeCell`.
+/// `ThreadLocalState` (private) accessed through an `UnsafeCell`.
 ///
 /// ```ignore
 /// use miniextendr_api::refcount_protect::ThreadLocalArena;


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

Fixes #1156.

Docs-only. `miniextendr-api/src/into_r/result.rs`'s module doc claimed:

> These impls only fire under `#[miniextendr(unwrap_in_r)]` (Result-as-value).

That is true only for `impl<T, E: Display> IntoR for Result<T, E>` (the `list(error = ...)` impl). `impl<T> IntoR for Result<T, NullOnErr>` fires whenever the error type is `()`, independent of `unwrap_in_r` — in `miniextendr-macros/src/return_type_analysis.rs::analyze_result_type` the `err_is_unit` branch precedes the `unwrap_in_r` branch, so `Result<T, ()>` returns `NULL` on `Err(())` in both modes.

Changes (all rustdoc, standalone — no links to `docs/*.md`):

- **Module doc "Tradeoff" section**: split into two statements, one per impl, each stating its actual gating condition — `Result<T, E: Display>` fires only under `unwrap_in_r` (error-boundary semantics otherwise); `Result<T, NullOnErr>` fires whenever `E = ()`, `unwrap_in_r` irrelevant.
- **Module doc intro**: "pass Results to R as lists with `ok` and `err` fields" → the actual shape (`Err` becomes `list(error = ...)`; `Ok` is the bare value). Same fix for the failure-mode sentence ("inspect `$ok` / `$err`" → "check `$error`"), matching the impl's own example.
- **`Result<T, E: Display>` impl doc**: added an explicit exception note — `E = ()` never reaches this impl in either mode.
- **`NullOnErr` struct + impl docs**: state the gating explicitly (fires whenever the error type is `()`, whether or not `unwrap_in_r` is set; the unit-error check runs first).
- Dropped an orphaned `// endregion` at end of file (no matching `// region:` opener).
- Fixed the crate's one pre-existing rustdoc warning (`refcount_protect.rs:657` linked private `ThreadLocalState` from public docs) so `cargo doc -p miniextendr-api --no-deps` is warning-free.

Verified: `cargo check -p miniextendr-api` and `cargo doc -p miniextendr-api --no-deps` clean; `cargo fmt --all` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>