### PR TITLE
fix(justfile): guard Cargo.lock source-mode dev-drift via recipe auto-restore (#1052)

### DIFF
--- a/docs/CARGO_LOCK_SHAPE.md
+++ b/docs/CARGO_LOCK_SHAPE.md
@@ -150,6 +150,17 @@ those are now harmless — `just vendor` will put them back in sync.
 The pre-commit hook will block the `path+` drift. Re-run the canonical
 regen (`just vendor` or `just update`) before staging.
 
+**The `just` recipes now self-clean.** Every drifting maintainer recipe
+auto-chains `just cargo-lock-restore` as its final step — the Rust-side
+`check` / `build` / `clippy` / `test` and the R-side `rcmdinstall` /
+`devtools-document` / `force-document` / `devtools-test` / `devtools-install` /
+`devtools-load`. `devtools-test` restores even on a red test (via an `EXIT`
+trap), so a failing suite never leaves the papercut behind. So after any of
+these `just` recipes, `git status` shows the lock clean with no manual
+`git checkout` needed; deliberate lock updates still go through `just update` /
+`just vendor`, which re-stamp tarball-shape. Raw `R CMD INSTALL` (no `just`)
+still drifts and relies on the pre-commit hook + `lock-shape-check` (#1052).
+
 ## Recovering a drifted lock
 
 ```bash

--- a/docs/CARGO_LOCK_SHAPE.md
+++ b/docs/CARGO_LOCK_SHAPE.md
@@ -154,8 +154,9 @@ regen (`just vendor` or `just update`) before staging.
 auto-chains `just cargo-lock-restore` as its final step — the Rust-side
 `check` / `build` / `clippy` / `test` and the R-side `rcmdinstall` /
 `devtools-document` / `force-document` / `devtools-test` / `devtools-install` /
-`devtools-load`. `devtools-test` restores even on a red test (via an `EXIT`
-trap), so a failing suite never leaves the papercut behind. So after any of
+`devtools-load` / `gctorture-full` / `wrappers-sync-check`. `devtools-test`,
+`gctorture-full`, and `wrappers-sync-check` restore even on a red test /
+check (via an `EXIT` trap), so a failing suite never leaves the papercut behind. So after any of
 these `just` recipes, `git status` shows the lock clean with no manual
 `git checkout` needed; deliberate lock updates still go through `just update` /
 `just vendor`, which re-stamp tarball-shape. Raw `R CMD INSTALL` (no `just`)

--- a/justfile
+++ b/justfile
@@ -616,7 +616,9 @@ test-bootstrap-vendor:
 gctorture-full STEP="100": _assert-no-vendor-leak configure
     set -euo pipefail
     libdir="$(mktemp -d)"
-    trap 'rm -rf "$libdir"' EXIT
+    # The source-mode `R CMD INSTALL` below drifts rpkg/src/rust/Cargo.lock; restore
+    # it (and clean the temp lib) on every exit path, incl. a failed sweep. (#1052)
+    trap 'rm -rf "$libdir"; just cargo-lock-restore' EXIT
     R CMD INSTALL --library="$libdir" rpkg
     R_LIBS_USER="$libdir" Rscript scripts/gctorture-full-sweep.R rpkg/tests/testthat {{STEP}}
 
@@ -1189,6 +1191,9 @@ lint-sync-check:
 [script("bash")]
 wrappers-sync-check: _assert-no-vendor-leak configure
     set -euo pipefail
+    # The source-mode `R CMD INSTALL` below drifts rpkg/src/rust/Cargo.lock; restore
+    # it on every exit path, incl. the exit-1 diff-failure branches. (#1052)
+    trap 'just cargo-lock-restore' EXIT
 
     # Install regenerates R/miniextendr-wrappers.R + src/rust/wasm_registry.rs on disk.
     R CMD INSTALL rpkg >/dev/null

--- a/justfile
+++ b/justfile
@@ -620,22 +620,32 @@ gctorture-full STEP="100": _assert-no-vendor-leak configure
     R CMD INSTALL --library="$libdir" rpkg
     R_LIBS_USER="$libdir" Rscript scripts/gctorture-full-sweep.R rpkg/tests/testthat {{STEP}}
 
+# Deliberate lock updates go through `just update` / `just vendor` (they re-stamp
+# tarball-shape); the R-side dev recipes below only DRIFT rpkg/src/rust/Cargo.lock
+# as a source-mode build side effect, so each auto-chains `just cargo-lock-restore`
+# to self-clean (matching check/build/clippy). devtools-test restores even on a red
+# test via a trap, so a failing suite never leaves the papercut behind. (#1052)
 # Load and test rpkg with devtools
+[script("bash")]
 devtools-test FILTER="": _assert-no-vendor-leak devtools-document
-    if [ -z "{{FILTER}}" ]; then \
-      Rscript -e 'testthat::set_max_fails(Inf); devtools::test("rpkg")'; \
-    else \
-      Rscript -e 'testthat::set_max_fails(Inf); devtools::test("rpkg", filter = "{{FILTER}}")'; \
+    set -euo pipefail
+    trap 'just cargo-lock-restore' EXIT
+    if [ -z "{{FILTER}}" ]; then
+      Rscript -e 'testthat::set_max_fails(Inf); devtools::test("rpkg")'
+    else
+      Rscript -e 'testthat::set_max_fails(Inf); devtools::test("rpkg", filter = "{{FILTER}}")'
     fi
 
 # Load rpkg with devtools::load_all
 alias devtools-load_all := devtools-load
 devtools-load: _assert-no-vendor-leak devtools-document
     Rscript -e 'devtools::load_all("rpkg")'
+    @just cargo-lock-restore
 
 # Install rpkg with devtools::install
 devtools-install: _assert-no-vendor-leak devtools-document
     Rscript -e 'devtools::install("rpkg")'
+    @just cargo-lock-restore
 
 # Install R dependencies used by the repo (devtools, roxygen2, testthat, R6, S7, vctrs, etc.)
 install_deps:
@@ -707,12 +717,14 @@ devtools-check: devtools-document
 #   just rcmdinstall && just force-document
 devtools-document: configure-fast
     Rscript -e 'if (roxygen2::needs_roxygenize("rpkg")) { devtools::document("rpkg") } else { cat("devtools-document: man/ up to date — skipping (use `just force-document` to override)\n") }'
+    @just cargo-lock-restore
 
 # Force-document rpkg unconditionally — bypasses the needs_roxygenize() check.
 # Use after Rust/macro changes where the mtime cache may not have caught up:
 #   just rcmdinstall && just force-document
 force-document: configure-fast
     Rscript -e 'devtools::document("rpkg")'
+    @just cargo-lock-restore
 
 # Document ALL R packages in the workspace
 # This includes: rpkg, minirextendr, and cross-package test packages
@@ -726,6 +738,7 @@ configure-all: configure cross-configure
 alias rcmdinstall := r-cmd-install
 r-cmd-install *args: _assert-no-vendor-leak configure
     R CMD INSTALL {{args}} rpkg
+    @just cargo-lock-restore
 
 # Build R package tarball
 # Depends on `r-cmd-install` so the host wrapper-gen pass regenerates the UNTRACKED

--- a/rpkg/src/rust/Cargo.lock
+++ b/rpkg/src/rust/Cargo.lock
@@ -2047,6 +2047,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-api"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#55573680f068ea45c68dfb81cd18f7e01bcf9fd3"
 dependencies = [
  "aho-corasick",
  "arrow-array",
@@ -2097,6 +2098,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-lint"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#55573680f068ea45c68dfb81cd18f7e01bcf9fd3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2106,6 +2108,7 @@ dependencies = [
 [[package]]
 name = "miniextendr-macros"
 version = "0.1.0"
+source = "git+https://github.com/A2-ai/miniextendr#55573680f068ea45c68dfb81cd18f7e01bcf9fd3"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Extends the existing `@just cargo-lock-restore` auto-chain to the R-side dev recipes so a routine local build no longer leaves `rpkg/src/rust/Cargo.lock` dirty. A second commit re-stamps the committed lock, which had itself drifted to path-shape on `main` — see #1222 for the CI gap that let that happen (that follow-up adds the missing gate; this PR only fixes the current symptom).

Closes #1052.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Every source-mode build drops the canonical `source = "git+..."` lines from the three framework crates in `rpkg/src/rust/Cargo.lock`, so `git status` shows the lock modified after almost any local build. The Rust-side `check`/`build`/`clippy`/`test` recipes already self-clean via `@just cargo-lock-restore`; this extends the same proven auto-chain to the R-side recipes that also drift: `rcmdinstall`, `devtools-document`, `force-document`, `devtools-test`, `devtools-install`, `devtools-load`.
- `devtools-test` ends in a test step that must restore **even on a red suite**, so it uses the trap-join pattern (`[script("bash")]` + `trap 'just cargo-lock-restore' EXIT`) rather than plain last-line chaining (which `just` skips on a failing line). The rest match the existing plain last-line pattern.
- A one-line comment above the first chained R-side recipe notes that deliberate lock updates still go through `just update` / `just vendor` (which re-stamp tarball-shape); the recipe restores are for the involuntary build-side-effect drift only.
- `docs/CARGO_LOCK_SHAPE.md` "When does the lock drift?" gains a paragraph noting the `just` recipes now self-clean.
- Second commit re-stamps the committed `Cargo.lock` back to canonical tarball-shape. It had drifted to path-shape on `main` (the three framework crates were missing their `git+url` source lines) and had been that way for many commits because CI does not gate `lock-shape-check` (tracked in #1222). That is a prerequisite for this guard to be meaningful: `cargo-lock-restore` restores to the committed shape, so if the committed shape is itself drifted the guard just preserves the drift. Surgical `cargo revendor --stamp-lock` (3 source lines added, no vendoring, no version bump).

## Test plan
- [x] `just rcmdinstall` (cold compile, source mode) then `git status --porcelain rpkg/src/rust/Cargo.lock` is empty; install log shows `git restore --worktree -- rpkg/src/rust/Cargo.lock` ran as the final line.
- [x] `just devtools-test <filter>` with a deliberately failing test: suite goes red (`[ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]`), the `EXIT` trap still fires the restore, and the lock is left clean. Temporary test removed afterward.
- [x] `just lock-shape-check` green after the re-stamp.
- [x] Round-trip: hand-strip the `git+url` source lines (simulating cargo's drift) then `just cargo-lock-restore` recovers a clean, `lock-shape-check`-green lock.

## Notes
- Raw `R CMD INSTALL rpkg` (no `just`) still drifts; that path is explicitly deferred to the existing pre-commit hook + `lock-shape-check` backstop, per the issue's own fallback section. Deferral rationale posted as a closing comment on #1052 (no new issue, it is the issue's own fallback).
- The re-stamped `#<sha>` points at this branch's commit; it is cosmetic (cargo's source replacement keys on the URL, not the commit) and `just vendor` re-stamps the live HEAD at release time.
- `lock-shape-check` / `cargo-lock-restore` are not referenced in `.github/`, so this drift never turned CI red; adding that gate is tracked in #1222.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
