### PR TITLE
docs: sync RHash return type + parallel skill thread-control API (#1108, #1130)

### DIFF
--- a/docs/ADAPTER_TRAITS.md
+++ b/docs/ADAPTER_TRAITS.md
@@ -83,7 +83,7 @@ These have blanket implementations so you just need to export them for your type
 | `RDebug` | `Debug` | `debug_str()`, `debug_str_pretty()` |
 | `RDisplay` | `Display` | `as_r_string()` |
 | `RFromStr` | `FromStr` | `from_str(s) -> Option<Self>` |
-| `RHash` | `Hash` | `hash() -> i64` |
+| `RHash` | `Hash` | `hash() -> String` |
 | `ROrd` | `Ord` | `cmp(&self, other) -> i32` |
 | `RPartialOrd` | `PartialOrd` | `partial_cmp(&self, other) -> Option<i32>` |
 | `RError` | `Error` | `error_message()`, `error_chain()`, `error_chain_length()` |

--- a/minirextendr/inst/claude/skills/miniextendr-parallel/SKILL.md
+++ b/minirextendr/inst/claude/skills/miniextendr-parallel/SKILL.md
@@ -93,9 +93,17 @@ unrestricted — and the conversions themselves have parallel variants
 - **Chunk boundaries depend on thread count**, so chunk-seeded randomness
   differs across machines. For cross-machine reproducibility pin the pool:
   `rayon::ThreadPoolBuilder::new().num_threads(4).build_global()`.
-- Respect user/CRAN thread limits: honor an env var or R option for thread
-  count rather than silently taking all cores (CRAN policy caps checks at 2
-  cores — make thread count configurable).
+- **Respect user/CRAN thread limits** — don't silently take all cores. On the
+  Rust side, `miniextendr_api::optionals::parallel::effective_threads()`,
+  `::ensure_pool()`, and `::set_threads()` centralize this;
+  `effective_threads()` already applies the CRAN core cap
+  (`_R_CHECK_LIMIT_CORES_`). To let R users tune the count, expose thin
+  wrappers like `miniextendr_num_threads()` / `miniextendr_set_threads()` — the
+  miniextendr exemplar package ships these, but scaffolded packages don't get
+  them automatically yet (tracked upstream in issue #1132). For the full
+  precedence table (env var, R option, explicit call, CRAN cap), see the
+  miniextendr manual's "Controlling Parallelism from R" section — don't
+  restate it here.
 
 ## Long-lived / hand-rolled threads
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `docs/ADAPTER_TRAITS.md`: fixed the `RHash` table cell, which said `hash() -> i64` but the trait actually returns `String` (verified against `miniextendr-api/src/adapter_traits.rs`).
- `minirextendr/inst/claude/skills/miniextendr-parallel/SKILL.md`: replaced the generic "honor an env var or R option for thread count" guidance with a pointer to the concrete API that now exists — `miniextendr_api::optionals::parallel::{effective_threads, ensure_pool, set_threads}` on the Rust side, `miniextendr_num_threads()` / `miniextendr_set_threads()` R wrappers in `rpkg/src/rust/thread_control.rs`, and a pointer to `docs/RAYON.md`'s "Controlling Parallelism from R" section for the full precedence table (not restated here, per #1133).
- Closes #1108, closes #1130.

## Test plan
- [ ] `grep -n "fn hash" miniextendr-api/src/adapter_traits.rs` shows `fn hash(&self) -> String;` (confirms the doc fix matches the trait signature).
- [ ] `grep -n "pub fn effective_threads\|pub fn ensure_pool\|pub fn set_threads" miniextendr-api/src/optionals/parallel.rs` shows all three symbols exist under those exact names.
- [ ] `grep -n "miniextendr_num_threads\|miniextendr_set_threads" rpkg/src/rust/thread_control.rs` shows both R-callable wrappers exist.
- [ ] `grep -n "Controlling Parallelism from R" docs/RAYON.md` confirms the section exists to point at.
- [ ] Docs-only change: no Rust compilation or R installation required.

---
_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>