### PR TITLE
fix(api): batch all NA/parse failures in string-parse vector conversions (#1143)

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -1890,6 +1890,38 @@ macro_rules! impl_vec_option_try_from_sexp_list {
     };
 }
 
+/// Cap on the number of per-element failures listed in a batched vector
+/// conversion error; the remainder is summarized as `"and N more"`.
+const BATCHED_ERROR_CAP: usize = 10;
+
+/// Combine indexed per-element conversion failures into one batched
+/// [`SexpError::InvalidValue`].
+///
+/// Backs the `Vec<T>` / `Vec<Option<T>>` arms of
+/// [`try_from_sexp_via_str_parse!`]: instead of bailing on the first NA or
+/// parse failure, those arms walk the whole vector, accumulate the
+/// already-formatted per-element messages, and hand them here. Entries are
+/// joined with `"; "`; at most the first 10 are listed and the remainder is
+/// summarized as `"and N more"`.
+///
+/// Public (but hidden) because `try_from_sexp_via_str_parse!` is
+/// `#[macro_export]` and expands in downstream crates — not intended to be
+/// called directly.
+#[doc(hidden)]
+pub fn batch_conversion_errors(container: &str, errors: Vec<String>) -> SexpError {
+    debug_assert!(!errors.is_empty(), "batching zero conversion errors");
+    let total = errors.len();
+    let mut msg = format!(
+        "{container} conversion failed: {}",
+        errors[..total.min(BATCHED_ERROR_CAP)].join("; ")
+    );
+    if total > BATCHED_ERROR_CAP {
+        use std::fmt::Write;
+        let _ = write!(msg, "; and {} more", total - BATCHED_ERROR_CAP);
+    }
+    SexpError::InvalidValue(msg)
+}
+
 /// Implement the four string-parse `TryFromSexp` impls (`T`, `Option<T>`,
 /// `Vec<T>`, `Vec<Option<T>>`) for a type parsed from an R character vector.
 ///
@@ -1904,10 +1936,12 @@ macro_rules! impl_vec_option_try_from_sexp_list {
 /// - `T`: `NA_character_` / `NULL` → `SexpError::Na`; parse failure →
 ///   `InvalidValue("invalid <label>: <err>")`.
 /// - `Option<T>`: `NA_character_` / `NULL` → `None`.
-/// - `Vec<T>`: any NA element →
-///   `InvalidValue("NA at index <i> not allowed for Vec<T>")`; parse failure →
-///   `InvalidValue("invalid <label> at index <i>: <err>")`.
-/// - `Vec<Option<T>>`: NA elements → `None`; parse failures error with index.
+/// - `Vec<T>`: NA elements and parse failures are collected across the whole
+///   vector into one batched `InvalidValue` (see [`batch_conversion_errors`]).
+///   Per-element entries keep the `"NA at index <i> not allowed for Vec<T>"`
+///   and `"invalid <label> at index <i>: <err>"` shapes; the first 10 are
+///   listed and the remainder is summarized as `"and N more"`.
+/// - `Vec<Option<T>>`: NA elements → `None`; parse failures batch as above.
 ///
 /// The parse body is a closure-style `|s| expr` where `s: &str`, returning
 /// `Result<T, E>` with `E: Display`.
@@ -1961,29 +1995,34 @@ macro_rules! try_from_sexp_via_str_parse {
 
             fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 let values: Vec<Option<String>> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
-                values
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, opt)| {
-                        let s = opt.ok_or_else(|| {
-                            $crate::from_r::SexpError::InvalidValue(format!(
-                                concat!(
-                                    "NA at index {} not allowed for Vec<",
-                                    stringify!($ty),
-                                    ">"
-                                ),
-                                i
-                            ))
-                        })?;
-                        let $s: &str = &s;
-                        ($parse).map_err(|e| {
-                            $crate::from_r::SexpError::InvalidValue(format!(
-                                concat!("invalid ", $label, " at index {}: {}"),
-                                i, e
-                            ))
-                        })
-                    })
-                    .collect()
+                let mut result = Vec::with_capacity(values.len());
+                let mut errors: Vec<String> = Vec::new();
+                for (i, opt) in values.into_iter().enumerate() {
+                    match opt {
+                        None => errors.push(format!(
+                            concat!("NA at index {} not allowed for Vec<", stringify!($ty), ">"),
+                            i
+                        )),
+                        Some(s) => {
+                            let $s: &str = &s;
+                            match ($parse) {
+                                Ok(v) => result.push(v),
+                                Err(e) => errors.push(format!(
+                                    concat!("invalid ", $label, " at index {}: {}"),
+                                    i, e
+                                )),
+                            }
+                        }
+                    }
+                }
+                if errors.is_empty() {
+                    Ok(result)
+                } else {
+                    Err($crate::from_r::batch_conversion_errors(
+                        concat!("Vec<", stringify!($ty), ">"),
+                        errors,
+                    ))
+                }
             }
         }
 
@@ -1992,22 +2031,31 @@ macro_rules! try_from_sexp_via_str_parse {
 
             fn try_from_sexp(sexp: $crate::SEXP) -> Result<Self, Self::Error> {
                 let values: Vec<Option<String>> = $crate::from_r::TryFromSexp::try_from_sexp(sexp)?;
-                values
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, opt)| match opt {
-                        None => Ok(None),
+                let mut result = Vec::with_capacity(values.len());
+                let mut errors: Vec<String> = Vec::new();
+                for (i, opt) in values.into_iter().enumerate() {
+                    match opt {
+                        None => result.push(None),
                         Some(s) => {
                             let $s: &str = &s;
-                            ($parse).map(Some).map_err(|e| {
-                                $crate::from_r::SexpError::InvalidValue(format!(
+                            match ($parse) {
+                                Ok(v) => result.push(Some(v)),
+                                Err(e) => errors.push(format!(
                                     concat!("invalid ", $label, " at index {}: {}"),
                                     i, e
-                                ))
-                            })
+                                )),
+                            }
                         }
-                    })
-                    .collect()
+                    }
+                }
+                if errors.is_empty() {
+                    Ok(result)
+                } else {
+                    Err($crate::from_r::batch_conversion_errors(
+                        concat!("Vec<Option<", stringify!($ty), ">>"),
+                        errors,
+                    ))
+                }
             }
         }
     };

--- a/miniextendr-api/tests/str_parse.rs
+++ b/miniextendr-api/tests/str_parse.rs
@@ -2,12 +2,26 @@
 //! (uuid / url / regex / num-bigint), including the NA-policy standardization:
 //! scalar NA errors (`SexpError::Na`), `Option` NA maps to `None`, `Vec<T>`
 //! rejects NA with an indexed error, `Vec<Option<T>>` maps NA to `None`.
+//!
+//! The `Vec<T>` / `Vec<Option<T>>` arms batch all per-element failures into
+//! one diagnostic (capped at 10 + "and N more") instead of bailing on the
+//! first (#1143).
 
 mod r_test_utils;
 
-#[cfg(any(feature = "uuid", feature = "regex"))]
+#[cfg(any(
+    feature = "uuid",
+    feature = "regex",
+    feature = "url",
+    feature = "num-bigint"
+))]
 use miniextendr_api::from_r::{SexpError, TryFromSexp};
-#[cfg(any(feature = "uuid", feature = "regex"))]
+#[cfg(any(
+    feature = "uuid",
+    feature = "regex",
+    feature = "url",
+    feature = "num-bigint"
+))]
 use miniextendr_api::into_r::IntoR;
 
 #[cfg(feature = "uuid")]
@@ -85,6 +99,113 @@ fn uuid_vec_option_na_is_none() {
         assert_eq!(v.len(), 2);
         assert!(v[0].is_some());
         assert!(v[1].is_none());
+    });
+}
+
+// Batched diagnostics (#1143): the vector arms collect every failing element
+// into one error instead of bailing on the first.
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_batches_all_na_and_parse_failures() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![
+            Some(VALID_UUID.to_string()),
+            None,
+            Some("bad".to_string()),
+            Some(VALID_UUID.to_string()),
+            Some("worse".to_string()),
+        ]
+        .into_sexp();
+        let err = <Vec<Uuid> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Vec<Uuid> conversion failed"), "got: {msg}");
+        assert!(
+            msg.contains("NA at index 1 not allowed for Vec<Uuid>"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("invalid UUID at index 2"), "got: {msg}");
+        assert!(msg.contains("invalid UUID at index 4"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_batch_caps_at_ten_and_summarizes_rest() {
+    r_test_utils::with_r_thread(|| {
+        let sexp: Vec<String> = (0..15).map(|i| format!("bad-{i}")).collect();
+        let err = <Vec<Uuid> as TryFromSexp>::try_from_sexp(sexp.into_sexp()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid UUID at index 0"), "got: {msg}");
+        assert!(msg.contains("invalid UUID at index 9"), "got: {msg}");
+        assert!(!msg.contains("at index 10"), "got: {msg}");
+        assert!(msg.contains("and 5 more"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn uuid_vec_option_na_stays_none_while_parse_failures_batch() {
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![
+            Some(VALID_UUID.to_string()),
+            None,
+            Some("bad".to_string()),
+            None,
+            Some("worse".to_string()),
+        ]
+        .into_sexp();
+        let err = <Vec<Option<Uuid>> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Vec<Option<Uuid>> conversion failed"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("invalid UUID at index 2"), "got: {msg}");
+        assert!(msg.contains("invalid UUID at index 4"), "got: {msg}");
+        // NA elements are still allowed as None — they must not appear as errors.
+        assert!(!msg.contains("NA at index"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn url_vec_batches_all_parse_failures() {
+    use miniextendr_api::Url;
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![
+            "https://example.com".to_string(),
+            "not a url".to_string(),
+            "::also-bad::".to_string(),
+        ]
+        .into_sexp();
+        let err = <Vec<Url> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        assert!(matches!(err, SexpError::InvalidValue(_)), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("Vec<Url> conversion failed"), "got: {msg}");
+        assert!(msg.contains("invalid URL at index 1"), "got: {msg}");
+        assert!(msg.contains("invalid URL at index 2"), "got: {msg}");
+    });
+}
+
+#[cfg(feature = "num-bigint")]
+#[test]
+fn bigint_vec_batches_all_parse_failures() {
+    use miniextendr_api::BigInt;
+    r_test_utils::with_r_thread(|| {
+        let sexp = vec![
+            "123".to_string(),
+            "xyz".to_string(),
+            "456".to_string(),
+            "1.5".to_string(),
+        ]
+        .into_sexp();
+        let err = <Vec<BigInt> as TryFromSexp>::try_from_sexp(sexp).unwrap_err();
+        assert!(matches!(err, SexpError::InvalidValue(_)), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("Vec<BigInt> conversion failed"), "got: {msg}");
+        assert!(msg.contains("invalid BigInt at index 1"), "got: {msg}");
+        assert!(msg.contains("invalid BigInt at index 3"), "got: {msg}");
     });
 }
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## Approach

The `Vec<T>` / `Vec<Option<T>>` arms of `try_from_sexp_via_str_parse!` (`miniextendr-api/src/from_r.rs`, shared by the uuid / url / regex / num-bigint adapters) short-circuited on the first NA or parse failure via `.collect::<Result<_,_>>()`. Per the project principle "collect all errors in vectorized ops", both arms now walk the whole vector, accumulate the already-formatted per-element messages, and hand them to a new `batch_conversion_errors(container, errors)` helper that returns one `SexpError::InvalidValue` — same "; "-joined shape as the existing tuple batching in `from_r/tuples.rs` (`batch_tuple_errors`), capped at the first 10 entries with the remainder summarized as `and N more`.

Per-element message shapes are unchanged (`NA at index <i> not allowed for Vec<T>`, `invalid <label> at index <i>: <err>`), so existing substring expectations keep passing. The helper is `#[doc(hidden)] pub` because the macro is `#[macro_export]` and expands in downstream crates.

## Old vs new

Input `c(<valid>, NA, "bad", <valid>, "worse")` as `Vec<Uuid>`:

Before (first failure only):

```
invalid value: NA at index 1 not allowed for Vec<Uuid>
```

After (all failures, one diagnostic):

```
invalid value: Vec<Uuid> conversion failed: NA at index 1 not allowed for Vec<Uuid>; invalid UUID at index 2: invalid length: expected length 32 for simple format, found 3; invalid UUID at index 4: invalid character: found `w` at 1
```

Cap behavior, 15 bad elements:

```
invalid value: Vec<Uuid> conversion failed: invalid UUID at index 0: ...; [indices 1-8 elided here]; invalid UUID at index 9: invalid group count: expected 5, found 2; and 5 more
```

`Vec<Option<T>>` still maps NA to `None`; only parse failures batch.

## rpkg testthat

`rpkg/tests/testthat/test-feature-adapters.R:61` (`expect_error(docid_roundtrip("not-a-uuid"), "invalid UUID")`) exercises the **scalar** arm, which is untouched — and `invalid UUID` also survives verbatim in every vector entry. No rpkg test change needed; grepped `rpkg/tests` for `not allowed for Vec` / adapter `conversion failed` expectations — none exist against the vector shapes.

## Numeric-parse decision

Evaluated extending the batching to the numeric-coercion vector conversions: they are **not** the same one-site shape — `from_numeric_vec_with`'s four SEXPTYPE branches, `coerce_slice_to_vec`, the `na_vectors.rs` closures, and `strict.rs`'s `checked_vec_*` all short-circuit, and their per-element errors carry no index at all (`{e:?}` debug output). Deferred to #1192 with a full sketch (including reusing `batch_conversion_errors`).

## Verification

- `cargo test -p miniextendr-api --features uuid,url,regex,num-bigint --test str_parse` — 12/12 pass (5 new tests: multi-failure batching incl. mixed NA+parse, cap + "and N more", `Vec<Option<T>>` NA-stays-None while failures batch, plus url and num-bigint legs).
- `just test` — root workspace green except the 7 known pre-existing `derive_dataframe_*` trybuild snapshot mismatches (local rustc vs CI stable drift; not overwritten per repo policy). The cross-package consumer/producer and rpkg/src/rust workspace legs (which the recipe's `&&` chain skips after the trybuild failure) were run manually — all exit 0.
- All three CI clippy configs pass with `-D warnings`: `clippy_default`, `clippy_all` (full-codegen + curated feature list from `.github/workflows/ci.yml`), `clippy_all_s7` (full-codegen-s7).
- `cargo fmt --all --check` clean.

Fixes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
