### PR TITLE
fix(api): drop the dead ALTREP bridge stack from the iterator/stream data adaptors

### DIFF
--- a/docs/ALTREP.md
+++ b/docs/ALTREP.md
@@ -1605,7 +1605,15 @@ impl OptionallyMaterialized {
 
 ## Iterator-Backed ALTREP
 
-miniextendr provides two iterator-backed ALTREP variants:
+miniextendr provides two iterator-backed ALTREP variants.
+
+The `*Data` types below are **data adaptors**: they implement only the
+data-level traits (`AltrepLen` + the matching `Alt*Data` trait) and cannot back
+a live R vector by themselves (they do not implement `RegisterAltrep`). To
+expose one to R, wrap it in a concrete struct deriving the matching
+`#[derive(Altrep*)]` with `#[altrep(manual)]` and delegate the data-trait
+methods to the inner adaptor — see the wrapper walkthrough in
+[SPARSE_ITERATOR_ALTREP.md](SPARSE_ITERATOR_ALTREP.md) for a complete example.
 
 ### `IterState` (Prefix Caching)
 

--- a/miniextendr-api/src/altrep_data/iter.rs
+++ b/miniextendr-api/src/altrep_data/iter.rs
@@ -1,13 +1,47 @@
-//! Iterator-backed ALTREP data types.
+//! Iterator-backed ALTREP data adaptors.
 //!
-//! Provides lazy ALTREP vectors backed by Rust iterators. Elements are generated
-//! on-demand and cached for repeat access.
+//! Provides lazy backing data for ALTREP vectors from Rust iterators. Elements
+//! are generated on-demand and cached for repeat access.
+//!
+//! ## Data adaptors, not R-facing vectors
+//!
+//! The `*Data` types in these submodules implement only the data-level traits
+//! ([`AltrepLen`](crate::altrep_data::AltrepLen) + the matching `Alt*Data`
+//! trait). They do **not** implement
+//! [`RegisterAltrep`](crate::altrep::RegisterAltrep), so they cannot back a
+//! live R SEXP by themselves. To expose one to R, wrap it in a concrete
+//! struct deriving the matching `Altrep*` derive with `#[altrep(manual)]` and
+//! delegate the data-trait methods to the inner adaptor (the derive cannot be
+//! applied to the adaptors directly because they are generic over the
+//! iterator type):
+//!
+//! ```ignore
+//! use miniextendr_api::altrep_data::{AltIntegerData, AltrepLen, IterIntData};
+//!
+//! #[derive(miniextendr_api::AltrepInteger)]
+//! #[altrep(class = "MyLazyInts", manual)]
+//! struct MyLazyInts {
+//!     inner: IterIntData<Box<dyn Iterator<Item = i32>>>,
+//! }
+//!
+//! impl AltrepLen for MyLazyInts {
+//!     fn len(&self) -> usize {
+//!         self.inner.len()
+//!     }
+//! }
+//!
+//! impl AltIntegerData for MyLazyInts {
+//!     fn elt(&self, i: usize) -> i32 {
+//!         self.inner.elt(i)
+//!     }
+//! }
+//! ```
 //!
 //! ## Submodules
 //!
-//! - [`state`]: Core `IterState<I, T>` + standard wrapper types (Int, Real, Logical, Raw)
+//! - [`state`]: Core `IterState<I, T>` + standard data adaptors (Int, Real, Logical, Raw)
 //! - [`coerce`]: Coerced variants (`IterIntCoerceData`, `IterRealCoerceData`, `IterIntFromBoolData`)
-//!   plus the String/List/Complex wrapper types (`IterStringData`, `IterListData`, `IterComplexData`)
+//!   plus the String/List/Complex data adaptors (`IterStringData`, `IterListData`, `IterComplexData`)
 //! - [`sparse`]: Sparse iterators using `nth()` for skip-ahead (`SparseIterState`)
 //! - [`windowed`]: Sliding-window iterators (`WindowedIterState`)
 

--- a/miniextendr-api/src/altrep_data/iter/coerce.rs
+++ b/miniextendr-api/src/altrep_data/iter/coerce.rs
@@ -1,7 +1,13 @@
-//! Iterator-backed ALTREP with coercion support.
+//! Iterator-backed ALTREP data adaptors with coercion support.
 //!
 //! Provides `IterIntCoerceData`, `IterRealCoerceData`, and `IterIntFromBoolData`
-//! for iterators that produce values coercible to the target R type.
+//! for iterators that produce values coercible to the target R type, plus the
+//! string/list/complex adaptors (`IterStringData`, `IterListData`,
+//! `IterComplexData`).
+//!
+//! See the [`super`](crate::altrep_data::iter) module docs for how to expose
+//! these adaptors to R (wrap in a `#[derive(Altrep*)]` + `#[altrep(manual)]`
+//! struct).
 
 use super::IterState;
 use crate::SEXP;
@@ -9,9 +15,12 @@ use crate::altrep_data::{
     AltComplexData, AltIntegerData, AltListData, AltRealData, AltStringData, AltrepLen, fill_region,
 };
 
-/// Iterator-backed integer vector with coercion from any integer-like type.
+/// Iterator-backed integer vector data adaptor with coercion from any integer-like type.
 ///
-/// Wraps an iterator producing values that coerce to `i32` (e.g., `u16`, `i8`, etc.).
+/// Wraps an iterator producing values that coerce to `i32` (e.g., `u16`, `i8`, etc.)
+/// and implements the data-level traits ([`AltrepLen`] + [`AltIntegerData`]).
+/// To expose it to R, wrap it in a `#[derive(AltrepInteger)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 ///
 /// # Example
 ///
@@ -90,24 +99,7 @@ where
     }
 }
 
-impl<I, T> crate::externalptr::TypedExternal for IterIntCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<i32> + Copy + 'static,
-{
-    const TYPE_NAME: &'static str = "IterIntCoerceData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterIntCoerceData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntCoerceData\0";
-}
-
-// Bridge stack (InferBase + Altrep + AltVec + AltInteger) via the generic
-// `impl_alt*_from_data!` family — see audit D1 / miniextendr-api/CLAUDE.md.
-crate::impl_altinteger_from_data_generic!(
-    {I, T} IterIntCoerceData<I, T>
-    {I: Iterator<Item = T> + 'static, T: crate::coerce::Coerce<i32> + Copy + 'static}
-);
-
-/// Iterator-backed real vector with coercion from any float-like type.
+/// Iterator-backed real vector data adaptor with coercion from any float-like type.
 ///
 /// Wraps an iterator producing values that coerce to `f64` (e.g., `f32`, integer types).
 ///
@@ -187,22 +179,7 @@ where
     }
 }
 
-impl<I, T> crate::externalptr::TypedExternal for IterRealCoerceData<I, T>
-where
-    I: Iterator<Item = T> + 'static,
-    T: crate::coerce::Coerce<f64> + Copy + 'static,
-{
-    const TYPE_NAME: &'static str = "IterRealCoerceData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterRealCoerceData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRealCoerceData\0";
-}
-
-crate::impl_altreal_from_data_generic!(
-    {I, T} IterRealCoerceData<I, T>
-    {I: Iterator<Item = T> + 'static, T: crate::coerce::Coerce<f64> + Copy + 'static}
-);
-
-/// Iterator-backed integer vector with coercion from bool.
+/// Iterator-backed integer vector data adaptor with coercion from bool.
 ///
 /// Wraps an iterator producing `bool` values that coerce to `i32`.
 /// Useful for converting boolean iterators to integer vectors.
@@ -267,21 +244,12 @@ where
     }
 }
 
-impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal
-    for IterIntFromBoolData<I>
-{
-    const TYPE_NAME: &'static str = "IterIntFromBoolData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterIntFromBoolData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntFromBoolData\0";
-}
-
-crate::impl_altinteger_from_data_generic!(
-    {I} IterIntFromBoolData<I> {I: Iterator<Item = bool> + 'static}
-);
-
-/// Iterator-backed string vector.
+/// Iterator-backed string vector data adaptor.
 ///
-/// Wraps an iterator producing `String` values and exposes it as an ALTREP character vector.
+/// Wraps an iterator producing `String` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltStringData`]) for backing an ALTREP character
+/// vector. To expose it to R, wrap it in a `#[derive(AltrepString)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 ///
 /// # Performance Warning
 ///
@@ -360,22 +328,12 @@ where
     }
 }
 
-impl<I: Iterator<Item = String> + 'static> crate::externalptr::TypedExternal for IterStringData<I> {
-    const TYPE_NAME: &'static str = "IterStringData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterStringData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterStringData\0";
-}
-
-// String ALTREP elt calls Rf_mkCharLenCE (R API) — the generic macro's
-// `__impl_altrep_base!` uses RUnwind (catches R longjmps), matching the
-// hand-rolled guard this replaces.
-crate::impl_altstring_from_data_generic!(
-    {I} IterStringData<I> {I: Iterator<Item = String> + 'static}
-);
-
-/// Iterator-backed list vector.
+/// Iterator-backed list vector data adaptor.
 ///
-/// Wraps an iterator producing R `SEXP` values and exposes it as an ALTREP list.
+/// Wraps an iterator producing R `SEXP` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltListData`]) for backing an ALTREP list. To
+/// expose it to R, wrap it in a `#[derive(AltrepList)]` + `#[altrep(manual)]`
+/// struct (see the [module docs](crate::altrep_data::iter)).
 ///
 /// # Safety
 ///
@@ -449,19 +407,12 @@ where
     }
 }
 
-impl<I: Iterator<Item = SEXP> + 'static> crate::externalptr::TypedExternal for IterListData<I> {
-    const TYPE_NAME: &'static str = "IterListData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterListData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterListData\0";
-}
-
-crate::impl_altlist_from_data_generic!(
-    {I} IterListData<I> {I: Iterator<Item = SEXP> + 'static}
-);
-
-/// Iterator-backed complex number vector.
+/// Iterator-backed complex number vector data adaptor.
 ///
-/// Wraps an iterator producing `Rcomplex` values and exposes it as an ALTREP complex vector.
+/// Wraps an iterator producing `Rcomplex` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltComplexData`]) for backing an ALTREP complex
+/// vector. To expose it to R, wrap it in a `#[derive(AltrepComplex)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 ///
 /// # Example
 ///
@@ -531,16 +482,3 @@ where
         fill_region(start, len, self.len(), buf, |idx| self.elt(idx))
     }
 }
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExternal
-    for IterComplexData<I>
-{
-    const TYPE_NAME: &'static str = "IterComplexData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterComplexData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterComplexData\0";
-}
-
-crate::impl_altcomplex_from_data_generic!(
-    {I} IterComplexData<I> {I: Iterator<Item = crate::Rcomplex> + 'static}
-);
-// endregion

--- a/miniextendr-api/src/altrep_data/iter/sparse.rs
+++ b/miniextendr-api/src/altrep_data/iter/sparse.rs
@@ -1,7 +1,11 @@
-//! Sparse iterator-backed ALTREP with skipping support.
+//! Sparse iterator-backed ALTREP data adaptors with skipping support.
 //!
 //! Provides `SparseIterState<I, T>` which uses `Iterator::nth()` to skip elements
-//! efficiently, and wrapper types for each ALTREP family.
+//! efficiently, and data-adaptor types for each ALTREP family.
+//!
+//! See the [`super`](crate::altrep_data::iter) module docs for how to expose
+//! these adaptors to R (wrap in a `#[derive(Altrep*)]` + `#[altrep(manual)]`
+//! struct).
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -168,7 +172,7 @@ where
     }
 }
 
-/// Sparse iterator-backed integer vector data.
+/// Sparse iterator-backed integer vector data adaptor.
 ///
 /// Uses `Iterator::nth()` to skip directly to requested indices.
 /// Only accessed elements are cached; skipped elements return `NA_INTEGER`.
@@ -227,17 +231,7 @@ impl<I: Iterator<Item = i32>> AltIntegerData for SparseIterIntData<I> {
     }
 }
 
-impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal for SparseIterIntData<I> {
-    const TYPE_NAME: &'static str = "SparseIterIntData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"SparseIterIntData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterIntData\0";
-}
-
-crate::impl_altinteger_from_data_generic!(
-    {I} SparseIterIntData<I> {I: Iterator<Item = i32> + 'static}
-);
-
-/// Sparse iterator-backed real (f64) vector data.
+/// Sparse iterator-backed real (f64) vector data adaptor.
 ///
 /// Uses `Iterator::nth()` to skip directly to requested indices.
 /// Only accessed elements are cached; skipped elements return `NaN`.
@@ -283,19 +277,7 @@ impl<I: Iterator<Item = f64>> AltRealData for SparseIterRealData<I> {
     }
 }
 
-impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal
-    for SparseIterRealData<I>
-{
-    const TYPE_NAME: &'static str = "SparseIterRealData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"SparseIterRealData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterRealData\0";
-}
-
-crate::impl_altreal_from_data_generic!(
-    {I} SparseIterRealData<I> {I: Iterator<Item = f64> + 'static}
-);
-
-/// Sparse iterator-backed logical vector data.
+/// Sparse iterator-backed logical vector data adaptor.
 pub struct SparseIterLogicalData<I: Iterator<Item = bool>> {
     state: SparseIterState<I, bool>,
 }
@@ -337,19 +319,7 @@ impl<I: Iterator<Item = bool>> AltLogicalData for SparseIterLogicalData<I> {
     }
 }
 
-impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal
-    for SparseIterLogicalData<I>
-{
-    const TYPE_NAME: &'static str = "SparseIterLogicalData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"SparseIterLogicalData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterLogicalData\0";
-}
-
-crate::impl_altlogical_from_data_generic!(
-    {I} SparseIterLogicalData<I> {I: Iterator<Item = bool> + 'static}
-);
-
-/// Sparse iterator-backed raw (u8) vector data.
+/// Sparse iterator-backed raw (u8) vector data adaptor.
 pub struct SparseIterRawData<I: Iterator<Item = u8>> {
     state: SparseIterState<I, u8>,
 }
@@ -392,17 +362,7 @@ impl<I: Iterator<Item = u8>> AltRawData for SparseIterRawData<I> {
     }
 }
 
-impl<I: Iterator<Item = u8> + 'static> crate::externalptr::TypedExternal for SparseIterRawData<I> {
-    const TYPE_NAME: &'static str = "SparseIterRawData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"SparseIterRawData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterRawData\0";
-}
-
-crate::impl_altraw_from_data_generic!(
-    {I} SparseIterRawData<I> {I: Iterator<Item = u8> + 'static}
-);
-
-/// Sparse iterator-backed complex number vector.
+/// Sparse iterator-backed complex number vector data adaptor.
 pub struct SparseIterComplexData<I>
 where
     I: Iterator<Item = crate::Rcomplex>,
@@ -462,16 +422,3 @@ where
         fill_region(start, len, self.len(), buf, |idx| self.elt(idx))
     }
 }
-
-impl<I: Iterator<Item = crate::Rcomplex> + 'static> crate::externalptr::TypedExternal
-    for SparseIterComplexData<I>
-{
-    const TYPE_NAME: &'static str = "SparseIterComplexData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"SparseIterComplexData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::SparseIterComplexData\0";
-}
-
-crate::impl_altcomplex_from_data_generic!(
-    {I} SparseIterComplexData<I> {I: Iterator<Item = crate::Rcomplex> + 'static}
-);
-// endregion

--- a/miniextendr-api/src/altrep_data/iter/state.rs
+++ b/miniextendr-api/src/altrep_data/iter/state.rs
@@ -1,10 +1,16 @@
-//! Core iterator-backed ALTREP infrastructure.
+//! Core iterator-backed ALTREP data adaptors.
 //!
 //! Provides `IterState<I, T>` (the shared lazy-caching state machine) and
-//! wrapper types for the integer/real/logical/raw ALTREP families:
+//! data-adaptor types for the integer/real/logical/raw ALTREP families:
 //! `IterIntData`, `IterRealData`, `IterLogicalData`, `IterRawData`. The
-//! string/list/complex wrappers (`IterStringData`, `IterListData`,
+//! string/list/complex adaptors (`IterStringData`, `IterListData`,
 //! `IterComplexData`) live in `super::coerce`.
+//!
+//! See the [`super`](crate::altrep_data::iter) module docs for how to expose
+//! these adaptors to R: they implement only the data-level traits
+//! ([`AltrepLen`] + `Alt*Data`) and must be wrapped in a concrete
+//! `#[derive(Altrep*)]` + `#[altrep(manual)]` struct to back a live ALTREP
+//! vector.
 
 use std::cell::RefCell;
 use std::sync::OnceLock;
@@ -217,9 +223,12 @@ where
     }
 }
 
-/// Iterator-backed integer vector data.
+/// Iterator-backed integer vector data adaptor.
 ///
-/// Wraps an iterator producing `i32` values and exposes it as an ALTREP integer vector.
+/// Wraps an iterator producing `i32` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltIntegerData`]) for backing an ALTREP integer
+/// vector. To expose it to R, wrap it in a `#[derive(AltrepInteger)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 ///
 /// # Example
 ///
@@ -273,19 +282,12 @@ impl<I: Iterator<Item = i32>> AltIntegerData for IterIntData<I> {
     }
 }
 
-impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal for IterIntData<I> {
-    const TYPE_NAME: &'static str = "IterIntData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterIntData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterIntData\0";
-}
-
-crate::impl_altinteger_from_data_generic!(
-    {I} IterIntData<I> {I: Iterator<Item = i32> + 'static}
-);
-
-/// Iterator-backed real (f64) vector data.
+/// Iterator-backed real (f64) vector data adaptor.
 ///
-/// Wraps an iterator producing `f64` values and exposes it as an ALTREP real vector.
+/// Wraps an iterator producing `f64` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltRealData`]) for backing an ALTREP real vector.
+/// To expose it to R, wrap it in a `#[derive(AltrepReal)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 pub struct IterRealData<I: Iterator<Item = f64>> {
     state: IterState<I, f64>,
 }
@@ -328,19 +330,12 @@ impl<I: Iterator<Item = f64>> AltRealData for IterRealData<I> {
     }
 }
 
-impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal for IterRealData<I> {
-    const TYPE_NAME: &'static str = "IterRealData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterRealData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRealData\0";
-}
-
-crate::impl_altreal_from_data_generic!(
-    {I} IterRealData<I> {I: Iterator<Item = f64> + 'static}
-);
-
-/// Iterator-backed logical vector data.
+/// Iterator-backed logical vector data adaptor.
 ///
-/// Wraps an iterator producing `bool` values and exposes it as an ALTREP logical vector.
+/// Wraps an iterator producing `bool` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltLogicalData`]) for backing an ALTREP logical
+/// vector. To expose it to R, wrap it in a `#[derive(AltrepLogical)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 pub struct IterLogicalData<I: Iterator<Item = bool>> {
     state: IterState<I, bool>,
 }
@@ -382,19 +377,12 @@ impl<I: Iterator<Item = bool>> AltLogicalData for IterLogicalData<I> {
     }
 }
 
-impl<I: Iterator<Item = bool> + 'static> crate::externalptr::TypedExternal for IterLogicalData<I> {
-    const TYPE_NAME: &'static str = "IterLogicalData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterLogicalData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterLogicalData\0";
-}
-
-crate::impl_altlogical_from_data_generic!(
-    {I} IterLogicalData<I> {I: Iterator<Item = bool> + 'static}
-);
-
-/// Iterator-backed raw (u8) vector data.
+/// Iterator-backed raw (u8) vector data adaptor.
 ///
-/// Wraps an iterator producing `u8` values and exposes it as an ALTREP raw vector.
+/// Wraps an iterator producing `u8` values and implements the data-level
+/// traits ([`AltrepLen`] + [`AltRawData`]) for backing an ALTREP raw vector.
+/// To expose it to R, wrap it in a `#[derive(AltrepRaw)]` +
+/// `#[altrep(manual)]` struct (see the [module docs](crate::altrep_data::iter)).
 pub struct IterRawData<I: Iterator<Item = u8>> {
     state: IterState<I, u8>,
 }
@@ -436,14 +424,3 @@ impl<I: Iterator<Item = u8>> AltRawData for IterRawData<I> {
         fill_region(start, len, self.len(), buf, |idx| self.elt(idx))
     }
 }
-
-impl<I: Iterator<Item = u8> + 'static> crate::externalptr::TypedExternal for IterRawData<I> {
-    const TYPE_NAME: &'static str = "IterRawData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"IterRawData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::IterRawData\0";
-}
-
-crate::impl_altraw_from_data_generic!(
-    {I} IterRawData<I> {I: Iterator<Item = u8> + 'static}
-);
-// endregion

--- a/miniextendr-api/src/altrep_data/iter/windowed.rs
+++ b/miniextendr-api/src/altrep_data/iter/windowed.rs
@@ -1,12 +1,18 @@
-//! Windowed iterator-backed ALTREP infrastructure.
+//! Windowed iterator-backed ALTREP data adaptors.
 //!
 //! Provides `WindowedIterState<I, T>` which keeps a sliding window of elements
-//! in memory, and wrapper types for each ALTREP family.
+//! in memory, and data-adaptor types for the integer/real ALTREP families.
+//!
+//! See the [`super`](crate::altrep_data::iter) module docs for how to expose
+//! these adaptors to R (wrap in a `#[derive(Altrep*)]` + `#[altrep(manual)]`
+//! struct).
 
 use std::cell::RefCell;
 use std::sync::OnceLock;
 
 use crate::altrep_data::{AltIntegerData, AltRealData, AltrepLen, fill_region};
+
+// region: WindowedIterState
 
 /// Core state for windowed iterator-backed ALTREP vectors.
 ///
@@ -220,9 +226,9 @@ where
 }
 // endregion
 
-// region: Windowed Iterator wrapper types
+// region: Windowed Iterator data adaptors
 
-/// Windowed iterator-backed integer vector data.
+/// Windowed iterator-backed integer vector data adaptor.
 ///
 /// Like [`super::IterIntData`], but only keeps a sliding window of elements in memory.
 /// Sequential forward access within the window is O(1). Access outside the
@@ -271,19 +277,7 @@ impl<I: Iterator<Item = i32>> AltIntegerData for WindowedIterIntData<I> {
     }
 }
 
-impl<I: Iterator<Item = i32> + 'static> crate::externalptr::TypedExternal
-    for WindowedIterIntData<I>
-{
-    const TYPE_NAME: &'static str = "WindowedIterIntData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"WindowedIterIntData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::WindowedIterIntData\0";
-}
-
-crate::impl_altinteger_from_data_generic!(
-    {I} WindowedIterIntData<I> {I: Iterator<Item = i32> + 'static}
-);
-
-/// Windowed iterator-backed real (f64) vector data.
+/// Windowed iterator-backed real (f64) vector data adaptor.
 ///
 /// Like [`super::IterRealData`], but only keeps a sliding window of elements in memory.
 /// Sequential forward access within the window is O(1). Access outside the
@@ -330,15 +324,4 @@ impl<I: Iterator<Item = f64>> AltRealData for WindowedIterRealData<I> {
     }
 }
 
-impl<I: Iterator<Item = f64> + 'static> crate::externalptr::TypedExternal
-    for WindowedIterRealData<I>
-{
-    const TYPE_NAME: &'static str = "WindowedIterRealData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"WindowedIterRealData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::WindowedIterRealData\0";
-}
-
-crate::impl_altreal_from_data_generic!(
-    {I} WindowedIterRealData<I> {I: Iterator<Item = f64> + 'static}
-);
 // endregion

--- a/miniextendr-api/src/altrep_data/stream.rs
+++ b/miniextendr-api/src/altrep_data/stream.rs
@@ -1,8 +1,14 @@
-//! Streaming ALTREP data backed by chunk-cached reader closures.
+//! Streaming ALTREP data adaptors backed by chunk-cached reader closures.
 //!
-//! These types provide ALTREP vectors where elements are loaded on-demand
-//! from a reader function in fixed-size chunks. Chunks are cached for
-//! repeated access within the same region.
+//! These types provide backing data for ALTREP vectors where elements are
+//! loaded on-demand from a reader function in fixed-size chunks. Chunks are
+//! cached for repeated access within the same region.
+//!
+//! Like the [`iter`](crate::altrep_data::iter) adaptors, these implement only
+//! the data-level traits ([`AltrepLen`] + `Alt*Data`); to expose one to R,
+//! wrap it in a concrete `#[derive(Altrep*)]` + `#[altrep(manual)]` struct
+//! that delegates the data-trait methods (see the
+//! [`iter`](crate::altrep_data::iter) module docs for the pattern).
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -11,7 +17,7 @@ use super::{AltIntegerData, AltRealData, AltrepLen};
 
 // region: StreamingRealData
 
-/// Streaming ALTREP for real (f64) vectors.
+/// Streaming data adaptor for ALTREP real (f64) vectors.
 ///
 /// Elements are loaded on-demand via a reader closure in fixed-size chunks.
 /// Chunks are cached in a `BTreeMap` for repeated access.
@@ -104,22 +110,11 @@ impl<F: Fn(usize, &mut [f64]) -> usize> AltRealData for StreamingRealData<F> {
     }
 }
 
-impl<F: Fn(usize, &mut [f64]) -> usize + 'static> crate::externalptr::TypedExternal
-    for StreamingRealData<F>
-{
-    const TYPE_NAME: &'static str = "StreamingRealData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"StreamingRealData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::StreamingRealData\0";
-}
-
-crate::impl_altreal_from_data_generic!(
-    {F} StreamingRealData<F> {F: Fn(usize, &mut [f64]) -> usize + 'static}
-);
 // endregion
 
 // region: StreamingIntData
 
-/// Streaming ALTREP for integer (i32) vectors.
+/// Streaming data adaptor for ALTREP integer (i32) vectors.
 ///
 /// Elements are loaded on-demand via a reader closure in fixed-size chunks.
 /// Chunks are cached in a `BTreeMap` for repeated access.
@@ -212,15 +207,4 @@ impl<F: Fn(usize, &mut [i32]) -> usize> AltIntegerData for StreamingIntData<F> {
     }
 }
 
-impl<F: Fn(usize, &mut [i32]) -> usize + 'static> crate::externalptr::TypedExternal
-    for StreamingIntData<F>
-{
-    const TYPE_NAME: &'static str = "StreamingIntData";
-    const TYPE_NAME_CSTR: &'static [u8] = b"StreamingIntData\0";
-    const TYPE_ID_CSTR: &'static [u8] = b"miniextendr_api::altrep::StreamingIntData\0";
-}
-
-crate::impl_altinteger_from_data_generic!(
-    {F} StreamingIntData<F> {F: Fn(usize, &mut [i32]) -> usize + 'static}
-);
 // endregion

--- a/miniextendr-api/src/altrep_impl/macros.rs
+++ b/miniextendr-api/src/altrep_impl/macros.rs
@@ -14,11 +14,15 @@
 //!
 //! Each family also has an `impl_alt<family>_from_data_generic!` sibling
 //! accepting a brace-delimited generic parameter list and where-clause
-//! (`{$gen} $ty {$where}[, $knob]*`) for adaptor types like
-//! `IterIntCoerceData<I, T>` — see `altrep_data::iter` / `altrep_data::stream`
-//! for the ~19 call sites this replaced (audit D1). The plain macros forward
-//! to their `_generic!` sibling with empty `{}` brackets, so each family has
-//! exactly one emission body regardless of which form is called.
+//! (`{$gen} $ty {$where}[, $knob]*`) for generic types like
+//! `struct Foo<T> { .. }`. The plain macros forward to their `_generic!`
+//! sibling with empty `{}` brackets, so each family has exactly one emission
+//! body regardless of which form is called.
+//!
+//! Note the iterator/stream data adaptors in `altrep_data::iter` /
+//! `altrep_data::stream` deliberately do **not** invoke these macros: they
+//! implement only the data-level traits and are meant to be wrapped by a
+//! concrete `#[derive(Altrep*)]` + `#[altrep(manual)]` struct (#1146).
 
 // region: Macros for generating trait implementations
 
@@ -60,10 +64,10 @@ macro_rules! impl_altinteger_from_data {
 
 /// Generic form of [`impl_altinteger_from_data!`]: accepts an optional
 /// generic parameter list and where-clause (`{T, U} Foo<T, U> {T: Bound, ..}`)
-/// so it can target `struct Foo<T> { .. }` adaptors — e.g. iterator-backed
-/// ALTREP types — not just concrete/monomorphic types. The non-generic macro
-/// above forwards here with empty `{}` brackets so there is exactly one
-/// emission body for both call shapes.
+/// so it can target `struct Foo<T> { .. }` types, not just
+/// concrete/monomorphic ones. The non-generic macro above forwards here with
+/// empty `{}` brackets so there is exactly one emission body for both call
+/// shapes.
 #[macro_export]
 macro_rules! impl_altinteger_from_data_generic {
     ({$($gen:tt)*} $ty:ty {$($whr:tt)*} $(, $knob:ident)*) => {
@@ -1154,7 +1158,7 @@ macro_rules! impl_altlist_from_data {
 
 /// Generic form of [`impl_altlist_from_data!`]: accepts an optional generic
 /// parameter list and where-clause so it can target `struct Foo<T> { .. }`
-/// adaptors, not just concrete types. The non-generic macro above forwards
+/// types, not just concrete ones. The non-generic macro above forwards
 /// here with empty `{}` brackets so there is exactly one emission body.
 #[macro_export]
 macro_rules! impl_altlist_from_data_generic {

--- a/miniextendr-api/tests/altrep_from_data_matrix.rs
+++ b/miniextendr-api/tests/altrep_from_data_matrix.rs
@@ -134,10 +134,11 @@ miniextendr_api::impl_altinteger_from_data!(IntSubsetSerialize, subset, serializ
 
 // region: Generic form — `impl_alt*_from_data_generic!` (audit D1)
 //
-// Coverage for the generic sibling that the ~19 hand-rolled iterator/stream
-// ALTREP adaptors (`altrep_data::iter::*`, `altrep_data::stream::*`) route
-// through: a type with a generic parameter and a `where` clause, mirroring
-// the shape those adaptors need (e.g. `IterIntCoerceData<I, T>`).
+// Coverage for the generic sibling on a type with a generic parameter and a
+// `where` clause. The non-generic macros forward here, so this exercises the
+// single emission body with non-empty `{$gen}` / `{$where}` brackets. (The
+// iterator/stream data adaptors in `altrep_data::iter` / `altrep_data::stream`
+// no longer invoke it — their bridge stack was unreachable dead code, #1146.)
 
 /// Generic fixture: wraps any `T: Copy + Into<i32> + 'static` in a `Vec`.
 struct GenericIntFixture<T>(Vec<T>)


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## What this does

Resolves part 1 of #1146 via the issue's **option (b)** — document the 19 iterator/stream ALTREP adaptor data types as data-adaptor building blocks and **delete** their provably-dead bridge stacks — per the repo's deletion-over-addition principle. Part 2 (the negative-index clamp guards' missing live-SEXP coverage, marked "not urgent" in the issue) is deliberately not addressed here and is split out to **#1190** so `Fixes #1146` doesn't silently close it.

## Reachability evidence for option (b)

- The bridge stack's only entry points, `InferBase::make_class` + `install_methods`, are called exclusively from `RegisterAltrep::get_or_init_class` impls: the `impl_register_altrep!` builtins macro (`miniextendr-api/src/altrep_impl/builtins.rs:538-544`), the hand-rolled `optionals/{arrow,nalgebra,ndarray}_impl.rs` impls, and the `#[derive(Altrep*)]` proc-macro output (`miniextendr-macros/src/altrep.rs:122-134`).
- None of the 19 adaptor types implement `RegisterAltrep` (grep: `impl RegisterAltrep for` hits only builtins + optionals), so their `Altrep`/`AltVec`/`Alt<Family>`/`InferBase` impls could never be registered or dispatched.
- Every consumer wraps them in its own `#[derive(Altrep*, manual)]` struct and delegates only the `AltrepLen`/`Alt*Data` data-trait methods: `rpkg/src/rust/lib.rs` (sparse fixtures), `rpkg/src/rust/streaming_altrep_tests.rs`, `miniextendr-bench/benches/altrep_iter.rs`. The wrapper gets its own independent bridge stack from the derive.
- No in-flight D1 migration PR touches these files (`gh pr list --search altrep` shows only the unrelated #1183), so there is no evidence the bridge stack is about to become load-bearing.

## Changes

- **Removed** the 19 `impl_alt*_from_data_generic!` invocations from `miniextendr-api/src/altrep_data/iter/{state,coerce,sparse,windowed}.rs` and `altrep_data/stream.rs`, plus the 19 `TypedExternal` impls that existed solely to satisfy the bridge's `AltrepExtract` blanket requirement (verified: no `ExternalPtr<Iter*/Sparse*/Windowed*/Streaming*>` usage anywhere in the repo).
- **Kept** the `impl_alt*_from_data_generic!` macros themselves — they are the single emission body the non-generic `impl_alt*_from_data!` macros forward to (used by builtins/ndarray, which *do* have `RegisterAltrep`), and retain independent generic-form coverage via `GenericIntFixture<T>` in `miniextendr-api/tests/altrep_from_data_matrix.rs`.
- **Docs**: module-level wrapper-pattern example in `altrep_data/iter.rs` (mirroring the rpkg fixtures), per-type doc rewording away from the over-promising "exposes it as an ALTREP … vector", matching notes in `stream.rs` and `docs/ALTREP.md`, and updated stale cross-references in `altrep_impl/macros.rs` + the matrix test.

## Verification

- `just check` — pass (the `MINIEXTENDR_DOC_LINT_DESC` deprecation warnings in rpkg/cross-package fixtures are pre-existing and fixed by open PR #1181).
- `just test` — pass except the 7 known pre-existing `derive_dataframe_*` trybuild snapshot mismatches (local rustc vs CI-stable E0080 note-format drift; snapshots intentionally not overwritten — CI is authoritative).
- All three CI clippy configs green locally with `-D warnings`: `clippy_default`, `clippy_all` (`full-codegen` + the curated integration list from `.github/workflows/ci.yml`), `clippy_all_s7` (`full-codegen-s7`).
- `just configure` + `cargo check` in `rpkg/src/rust` — pass (fixtures use only the kept data-trait surface).
- `cargo fmt --all` clean.

## Deferred

- #1190 — negative-index clamp guards (`__impl_alt_elt!` / `__impl_alt_get_region!`) have zero live-SEXP test coverage; needs an embedded-R harness, explicitly out of scope per the issue.

Fixes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
