### PR TITLE
fix(bench): repair broken R-side benchmark suite + fast-knob vaporware audit

### DIFF
--- a/reviews/2026-07-08-fast-knob-vaporware-and-stacked-pr-collateral.md
+++ b/reviews/2026-07-08-fast-knob-vaporware-and-stacked-pr-collateral.md
@@ -23,6 +23,21 @@ since the second abandonment three weeks ago. The code for attempt #2 is not
 lost — it is sitting on `origin/feat/g6-fast-default-666`, 86 commits behind
 `main`.
 
+## Update (2026-07-09): attempt #3 is now in flight as #1210
+
+Since this investigation, the feature has a **third** landing: PR #1210
+(`feat(macros): fast knob codegen base + fast-default cargo feature (#666)`,
+opened 2026-07-08) does exactly the first "Fix" option below — it rebases the
+`00c8ee01` / `3985865b` commits onto `main` standalone, off the declined
+`error_direct` stack. An independent review traced it end to end and judged it
+real and sound: `fast-default` reachably flips `no_preconditions` /
+`no_call_attribution` through `MethodContext::with_fast_flags` across all six
+class systems, with differential R fixtures for both knob positions. So the
+"silently blocked / shipped zero times" framing below is the **pre-#1210**
+state, not a standing TODO — the re-land is in review (still open, not yet
+merged). The loose end #1210 does not itself close is issue #669, still closed
+against its own recommendation.
+
 ## Timeline
 
 1. **2026-05-20** — `Mossa` (the maintainer) writes `e3279011` (fn/impl-level
@@ -122,7 +137,8 @@ clean cherry-pick.
 ## Fix
 
 Not applied in this pass — this review documents the investigation only.
-Options for whoever picks this up (flat, no priority implied):
+**The first option below is now in flight as #1210** (see the 2026-07-09 update
+above). Remaining options, flat, no priority implied:
 
 - Rebase `00c8ee01`/`3985865b` onto `main` standalone (drop the `error_direct`
   dependency entirely), reopen #666/#1017 against it, close #669 for real

--- a/reviews/2026-07-08-fast-knob-vaporware-and-stacked-pr-collateral.md
+++ b/reviews/2026-07-08-fast-knob-vaporware-and-stacked-pr-collateral.md
@@ -1,0 +1,148 @@
+# The `fast`/`no_preconditions`/`no_call_attribution` knobs — two abandoned
+# landings, an issue closed against its own recommendation, and stale docs
+# that still describe them as shipped
+
+**Date:** 2026-07-08
+**Area:** `miniextendr-macros` fn/impl attribute parsing, issue tracker hygiene,
+`analysis/scaffolding-*` evidence chain
+**Trigger:** benchmark-audit investigation (asked to go deeper on the finding
+that `analysis/scaffolding-fast-bench.R` references nonexistent functions)
+
+## TL;DR
+
+The `fast` knob (`no_preconditions` / `no_call_attribution` / `fast` /
+`no_fast` on `#[miniextendr]` fns and impl blocks) has been implemented
+**twice** and is on `main` **neither** time. It is not dead because the idea
+is bad — the measured wins (7.78x/8.54x/2.19x/3.36x) were never disputed. It
+died both times as **collateral damage of branch-stacking**: both attempts
+were stacked underneath a *different*, separately-controversial feature
+(`error_direct`), and closing the base closed the child with it. The
+`analysis/scaffolding-*` docs and `bench-class-dispatch.R`'s scaffolding
+predecessor still read as if the feature shipped; nobody has corrected them
+since the second abandonment three weeks ago. The code for attempt #2 is not
+lost — it is sitting on `origin/feat/g6-fast-default-666`, 86 commits behind
+`main`.
+
+## Timeline
+
+1. **2026-05-20** — `Mossa` (the maintainer) writes `e3279011` (fn/impl-level
+   `fast` knob codegen) + `ea4d22b4` (M2/M4 attribution benches) directly on
+   top of main-at-the-time. **Never opened as a PR** (or opened and not
+   merged) — both commits are dangling objects today, unreachable from any
+   ref (`git branch -a --contains e3279011` → empty), only recoverable via
+   their raw SHAs because they're still in the local object DB.
+2. **2026-06-09** — An automated Claude Code triage loop picks up issue #669
+   ("docs: surface the fast/no_preconditions/no_call_attribution knobs"),
+   discovers the feature doesn't exist on `main` (`FN_BOOL_FLAGS_HELP` has no
+   such flags; `e3279011`/`ea4d22b4` are dangling), writes
+   `reviews/2026-06-09-fast-knobs-never-merged.md` (PR #947), and comments on
+   #669 with the finding — **explicitly recommending the issue stay open** as
+   the blocked tracking item ("Suggest keeping this issue open... blocked on
+   the feature landing"). `Mossa` closes #669 as **COMPLETED** the same day,
+   34 minutes after the comment posts — the opposite of what the comment
+   recommended.
+3. **2026-06-11** — #663 (`infallible` knob), #664 (`borrow_args` knob), #668
+   (S7-dispatch perf research) all close as COMPLETED. Not re-audited in this
+   pass; worth a spot-check if picking this back up.
+4. **2026-06-13** — PR #1019 merges (`e74ec527`): re-lands *only* the 16
+   `analysis/scaffolding-*` docs/scripts and two inert divan benches
+   (`c_side_attribution.rs`, `error_path_attribution.rs`) from the
+   `e3279011`/`ea4d22b4` chain, explicitly scoped "No codegen, no regen, no
+   fixtures." Its own description says the real feature would land via a
+   stacked pair: **#950 (G6-PR1, `error_direct`, #665) → #1018 (G6-PR2, the
+   fast-knob base + `fast-default` cargo feature, #666)** — i.e. the docs
+   PR merged *before*, and independently of, the code PRs it describes.
+5. **2026-07-01** — `Mossa` reviews #950 (`error_direct`) and comments:
+   *"I don't think this is a good idea actually. It would need a bunch of
+   analysis and audits to ensure that this strategy is as good as the
+   current condition-object signals."* — a legitimate correctness concern
+   about `error_direct`'s C-side-direct-raise approach vs. the existing
+   tagged-condition path, **not** a comment about the fast knob. `Mossa`
+   closes both #950 and #1018 within 14 seconds of each other. #1018 was
+   stacked on #950's branch (`perf/error-direct-knob-665`), so closing the
+   base took the fast-knob PR down with it even though nobody raised an
+   objection to the fast-knob content itself.
+6. **2026-07-08 (today)** — `analysis/scaffolding-perf-roadmap.md` and
+   `analysis/scaffolding-fast-bench.R` (both still on `main` from step 4)
+   still read as if the feature is live: the roadmap's "quick start" tells
+   the next session to run `Rscript -e 'library(miniextendr);
+   fast_i32_fast(42L)'`, which errors. Issue #669 remains closed. Issues
+   #666 (`default-fast` cargo feature), #667 (should `internal` imply
+   `fast`?), #670 (typed-error transport), #1017 (per-method fast override)
+   remain open, all silently blocked on a base that was built twice and
+   shipped zero times.
+
+## Root cause
+
+Two independent things, not one:
+
+- **Branch-stacking makes an uncontroversial feature hostage to a
+  controversial one.** #1018's actual content (four new `#[miniextendr]`
+  flags, `fast-default` cargo feature, 15 testthat cases, UI snapshots) has
+  no recorded technical objection anywhere in this investigation. It died
+  solely because its branch's parent (`perf/error-direct-knob-665`) carried
+  a feature the maintainer decided needed more analysis. Nothing forced
+  `#666` to depend on `#665` other than PR-authoring convenience ("G6 landing
+  order").
+- **Docs-first landing order inverted the safety property it was supposed to
+  have.** PR #1019 was deliberately scoped as the safe, inert tail of a
+  3-PR stack ("No codegen, no regen, no fixtures") — reasonable in isolation,
+  but it merged the evidence *before* the code, so for the three weeks
+  between #1019 merging and #950/#1018 closing (and every day since), `main`
+  has had documentation asserting a shipped feature with zero corresponding
+  code. The 2026-06-09 triage comment predicted almost exactly this failure
+  mode for the *first* abandonment and it recurred anyway for the second.
+
+Separately, **the issue-closing pattern is closing things that aren't
+resolved.** #669 was closed against its own comment's explicit
+recommendation. Given the volume of triage in this repo (84 open issues per
+the 2026-07-07 ledger), this reads like closing-as-acknowledgment rather than
+closing-as-resolved — worth watching for elsewhere.
+
+## What's actually recoverable
+
+`origin/feat/g6-fast-default-666` (PR #1018's head) still exists and is not
+force-pushed over:
+
+```
+3985865b docs(rpkg): regen fast_fixtures.Rd to match current roxygen source
+00c8ee01 feat(macros): fast knob codegen base + fast-default cargo feature (#666)
+54e17a3e fix(error_direct): handle RCondition data field; forward data on fallback   <- from the #950 stack, not this feature
+```
+
+86 commits behind `main`, 4 ahead. The bottom commit (`54e17a3e`) belongs to
+the `error_direct` stack and would need to be dropped/rebased out; the top
+two are the fast-knob feature itself. A clean re-land would mean rebasing
+just `00c8ee01` + `3985865b` onto current `main` (not onto `#950`'s branch),
+which touches `miniextendr-macros/src/{lib,miniextendr_fn,miniextendr_impl,
+r_class_formatter}.rs` and all 6 class generators — files the 2026-07
+audit wave (A1-A14) has also been touching, so expect real conflicts, not a
+clean cherry-pick.
+
+## Fix
+
+Not applied in this pass — this review documents the investigation only.
+Options for whoever picks this up (flat, no priority implied):
+
+- Rebase `00c8ee01`/`3985865b` onto `main` standalone (drop the `error_direct`
+  dependency entirely), reopen #666/#1017 against it, close #669 for real
+  once `analysis/scaffolding-fast-bench.R` is runnable again.
+- Or: correct `analysis/scaffolding-perf-roadmap.md` and
+  `analysis/scaffolding-fast-bench.R` to stop asserting the feature is live
+  (mark them historical/aspirational) and leave re-implementation for later —
+  cheaper, but leaves #666/#667/#670/#1017 blocked indefinitely.
+- Either way: reopen #669 (or file a fresh consolidating issue) — its
+  underlying problem was never resolved, closing it just hid that fact.
+
+## Lesson
+
+`[[feedback_stop_punting_questions]]`-style automated recommendations can be
+overridden by a human closing the issue anyway — a comment saying "keep this
+open" is not self-enforcing. When a PR stack's tail (docs/benches) is scoped
+as "safe to merge independently," that safety is about *review risk*, not
+about *truth* — the docs still assert facts about the unmerged base PRs, and
+if those never land, the "safe" PR is the one now shipping a falsehood.
+Stack order matters for correctness, not just for review convenience: don't
+stack an uncontroversial feature under a controversial one on the same
+branch chain if the two are severable, or the controversial one's rejection
+takes the uncontroversial one with it.

--- a/rpkg/tests/testthat/bench-altrep-visual.R
+++ b/rpkg/tests/testthat/bench-altrep-visual.R
@@ -41,7 +41,7 @@ creation_bench <- bench::press(
 print(creation_bench[, c("size", "expression", "median", "mem_alloc", "n_gc")])
 
 # Plot creation performance
-p1 <- ggplot2::autoplot(creation_bench) +
+p1 <- ggplot2::autoplot(creation_bench, type = "jitter") +
   labs(
     title = "ALTREP vs Copy: Creation Performance",
     subtitle = "ALTREP shows dramatic speedup for large vectors (10M: 2000x faster)",
@@ -82,7 +82,7 @@ partial_bench <- bench::press(
 
 print(partial_bench[, c("size", "n_access", "expression", "median", "mem_alloc")])
 
-p2 <- ggplot2::autoplot(partial_bench) +
+p2 <- ggplot2::autoplot(partial_bench, type = "jitter") +
   labs(
     title = "ALTREP vs Copy: Partial Access Pattern",
     subtitle = "Zero-copy advantage when accessing only part of the data",
@@ -122,7 +122,7 @@ iteration_bench <- bench::press(
 
 print(iteration_bench[, c("size", "expression", "median", "mem_alloc")])
 
-p3 <- ggplot2::autoplot(iteration_bench) +
+p3 <- ggplot2::autoplot(iteration_bench, type = "jitter") +
   labs(
     title = "ALTREP vs Copy: Full Iteration",
     subtitle = "sum() faster with ALTREP, mean() faster with copy (multi-pass overhead)",

--- a/rpkg/tests/testthat/bench-altrep-visual.R
+++ b/rpkg/tests/testthat/bench-altrep-visual.R
@@ -41,7 +41,7 @@ creation_bench <- bench::press(
 print(creation_bench[, c("size", "expression", "median", "mem_alloc", "n_gc")])
 
 # Plot creation performance
-p1 <- ggplot2::autoplot(creation_bench, type = "jitter") +
+p1 <- ggplot2::autoplot(creation_bench) +
   labs(
     title = "ALTREP vs Copy: Creation Performance",
     subtitle = "ALTREP shows dramatic speedup for large vectors (10M: 2000x faster)",
@@ -82,7 +82,7 @@ partial_bench <- bench::press(
 
 print(partial_bench[, c("size", "n_access", "expression", "median", "mem_alloc")])
 
-p2 <- ggplot2::autoplot(partial_bench, type = "jitter") +
+p2 <- ggplot2::autoplot(partial_bench) +
   labs(
     title = "ALTREP vs Copy: Partial Access Pattern",
     subtitle = "Zero-copy advantage when accessing only part of the data",
@@ -122,7 +122,7 @@ iteration_bench <- bench::press(
 
 print(iteration_bench[, c("size", "expression", "median", "mem_alloc")])
 
-p3 <- ggplot2::autoplot(iteration_bench, type = "jitter") +
+p3 <- ggplot2::autoplot(iteration_bench) +
   labs(
     title = "ALTREP vs Copy: Full Iteration",
     subtitle = "sum() faster with ALTREP, mean() faster with copy (multi-pass overhead)",

--- a/rpkg/tests/testthat/bench-altrep-vs-sexp.R
+++ b/rpkg/tests/testthat/bench-altrep-vs-sexp.R
@@ -13,9 +13,14 @@ ITERS <- 100L
 sizes <- c(1000L, 100000L, 1000000L)
 
 bench_one <- function(label, expr, iters = ITERS) {
+  # `expr` is a promise: referencing it directly evaluates it ONCE and caches
+  # the value, so a naive loop just re-reads the cached result instead of
+  # re-invoking the call. substitute()+eval() forces fresh evaluation each time.
+  call <- substitute(expr)
+  env <- parent.frame()
   # Warm up
-  for (i in 1:5) expr
-  elapsed <- system.time(for (i in seq_len(iters)) expr)[["elapsed"]]
+  for (i in 1:5) eval(call, env)
+  elapsed <- system.time(for (i in seq_len(iters)) eval(call, env))[["elapsed"]]
   us_per_call <- (elapsed / iters) * 1e6
   cat(sprintf("  %-50s %10.1f us/call\n", label, us_per_call))
   invisible(us_per_call)

--- a/rpkg/tests/testthat/bench-class-dispatch.R
+++ b/rpkg/tests/testthat/bench-class-dispatch.R
@@ -5,18 +5,36 @@
 # R6, S3, S4, S7, Env.
 # Uses the Counter types defined in each class system's test module.
 # Measures: constructor, getter, mutator, and static method.
+#
+# `baseline` (plain `.Call`, no class dispatch) is the pure Rust-side floor —
+# same FFI/conversion cost every row pays. Each system's get()/mutate() time
+# minus baseline isolates the R-side dispatch tax of that abstraction ($,
+# UseMethod, standardGeneric, S7_dispatch, env $) from the shared Rust cost.
+#
+# Vctrs has no entry here: it's a vector-payload protocol (S3 class + custom
+# print/format/arith methods over an atomic vector), not object+method
+# dispatch — there's no single-call getter/mutator analog to compare against
+# R6/S3/S4/S7/Env's `obj$method()` shape. See bench-vctrs-protocol.R for its
+# own (differently-shaped) perf coverage.
 
 library(miniextendr)
 
 cat("\n=== Class System Method Dispatch Benchmark ===\n\n")
 
-ITERS <- 10000L
+ITERS <- 200000L  # 10000 was too coarse: system.time() ticks quantize to
+                  # ~1 us here, drowning sub-us dispatch deltas in noise.
 
 bench_one <- function(label, expr) {
+  # `expr` is an R promise: referencing it directly evaluates it ONCE and
+  # caches the value, so a naive `for (i in seq_len(ITERS)) expr` loop just
+  # re-reads that cached value instead of re-invoking the call. Capture the
+  # unevaluated call via substitute() and eval() it fresh every iteration.
+  call <- substitute(expr)
+  env <- parent.frame()
   # Warm up
-  for (i in 1:10) expr
+  for (i in 1:10) eval(call, env)
   # Measure
-  elapsed <- system.time(for (i in seq_len(ITERS)) expr)[["elapsed"]]
+  elapsed <- system.time(for (i in seq_len(ITERS)) eval(call, env))[["elapsed"]]
   us_per_call <- (elapsed / ITERS) * 1e6
   cat(sprintf("  %-50s %8.2f us/call\n", label, us_per_call))
   invisible(us_per_call)
@@ -48,26 +66,26 @@ results$s3_add      <- bench_one("s3_add(s3, 5L)",             s3_add(s3, 5L))
 cat("\n")
 
 # ---------------------------------------------------------------------------
-# 3. S4 class (S4Counter)
+# 3. S4 class (S4Counter) — `internal` (noexport): access via `:::`.
 # ---------------------------------------------------------------------------
 cat("S4 (S4Counter) — standardGeneric() dispatch:\n")
-s4 <- S4Counter(0L)
-results$s4_new      <- bench_one("S4Counter(0L)",              S4Counter(0L))
-results$s4_value    <- bench_one("s4_value(s4)",               s4_value(s4))
-results$s4_inc      <- bench_one("s4_inc(s4)",                 s4_inc(s4))
-results$s4_add      <- bench_one("s4_add(s4, 5L)",             s4_add(s4, 5L))
-results$s4_static   <- bench_one("S4Counter_default_counter()",S4Counter_default_counter())
+s4 <- miniextendr:::S4Counter(0L)
+results$s4_new      <- bench_one("S4Counter(0L)",              miniextendr:::S4Counter(0L))
+results$s4_value    <- bench_one("s4_value(s4)",               miniextendr:::s4_value(s4))
+results$s4_inc      <- bench_one("s4_inc(s4)",                 miniextendr:::s4_inc(s4))
+results$s4_add      <- bench_one("s4_add(s4, 5L)",             miniextendr:::s4_add(s4, 5L))
+results$s4_static   <- bench_one("S4Counter_default_counter()",miniextendr:::S4Counter_default_counter())
 cat("\n")
 
 # ---------------------------------------------------------------------------
-# 4. S7 class (S7Counter)
+# 4. S7 class (S7Counter) — `internal` (noexport): access via `:::`.
 # ---------------------------------------------------------------------------
 cat("S7 (S7Counter) — S7::S7_dispatch:\n")
-s7 <- S7Counter(0L)
-results$s7_new      <- bench_one("S7Counter(0L)",              S7Counter(0L))
-results$s7_value    <- bench_one("s7_value(s7)",               s7_value(s7))
-results$s7_inc      <- bench_one("s7_inc(s7)",                 s7_inc(s7))
-results$s7_add      <- bench_one("s7_add(s7, 5L)",             s7_add(s7, 5L))
+s7 <- miniextendr:::S7Counter(0L)
+results$s7_new      <- bench_one("S7Counter(0L)",              miniextendr:::S7Counter(0L))
+results$s7_value    <- bench_one("s7_value(s7)",               miniextendr:::s7_value(s7))
+results$s7_inc      <- bench_one("s7_inc(s7)",                 miniextendr:::s7_inc(s7))
+results$s7_add      <- bench_one("s7_add(s7, 5L)",             miniextendr:::s7_add(s7, 5L))
 cat("\n")
 
 # ---------------------------------------------------------------------------
@@ -111,4 +129,28 @@ cat(sprintf("  %-12s  %8.2f  %8.2f  %8.2f  %8.2f\n", "Env",
   results$env_new, results$env_value, results$env_tradd, results$env_static))
 cat(sprintf("  %-12s  %8s  %8s  %8.2f  %8s\n", "Baseline",
   "N/A", "N/A", results$baseline, "N/A"))
+cat("\n")
+
+# ---------------------------------------------------------------------------
+# R-side dispatch tax = get()/mutate() minus the plain-.Call baseline.
+# Caveat: `add(1L, 2L)` takes 2 explicit int args where get() takes 0 and
+# mutate() takes 1 (plus the implicit self/ExternalPtr conversion for both) —
+# it's not an exact arg-shape match, so a negative get() tax doesn't mean
+# "dispatch is free," it means the dispatch mechanism costs less than the two
+# extra integer conversions baseline pays for. Read these as relative
+# dispatch-mechanism cost across systems (S7 vs R6/S3/S4/Env), not as an
+# absolute per-system tax in isolation.
+# ---------------------------------------------------------------------------
+cat("=== R-side dispatch tax (us/call, vs plain .Call baseline) ===\n\n")
+cat(sprintf("  %-12s  %8s  %8s\n", "System", "get()", "mutate()"))
+cat(sprintf("  %-12s  %8.2f  %8.2f\n", "R6",
+  results$r6_value  - results$baseline, results$r6_add   - results$baseline))
+cat(sprintf("  %-12s  %8.2f  %8.2f\n", "S3",
+  results$s3_value  - results$baseline, results$s3_add   - results$baseline))
+cat(sprintf("  %-12s  %8.2f  %8.2f\n", "S4",
+  results$s4_value  - results$baseline, results$s4_add   - results$baseline))
+cat(sprintf("  %-12s  %8.2f  %8.2f\n", "S7",
+  results$s7_value  - results$baseline, results$s7_add   - results$baseline))
+cat(sprintf("  %-12s  %8.2f  %8.2f\n", "Env",
+  results$env_value - results$baseline, results$env_tradd - results$baseline))
 cat("\n")

--- a/rpkg/tests/testthat/bench-dots.R
+++ b/rpkg/tests/testthat/bench-dots.R
@@ -12,8 +12,13 @@ cat("\n=== Dots Collection and Validation Benchmark ===\n\n")
 ITERS <- 5000L
 
 bench_one <- function(label, expr, iters = ITERS) {
-  for (i in 1:10) expr
-  elapsed <- system.time(for (i in seq_len(iters)) expr)[["elapsed"]]
+  # `expr` is a promise: referencing it directly evaluates it ONCE and caches
+  # the value, so a naive loop just re-reads the cached result instead of
+  # re-invoking the call. substitute()+eval() forces fresh evaluation each time.
+  call <- substitute(expr)
+  env <- parent.frame()
+  for (i in 1:10) eval(call, env)
+  elapsed <- system.time(for (i in seq_len(iters)) eval(call, env))[["elapsed"]]
   us_per_call <- (elapsed / iters) * 1e6
   cat(sprintf("  %-55s %8.2f us/call\n", label, us_per_call))
   invisible(us_per_call)

--- a/rpkg/tests/testthat/bench-vctrs-protocol.R
+++ b/rpkg/tests/testthat/bench-vctrs-protocol.R
@@ -21,8 +21,13 @@ cat("\n=== Vctrs Protocol Overhead Benchmark ===\n\n")
 ITERS <- 2000L
 
 bench_one <- function(label, expr, iters = ITERS) {
-  for (i in 1:5) expr
-  elapsed <- system.time(for (i in seq_len(iters)) expr)[["elapsed"]]
+  # `expr` is a promise: referencing it directly evaluates it ONCE and caches
+  # the value, so a naive loop just re-reads the cached result instead of
+  # re-invoking the call. substitute()+eval() forces fresh evaluation each time.
+  call <- substitute(expr)
+  env <- parent.frame()
+  for (i in 1:5) eval(call, env)
+  elapsed <- system.time(for (i in seq_len(iters)) eval(call, env))[["elapsed"]]
   us_per_call <- (elapsed / iters) * 1e6
   cat(sprintf("  %-50s %8.2f us/call\n", label, us_per_call))
   invisible(us_per_call)
@@ -33,13 +38,13 @@ bench_one <- function(label, expr, iters = ITERS) {
 # ---------------------------------------------------------------------------
 cat("DerivedPercent (double-based):\n")
 
-pct_small  <- DerivedPercent$new(c(0.1, 0.5, 0.9))
-pct_medium <- DerivedPercent$new(seq(0, 1, length.out = 100))
+pct_small  <- new_derived_percent(c(0.1, 0.5, 0.9))
+pct_medium <- new_derived_percent(seq(0, 1, length.out = 100))
 raw_small  <- c(0.1, 0.5, 0.9)
 raw_medium <- seq(0, 1, length.out = 100)
 
 # Construction
-bench_one("DerivedPercent$new(3 elem)",      DerivedPercent$new(c(0.1, 0.5, 0.9)))
+bench_one("new_derived_percent(3 elem)",     new_derived_percent(c(0.1, 0.5, 0.9)))
 bench_one("raw numeric(3)",                  c(0.1, 0.5, 0.9))
 
 # vec_c (concatenation)
@@ -66,11 +71,11 @@ cat("\n")
 # ---------------------------------------------------------------------------
 cat("DerivedPoint (record-based, x/y fields):\n")
 
-pt_small  <- DerivedPoint$new(c(1, 2, 3), c(4, 5, 6))
-pt_medium <- DerivedPoint$new(seq_len(100), seq_len(100) * 2)
+pt_small  <- new_derived_point(c(1, 2, 3), c(4, 5, 6))
+pt_medium <- new_derived_point(as.double(seq_len(100)), seq_len(100) * 2)
 
 # Construction
-bench_one("DerivedPoint$new(3 elem)",        DerivedPoint$new(c(1,2,3), c(4,5,6)))
+bench_one("new_derived_point(3 elem)",       new_derived_point(c(1,2,3), c(4,5,6)))
 
 # vec_c
 bench_one("vec_c(pt, pt) small",             vec_c(pt_small, pt_small))
@@ -91,11 +96,11 @@ cat("\n")
 # ---------------------------------------------------------------------------
 cat("DerivedTemp (double-based with arithmetic):\n")
 
-temp_small  <- DerivedTemp$new(c(20, 25, 30))
-temp_medium <- DerivedTemp$new(seq(0, 100, length.out = 100))
+temp_small  <- new_derived_temp(c(20, 25, 30))
+temp_medium <- new_derived_temp(seq(0, 100, length.out = 100))
 
 # Construction
-bench_one("DerivedTemp$new(3 elem)",         DerivedTemp$new(c(20, 25, 30)))
+bench_one("new_derived_temp(3 elem)",        new_derived_temp(c(20, 25, 30)))
 
 # Arithmetic (if supported)
 tryCatch({

--- a/rproject.toml
+++ b/rproject.toml
@@ -6,6 +6,7 @@ r_version = "4.6"
 # The alias is only used in this file if you want to specifically require a dependency to come from a certain repository.
 # Example: { alias = "PPM", url = "https://packagemanager.posit.co/cran/latest" },
 repositories = [
+    {alias = "stratus", url = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2026-06-18/"},
     {alias = "CRAN", url = "https://cloud.r-project.org/"},
 ]
 
@@ -37,7 +38,7 @@ dependencies = [
     "knitr",
     "rcmdcheck",
     "rmarkdown",
-    {name = "roxygen2", url = "https://cran.r-project.org/src/contrib/roxygen2_8.0.0.tar.gz"},
+    "roxygen2",
     "withr",
     "yaml",
     "jsonlite",

--- a/rproject.toml
+++ b/rproject.toml
@@ -41,4 +41,5 @@ dependencies = [
     "withr",
     "yaml",
     "jsonlite",
+    "ggbeeswarm",
 ]

--- a/rv.lock
+++ b/rv.lock
@@ -862,7 +862,7 @@ dependencies = [
 [[packages]]
 name = "roxygen2"
 version = "8.0.0"
-source = { url = "https://cran.r-project.org/src/contrib/roxygen2_8.0.0.tar.gz", sha = "75816bf3a25554f5752254b985b7242490b0fabe68a5ada335c340b820ba34e8" }
+source = { repository = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2026-06-18" }
 force_source = false
 dependencies = [
     "brew",

--- a/rv.lock
+++ b/rv.lock
@@ -48,6 +48,13 @@ force_source = false
 dependencies = []
 
 [[packages]]
+name = "beeswarm"
+version = "0.4.0"
+source = { repository = "https://cloud.r-project.org/" }
+force_source = false
+dependencies = []
+
+[[packages]]
 name = "bench"
 version = "1.1.4"
 source = { repository = "https://cloud.r-project.org/" }
@@ -334,6 +341,19 @@ dependencies = [
     { name = "rstudioapi", requirement = "(>= 0.11)" },
     "sys",
     { name = "zip", requirement = "(>= 2.1.0)" },
+]
+
+[[packages]]
+name = "ggbeeswarm"
+version = "0.7.3"
+source = { repository = "https://cloud.r-project.org/" }
+force_source = false
+dependencies = [
+    { name = "ggplot2", requirement = "(>= 3.3.0)" },
+    "beeswarm",
+    "lifecycle",
+    "vipor",
+    "cli",
 ]
 
 [[packages]]
@@ -1147,6 +1167,13 @@ dependencies = [
     { name = "lifecycle", requirement = "(>= 1.0.3)" },
     { name = "rlang", requirement = "(>= 1.1.7)" },
 ]
+
+[[packages]]
+name = "vipor"
+version = "0.4.7"
+source = { repository = "https://cloud.r-project.org/" }
+force_source = false
+dependencies = []
 
 [[packages]]
 name = "viridisLite"


### PR DESCRIPTION
## Summary

- Fixes a promise-memoization bug shared by 4 hand-rolled `bench_one()`
  helpers (`bench-class-dispatch.R`, `bench-dots.R`,
  `bench-altrep-vs-sexp.R`, `bench-vctrs-protocol.R`): referencing the
  `expr` argument directly forces the R promise once and caches the
  value, so every "iteration" after warmup just re-read the cached
  result instead of re-invoking the call. All four scripts had been
  reporting near-zero, undifferentiated timings for their entire
  history. Fixed via `substitute()`/`eval()`.
- `bench-class-dispatch.R`: fixes unqualified calls to
  `#[miniextendr(internal)]` (noexport) `S4Counter`/`S7Counter` symbols
  (needed `miniextendr:::`), adds an explicit "R-side dispatch tax"
  table (get()/mutate() minus the plain-`.Call` baseline) to surface
  the R-vs-Rust split the script already implied.
- `bench-vctrs-protocol.R`: fixes calls to a nonexistent
  `DerivedPercent$new()`-style API — the real constructors are plain
  functions (`new_derived_percent()`, etc.) — plus an int/double arg
  mismatch.
- `bench-altrep-visual.R`: `ggplot2::autoplot()`'s default beeswarm
  plot type needed the (previously uninstalled) `ggbeeswarm` package,
  which halted `just bench-r` before it ever reached the later scripts
  alphabetically. Added via `rv add` (`rproject.toml`/`rv.lock`).
- `rproject.toml`: primary repository now points at the internal
  `stratus` snapshot mirror, CRAN kept as a fallback for packages
  stratus doesn't carry (`ggbeeswarm`+deps). `roxygen2` now resolves to
  `8.0.0` directly from stratus instead of a hardcoded CRAN tarball URL.
- `reviews/2026-07-08-fast-knob-vaporware-and-stacked-pr-collateral.md`:
  investigation into why `analysis/scaffolding-fast-bench.R` referenced
  nonexistent functions — traces two abandoned landings of the
  `fast`/`no_preconditions`/`no_call_attribution` knobs and finds the
  second died as collateral from being stacked under a separately-declined
  `error_direct` PR, not from any objection to its own content. Investigation
  only, no code changes here — the actual re-land is #1210.

`just bench-r` now runs to completion (exit 0) for the first time.

## Test plan

- [x] `Rscript rpkg/tests/testthat/bench-class-dispatch.R` runs clean,
      shows real per-system numbers (S7 ~4x R6/S3/S4, matching #668)
- [x] `Rscript rpkg/tests/testthat/bench-dots.R` / `bench-vctrs-protocol.R` /
      `bench-altrep-vs-sexp.R` run clean with plausible, differentiated timings
- [x] `just bench-r` (full suite) exits 0
- [x] `just configure && just rcmdinstall && just force-document` — no
      NAMESPACE/man drift

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)