### PR TITLE
fix(rpkg): 1-based inclusive bounds for slice_1d/slice_nd/axis_slice ndarray fixtures

### DIFF
--- a/rpkg/man/NdArrayDyn.Rd
+++ b/rpkg/man/NdArrayDyn.Rd
@@ -98,7 +98,21 @@ Get the element at the given n-dimensional 1-based index.
 \item{\code{indices}}{1-based indices, one per dimension. Errors on a non-positive index, an out-of-bounds index, or a length mismatch with the array's dimensionality.}
 }
 
+Extract a subarray bounded by \code{start} and \code{end} (1-based, inclusive on both ends per dimension — R's \code{x[s1:e1, s2:e2, ...]} convention). Elements are returned flattened in column-major (R) order.
+
+\describe{
+\item{\code{start}}{1-based inclusive start indices, one per dimension.}
+\item{\code{end}}{1-based inclusive end indices, one per dimension. Errors on a dimensionality mismatch or when any dimension violates \verb{1 <= start <= end <= extent}.}
+}
+
 Check if the given 1-based n-dimensional index is valid.
+
+Get all elements where dimension \code{axis} is fixed at position \code{index}. Both arguments are 1-based: \code{axis} follows R's \code{MARGIN} convention (1 = first dimension), and \code{index} matches \code{row}/\code{col}. Elements are returned in column-major (R) order.
+
+\describe{
+\item{\code{axis}}{1-based dimension selector (R's \code{MARGIN} convention). Errors if out of \verb{1..=ndim}.}
+\item{\code{index}}{1-based position along that dimension. Errors if out of \verb{1..=extent}.}
+}
 
 Reshape the array to new dimensions (data must fit exactly).
 
@@ -107,7 +121,11 @@ Reshape the array to new dimensions (data must fit exactly).
 }
 }
 \details{
-\code{get_nd} and \code{is_valid_nd} take 1-based indices (R-idiomatic,
-matching the rest of the package). \code{get_nd} and \code{reshape} error on an
-out-of-bounds/invalid argument instead of silently yielding no value.
+\code{get_nd}, \code{is_valid_nd}, \code{slice_nd}, and \code{axis_slice} take
+1-based indices (R-idiomatic, matching the rest of the package).
+\code{slice_nd} takes 1-based inclusive per-dimension bounds (R's
+\code{x[s1:e1, s2:e2, ...]} convention); \code{axis_slice}'s \code{axis} follows R's
+\code{MARGIN} convention (1 = first dimension). \code{get_nd}, \code{reshape},
+\code{slice_nd}, and \code{axis_slice} error on an out-of-bounds/invalid argument
+instead of silently yielding no value.
 }

--- a/rpkg/man/NdIntVec.Rd
+++ b/rpkg/man/NdIntVec.Rd
@@ -79,8 +79,17 @@ Get the element at the given 1-based index.
 \describe{
 \item{\code{index}}{1-based index. Errors if out of \verb{1..=length}.}
 }
+
+Extract the elements \code{start:end} (1-based, inclusive on both ends — R's \code{x[start:end]} convention).
+
+\describe{
+\item{\code{start}}{1-based inclusive start index.}
+\item{\code{end}}{1-based inclusive end index. Errors unless \verb{1 <= start <= end <= length}.}
+}
 }
 \details{
-\code{get} takes a 1-based index (R-idiomatic, matching the rest of
-the package) and errors on an out-of-bounds or non-positive index.
+\code{get} and \code{slice_1d} take 1-based indices (R-idiomatic, matching
+the rest of the package) and error on out-of-bounds or non-positive
+indices. \code{slice_1d} takes 1-based inclusive bounds (R's \code{x[start:end]}
+convention) and errors unless \verb{1 <= start <= end <= length}.
 }

--- a/rpkg/man/NdVec.Rd
+++ b/rpkg/man/NdVec.Rd
@@ -92,6 +92,13 @@ Get the element at the given 1-based index.
 \item{\code{index}}{1-based index. Errors if out of \verb{1..=length}.}
 }
 
+Extract the elements \code{start:end} (1-based, inclusive on both ends — R's \code{x[start:end]} convention).
+
+\describe{
+\item{\code{start}}{1-based inclusive start index.}
+\item{\code{end}}{1-based inclusive end index. Errors unless \verb{1 <= start <= end <= length}.}
+}
+
 Get elements at the given 1-based indices.
 
 \describe{
@@ -101,8 +108,10 @@ Get elements at the given 1-based indices.
 Check if the given 1-based index is valid.
 }
 \details{
-\code{get}, \code{get_many}, and \code{is_valid_index} take 1-based indices
-(R-idiomatic, matching the rest of the package). \code{get} errors on an
-out-of-bounds or non-positive index; \code{get_many} returns \code{NA} per
-out-of-bounds element instead (vectorized contract).
+\code{get}, \code{get_many}, \code{is_valid_index}, and \code{slice_1d} take 1-based
+indices (R-idiomatic, matching the rest of the package). \code{get} errors on
+an out-of-bounds or non-positive index; \code{get_many} returns \code{NA} per
+out-of-bounds element instead (vectorized contract). \code{slice_1d} takes
+1-based inclusive bounds (R's \code{x[start:end]} convention) and errors
+unless \verb{1 <= start <= end <= length}.
 }

--- a/rpkg/src/rust/ndarray_tests.rs
+++ b/rpkg/src/rust/ndarray_tests.rs
@@ -17,10 +17,12 @@ pub struct NdVec(Array1<f64>);
 
 /// NdVec methods: 1D numeric array operations, slicing, and conversion.
 /// @param data Numeric vector of array elements.
-/// @details `get`, `get_many`, and `is_valid_index` take 1-based indices
-///   (R-idiomatic, matching the rest of the package). `get` errors on an
-///   out-of-bounds or non-positive index; `get_many` returns `NA` per
-///   out-of-bounds element instead (vectorized contract).
+/// @details `get`, `get_many`, `is_valid_index`, and `slice_1d` take 1-based
+///   indices (R-idiomatic, matching the rest of the package). `get` errors on
+///   an out-of-bounds or non-positive index; `get_many` returns `NA` per
+///   out-of-bounds element instead (vectorized contract). `slice_1d` takes
+///   1-based inclusive bounds (R's `x[start:end]` convention) and errors
+///   unless `1 <= start <= end <= length`.
 // env pinned: method names collide with base R non-generics (var/get/row/col/
 // diag/reshape), which the s7-default flip cannot register S7 methods on (#1114).
 #[miniextendr(env)]
@@ -106,8 +108,19 @@ impl NdVec {
         RNdSlice::last(&self.0)
     }
 
+    /// Extract the elements `start:end` (1-based, inclusive on both ends —
+    /// R's `x[start:end]` convention).
+    /// @param start 1-based inclusive start index.
+    /// @param end 1-based inclusive end index. Errors unless `1 <= start <= end <= length`.
     fn slice_1d(&self, start: i32, end: i32) -> Vec<f64> {
-        RNdSlice::slice_1d(&self.0, start, end)
+        let len = RNdArrayOps::len(&self.0);
+        if start < 1 || start > end || end > len {
+            panic!(
+                "slice bounds [{start}, {end}] are out of bounds (must satisfy 1 <= start <= end <= length, length {len})"
+            );
+        }
+        // 1-based inclusive -> trait's 0-based half-open: [start - 1, end)
+        RNdSlice::slice_1d(&self.0, start - 1, end)
     }
 
     /// Get elements at the given 1-based indices.
@@ -288,9 +301,13 @@ pub struct NdArrayDyn(ArrayD<f64>);
 /// NdArrayDyn methods: N-dimensional array operations, indexing, and reshaping.
 /// @param shape Integer vector specifying array dimensions.
 /// @param data Numeric vector of array elements.
-/// @details `get_nd` and `is_valid_nd` take 1-based indices (R-idiomatic,
-///   matching the rest of the package). `get_nd` and `reshape` error on an
-///   out-of-bounds/invalid argument instead of silently yielding no value.
+/// @details `get_nd`, `is_valid_nd`, `slice_nd`, and `axis_slice` take
+///   1-based indices (R-idiomatic, matching the rest of the package).
+///   `slice_nd` takes 1-based inclusive per-dimension bounds (R's
+///   `x[s1:e1, s2:e2, ...]` convention); `axis_slice`'s `axis` follows R's
+///   `MARGIN` convention (1 = first dimension). `get_nd`, `reshape`,
+///   `slice_nd`, and `axis_slice` error on an out-of-bounds/invalid argument
+///   instead of silently yielding no value.
 // env pinned: method names collide with base R non-generics (var/get/row/col/
 // diag/reshape), which the s7-default flip cannot register S7 methods on (#1114).
 #[miniextendr(env)]
@@ -362,8 +379,29 @@ impl NdArrayDyn {
             .unwrap_or_else(|| panic!("indices {indices:?} out of bounds (shape {shape:?})"))
     }
 
-    fn slice_nd(&self, start: Vec<i32>, end: Vec<i32>) -> Option<Vec<f64>> {
-        RNdIndex::slice_nd(&self.0, start, end)
+    /// Extract a subarray bounded by `start` and `end` (1-based, inclusive on
+    /// both ends per dimension — R's `x[s1:e1, s2:e2, ...]` convention).
+    /// Elements are returned flattened in column-major (R) order.
+    /// @param start 1-based inclusive start indices, one per dimension.
+    /// @param end 1-based inclusive end indices, one per dimension. Errors on a dimensionality mismatch or when any dimension violates `1 <= start <= end <= extent`.
+    fn slice_nd(&self, start: Vec<i32>, end: Vec<i32>) -> Vec<f64> {
+        let shape = RNdIndex::shape_nd(&self.0);
+        if start.len() != shape.len() || end.len() != shape.len() {
+            panic!(
+                "start {start:?} and end {end:?} must each have one bound per dimension (shape {shape:?})"
+            );
+        }
+        for (i, &extent) in shape.iter().enumerate() {
+            let (s, e) = (start[i], end[i]);
+            if s < 1 || s > e || e > extent {
+                panic!(
+                    "slice bounds start {start:?}, end {end:?} are out of bounds (each dimension must satisfy 1 <= start <= end <= extent, shape {shape:?})"
+                );
+            }
+        }
+        // 1-based inclusive -> trait's 0-based half-open: [start - 1, end)
+        let zero_based_start: Vec<i32> = start.iter().map(|&s| s - 1).collect();
+        RNdIndex::slice_nd(&self.0, zero_based_start, end).expect("bounds validated above")
     }
 
     fn shape_nd(&self) -> Vec<i32> {
@@ -392,8 +430,27 @@ impl NdArrayDyn {
             && RNdIndex::is_valid_nd(&self.0, indices.into_iter().map(|i| i - 1).collect())
     }
 
+    /// Get all elements where dimension `axis` is fixed at position `index`.
+    /// Both arguments are 1-based: `axis` follows R's `MARGIN` convention
+    /// (1 = first dimension), and `index` matches `row`/`col`. Elements are
+    /// returned in column-major (R) order.
+    /// @param axis 1-based dimension selector (R's `MARGIN` convention). Errors if out of `1..=ndim`.
+    /// @param index 1-based position along that dimension. Errors if out of `1..=extent`.
     fn axis_slice(&self, axis: i32, index: i32) -> Vec<f64> {
-        RNdIndex::axis_slice(&self.0, axis, index)
+        let shape = RNdIndex::shape_nd(&self.0);
+        let ndim = RNdIndex::ndim(&self.0);
+        if axis < 1 || axis > ndim {
+            panic!(
+                "axis {axis} is out of bounds (must be a positive 1-based dimension selector, array has {ndim} dimensions)"
+            );
+        }
+        let extent = shape[usize::try_from(axis - 1).expect("axis >= 1 checked above")];
+        if index < 1 || index > extent {
+            panic!(
+                "index {index} is out of bounds along axis {axis} (must be a positive 1-based index, extent {extent})"
+            );
+        }
+        RNdIndex::axis_slice(&self.0, axis - 1, index - 1)
     }
 
     /// Reshape the array to new dimensions (data must fit exactly).
@@ -420,8 +477,10 @@ pub struct NdIntVec(Array1<i32>);
 
 /// NdIntVec methods: 1D integer array operations, slicing, and conversion.
 /// @param data Integer vector of array elements.
-/// @details `get` takes a 1-based index (R-idiomatic, matching the rest of
-///   the package) and errors on an out-of-bounds or non-positive index.
+/// @details `get` and `slice_1d` take 1-based indices (R-idiomatic, matching
+///   the rest of the package) and error on out-of-bounds or non-positive
+///   indices. `slice_1d` takes 1-based inclusive bounds (R's `x[start:end]`
+///   convention) and errors unless `1 <= start <= end <= length`.
 // env pinned: method names collide with base R non-generics (var/get/row/col/
 // diag/reshape), which the s7-default flip cannot register S7 methods on (#1114).
 #[miniextendr(env)]
@@ -497,8 +556,19 @@ impl NdIntVec {
         RNdSlice::last(&self.0)
     }
 
+    /// Extract the elements `start:end` (1-based, inclusive on both ends —
+    /// R's `x[start:end]` convention).
+    /// @param start 1-based inclusive start index.
+    /// @param end 1-based inclusive end index. Errors unless `1 <= start <= end <= length`.
     fn slice_1d(&self, start: i32, end: i32) -> Vec<i32> {
-        RNdSlice::slice_1d(&self.0, start, end)
+        let len = RNdArrayOps::len(&self.0);
+        if start < 1 || start > end || end > len {
+            panic!(
+                "slice bounds [{start}, {end}] are out of bounds (must satisfy 1 <= start <= end <= length, length {len})"
+            );
+        }
+        // 1-based inclusive -> trait's 0-based half-open: [start - 1, end)
+        RNdSlice::slice_1d(&self.0, start - 1, end)
     }
 
     // --- Conversion ---

--- a/rpkg/tests/testthat/test-ndarray.R
+++ b/rpkg/tests/testthat/test-ndarray.R
@@ -98,17 +98,19 @@ test_that("NdVec RNdSlice - slice_1d", {
   skip_if_ndarray_disabled()
   v <- NdVec$new(c(1, 2, 3, 4, 5))
 
-  # Normal slice [1, 4) -> elements 2, 3, 4
-  expect_equal(v$slice_1d(1L, 4L), c(2, 3, 4))
+  # 1-based inclusive bounds (R's x[start:end] convention)
+  expect_equal(v$slice_1d(2L, 4L), c(2, 3, 4))
+
+  # Single element
+  expect_equal(v$slice_1d(3L, 3L), 3)
 
   # Full slice
-  expect_equal(v$slice_1d(0L, 5L), c(1, 2, 3, 4, 5))
+  expect_equal(v$slice_1d(1L, 5L), c(1, 2, 3, 4, 5))
 
-  # Clamped end
-  expect_equal(v$slice_1d(3L, 100L), c(4, 5))
-
-  # Empty range
-  expect_equal(v$slice_1d(3L, 2L), numeric(0))
+  # Out-of-bounds / invalid ranges error
+  expect_error(v$slice_1d(0L, 5L), "out of bounds")
+  expect_error(v$slice_1d(3L, 100L), "out of bounds")
+  expect_error(v$slice_1d(3L, 2L), "out of bounds")
 })
 
 test_that("NdVec RNdSlice - get_many", {
@@ -294,12 +296,28 @@ test_that("NdArrayDyn RNdIndex - element access", {
 
 test_that("NdArrayDyn RNdIndex - slice_nd", {
   skip_if_ndarray_disabled()
-  # 3x3 array
+  # 3x3 array (row-major data):
+  # Row 1: [1, 2, 3], Row 2: [4, 5, 6], Row 3: [7, 8, 9]
   arr <- NdArrayDyn$new(c(3L, 3L), as.numeric(1:9))
 
-  # Slice [0:2, 0:2] - 2x2 subarray
-  slice <- arr$slice_nd(c(0L, 0L), c(2L, 2L))
-  expect_length(slice, 4)
+  # 1-based inclusive bounds (R's x[s1:e1, s2:e2] convention):
+  # top-left 2x2 subarray, flattened column-major
+  slice <- arr$slice_nd(c(1L, 1L), c(2L, 2L))
+  expect_equal(slice, c(1, 4, 2, 5))
+
+  # Bottom-right 2x2 subarray
+  expect_equal(arr$slice_nd(c(2L, 2L), c(3L, 3L)), c(5, 8, 6, 9))
+
+  # Single element
+  expect_equal(arr$slice_nd(c(2L, 2L), c(2L, 2L)), 5)
+
+  # Dimensionality mismatch errors
+  expect_error(arr$slice_nd(c(1L), c(2L, 2L)), "one bound per dimension")
+
+  # Out-of-bounds / invalid ranges error
+  expect_error(arr$slice_nd(c(0L, 1L), c(2L, 2L)), "out of bounds")
+  expect_error(arr$slice_nd(c(1L, 1L), c(4L, 2L)), "out of bounds")
+  expect_error(arr$slice_nd(c(2L, 2L), c(1L, 1L)), "out of bounds")
 })
 
 test_that("NdArrayDyn RNdIndex - flatten", {
@@ -328,19 +346,26 @@ test_that("NdArrayDyn RNdIndex - is_valid_nd", {
 
 test_that("NdArrayDyn RNdIndex - axis_slice", {
   skip_if_ndarray_disabled()
-  # 2x3 array
+  # 2x3 array (row-major data): Row 1: [1, 2, 3], Row 2: [4, 5, 6]
   arr <- NdArrayDyn$new(c(2L, 3L), as.numeric(1:6))
 
-  # Row 0 (axis 0, index 0)
-  row0 <- arr$axis_slice(0L, 0L)
-  expect_length(row0, 3)
+  # Both arguments are 1-based; axis follows R's MARGIN convention
+  # (1 = first dimension). Row 1 (axis 1, index 1):
+  expect_equal(arr$axis_slice(1L, 1L), c(1, 2, 3))
 
-  # Column 1 (axis 1, index 1)
-  col1 <- arr$axis_slice(1L, 1L)
-  expect_length(col1, 2)
+  # Row 2
+  expect_equal(arr$axis_slice(1L, 2L), c(4, 5, 6))
 
-  # Invalid axis
-  expect_length(arr$axis_slice(2L, 0L), 0)
+  # Column 2 (axis 2, index 2)
+  expect_equal(arr$axis_slice(2L, 2L), c(2, 5))
+
+  # Out-of-bounds axis errors
+  expect_error(arr$axis_slice(3L, 1L), "axis 3 is out of bounds")
+  expect_error(arr$axis_slice(0L, 1L), "axis 0 is out of bounds")
+
+  # Out-of-bounds index along the axis errors
+  expect_error(arr$axis_slice(1L, 3L), "out of bounds along axis 1")
+  expect_error(arr$axis_slice(1L, 0L), "out of bounds along axis 1")
 })
 
 test_that("NdArrayDyn RNdIndex - reshape", {
@@ -528,8 +553,14 @@ test_that("NdIntVec slice_1d works", {
   skip_if_ndarray_disabled()
   v <- NdIntVec$new(1:5)
 
-  expect_equal(v$slice_1d(1L, 4L), 2:4)
-  expect_equal(v$slice_1d(0L, 5L), 1:5)
+  # 1-based inclusive bounds (R's x[start:end] convention)
+  expect_equal(v$slice_1d(2L, 4L), 2:4)
+  expect_equal(v$slice_1d(1L, 5L), 1:5)
+
+  # Out-of-bounds / invalid ranges error
+  expect_error(v$slice_1d(0L, 5L), "out of bounds")
+  expect_error(v$slice_1d(2L, 6L), "out of bounds")
+  expect_error(v$slice_1d(4L, 2L), "out of bounds")
 })
 
 test_that("NdIntVec variance and std work", {


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

Follow-up to the A2 audit conversion (#1160), which converted the ndarray/rarray fixture element accessors to 1-based indexing with an error-on-OOB contract but deliberately left the three range-based methods 0-based. This PR extends the same conversion pattern and error contract to those methods in `rpkg/src/rust/ndarray_tests.rs` (`rarray_tests.rs` has no range-based methods, so it is untouched).

### Convention decisions

- **`NdVec::slice_1d` / `NdIntVec::slice_1d`** — 1-based **inclusive** bounds, R's `x[start:end]` convention. Errors unless `1 <= start <= end <= length`, replacing the old silent clamp/empty-vector behavior. The 1-based inclusive pair maps onto the trait's 0-based half-open range as `[start - 1, end)`.
- **`NdArrayDyn::slice_nd`** — same convention per dimension (`x[s1:e1, s2:e2, ...]`). Errors on a dimensionality mismatch or when any dimension violates `1 <= start <= end <= extent`. Return type changes `Option<Vec<f64>>` → `Vec<f64>` since invalid bounds now error instead of yielding no value (matching how A2 converted `reshape`).
- **`NdArrayDyn::axis_slice`** — **both** arguments converted to 1-based. The issue allowed keeping `axis` 0-based as a dimension selector, but `axis` follows R's `MARGIN` convention (1 = first dimension, as in `apply()`): mixing a 0-based selector with a 1-based position in the same call would recreate a smaller version of the exact inconsistency the audit flagged. `index` matches the converted `row`/`col`. Errors on an out-of-bounds `axis` or `index`, replacing the silent empty vector.

All conventions are stated explicitly in the roxygen doc comments (method-level `@param` contracts plus the impl-level `@details`), and `man/NdVec.Rd` / `man/NdIntVec.Rd` / `man/NdArrayDyn.Rd` are regenerated in sync. No NAMESPACE or Cargo.lock churn (signatures' R surface unchanged).

### Verification

- `just configure && just rcmdinstall && just force-document` — clean (the ~118 pre-existing `MINIEXTENDR_DOC_LINT_DESC` warnings in unrelated ALTREP fixtures are already tracked as #1172).
- `just devtools-test "ndarray|rarray|adapter-traits"` — **[ FAIL 0 | WARN 0 | SKIP 0 | PASS 266 ]**. `test-ndarray.R` updated to the new conventions with value-level assertions (column-major flattening checked against known data) and OOB error-path coverage for every converted method: non-positive start, end > extent, start > end, dimensionality mismatch, OOB axis, OOB index-along-axis.
- `cargo fmt --all -- --check` clean on both workspaces.

Fixes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>