### PR TITLE
refactor(minirextendr): unify .Rbuildignore/.gitignore scaffolding via shared mx_ignore_patterns() (#1151)

### DIFF
--- a/minirextendr/R/create.R
+++ b/minirextendr/R/create.R
@@ -262,9 +262,19 @@ create_rpkg_subdirectory <- function(data, rpkg_name = "rpkg") {
   use_miniextendr_build_rs(path = rpkg_path, subdir = "rpkg")
   use_template("lib.rs", save_as = file.path(rpkg_name, "src", "rust", "lib.rs"), subdir = "rpkg", data = data)
 
-  # Ignore files
-  use_template("Rbuildignore", save_as = file.path(rpkg_name, ".Rbuildignore"), subdir = "rpkg")
-  use_template("gitignore", save_as = file.path(rpkg_name, ".gitignore"), subdir = "rpkg")
+  # Ignore files. Content comes from the same "read template, filter comments"
+  # prep as the standalone use_miniextendr_rbuildignore() /
+  # use_miniextendr_gitignore() — see mx_ignore_patterns() (#1151) — but this
+  # path keeps its fresh-file overwrite semantics (re-running the scaffold
+  # resets scaffolding files) rather than usethis's append + dedupe into a
+  # pre-existing file. For a brand-new file the two write paths are
+  # byte-identical, so fresh scaffolds match the standalone output exactly.
+  rbuildignore_path <- usethis::proj_path(rpkg_name, ".Rbuildignore")
+  writeLines(mx_ignore_patterns("Rbuildignore", subdir = "rpkg"), rbuildignore_path)
+  bullet_created(file.path(rpkg_name, ".Rbuildignore"))
+  gitignore_path <- usethis::proj_path(rpkg_name, ".gitignore")
+  writeLines(mx_ignore_patterns("gitignore", subdir = "rpkg"), gitignore_path)
+  bullet_created(file.path(rpkg_name, ".gitignore"))
 
   invisible(TRUE)
 }

--- a/minirextendr/R/use-r.R
+++ b/minirextendr/R/use-r.R
@@ -143,15 +143,11 @@ use_miniextendr_description <- function(path = ".") {
 #' @keywords internal
 use_miniextendr_rbuildignore <- function(path = ".") {
   with_project(path)
-  # Read template content (already regex patterns, skip escaping)
-  template_content <- readLines(template_path("Rbuildignore"))
-
-  # Filter out empty lines and comments for usethis
-  patterns <- template_content[nzchar(template_content) & !grepl("^#", template_content)]
-
-  # usethis handles deduplication and file creation automatically
-  # escape = FALSE because our template already contains regex patterns
-  usethis::use_build_ignore(patterns, escape = FALSE)
+  # Shared "read template, filter comments" prep with the monorepo path
+  # (create_rpkg_subdirectory()) — see mx_ignore_patterns() (#1151).
+  # usethis handles deduplication and file creation automatically;
+  # escape = FALSE because our template already contains regex patterns.
+  usethis::use_build_ignore(mx_ignore_patterns("Rbuildignore"), escape = FALSE)
 
   invisible(TRUE)
 }
@@ -166,14 +162,10 @@ use_miniextendr_rbuildignore <- function(path = ".") {
 #' @keywords internal
 use_miniextendr_gitignore <- function(path = ".") {
   with_project(path)
-  # Read template content
-  template_content <- readLines(template_path("gitignore"))
-
-  # Filter out empty lines and comments for usethis
-  patterns <- template_content[nzchar(template_content) & !grepl("^#", template_content)]
-
-  # usethis handles deduplication and file creation automatically
-  usethis::use_git_ignore(patterns, directory = ".")
+  # Shared "read template, filter comments" prep with the monorepo path
+  # (create_rpkg_subdirectory()) — see mx_ignore_patterns() (#1151).
+  # usethis handles deduplication and file creation automatically.
+  usethis::use_git_ignore(mx_ignore_patterns("gitignore"), directory = ".")
 
   invisible(TRUE)
 }

--- a/minirextendr/R/utils.R
+++ b/minirextendr/R/utils.R
@@ -203,6 +203,31 @@ mx_license_content <- function(pkg_name) {
           format(Sys.Date(), "%Y"), pkg_name)
 }
 
+#' Ignore-file patterns from an ignore template
+#'
+#' Reads an ignore-file template (`Rbuildignore` / `gitignore`) and filters it
+#' down to the bare patterns: blank lines and `#` comment lines are dropped.
+#' Shared prep step between the standalone path
+#' (`use_miniextendr_rbuildignore()` / `use_miniextendr_gitignore()`, which
+#' hand the patterns to `usethis::use_build_ignore()` /
+#' `usethis::use_git_ignore()` for append + dedupe into a possibly
+#' pre-existing file) and the monorepo path (`create_rpkg_subdirectory()`,
+#' which writes them to a brand-new file). Empirically the two write paths
+#' produce byte-identical files when the target does not yet exist (usethis
+#' writes exactly the given lines, in order, newline-terminated), so a fresh
+#' scaffold gets the same ignore-file content on both paths. See #1151.
+#'
+#' @param template Template file name (`"Rbuildignore"` or `"gitignore"`),
+#'   resolved against the active template type via `template_path()`.
+#' @param subdir Optional subdirectory within the template type (e.g. `"rpkg"`
+#'   when scaffolding the R package subdirectory of a monorepo).
+#' @return Character vector of ignore patterns.
+#' @noRd
+mx_ignore_patterns <- function(template, subdir = NULL) {
+  lines <- readLines(template_path(template, subdir = subdir))
+  lines[nzchar(lines) & !grepl("^#", lines)]
+}
+
 #' Copy the bundled config.guess / config.sub autoconf helper scripts
 #'
 #' All three scaffold paths need these under `tools/` for cross-compilation

--- a/minirextendr/tests/testthat/test-ignore-scaffolding.R
+++ b/minirextendr/tests/testthat/test-ignore-scaffolding.R
@@ -1,0 +1,127 @@
+# Tests for the unified .Rbuildignore / .gitignore scaffolding (#1151)
+#
+# The standalone path (use_miniextendr_rbuildignore() /
+# use_miniextendr_gitignore()) and the monorepo path
+# (create_rpkg_subdirectory()) share the "read template, filter comments"
+# prep step — mx_ignore_patterns() in R/utils.R. The standalone path keeps
+# usethis's append + dedupe write into a possibly pre-existing file; the
+# monorepo path keeps its fresh-file overwrite. For a brand-new file the two
+# writes are byte-identical, so fresh scaffolds produce the same content on
+# both paths.
+
+test_that("mx_ignore_patterns() filters blank and comment lines, preserving order", {
+  minirextendr:::set_template_type("rpkg")
+  withr::defer(minirextendr:::set_template_type("rpkg"))
+
+  for (tpl in c("Rbuildignore", "gitignore")) {
+    raw <- readLines(
+      system.file("templates", "rpkg", tpl, package = "minirextendr", mustWork = TRUE)
+    )
+    patterns <- minirextendr:::mx_ignore_patterns(tpl)
+
+    expect_true(length(patterns) > 0)
+    expect_true(all(nzchar(patterns)))
+    expect_false(any(grepl("^#", patterns)))
+    # Every pattern comes from the template, in template order
+    expect_identical(patterns, raw[raw %in% patterns])
+  }
+
+  # Spot-check load-bearing patterns survive the filter
+  expect_true("^vendor$" %in% minirextendr:::mx_ignore_patterns("Rbuildignore"))
+  expect_true("vendor/" %in% minirextendr:::mx_ignore_patterns("gitignore"))
+})
+
+test_that("standalone fresh scaffold writes exactly the filtered template patterns", {
+  tmp <- withr::local_tempdir()
+  writeLines(c("Package: ignpkg", "Version: 0.0.1"), file.path(tmp, "DESCRIPTION"))
+  usethis::local_project(tmp, force = TRUE, setwd = FALSE)
+  minirextendr:::set_template_type("rpkg")
+  withr::defer(minirextendr:::set_template_type("rpkg"))
+
+  suppressMessages({
+    minirextendr:::use_miniextendr_rbuildignore(path = tmp)
+    minirextendr:::use_miniextendr_gitignore(path = tmp)
+  })
+
+  # Brand-new files: usethis writes exactly the filtered patterns, in order.
+  # This is the byte-identity that lets the monorepo path's fresh
+  # writeLines() produce the same content (#1151).
+  expect_identical(readLines(file.path(tmp, ".Rbuildignore")),
+                   minirextendr:::mx_ignore_patterns("Rbuildignore"))
+  expect_identical(readLines(file.path(tmp, ".gitignore")),
+                   minirextendr:::mx_ignore_patterns("gitignore"))
+})
+
+test_that("monorepo scaffold ignore files match the standalone fresh-scaffold content", {
+  skip_if_not(nzchar(Sys.which("cargo")), "Rust toolchain not available")
+
+  tmp <- withr::local_tempdir()
+  usethis::local_project(tmp, force = TRUE, setwd = FALSE)
+  minirextendr:::set_template_type("monorepo")
+  withr::defer(minirextendr:::set_template_type("rpkg"))
+
+  data <- list(
+    package = "mypkg",
+    package_rs = "mypkg",
+    Package = "Mypkg",
+    crate_name = "mypkg-rs",
+    rpkg_name = "rpkg",
+    features_var = "CARGO_FEATURES",
+    year = "2026"
+  )
+  suppressMessages(minirextendr:::create_rpkg_subdirectory(data, rpkg_name = "rpkg"))
+
+  rbuild <- readLines(file.path(tmp, "rpkg", ".Rbuildignore"))
+  gitign <- readLines(file.path(tmp, "rpkg", ".gitignore"))
+
+  # Written content is the filtered monorepo template ...
+  expect_identical(rbuild,
+                   minirextendr:::mx_ignore_patterns("Rbuildignore", subdir = "rpkg"))
+  expect_identical(gitign,
+                   minirextendr:::mx_ignore_patterns("gitignore", subdir = "rpkg"))
+
+  # ... and identical to what the standalone path writes on a fresh scaffold
+  # (the rpkg and monorepo/rpkg templates are kept in sync).
+  minirextendr:::set_template_type("rpkg")
+  expect_identical(rbuild, minirextendr:::mx_ignore_patterns("Rbuildignore"))
+  expect_identical(gitign, minirextendr:::mx_ignore_patterns("gitignore"))
+})
+
+test_that("standalone path appends and dedupes into a pre-existing ignore file", {
+  tmp <- withr::local_tempdir()
+  writeLines(c("Package: ignpkg", "Version: 0.0.1"), file.path(tmp, "DESCRIPTION"))
+  usethis::local_project(tmp, force = TRUE, setwd = FALSE)
+  minirextendr:::set_template_type("rpkg")
+  withr::defer(minirextendr:::set_template_type("rpkg"))
+
+  rb_patterns <- minirextendr:::mx_ignore_patterns("Rbuildignore")
+  gi_patterns <- minirextendr:::mx_ignore_patterns("gitignore")
+
+  # Pre-existing files with user content plus one already-present pattern
+  rb_pre <- c("# user comment", "^my_own_file$", rb_patterns[1])
+  gi_pre <- c("# user comment", "my_own_file", gi_patterns[1])
+  writeLines(rb_pre, file.path(tmp, ".Rbuildignore"))
+  writeLines(gi_pre, file.path(tmp, ".gitignore"))
+
+  suppressMessages({
+    minirextendr:::use_miniextendr_rbuildignore(path = tmp)
+    minirextendr:::use_miniextendr_gitignore(path = tmp)
+  })
+
+  rb_after <- readLines(file.path(tmp, ".Rbuildignore"))
+  gi_after <- readLines(file.path(tmp, ".gitignore"))
+
+  # User content preserved verbatim at the top
+  expect_identical(rb_after[seq_along(rb_pre)], rb_pre)
+  expect_identical(gi_after[seq_along(gi_pre)], gi_pre)
+
+  # Already-present pattern was not re-appended
+  expect_identical(sum(rb_after == rb_patterns[1]), 1L)
+  expect_identical(sum(gi_after == gi_patterns[1]), 1L)
+
+  # All template patterns present, nothing duplicated
+  expect_true(all(rb_patterns %in% rb_after))
+  expect_true(all(gi_patterns %in% gi_after))
+  expect_false(any(duplicated(rb_after)))
+  expect_false(any(duplicated(gi_after)))
+})


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

Follow-up to the D8 scaffold-enumeration dedup: the standalone path (`use_miniextendr_rbuildignore()` / `use_miniextendr_gitignore()`) and the monorepo path (`create_rpkg_subdirectory()`) scaffolded `.Rbuildignore` / `.gitignore` through two unrelated code paths.

#### Which route the evidence chose

Issue #1151 gated the unification on an empirical question: is `usethis::use_build_ignore()` / `use_git_ignore()` output byte-identical to a straight template copy for a brand-new file? Measured (usethis 3.2.1, R 4.6.0):

- **usethis fresh-file output vs straight template copy: DIFFERENT.** The standalone path filters blank/comment lines before handing patterns to usethis, and they never come back — 33 vs 49 lines for `Rbuildignore`, 20 vs 37 for `gitignore`. So the monorepo path could **not** be routed through the standalone functions while keeping its current output; the issue's fallback route applies.
- **usethis fresh-file output vs `writeLines()` of the filtered patterns: IDENTICAL** (both files). usethis writes exactly the given lines, in order, newline-terminated.
- Pre-existing file: usethis keeps user lines first, appends only missing patterns, never re-appends duplicates.

#### What changed

- New shared helper `mx_ignore_patterns(template, subdir)` in `minirextendr/R/utils.R` (alongside `mx_license_content()` etc. in the shared-scaffold-content region): read the ignore template, drop blank/`#` comment lines.
- **Standalone** (`R/use-r.R`): both functions now call the helper, then hand the patterns to `usethis::use_build_ignore(escape = FALSE)` / `use_git_ignore()` as before — append + dedupe into a possibly pre-existing file preserved, output unchanged.
- **Monorepo** (`R/create.R`): `create_rpkg_subdirectory()` now writes the helper's patterns with a fresh-file `writeLines()` instead of a raw `use_template()` copy — overwrite semantics preserved. Because of the byte-identity above, both paths now produce **identical ignore-file content on a fresh scaffold**. Intended behavior change: monorepo-scaffolded ignore files no longer carry the template's comment/blank lines, matching what standalone users have always received (the commented originals remain in `inst/templates/` for maintainers).

#### Tests

New `minirextendr/tests/testthat/test-ignore-scaffolding.R`:
- `mx_ignore_patterns()` filters blanks/comments, preserves order, keeps load-bearing patterns (`^vendor$`, `vendor/`).
- Standalone fresh scaffold writes exactly the filtered patterns (locks the byte-identity the design rests on).
- Monorepo `create_rpkg_subdirectory()` output equals the filtered monorepo template **and** the standalone fresh-scaffold content.
- Standalone append + dedupe on a pre-existing file: user content preserved verbatim at the top, no duplicate patterns, all template patterns present.

No test asserted on the old function bodies (the brittle `deparse(body)` tests were previously dropped), so none needed updating.

#### Verification

- `just minirextendr-test`: full suite green — `[ FAIL 0 | WARN 0 | SKIP 3 | PASS 688 ]` (log grepped for `[ FAIL`; the 3 skips are pre-existing tool-availability skips in `test-use-native.R`).
- `just templates-check`: clean — no template-synced files touched, so no `patches/templates.patch` regeneration needed.

Fixes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
