### PR TITLE
docs(native): document bindgen --wrap-static-fns C++-mode limitation (#127)

### DIFF
--- a/docs/NATIVE_R_PACKAGES.md
+++ b/docs/NATIVE_R_PACKAGES.md
@@ -328,6 +328,21 @@ int cli_progress_num__extern(void) {
 The Rust FFI then links against `cli_progress_num__extern` instead of
 `cli_progress_num`.
 
+### Known limitation: `--wrap-static-fns` is silently ignored in C++ mode
+
+`--wrap-static-fns` only emits the shim file when bindgen parses headers in **C
+mode** (`-x c`). In **C++ mode** (`-x c++`, which the corpus probe uses for the
+52% that parse) the flag is **silently ignored** — no `*_static_wrappers.c` is
+generated, so any `static` / `static inline` `R_GetCCallable` accessors declared
+in a C++ header get no shim and fail to link. This is an upstream bindgen
+limitation ([rust-lang/rust-bindgen](https://github.com/rust-lang/rust-bindgen)).
+
+`use_native_package()` sidesteps this by classifying pure-C packages and parsing
+them in C mode, which preserves shim generation. The remaining gap is only C++
+packages that *also* expose `static inline` `R_GetCCallable` functions (rare).
+For those, write the C shim by hand, or invoke bindgen a second time in C mode
+for just those functions.
+
 ## Runtime resolution
 
 At runtime, the call chain is:

--- a/docs/NATIVE_R_PACKAGES.md
+++ b/docs/NATIVE_R_PACKAGES.md
@@ -331,11 +331,12 @@ The Rust FFI then links against `cli_progress_num__extern` instead of
 ### Known limitation: `--wrap-static-fns` is silently ignored in C++ mode
 
 `--wrap-static-fns` only emits the shim file when bindgen parses headers in **C
-mode** (`-x c`). In **C++ mode** (`-x c++`, which the corpus probe uses for the
-52% that parse) the flag is **silently ignored** — no `*_static_wrappers.c` is
-generated, so any `static` / `static inline` `R_GetCCallable` accessors declared
-in a C++ header get no shim and fail to link. This is an upstream bindgen
-limitation ([rust-lang/rust-bindgen](https://github.com/rust-lang/rust-bindgen)).
+mode** (`-x c`). In **C++ mode** (`-x c++` — the mode under which 52% of the
+tested CRAN corpus parses; see the corpus section below) the flag is **silently
+ignored** — no `*_static_wrappers.c` is generated, so any `static` / `static
+inline` `R_GetCCallable` accessors declared in a C++ header get no shim and fail
+to link. This is an upstream bindgen limitation
+([rust-lang/rust-bindgen#3157](https://github.com/rust-lang/rust-bindgen/issues/3157)).
 
 `use_native_package()` sidesteps this by classifying pure-C packages and parsing
 them in C mode, which preserves shim generation. The remaining gap is only C++


### PR DESCRIPTION
Documents the known bindgen limitation in `docs/NATIVE_R_PACKAGES.md`: `--wrap-static-fns` only emits the shim file in C mode and is silently ignored in C++ mode.

- Adds a "Known limitation" subsection right after the `--wrap-static-fns` explanation.
- Notes that `use_native_package()` already routes pure-C packages through C mode (preserving shim generation), so the residual gap is only C++ packages that also expose `static inline` `R_GetCCallable` accessors — for which a hand-written shim or a separate C-mode bindgen pass is the workaround.
- Upstream: rust-lang/rust-bindgen.

Docs-only; no code change. Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)