### PR TITLE
refactor(serde): share VecsxpCursor across lazy pull-based de.rs accessors

### DIFF
--- a/miniextendr-api/src/serde/de.rs
+++ b/miniextendr-api/src/serde/de.rs
@@ -848,19 +848,54 @@ impl<'de> SeqAccess<'de> for VectorElementSeqAccess {
     }
 }
 
-/// Access elements of an R list as a sequence.
-struct ListSeqAccess {
+/// Shared `index`/`len` bookkeeping for the lazy pull-based accessors over a
+/// VECSXP (#1149).
+///
+/// serde's `SeqAccess`/`MapAccess` machinery pulls one element at a time and
+/// must report end-of-iteration as `Ok(None)`, so the eager `map_vecsxp_with`
+/// walk in `from_r.rs` doesn't fit here. The cursor owns only the bounds
+/// check, the advance, and the `vector_elt` pull; type/shape validation stays
+/// in the accessor constructors and per-element deserialization stays serde's
+/// job.
+struct VecsxpCursor {
     sexp: SEXP,
     index: usize,
     len: usize,
 }
 
-impl ListSeqAccess {
+impl VecsxpCursor {
     fn new(sexp: SEXP) -> Self {
-        ListSeqAccess {
+        VecsxpCursor {
             sexp,
             index: 0,
             len: sexp.len(),
+        }
+    }
+
+    /// Index of the element the next `next_elt` call pulls, or `None` when
+    /// exhausted. Does not advance — `NamedListMapAccess` peeks the key here
+    /// and only advances when the paired value is pulled.
+    fn peek_index(&self) -> Option<usize> {
+        (self.index < self.len).then_some(self.index)
+    }
+
+    /// Pull the current element and advance; `None` when exhausted.
+    fn next_elt(&mut self) -> Option<SEXP> {
+        let index = self.peek_index()?;
+        self.index += 1;
+        Some(self.sexp.vector_elt(index as isize))
+    }
+}
+
+/// Access elements of an R list as a sequence.
+struct ListSeqAccess {
+    cursor: VecsxpCursor,
+}
+
+impl ListSeqAccess {
+    fn new(sexp: SEXP) -> Self {
+        ListSeqAccess {
+            cursor: VecsxpCursor::new(sexp),
         }
     }
 }
@@ -872,12 +907,9 @@ impl<'de> SeqAccess<'de> for ListSeqAccess {
         &mut self,
         seed: T,
     ) -> Result<Option<T::Value>, Self::Error> {
-        if self.index >= self.len {
+        let Some(elem) = self.cursor.next_elt() else {
             return Ok(None);
-        }
-
-        let elem = self.sexp.vector_elt(self.index as isize);
-        self.index += 1;
+        };
         seed.deserialize(RDeserializer::from_sexp(elem)).map(Some)
     }
 }
@@ -887,10 +919,8 @@ impl<'de> SeqAccess<'de> for ListSeqAccess {
 
 /// Access named list as a map/struct.
 struct NamedListMapAccess {
-    sexp: SEXP,
     names: SEXP,
-    index: usize,
-    len: usize,
+    cursor: VecsxpCursor,
 }
 
 impl NamedListMapAccess {
@@ -908,20 +938,14 @@ impl NamedListMapAccess {
                 actual: "list (names attribute is not character)".into(),
             });
         }
-        let len = sexp.len();
-        let names_len = names.len();
-        if names_len != len {
+        let cursor = VecsxpCursor::new(sexp);
+        if names.len() != cursor.len {
             return Err(RSerdeError::TypeMismatch {
                 expected: "named list",
                 actual: "list (names length mismatch)".into(),
             });
         }
-        Ok(NamedListMapAccess {
-            sexp,
-            names,
-            index: 0,
-            len,
-        })
+        Ok(NamedListMapAccess { names, cursor })
     }
 }
 
@@ -932,11 +956,11 @@ impl<'de> MapAccess<'de> for NamedListMapAccess {
         &mut self,
         seed: K,
     ) -> Result<Option<K::Value>, Self::Error> {
-        if self.index >= self.len {
+        let Some(index) = self.cursor.peek_index() else {
             return Ok(None);
-        }
+        };
 
-        let name_charsxp = self.names.string_elt(self.index as isize);
+        let name_charsxp = self.names.string_elt(index as isize);
         let name = unsafe { charsxp_to_str(name_charsxp) };
 
         // Create a string deserializer for the key
@@ -947,8 +971,12 @@ impl<'de> MapAccess<'de> for NamedListMapAccess {
         &mut self,
         seed: V,
     ) -> Result<V::Value, Self::Error> {
-        let elem = self.sexp.vector_elt(self.index as isize);
-        self.index += 1;
+        // serde's MapAccess contract: next_value_seed is only called after
+        // next_key_seed returned Some, so the cursor cannot be exhausted here.
+        let elem = self
+            .cursor
+            .next_elt()
+            .expect("next_value_seed called past end of named list");
         seed.deserialize(RDeserializer::from_sexp(elem))
     }
 }


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## What

Follow-up to audit D6 / PR #1150. The lazy pull-based serde accessors in `miniextendr-api/src/serde/de.rs` each hand-rolled the same `index >= len` / `index += 1` / `vector_elt` bookkeeping. This PR introduces a small private `VecsxpCursor` (len + index, `next_elt()` / `peek_index()`) shared by the three sites:

- `ListSeqAccess::next_element_seed` — `cursor.next_elt()` (pull + advance)
- `NamedListMapAccess::next_key_seed` — `cursor.peek_index()` (bounds check without advancing; the key is read from the parallel names STRSXP)
- `NamedListMapAccess::next_value_seed` — `cursor.next_elt()` (pull + advance)

Type/shape validation stays in the accessor constructors (`ListSeqAccess::new` / `NamedListMapAccess::new` — checks unchanged), per-element deserialization stays serde's job, and `Ok(None)` end-of-iteration semantics are preserved exactly. Side benefit: the map access's previously implicit invariant ("key peeks, value advances") is now explicit in the cursor API instead of living in raw field manipulation.

## Scope choices

- `VectorSeqAccess` / `VectorElementDeserializer` are deliberately untouched. They iterate *atomic* vectors (no `vector_elt` pull — the element deserializer holds the index, and `vector_elt` is VECSXP-only), so the cursor win there is marginal — and **open PR #1178 (`fix/1166-serde-vec-na-message`) modifies `VectorElementDeserializer` in this same file**. This PR's de.rs hunks start below #1178's (old lines ~851+ vs ~732–824), so the two should merge cleanly, but please merge sequentially and re-run serde tests after the second lands.
- `deserialize_enum`'s single `vector_elt(0)` (data-variant arm) has no loop/bookkeeping — nothing to dedup there.
- Honest net accounting per the issue's own "speculative win" framing: +54/−26 lines, with roughly 40% of the additions being doc comments that capture the issue's analysis of why the eager `map_vecsxp_with` helper doesn't fit the pull-based accessors. The win is centralizing the increment-and-bounds-check invariant, not raw line count.
- One behavior-adjacent edge: an out-of-contract `next_value_seed` (called without a preceding successful `next_key_seed`) now panics with a clear message instead of calling `vector_elt` past the end. serde's `MapAccess` contract explicitly permits panicking there; in-contract behavior is identical.

## Verification

- `cargo test -p miniextendr-api --features serde`: 703 passed, 0 failed — all serde test binaries ran with real counts (`serde_nested_vec_all_types` 30, `dataframe_de` 26, `serde_streaming` 14, `list` 6, `serde_nested_vec` 8, `serde_columnar` 22, ...).
- `just test`: root workspace 1055 passed / 0 failed except the 7 known pre-existing `derive_dataframe_*` trybuild snapshot mismatches (local rustc vs CI stable drift — snapshots left alone, CI is authoritative). Cross-package consumer/producer and `rpkg/src/rust` manifests: 45 passed, 0 failed, no dirtied lockfiles.
- All three CI clippy configs green locally with `-D warnings` (`clippy_default`, `clippy_all`, `clippy_all_s7`; feature lists taken from `.github/workflows/ci.yml`).
- `cargo fmt --all --check` clean.

Fixes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
