### PR TITLE
fix(macros): typed_list! attribute-path errors use Display, not Debug (audit A8)

### DIFF
--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -380,6 +380,26 @@ fn validate_extern_signature(
     Ok(())
 }
 
+/// Builds the `let dots_typed = <dots>.typed(<spec>)...` statement injected
+/// at the start of a function body when `#[miniextendr(dots =
+/// typed_list!(...))]` is used.
+///
+/// Uses `unwrap_or_else(|e| panic!("...: {e}"))` rather than
+/// `Result::expect`, which formats the error with `Debug` instead of
+/// `Display` — for `TypedListError` that leaks PascalCase enum-variant names
+/// (`Missing { name: "x" }`) into the R-visible message instead of the
+/// human-phrased text (`missing required field: "x"`) that the direct
+/// `typed_list!` path already produces via `Display`. See audit A8.
+fn build_dots_validation_stmt(
+    dots_param: &syn::Ident,
+    spec_tokens: &proc_macro2::TokenStream,
+) -> syn::Stmt {
+    syn::parse_quote! {
+        let dots_typed = #dots_param.typed(#spec_tokens)
+            .unwrap_or_else(|e| panic!("dots validation failed: {e}"));
+    }
+}
+
 /// Emit the `extern "C-unwind"` helper + `R_CallMethodDef` registration for
 /// each standalone-fn `match_arg` param.
 ///
@@ -1426,10 +1446,7 @@ pub fn miniextendr(
         let dots_param = named_dots.clone().unwrap_or_else(|| {
             syn::Ident::new("__miniextendr_dots", proc_macro2::Span::call_site())
         });
-        let validation_stmt: syn::Stmt = syn::parse_quote! {
-            let dots_typed = #dots_param.typed(#spec_tokens)
-                .expect("dots validation failed");
-        };
+        let validation_stmt = build_dots_validation_stmt(&dots_param, spec_tokens);
         original_item.block.stmts.insert(0, validation_stmt);
     }
 
@@ -2614,7 +2631,8 @@ pub fn derive_vctrs(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// This injects validation at the start of the function body:
 /// ```ignore
-/// let dots_typed = _dots.typed(typed_list!(...)).expect("dots validation failed");
+/// let dots_typed = _dots.typed(typed_list!(...))
+///     .unwrap_or_else(|e| panic!("dots validation failed: {e}"));
 /// ```
 ///
 /// See the [`#[miniextendr]`](macro@miniextendr) attribute documentation for more details.

--- a/miniextendr-macros/src/tests.rs
+++ b/miniextendr-macros/src/tests.rs
@@ -139,6 +139,30 @@ fn miniextendr_attr_accepts_unwrap_in_r() {
 }
 
 #[test]
+fn dots_validation_stmt_formats_error_with_display_not_debug() {
+    // Audit A8: `#[miniextendr(dots = typed_list!(...))]` used to inject
+    // `.expect("dots validation failed")`, which Debug-formats the
+    // `TypedListError` and leaks PascalCase enum-variant names (e.g.
+    // `Missing { name: "x" }`) into the R-visible message — a different
+    // style than the direct `typed_list!` path, which already goes through
+    // `TypedListError`'s human-phrased `Display` impl. Pin that the
+    // generated statement uses `unwrap_or_else` + `{e}` (Display) instead
+    // of `expect` (Debug).
+    let dots_param = syn::Ident::new("__miniextendr_dots", proc_macro2::Span::call_site());
+    // The real `spec_tokens` is the whole `typed_list!(...)` invocation captured
+    // as an expression (see `dots_spec` in miniextendr_fn.rs), not the bare spec
+    // interior — pass the same shape so `parse_quote!` sees valid Rust.
+    let spec_tokens = quote::quote! { typed_list!(x => numeric()) };
+
+    let stmt = crate::build_dots_validation_stmt(&dots_param, &spec_tokens);
+    let s = normalize_tokens(quote::quote! { #stmt });
+
+    assert!(s.contains("unwrap_or_else"));
+    assert!(s.contains("panic!(\"dotsvalidationfailed:{e}\")"));
+    assert!(!s.contains(".expect("));
+}
+
+#[test]
 fn parsed_fn_adds_inline_never_for_rust_abi() {
     let mut parsed: MiniextendrFunctionParsed = syn::parse2(quote::quote! { fn f() {} }).unwrap();
     parsed.add_inline_never_if_needed();

--- a/rpkg/tests/testthat/test-dots-more.R
+++ b/rpkg/tests/testthat/test-dots-more.R
@@ -100,16 +100,20 @@ test_that("validate_with_attribute works with valid input", {
 })
 
 test_that("validate_with_attribute fails on missing required field", {
+  # Same wording as the direct typed_list! path (Display, not Debug) — see
+  # "validate_numeric_args validates type and length" above.
   expect_error(
     validate_with_attribute(x = 1.0),
-    "Missing"
+    "missing"
   )
 })
 
 test_that("validate_with_attribute fails on wrong type", {
+  # Same wording as the direct typed_list! path (Display, not Debug) — see
+  # "validate_numeric_args validates type and length" above.
   expect_error(
     validate_with_attribute(x = "not a number", y = 2.0),
-    "WrongType"
+    "wrong type"
   )
 })
 
@@ -121,4 +125,24 @@ test_that("validate_attr_optional works without optional field", {
 test_that("validate_attr_optional works with optional field", {
   result <- validate_attr_optional(name = "Bob", greeting = "Hi")
   expect_equal(result, "Hi, Bob!")
+})
+
+test_that("direct and attribute-sugar typed_list paths share one message style", {
+  # Audit A8: the attribute-sugar path used to Debug-format TypedListError
+  # (PascalCase variant names like `Missing { name: "y" }`), so a user regex
+  # matching one entry point missed the other. Both now go through the
+  # Display impl — assert the SAME regex matches both paths.
+  missing_re <- "missing required field"
+  expect_error(validate_numeric_args(beta = list(1, 2)), missing_re) # direct
+  expect_error(validate_with_attribute(x = 1.0), missing_re) # attribute sugar
+
+  wrong_type_re <- "has wrong type: expected"
+  expect_error(
+    validate_numeric_args(alpha = 1:4, beta = list(1, 2)), # direct
+    wrong_type_re
+  )
+  expect_error(
+    validate_with_attribute(x = "not a number", y = 2.0), # attribute sugar
+    wrong_type_re
+  )
 })


### PR DESCRIPTION
## What

`#[miniextendr(dots = typed_list!(...))]` (the attribute-sugar path) surfaced
`typed_list!` validation failures in a **different message style** than direct
`typed_list!` usage, because the injected validation statement formatted the
error with `Debug` instead of `Display`.

Audit A8 (`audit/2026-07-03-api-sense-conversions-dataframe-errors.md` #4): an R
user's `grepl("wrong type", conditionMessage(e))` matched one entry point but
not the other.

## Root cause

`miniextendr-macros/src/lib.rs` injected:

```rust
let dots_typed = _dots.typed(typed_list!(...)).expect("dots validation failed");
```

`Result::expect` formats the error with `Debug`, and `TypedListError`'s `Debug`
is the derived form — so the R-visible message leaked PascalCase enum variants:

```
dots validation failed: Missing { name: "y" }
```

The direct `typed_list!` path already goes through `TypedListError`'s
hand-written `Display` impl (`miniextendr-api/src/typed_list.rs`), which is
human-phrased.

## Fix

Route the attribute path through `Display` too, via a small
`build_dots_validation_stmt` helper:

```rust
let dots_typed = _dots.typed(typed_list!(...))
    .unwrap_or_else(|e| panic!("dots validation failed: {e}"));
```

Now both entry points produce the same style:

```
dots validation failed: missing required field: "y"
dots validation failed: field "x" has wrong type: expected numeric, got character
```

(`panic!` is correct here — the framework converts panics to R conditions;
MXL300 forbids `Rf_error`, not `panic!`.)

`TypedListError::Display` already covers every variant the direct-path tests
assert (`missing`, `wrong type`, `wrong length`, `extra`, `duplicate`), so no
other change was needed — verified, not assumed. Grepped the macros crate: the
one emitter above is the only `.expect`-on-`typed()` site.

## Tests

- **Macro-side unit test** (`miniextendr-macros/src/tests.rs`): pins that the
  generated statement uses `unwrap_or_else` + `{e}` (Display), not `.expect`
  (Debug).
- **testthat** (`rpkg/tests/testthat/test-dots-more.R`): the two attribute-path
  assertions now expect the Display phrasing, and a new test asserts the **same
  regex matches both** the direct-macro and attribute-sugar paths for the
  missing-field and wrong-type cases (the audit's user story).

`just check`, `just test` (only the 7 known `derive_dataframe_*` trybuild
snapshots drift on local rustc — untouched, CI-authoritative), all three CI
clippy variants (`default` / `all` / `all_s7`) with `-D warnings`, `just fmt`
clean. Full `just devtools-test`: `[ FAIL 0 | WARN 0 | SKIP 23 | PASS 6970 ]`.
Branch rebased onto current `main` (picks up #1197 / #1199 / #1201, all
orthogonal — no file overlap); workspace re-checked clean against the new base.

Message-only change, no new SEXP storage across allocations → no gc-stress
fixture needed. NAMESPACE/man unchanged (no export or roxygen changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
