### PR TITLE
fix(minirextendr): make `just minirextendr-check` green — pak cache guard, ASCII escapes, pkgbuild Suggests

### DIFF
--- a/minirextendr/DESCRIPTION
+++ b/minirextendr/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
 Suggests:
     devtools,
     knitr,
+    pkgbuild,
     pkgload,
     rcmdcheck,
     rmarkdown,

--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -360,7 +360,7 @@ use_miniextendr <- function(path = ".",
       # Scaffold as a standalone rpkg into this directory instead.
       rust_root <- find_rust_root(proj_dir)
       cli::cli_alert_info(
-        "Found a Rust project at {.path {rust_root}}, but {.path {proj_dir}} has no {.file Cargo.toml} of its own — scaffolding as a standalone {.val rpkg}."
+        "Found a Rust project at {.path {rust_root}}, but {.path {proj_dir}} has no {.file Cargo.toml} of its own \u2014 scaffolding as a standalone {.val rpkg}."
       )
       cli::cli_alert_info(
         "To create a monorepo layout instead, run {.fn use_miniextendr} from the Rust workspace root."

--- a/minirextendr/R/doctor.R
+++ b/minirextendr/R/doctor.R
@@ -137,7 +137,7 @@ miniextendr_doctor <- function(path = ".", webr = FALSE) {
     )
     tarball_present <- !is.null(vendor_tarball_path) && file.exists(vendor_tarball_path)
     if (tarball_present) {
-      # Marker is inert (tarball mode wins), but still stale — inform rather than warn.
+      # Marker is inert (tarball mode wins), but still stale -- inform rather than warn.
       cli::cli_alert_info(
         "{.path .miniextendr-local} is present but inert: tarball mode wins over the \\
 local override. Remove the marker before distributing: \\
@@ -150,7 +150,7 @@ local override. Remove the marker before distributing: \\
 {.path {local_mx_path}}). Run {.code unuse_local_miniextendr()} before \\
 vendoring or distributing this package."
       )
-      results$warn <- c(results$warn, ".miniextendr-local override active — run unuse_local_miniextendr() before distributing")
+      results$warn <- c(results$warn, ".miniextendr-local override active \u2014 run unuse_local_miniextendr() before distributing")
     }
   } else if (!is.null(local_marker_path)) {
     cli::cli_alert_success("No {.path .miniextendr-local} override marker")
@@ -171,7 +171,7 @@ This is the manual workaround from #823; use \\
 {.code use_local_miniextendr()} instead so configure.ac manages the \\
 patch block in {.path src/rust/.cargo/config.toml}."
       )
-      results$warn <- c(results$warn, "hand-rolled [patch] block in src/rust/Cargo.toml — use use_local_miniextendr()")
+      results$warn <- c(results$warn, "hand-rolled [patch] block in src/rust/Cargo.toml \u2014 use use_local_miniextendr()")
     }
   }
 
@@ -397,7 +397,7 @@ parse_relative_path_deps <- function(lines) {
         # Extract crate name from [dependencies.crate_name]
         current_crate <- sub("^\\[dependencies\\.([^]]+)\\].*", "\\1", stripped)
       } else {
-        # Any other section (including [patch.crates-io]) — stop watching.
+        # Any other section (including [patch.crates-io]) -- stop watching.
         section <- "other"
         current_crate <- NULL
       }

--- a/minirextendr/R/local-miniextendr.R
+++ b/minirextendr/R/local-miniextendr.R
@@ -94,7 +94,7 @@ unuse_local_miniextendr <- function(path = ".") {
   with_project(path)
   marker <- usethis::proj_path(".miniextendr-local")
   if (!fs::file_exists(marker)) {
-    cli::cli_alert_info("No {.path .miniextendr-local} marker present — nothing to remove.")
+    cli::cli_alert_info("No {.path .miniextendr-local} marker present \u2014 nothing to remove.")
     return(invisible(FALSE))
   }
   fs::file_delete(marker)

--- a/minirextendr/R/use-claude-skills.R
+++ b/minirextendr/R/use-claude-skills.R
@@ -6,7 +6,7 @@
 #' project so coding agents working in the package get progressive-loading
 #' context about the miniextendr build pipeline, conversions, class systems,
 #' data.frame interface, parallelism rules, debugging recipes, and the
-#' release/vendoring story — all framed for the scaffolded-package layout
+#' release/vendoring story -- all framed for the scaffolded-package layout
 #' (`src/rust/lib.rs`, `configure`, `tools/`).
 #'
 #' Re-running upgrades in place: each bundled skill directory is deleted and
@@ -17,7 +17,7 @@
 #' When the project root is an R package (a `DESCRIPTION` is present),
 #' `^\.claude$` is added to `.Rbuildignore` so the skills never ship in the
 #' tarball. An `AGENTS.md` stub pointing non-Claude agents at the skill set is
-#' written only if the file does not already exist — it is user-owned content.
+#' written only if the file does not already exist -- it is user-owned content.
 #'
 #' @param path Path to the project root, or `"."` to use the current directory.
 #'   For monorepo layouts call this at the workspace root (where agents run),
@@ -80,7 +80,7 @@ write_agents_md_stub <- function() {
       "",
       "Ground rules:",
       "",
-      "- Rebuild after Rust changes with `minirextendr::miniextendr_build()` —",
+      "- Rebuild after Rust changes with `minirextendr::miniextendr_build()` \u2014",
       "  not bare `R CMD INSTALL .` / `devtools::install()` (they skip wrapper",
       "  generation on a fresh tree; the guide skill explains why).",
       "- Never hand-edit generated files (`R/*-wrappers.R`, `src/Makevars`,",

--- a/minirextendr/R/workflow.R
+++ b/minirextendr/R/workflow.R
@@ -95,7 +95,7 @@ miniextendr_configure <- function(path = ".") {
 #' That creates a chicken-and-egg ordering: `document()` can only see the
 #' wrappers after install, but install collates `NAMESPACE` (the export set the
 #' installed image actually exposes) *before* `document()` rewrites it. On a
-#' first build — or any build that adds or renames an exported function — the
+#' first build -- or any build that adds or renames an exported function -- the
 #' freshly-installed image therefore lags the on-disk `NAMESPACE` by one build,
 #' and `library(pkg)` exposes nothing new until the package is built a second
 #' time.
@@ -112,7 +112,7 @@ miniextendr_configure <- function(path = ".") {
 #' are produced by the wrapper-gen pass during install, but a plain
 #' `devtools::install(build = TRUE)` cannot bootstrap them: its `R CMD build`
 #' step runs `bootstrap.R`, which auto-vendors into `inst/vendor.tar.xz`, and
-#' that latch flips `./configure` into offline *tarball* mode — which ships
+#' that latch flips `./configure` into offline *tarball* mode -- which ships
 #' pre-generated wrappers and skips wrapper generation. With no wrappers to
 #' ship, the install either fails loudly ("tarball is missing pre-generated
 #' wrappers") or, worse, leaves the namespace empty.
@@ -124,7 +124,7 @@ miniextendr_configure <- function(path = ".") {
 #' runs. The `MINIEXTENDR_FORCE_WRAPPER_GEN` override forces the
 #' wrapper-gen pass regardless of which install mode configure resolves to: in
 #' a non-git tree configure's self-repair branch may legitimately re-seal the
-#' latch (cargo-revendor on PATH), and that is fine — the FORCE override
+#' latch (cargo-revendor on PATH), and that is fine -- the FORCE override
 #' ensures wrapper generation proceeds. Once wrappers are present, the normal
 #' build path runs unchanged.
 #'
@@ -143,7 +143,7 @@ miniextendr_build <- function(path = ".", install = TRUE) {
   # A build = TRUE install (Step 3/5 below) runs the package's bootstrap.R in the
   # source tree, which auto-vendors when no inst/vendor.tar.xz is present: that
   # FREEZES src/rust/Cargo.toml (rewriting a `path = "../../../my-core"` sibling
-  # to `vendor/my-core`) and leaves inst/vendor.tar.xz behind — flipping the tree
+  # to `vendor/my-core`) and leaves inst/vendor.tar.xz behind -- flipping the tree
   # into tarball mode and stranding the next source-mode build. The dev loop must
   # leave a clean source tree, so snapshot the manifest/lock + tarball presence
   # now and restore on exit (mirrors the `just cran-prep` trap, git-independent).
@@ -177,7 +177,7 @@ miniextendr_build <- function(path = ".", install = TRUE) {
       # R/<pkg>-wrappers.R does not exist yet. The normal devtools::install()
       # below uses build = TRUE, whose R CMD build step runs bootstrap.R, which
       # auto-vendors inst/vendor.tar.xz and flips ./configure into tarball mode
-      # — a mode that SKIPS wrapper generation. So the very build that should
+      # -- a mode that SKIPS wrapper generation. So the very build that should
       # have created the wrappers can't, and library() exposes nothing. Detect
       # this and generate the wrappers first via an in-place source-mode install
       # (build = FALSE), which never touches inst/vendor.tar.xz.
@@ -206,7 +206,7 @@ miniextendr_build <- function(path = ".", install = TRUE) {
 
     # Chicken-and-egg fix: the wrappers file is generated during install and
     # document() reads its @export tags to write NAMESPACE. So the install in
-    # Step 3 collated the *previous* NAMESPACE — if document() just added or
+    # Step 3 collated the *previous* NAMESPACE -- if document() just added or
     # renamed exports, the installed image is one build behind. Reinstall once
     # so library(pkg) exposes the new exports in a single miniextendr_build()
     # pass. The reinstall is bounded to one pass: after it the wrappers and
@@ -242,7 +242,7 @@ miniextendr_build <- function(path = ".", install = TRUE) {
 # lazy-load DB (R/<pkg>.rdb). On R >= 4.6 (libdeflate-compressed .rdb) that read
 # can fail with "internal error 1 in R_decompress1 with libdeflate" / "lazy-load
 # database is corrupt", aborting the build. The build session never needs the
-# package loaded — document() works from source — so reloading is both pointless
+# package loaded -- document() works from source -- so reloading is both pointless
 # and the trigger. Skipping it makes the install -> document hand-off robust.
 install_pkg <- function(pkg_path) {
   old_force <- Sys.getenv("MINIEXTENDR_FORCE_WRAPPER_GEN", unset = NA)
@@ -319,13 +319,13 @@ wrappers_file_exists <- function(pkg_path) {
 #' @noRd
 bootstrap_fresh_wrappers <- function(pkg_path) {
   cli::cli_alert_info(c(
-    "No generated {.path R/*-wrappers.R} found — bootstrapping wrappers ",
+    "No generated {.path R/*-wrappers.R} found \u2014 bootstrapping wrappers ",
     "before the full build."
   ))
 
   # Clear any stale tarball-mode latch so configure gets a clean start.
   # In a non-git tree configure's self-repair may re-seal inst/vendor.tar.xz
-  # (cargo-revendor on PATH); that is fine — MINIEXTENDR_FORCE_WRAPPER_GEN
+  # (cargo-revendor on PATH); that is fine -- MINIEXTENDR_FORCE_WRAPPER_GEN
   # below ensures the wrapper-gen pass runs regardless of install mode.
   clear_install_mode_latch(pkg_path)
 
@@ -346,7 +346,7 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
   )
 
   tryCatch(
-    # reload = FALSE: see install_pkg() — avoid loading the .rdb-backed namespace
+    # reload = FALSE: see install_pkg() -- avoid loading the .rdb-backed namespace
     # that the document()+reinstall below would then corrupt for pkgload (#1000).
     devtools::install(pkg_path, build = FALSE, upgrade = FALSE, quiet = FALSE,
                       reload = FALSE),
@@ -396,7 +396,7 @@ bootstrap_fresh_wrappers <- function(pkg_path) {
 #' offline tarball mode. The unpacked `vendor/` directory and the
 #' tarball-mode `src/rust/.cargo/config.toml` are downstream artifacts of the
 #' same mode. Clearing all three guarantees the next `./configure` resolves in
-#' source mode. Safe and idempotent — no-op if nothing is present.
+#' source mode. Safe and idempotent -- no-op if nothing is present.
 #'
 #' @param pkg_path Absolute path to the package root.
 #' @return Invisibly `TRUE`.
@@ -455,7 +455,7 @@ miniextendr_vendor <- function(path = ".") {
   # [patch."git+url"] override active (it pins cargo's CWD to the manifest
   # dir, so a monorepo .cargo/config.toml is honoured), then stamps the
   # framework crates' `source = "git+url#<sha>"` attribution back into
-  # Cargo.lock — the shape offline source-replacement needs. So a cross-crate
+  # Cargo.lock -- the shape offline source-replacement needs. So a cross-crate
   # feature/dep rename resolves against the local workspace, not git@main
   # (#883), and there is no bare-git "regenerate the lock first" dance: the
   # step that disabled the patch was exactly what broke cross-surface renames.

--- a/minirextendr/tests/testthat/setup-pak-cache.R
+++ b/minirextendr/tests/testthat/setup-pak-cache.R
@@ -1,0 +1,28 @@
+# pak-driven installs under R CMD check (#1154).
+#
+# devtools::install() (>= 2.5.0) unconditionally runs pak::local_install_deps()
+# before R CMD INSTALL, and pak resolves through pkgcache. pkgcache hard-errors
+# inside the pak subprocess when it detects R CMD check (via
+# _R_CHECK_PACKAGE_NAME_) and no explicit cache location:
+#
+#   "R_USER_CACHE_DIR env var not set during package check"
+#
+# -- a deliberate guard so a check run cannot write into the user's real cache.
+# That killed every install-driven template test under `just minirextendr-check`
+# while the same tests pass under `just minirextendr-test` (no check env, so
+# pkgcache falls back to the user cache as usual).
+#
+# Remedy prescribed by pkgcache's README: point R_USER_CACHE_DIR at a throwaway
+# directory for the check run. It must happen HERE, in a setup file, before the
+# suite's first pak call: pak keeps a persistent worker subprocess that
+# snapshots its environment at creation, so a per-test withr::with_envvar()
+# comes too late once any earlier test has touched pak (empirically verified:
+# setting the var after one failed pak call still reproduces the error).
+#
+# Outside R CMD check this is a no-op, so dev runs keep pak's warm user-level
+# cache and its speed.
+if (testthat::is_checking() && !nzchar(Sys.getenv("R_USER_CACHE_DIR"))) {
+  check_cache <- file.path(tempdir(), "minirextendr-check-r-user-cache")
+  dir.create(check_cache, recursive = TRUE, showWarnings = FALSE)
+  Sys.setenv(R_USER_CACHE_DIR = check_cache)
+}

--- a/minirextendr/tests/testthat/test-templates.R
+++ b/minirextendr/tests/testthat/test-templates.R
@@ -776,19 +776,20 @@ test_that("MINIEXTENDR_FORCE_WRAPPER_GEN propagates through install(build = TRUE
   templib <- file.path(tmp, "library")
   dir.create(templib)
 
-  pak_cache_dir <- file.path(tmp, "pak_cache")
-  dir.create(pak_cache_dir, showWarnings = FALSE)
+  # R_USER_CACHE_DIR handling for the pak::local_install_deps() step inside
+  # devtools::install() lives in setup-pak-cache.R (#1154). A per-test
+  # withr::with_envvar() here cannot work: pak's persistent subprocess
+  # snapshots its environment at creation, so the override never reaches it
+  # once any earlier test has used pak.
 
   run_build_install <- function() {
     unlink(result_file)
-    withr::with_envvar(list(R_USER_CACHE_DIR = pak_cache_dir), {
-      withr::with_libpaths(templib, action = "prefix", {
-        suppressMessages(
-          devtools::install(pkg_path, build = TRUE, upgrade = FALSE,
-                            quiet = TRUE, reload = FALSE,
-                            dependencies = FALSE)
-        )
-      })
+    withr::with_libpaths(templib, action = "prefix", {
+      suppressMessages(
+        devtools::install(pkg_path, build = TRUE, upgrade = FALSE,
+                          quiet = TRUE, reload = FALSE,
+                          dependencies = FALSE)
+      )
     })
     skip_if_not(file.exists(result_file),
                 "probe Makevars did not run (no SHLIB build on this platform)")


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

`just minirextendr-check` (R CMD check on the built minirextendr tarball) was red on every branch with 1 ERROR + 2 WARNINGs, so the strongest gate gave no signal. All three findings from #1154 are fixed:

- **ERROR (pak dies in every install-driven template test).** The real failure mode is not network: pkgcache hard-errors inside the pak subprocess with `R_USER_CACHE_DIR env var not set during package check`, a deliberate guard so a check run cannot write into the user's real cache. `devtools::install()` (>= 2.5.0) unconditionally runs `pak::local_install_deps()`, so the tests at `test-templates.R:567/671/769` all died the same way. Fix: new `tests/testthat/setup-pak-cache.R` points `R_USER_CACHE_DIR` at a throwaway tempdir, only when `testthat::is_checking()` and the variable is unset. It must be a setup file: pak keeps a persistent worker subprocess that snapshots its environment at creation, so the pre-existing per-test `withr::with_envvar()` in the #911 test could never reach it once any earlier test had touched pak (empirically verified by reproducing the error with a late `Sys.setenv()`; that ineffective wrapper is removed, with a comment pointing at the setup file). Outside check the variable is untouched, so `just minirextendr-test` keeps running these tests unchanged, and there are no skips anywhere (the tests now run under check too).
- **WARNING (non-ASCII code files).** Em-dashes in string literals in `R/doctor.R`, `R/local-miniextendr.R`, `R/use-claude-skills.R`, `R/workflow.R`, plus a new one in `R/create.R` that landed with #1169 after the issue was filed, are replaced with `\u2014` escapes (identical rendering). Em-dashes in comments of those files were normalized to ASCII `--` while there (the check only flags non-ASCII outside comments, which is why only files with em-dashes in strings were listed). A parse-level sweep confirms no non-ASCII remains outside comments anywhere in `R/`.
- **WARNING (undeclared `::` import in tests).** `pkgbuild` added to `Suggests` (used via `pkgbuild::has_build_tools()` in `test-templates.R`).

Fixes #1154

## Test plan

- [x] `just minirextendr-test` fully green: `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 664 ]`
- [x] `just minirextendr-check` on the built tarball: `Status: OK` (`0 errors ✔ | 0 warnings ✔ | 0 notes ✔`, duration 6m 38.2s)

## Notes

- The pak failure was misdiagnosed in the issue as a network/offline problem; the fix is keyed on the actual failure mode (pkgcache's check-time cache guard, with the remedy its README prescribes), so no test is skipped and the check gate now exercises the full install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
