### PR TITLE
docs: worktree R library via rv shared cache; add just worktree-sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,12 @@ Some agent sandboxes block compilation. For any compiling command (`just force-d
 ## Agent Worktrees
 
 - Run agents in worktrees (`isolation: "worktree"`) to avoid collisions.
-- **Worktrees start with no R library**: `rv/library/` is gitignored, so a fresh worktree can't `R CMD INSTALL` (`ERROR: dependencies '…' are not available`, compile never starts). Symlink it to the main repo's populated one once: `ln -s /Users/elea/Documents/GitHub/miniextendr/rv/library rv/library`. Installs then land in the shared dev library, and the symlink vanishes when the worktree is removed (`rv/` is gitignored).
+- **Worktree R library: `rv sync` per worktree, then install** (never symlink to main). `rv/library/` is gitignored, so a fresh worktree's library is empty. Populate it from rv's shared global cache (`~/.cache/rv`, warm from main — same `rproject.toml`), then install the dev packages:
+  ```bash
+  just worktree-sync   # = RV_LINK_MODE=symlink rv sync — symlinks the ~110 cached deps into this worktree's OWN rv/library (~8s)
+  just configure && just rcmdinstall && just force-document
+  ```
+  `RV_LINK_MODE=symlink` (in `just worktree-sync`) links deps as symlinks into `~/.cache/rv` (zero-copy, no recompile/download) instead of the macOS copy-on-write default. Each worktree gets its own real `rv/library` (deps = symlinks to the shared read-only cache; dev packages = real installed dirs), so parallel worktrees never race and main is untouched. rv's native cross-project cache model: https://a2-ai.github.io/rv-docs/concepts/cache/ . **Order matters**: `rv sync` prunes anything not in the lockfile — including `miniextendr`/`minirextendr` (`dependencies_only`) — so sync first, install second; a later `rv sync` wipes the dev packages (re-install). **Never `ln -s rv/library`** to main (the old fix; reintroduces the shared-install race).
 - **Merge**: rebase worktree onto current main, *then* merge. Rebase must happen immediately before the merge, not when the agent finishes.
 - **Sequential merging** of multiple worktrees: rebase → merge → rebase next → merge. Each rebase must see prior merge commits on main, otherwise changes get silently overwritten.
 - **Never copy whole files** worktree → main — rebase/merge is the only correct flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,14 @@ Claude Code sandbox blocks compilation. For any compiling command
 ### Agent worktrees
 
 - Run agents in worktrees (`isolation: "worktree"`) to avoid collisions.
-- **Worktrees start with no R library**: `rv/library/` is gitignored, so a fresh worktree can't `just rcmdinstall` / `R CMD INSTALL` (`ERROR: dependencies '…' are not available`, compile never starts). Symlink it to the main repo's populated one once: `ln -s /Users/elea/Documents/GitHub/miniextendr/rv/library rv/library`. Installs then land in the shared dev library, and the symlink vanishes when the worktree is removed (`rv/` is gitignored).
+- **Worktree R library: `rv sync` per worktree, then install** (never symlink to main). `rv/library/` is gitignored, so a fresh worktree's library is empty. Populate it from rv's shared global cache (`~/.cache/rv`, already warm from main — same `rproject.toml` → same cache), then install the dev packages:
+  ```bash
+  just worktree-sync   # = RV_LINK_MODE=symlink rv sync — symlinks the ~110 cached deps into this worktree's OWN rv/library (~8s)
+  just configure && just rcmdinstall && just force-document
+  ```
+  `RV_LINK_MODE=symlink` (baked into `just worktree-sync`) links each dependency as a symlink into `~/.cache/rv` (zero-copy, no recompile or download) rather than the macOS copy-on-write default — either works, symlink is cheapest across many worktrees. Each worktree then gets its **own real `rv/library`** (deps = symlinks to the shared read-only cache; `miniextendr`/`minirextendr` = real dirs installed into it), so parallel worktrees **never race** on a shared install and main's library is untouched. This is rv's native cross-project cache model — see [rv-docs: cache](https://a2-ai.github.io/rv-docs/concepts/cache/) and [env vars](https://a2-ai.github.io/rv-docs/reference/env_vars/).
+  - **Order matters**: `rv sync` "replaces the library with exactly the lockfile", so it *prunes* anything not listed — including `miniextendr`/`minirextendr` (they're `dependencies_only` in `rproject.toml`). Sync **first**, install the dev packages **second**. Re-running `rv sync` wipes the installed dev packages → re-install after.
+  - **Never `ln -s rv/library`** to main. That was the old fix; it forces every worktree into main's single shared library, which is the parallel-install race (spliced `wrappers.R`, one-builder-per-worktree serialization). Don't edit rv's `rv/scripts/*` or the repo `.Rprofile` for this either — the cache model already handles it.
 - **Merge**: rebase worktree onto current main, *then* merge. Rebase must happen immediately before the merge, not when the agent finishes.
 - **Sequential merging** of multiple worktrees: rebase → merge → rebase next → merge. Each rebase must see prior merge commits on main, otherwise changes get silently overwritten.
 - **Never copy whole files** worktree → main — rebase/merge is the only correct flow.

--- a/justfile
+++ b/justfile
@@ -651,6 +651,16 @@ install_deps:
 dev-tools-install: revendor-install
     cargo install cargo-limit
 
+# Symlinks rv's cached deps from ~/.cache/rv (warm from main, same rproject.toml)
+# into THIS checkout's own rv/library in seconds — no recompile/download — so
+# parallel worktrees never race on a shared install and main's library stays
+# untouched. Caveat: `rv sync` replaces the library with exactly the lockfile, so
+# it prunes miniextendr/minirextendr (dependencies_only) — re-install after any
+# resync. Never `ln -s rv/library` to main. See CLAUDE.md → "Agent worktrees".
+# Bootstrap a fresh worktree's R library from rv's shared cache (run before configure/install)
+worktree-sync:
+    RV_LINK_MODE=symlink rv sync
+
 # Install Windows system tooling via Scoop (https://scoop.sh). Currently installs
 # `rv` (https://github.com/a2-ai/rv), the R version manager used on this repo.
 [windows]

--- a/rpkg/CLAUDE.md
+++ b/rpkg/CLAUDE.md
@@ -15,6 +15,12 @@ just r-cmd-build / r-cmd-check  # tarball + check
 ```
 After **anything** that affects R wrapper output (proc-macro roxygen, `r_wrappers.rs`, adding `#[miniextendr]` fns) run `just rcmdinstall && just force-document`, then commit `NAMESPACE` + `man/*.Rd` in the same PR. `R/miniextendr-wrappers.R` and `src/rust/wasm_registry.rs` are **gitignored** (regenerated on every install, like `inst/vendor.tar.xz`) — nothing to commit there. CI's `just wrappers-sync-check` regenerates wrappers.R and git-diffs NAMESPACE + man to catch drift.
 
+## Where installs land (main vs worktree)
+`just rcmdinstall` / `R CMD INSTALL` deposit `miniextendr` into `.libPaths()[1]`,
+which rv's `activate.R` sets to this checkout's own `rv/library/<ver>/<arch>`.
+- **Main checkout**: installs land in `<repo>/rv/library/…`, alongside all deps.
+- **Linked worktree**: run `just worktree-sync` (= `RV_LINK_MODE=symlink rv sync`) **first** — it symlinks the cached deps from `~/.cache/rv` (shared, warm from main) into the worktree's own `rv/library`, then `rcmdinstall` installs `miniextendr` there as a real dir. The worktree is fully isolated; main is untouched; parallel worktrees don't race. `rv sync` prunes non-lockfile packages, so sync **before** installing dev packages (and re-install if you sync again). Full flow + rationale in root `CLAUDE.md` → *Agent worktrees*. **Never `ln -s` `rv/library`** to main — reintroduces the parallel-install race.
+
 ## File-edit rules (templates → generated)
 - `src/Makevars` ← `src/Makevars.in`
 - `src/rust/.cargo/config.toml` ← `src/rust/cargo-config.toml.in`


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Fresh git worktrees start with an empty `rv/library`. The old fix (`ln -s rv/library` to main) forced every worktree into main's single shared library, so parallel installs raced (spliced `wrappers.R`, one-builder-per-worktree serialization).
- Switch to rv's native shared global cache. `RV_LINK_MODE=symlink rv sync` symlinks the ~110 cached deps from `~/.cache/rv` into each worktree's own `rv/library` in seconds (no recompile or download), then the dev packages install there as real dirs. Each worktree is fully isolated, main's library stays untouched, and there is no cross-worktree race.
- Add a `just worktree-sync` recipe that bakes in the `RV_LINK_MODE=symlink` env var so it is not easy to forget.
- Rewrite the worktree guidance in `CLAUDE.md` (Agent worktrees), mirror it in `AGENTS.md`, and update `rpkg/CLAUDE.md` (Where installs land).
- Document the ordering caveat: `rv sync` replaces the library with exactly the lockfile, so it prunes `miniextendr`/`minirextendr` (they are `dependencies_only`). Sync first, install second, re-install after any resync.

## Test plan
- [x] `just worktree-sync` in a fresh worktree: 8.1s, 110 deps linked as symlinks into `~/.cache/rv`.
- [x] `R CMD INSTALL rpkg` from the worktree deposits `miniextendr` in the worktree's own library as a real dir.
- [x] `library(miniextendr)` loads from the worktree; deps resolve via the cache symlinks.
- [x] Main's `rv/library` is untouched (miniextendr mtime unchanged, no stray `00LOCK`).
- [ ] Reviewer: `just --list` shows `worktree-sync` with a sensible one-line summary.

## Notes
- Docs plus one justfile recipe only. No code or build-pipeline changes.
- rv's generated files (`rv/scripts/*`) and the repo `.Rprofile` are intentionally left untouched; an earlier `.Rprofile` libpath-layering attempt was discarded in favor of rv's cache model.
- Follows rv's documented behavior: https://a2-ai.github.io/rv-docs/concepts/cache/ and /reference/env_vars/ .

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
