### PR TITLE
refactor(api): finish OwnedProtect/ProtectScope migration; make condition-value producers unsafe (#1023, #1106)

### DIFF
--- a/miniextendr-api/src/cached_class.rs
+++ b/miniextendr-api/src/cached_class.rs
@@ -228,10 +228,9 @@ pub fn set_posixct_tz(sexp: crate::SEXP, iana: &str) {
     unsafe {
         let tzone_charsxp = crate::SEXP::charsxp(iana);
         let tzone_sexp = crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, 1);
-        crate::sys::Rf_protect(tzone_sexp);
+        let _guard = crate::OwnedProtect::new(tzone_sexp);
         tzone_sexp.set_string_elt(0, tzone_charsxp);
         sexp.set_attr(tzone_symbol(), tzone_sexp);
-        crate::sys::Rf_unprotect(1);
     }
 }
 

--- a/miniextendr-api/src/convert.rs
+++ b/miniextendr-api/src/convert.rs
@@ -769,9 +769,8 @@ impl<K: AsRef<str>, V: Clone + AtomicElement> IntoR for AsNamedVector<&[(K, V)]>
         let (keys, values): (Vec<&K>, Vec<V>) = self.0.iter().map(|(k, v)| (k, v.clone())).unzip();
         let sexp = V::vec_to_sexp(values);
         unsafe {
-            crate::sys::Rf_protect(sexp);
+            let _guard = crate::OwnedProtect::new(sexp);
             crate::named_vector::set_names_on_sexp(sexp, &keys);
-            crate::sys::Rf_unprotect(1);
         }
         sexp
     }
@@ -786,9 +785,8 @@ where
     let (keys, values): (Vec<K>, Vec<V>) = pairs.into_iter().unzip();
     let sexp = V::vec_to_sexp(values);
     unsafe {
-        crate::sys::Rf_protect(sexp);
+        let _guard = crate::OwnedProtect::new(sexp);
         crate::named_vector::set_names_on_sexp(sexp, &keys);
-        crate::sys::Rf_unprotect(1);
     }
     sexp
 }

--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -56,29 +56,33 @@ pub extern "C" fn miniextendr_assert_utf8_locale() {
         "must be called from R main thread"
     );
     use crate::SexpExt;
-    use crate::sys::{R_BaseEnv, Rf_eval, Rf_install, Rf_protect, Rf_unprotect};
+    use crate::sys::{R_BaseEnv, Rf_eval, Rf_install};
 
     unsafe {
-        // Call l10n_info()
-        let call = crate::sys::Rf_lang1(Rf_install(c"l10n_info".as_ptr()));
-        Rf_protect(call);
-        let info = Rf_eval(call, R_BaseEnv);
-        Rf_protect(info);
+        // Read `l10n_info()[["UTF-8"]]` inside a scope so the temporaries
+        // (call, info) are unprotected *before* the error branch below —
+        // matching the original ordering (a longjmp out of `Rf_error` would
+        // skip the scope's Drop).
+        let is_utf8 = {
+            let scope = crate::ProtectScope::new();
+            // Call l10n_info()
+            let call = scope.protect_raw(crate::sys::Rf_lang1(Rf_install(c"l10n_info".as_ptr())));
+            let info = scope.protect_raw(Rf_eval(call, R_BaseEnv));
 
-        // Find the "UTF-8" element by name
-        let names = info.get_names();
-        let n = info.xlength();
-        let mut is_utf8 = false;
-        for i in 0..n {
-            let name_charsxp = names.string_elt(i);
-            if name_charsxp.r_char_str() == Some("UTF-8") {
-                let elt = info.vector_elt(i);
-                is_utf8 = elt.logical_elt(0) != 0;
-                break;
+            // Find the "UTF-8" element by name
+            let names = info.get_names();
+            let n = info.xlength();
+            let mut is_utf8 = false;
+            for i in 0..n {
+                let name_charsxp = names.string_elt(i);
+                if name_charsxp.r_char_str() == Some("UTF-8") {
+                    let elt = info.vector_elt(i);
+                    is_utf8 = elt.logical_elt(0) != 0;
+                    break;
+                }
             }
-        }
-
-        Rf_unprotect(2);
+            is_utf8
+        };
 
         if !is_utf8 {
             crate::sys::Rf_error_unchecked(

--- a/miniextendr-api/src/error_value.rs
+++ b/miniextendr-api/src/error_value.rs
@@ -89,8 +89,9 @@
 //! STRSXP, the kind scalar STRSXP, the optional class scalar STRSXP, the
 //! `TRUE` marker LGLSXP, and — when a `data` payload is present — the data
 //! VECSXP, its names STRSXP, and each materialised field value. Each is
-//! `Rf_protect`ed before the next allocation; `prot` counts them;
-//! `Rf_unprotect(prot)` balances at exit on every branch. Field values are
+//! added to a single [`ProtectScope`](crate::ProtectScope) before the next
+//! allocation; the scope releases them all together (`UNPROTECT`) when it
+//! drops at function exit — on every branch. Field values are
 //! materialised one at a time and rooted into the protected data list
 //! immediately (same shape as `List::from_pairs`) so an unrooted value SEXP
 //! never survives across the next allocation.
@@ -169,15 +170,19 @@ fn to_cstring_lossy(s: &str, fallback: &str) -> std::ffi::CString {
 ///
 /// # Safety
 ///
-/// See [`make_rust_condition_value_with_data`].
+/// Must be called from R's main thread in a valid R allocation context — the
+/// body performs raw R allocation (`Rf_allocVector`, `SET_VECTOR_ELT`,
+/// `SETATTRIB`) which is UB off the main thread. See
+/// [`make_rust_condition_value_with_data`] for the full contract.
 #[inline]
-pub fn make_rust_condition_value(
+pub unsafe fn make_rust_condition_value(
     message: &str,
     kind: &str,
     class: Option<&str>,
     call: Option<SEXP>,
 ) -> SEXP {
-    make_rust_condition_value_with_data(message, kind, class, call, None)
+    // SAFETY: caller upholds the main-thread + valid-allocation-context contract.
+    unsafe { make_rust_condition_value_with_data(message, kind, class, call, None) }
 }
 
 /// Build a tagged condition-value SEXP for transport across the Rust→R boundary.
@@ -189,18 +194,24 @@ pub fn make_rust_condition_value(
 ///
 /// # Safety
 ///
-/// Must be called from R's main thread (standard R API constraint).
+/// Must be called from R's main thread in a valid R allocation context
+/// (standard R API constraint): the body performs raw R allocation
+/// (`Rf_allocVector`, `SET_VECTOR_ELT`, `SETATTRIB`) which is UB off the main
+/// thread. In practice every caller reaches this through
+/// [`crate::unwind_protect::with_r_unwind_protect`] (or a proc-macro-generated
+/// panic handler), both of which run on the main thread.
 /// The returned SEXP is unprotected — caller must protect if needed.
 ///
 /// # PROTECT discipline
 ///
 /// Every fresh allocation (msg, kind, optional class, true-marker, and — when
-/// present — the `data` VECSXP, its names, and each field value) is protected
-/// before the next allocation that might trigger a GC barrier. The `prot`
-/// counter is incremented on each `Rf_protect` and balanced by
-/// `Rf_unprotect(prot)` at exit on all branches. This pattern was established
-/// by PR #344 commit `af6b4875` to fix a `recursive gc invocation` segfault on
-/// R-devel.
+/// present — the `data` VECSXP, its names, and each field value) is added to a
+/// single [`ProtectScope`](crate::ProtectScope) before the next allocation
+/// that might trigger a GC barrier. The scope releases them all together
+/// (`UNPROTECT`) when it drops at function exit, on every branch — the RAII
+/// equivalent of the former hand-counted `prot` / `Rf_unprotect(prot)` ladder.
+/// This discipline was established by PR #344 commit `af6b4875` to fix a
+/// `recursive gc invocation` segfault on R-devel.
 ///
 /// # Arguments
 ///
@@ -212,7 +223,7 @@ pub fn make_rust_condition_value(
 ///   ...` form). When `Some`, each `(name, value)` becomes a named element of a
 ///   list stored in slot `[4]`; the R helper splices these into the condition
 ///   object so handlers can read `e$<name>`. When `None`, slot `[4]` is `NULL`.
-pub fn make_rust_condition_value_with_data(
+pub unsafe fn make_rust_condition_value_with_data(
     message: &str,
     kind: &str,
     class: Option<&str>,
@@ -225,24 +236,21 @@ pub fn make_rust_condition_value_with_data(
         // trigger old-to-new GC barriers; R-devel's GC fires more aggressively
         // here than R-release/oldrel, so unprotected intermediates corrupt the
         // heap on R-devel even when R 4.5/4.4 happen to survive (PR #344 fix).
-        let list = sys::Rf_allocVector(SEXPTYPE::VECSXP, 5);
-        sys::Rf_protect(list);
-        let mut prot = 1;
+        // A single ProtectScope roots every intermediate; it releases them all
+        // when it drops at function exit.
+        let scope = crate::ProtectScope::new();
+        let list = scope.protect_raw(sys::Rf_allocVector(SEXPTYPE::VECSXP, 5));
 
         // Element 0: error message
         let msg_cstr = to_cstring_lossy(message, "<invalid error message>");
         let msg_charsxp = sys::Rf_mkCharCE(msg_cstr.as_ptr(), CE_UTF8);
-        let msg_sexp = SEXP::scalar_string(msg_charsxp);
-        sys::Rf_protect(msg_sexp);
-        prot += 1;
+        let msg_sexp = scope.protect_raw(SEXP::scalar_string(msg_charsxp));
         list.set_vector_elt(0, msg_sexp);
 
         // Element 1: kind string
         let kind_cstr = to_cstring_lossy(kind, kind::OTHER_RUST_ERROR);
         let kind_charsxp = sys::Rf_mkCharCE(kind_cstr.as_ptr(), CE_UTF8);
-        let kind_sexp = SEXP::scalar_string(kind_charsxp);
-        sys::Rf_protect(kind_sexp);
-        prot += 1;
+        let kind_sexp = scope.protect_raw(SEXP::scalar_string(kind_charsxp));
         list.set_vector_elt(1, kind_sexp);
 
         // Element 2: optional custom class (NULL when not provided).
@@ -250,10 +258,7 @@ pub fn make_rust_condition_value_with_data(
         let class_sexp = if let Some(class_name) = class {
             let class_cstr = to_cstring_lossy(class_name, "rust_condition");
             let class_charsxp = sys::Rf_mkCharCE(class_cstr.as_ptr(), CE_UTF8);
-            let s = SEXP::scalar_string(class_charsxp);
-            sys::Rf_protect(s);
-            prot += 1;
-            s
+            scope.protect_raw(SEXP::scalar_string(class_charsxp))
         } else {
             SEXP::nil()
         };
@@ -278,12 +283,8 @@ pub fn make_rust_condition_value_with_data(
                 .len()
                 .try_into()
                 .expect("condition data length exceeds isize::MAX");
-            let data_list = sys::Rf_allocVector(SEXPTYPE::VECSXP, n);
-            sys::Rf_protect(data_list);
-            prot += 1;
-            let data_names = sys::Rf_allocVector(SEXPTYPE::STRSXP, n);
-            sys::Rf_protect(data_names);
-            prot += 1;
+            let data_list = scope.protect_raw(sys::Rf_allocVector(SEXPTYPE::VECSXP, n));
+            let data_names = scope.protect_raw(sys::Rf_allocVector(SEXPTYPE::STRSXP, n));
             for (i, (name, value)) in fields.into_iter().enumerate() {
                 let idx: isize = i.try_into().expect("index exceeds isize::MAX");
                 // Materialise the value and immediately root it in data_list
@@ -305,12 +306,9 @@ pub fn make_rust_condition_value_with_data(
         // fresh LGLSXP — protect across the SETATTRIB call.
         list.set_names(condition_names_sexp());
         list.set_class(rust_condition_class_sexp());
-        let true_marker = SEXP::scalar_logical(true);
-        sys::Rf_protect(true_marker);
-        prot += 1;
+        let true_marker = scope.protect_raw(SEXP::scalar_logical(true));
         list.set_attr(rust_condition_attr_symbol(), true_marker);
 
-        sys::Rf_unprotect(prot);
         list
     }
 }

--- a/miniextendr-api/src/externalptr.rs
+++ b/miniextendr-api/src/externalptr.rs
@@ -695,6 +695,10 @@ impl<T: TypedExternal> ExternalPtr<T> {
         let type_sym = unsafe { type_symbol::<T>() };
         let type_id_sym = unsafe { type_id_symbol::<T>() };
 
+        // keep raw: this protect/unprotect straddles the ProtectPool handoff
+        // (`root_owned` below), a two-stage rooting boundary that outlives this
+        // function via the pool key — not a lexical RAII scope. `OwnedProtect` /
+        // `ProtectScope` would misrepresent the ownership transfer.
         let prot = unsafe { Rf_allocVector(SEXPTYPE::VECSXP, PROT_VEC_LEN) };
         unsafe { Rf_protect(prot) };
         prot.set_vector_elt(PROT_TYPE_ID_INDEX, type_id_sym);

--- a/miniextendr-api/src/into_r/collections.rs
+++ b/miniextendr-api/src/into_r/collections.rs
@@ -57,12 +57,11 @@ fn map_to_named_list<V: IntoR>(iter: impl ExactSizeIterator<Item = (String, V)>)
             .len()
             .try_into()
             .expect("map length exceeds isize::MAX");
-        let list = crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n);
-        crate::sys::Rf_protect(list);
+        let scope = crate::ProtectScope::new();
+        let list = scope.protect_raw(crate::sys::Rf_allocVector(crate::SEXPTYPE::VECSXP, n));
 
         // Allocate names vector
-        let names = crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n);
-        crate::sys::Rf_protect(names);
+        let names = scope.protect_raw(crate::sys::Rf_allocVector(crate::SEXPTYPE::STRSXP, n));
 
         for (i, (key, value)) in iter.enumerate() {
             let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
@@ -77,7 +76,6 @@ fn map_to_named_list<V: IntoR>(iter: impl ExactSizeIterator<Item = (String, V)>)
         // Attach names attribute
         list.set_names(names);
 
-        crate::sys::Rf_unprotect(2);
         list
     }
 }
@@ -91,11 +89,16 @@ unsafe fn map_to_named_list_unchecked<V: IntoR>(
             .len()
             .try_into()
             .expect("map length exceeds isize::MAX");
-        let list = crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::VECSXP, n);
-        crate::sys::Rf_protect(list);
+        let scope = crate::ProtectScope::new();
+        let list = scope.protect_raw(crate::sys::Rf_allocVector_unchecked(
+            crate::SEXPTYPE::VECSXP,
+            n,
+        ));
 
-        let names = crate::sys::Rf_allocVector_unchecked(crate::SEXPTYPE::STRSXP, n);
-        crate::sys::Rf_protect(names);
+        let names = scope.protect_raw(crate::sys::Rf_allocVector_unchecked(
+            crate::SEXPTYPE::STRSXP,
+            n,
+        ));
 
         for (i, (key, value)) in iter.enumerate() {
             let idx: crate::R_xlen_t = i.try_into().expect("index exceeds isize::MAX");
@@ -107,7 +110,6 @@ unsafe fn map_to_named_list_unchecked<V: IntoR>(
 
         list.set_attr_unchecked(crate::SEXP::names_symbol(), names);
 
-        crate::sys::Rf_unprotect(2);
         list
     }
 }

--- a/miniextendr-api/src/optionals/datetime_realsxp.rs
+++ b/miniextendr-api/src/optionals/datetime_realsxp.rs
@@ -202,10 +202,9 @@ macro_rules! impl_realsxp_datetime {
         $crate::into_r::into_r_infallible!($ty, |this| {
             unsafe {
                 let vec = $crate::sys::Rf_allocVector($crate::SEXPTYPE::REALSXP, 1);
-                $crate::sys::Rf_protect(vec);
+                let _guard = $crate::OwnedProtect::new(vec);
                 vec.set_real_elt(0, ($encode)(this));
                 ($set_class)(vec);
-                $crate::sys::Rf_unprotect(1);
                 vec
             }
         });
@@ -217,13 +216,12 @@ macro_rules! impl_realsxp_datetime {
         $crate::into_r::into_r_infallible!(Option<$ty>, |this| {
             unsafe {
                 let vec = $crate::sys::Rf_allocVector($crate::SEXPTYPE::REALSXP, 1);
-                $crate::sys::Rf_protect(vec);
+                let _guard = $crate::OwnedProtect::new(vec);
                 match this {
                     Some(t) => vec.set_real_elt(0, ($encode)(t)),
                     None => vec.set_real_elt(0, f64::NAN),
                 }
                 ($set_class)(vec);
-                $crate::sys::Rf_unprotect(1);
                 vec
             }
         });
@@ -235,12 +233,11 @@ macro_rules! impl_realsxp_datetime {
         $crate::into_r::into_r_infallible!(Vec<$ty>, |this| {
             unsafe {
                 let (vec, dst) = $crate::into_r::alloc_r_vector::<f64>(this.len());
-                $crate::sys::Rf_protect(vec);
+                let _guard = $crate::OwnedProtect::new(vec);
                 for (slot, t) in dst.iter_mut().zip(this) {
                     *slot = ($encode)(t);
                 }
                 ($set_class)(vec);
-                $crate::sys::Rf_unprotect(1);
                 vec
             }
         });
@@ -252,7 +249,7 @@ macro_rules! impl_realsxp_datetime {
         $crate::into_r::into_r_infallible!(Vec<Option<$ty>>, |this| {
             unsafe {
                 let (vec, dst) = $crate::into_r::alloc_r_vector::<f64>(this.len());
-                $crate::sys::Rf_protect(vec);
+                let _guard = $crate::OwnedProtect::new(vec);
                 for (slot, opt) in dst.iter_mut().zip(this) {
                     *slot = match opt {
                         Some(t) => ($encode)(t),
@@ -260,7 +257,6 @@ macro_rules! impl_realsxp_datetime {
                     };
                 }
                 ($set_class)(vec);
-                $crate::sys::Rf_unprotect(1);
                 vec
             }
         });

--- a/miniextendr-api/src/optionals/jiff_impl.rs
+++ b/miniextendr-api/src/optionals/jiff_impl.rs
@@ -47,7 +47,7 @@ use super::datetime_realsxp::impl_realsxp_datetime;
 use crate::cached_class::{date_class_sexp, set_posixct_tz, set_posixct_utc};
 use crate::from_r::{SexpError, SexpNaError, SexpTypeError, TryFromSexp, charsxp_to_string_lossy};
 use crate::into_r::IntoR;
-use crate::sys::{Rf_allocVector, Rf_protect, Rf_unprotect};
+use crate::sys::Rf_allocVector;
 use crate::{SEXP, SEXPTYPE, SexpExt};
 
 /// Unix epoch as a civil::Date constant.
@@ -186,7 +186,7 @@ impl IntoR for Zoned {
     fn into_sexp(self) -> SEXP {
         unsafe {
             let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
-            Rf_protect(vec);
+            let _guard = crate::OwnedProtect::new(vec);
             let ts = self.timestamp();
             vec.set_real_elt(
                 0,
@@ -194,7 +194,6 @@ impl IntoR for Zoned {
             );
             let iana = self.time_zone().iana_name().unwrap_or("UTC");
             set_posixct_tz(vec, iana);
-            Rf_unprotect(1);
             vec
         }
     }
@@ -246,10 +245,9 @@ impl IntoR for Option<Zoned> {
             Some(z) => z.into_sexp(),
             None => unsafe {
                 let vec = Rf_allocVector(SEXPTYPE::REALSXP, 1);
-                Rf_protect(vec);
+                let _guard = crate::OwnedProtect::new(vec);
                 vec.set_real_elt(0, f64::NAN);
                 set_posixct_utc(vec);
-                Rf_unprotect(1);
                 vec
             },
         }
@@ -348,14 +346,13 @@ impl IntoR for Vec<Zoned> {
             }
 
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
-            Rf_protect(vec);
+            let _guard = crate::OwnedProtect::new(vec);
             for (slot, z) in dst.iter_mut().zip(self) {
                 let ts = z.timestamp();
                 *slot =
                     ts.as_second() as f64 + (f64::from(ts.subsec_nanosecond()) / 1_000_000_000.0);
             }
             set_posixct_tz(vec, &first_iana);
-            Rf_unprotect(1);
             vec
         }
     }
@@ -431,7 +428,7 @@ impl IntoR for Vec<Option<Zoned>> {
                 .to_string();
 
             let (vec, dst) = crate::into_r::alloc_r_vector::<f64>(self.len());
-            Rf_protect(vec);
+            let _guard = crate::OwnedProtect::new(vec);
             for (slot, opt) in dst.iter_mut().zip(self) {
                 *slot = match opt {
                     Some(z) => {
@@ -443,7 +440,6 @@ impl IntoR for Vec<Option<Zoned>> {
                 };
             }
             set_posixct_tz(vec, &first_iana);
-            Rf_unprotect(1);
             vec
         }
     }
@@ -459,19 +455,21 @@ fn set_difftime_secs_class(sexp: SEXP) {
     unsafe {
         use crate::SexpExt as _;
         // Build class = "difftime"
-        let class_sexp = Rf_allocVector(SEXPTYPE::STRSXP, 1);
-        Rf_protect(class_sexp);
-        class_sexp.set_string_elt(0, SEXP::charsxp("difftime"));
-        sexp.set_class(class_sexp);
-        Rf_unprotect(1);
+        {
+            let class_sexp = Rf_allocVector(SEXPTYPE::STRSXP, 1);
+            let _guard = crate::OwnedProtect::new(class_sexp);
+            class_sexp.set_string_elt(0, SEXP::charsxp("difftime"));
+            sexp.set_class(class_sexp);
+        }
 
         // Set units = "secs"
-        let units_sym = SEXP::symbol("units");
-        let units_sexp = Rf_allocVector(SEXPTYPE::STRSXP, 1);
-        Rf_protect(units_sexp);
-        units_sexp.set_string_elt(0, SEXP::charsxp("secs"));
-        sexp.set_attr(units_sym, units_sexp);
-        Rf_unprotect(1);
+        {
+            let units_sym = SEXP::symbol("units");
+            let units_sexp = Rf_allocVector(SEXPTYPE::STRSXP, 1);
+            let _guard = crate::OwnedProtect::new(units_sexp);
+            units_sexp.set_string_elt(0, SEXP::charsxp("secs"));
+            sexp.set_attr(units_sym, units_sexp);
+        }
     }
 }
 
@@ -977,9 +975,8 @@ impl JiffZonedVec {
         let tzone = self.tzone.clone();
         let altrep = self.into_sexp_altrep();
         unsafe {
-            crate::sys::Rf_protect(altrep);
+            let _guard = crate::OwnedProtect::new(altrep);
             set_posixct_tz(altrep, &tzone);
-            crate::sys::Rf_unprotect(1);
         }
         altrep
     }

--- a/miniextendr-api/src/r_memory.rs
+++ b/miniextendr-api/src/r_memory.rs
@@ -105,6 +105,9 @@ pub fn sexprec_data_offset() -> usize {
 /// Must be called on R's main thread with R initialized.
 pub unsafe fn init_sexprec_data_offset() {
     unsafe {
+        // keep raw: bootstrap init probe. Runs before the crate's protect
+        // infrastructure is guaranteed set up; a one-shot balanced protect of a
+        // throwaway REALSXP is the clearest expression here.
         let test = sys::Rf_protect(sys::Rf_allocVector(SEXPTYPE::REALSXP, 1));
         let sexp_addr = test.0 as usize;
         let data_addr = sys::DATAPTR_RO(test) as usize;

--- a/miniextendr-api/src/rarray.rs
+++ b/miniextendr-api/src/rarray.rs
@@ -861,7 +861,7 @@ unsafe fn get_dims<const NDIM: usize>(sexp: SEXP) -> [usize; NDIM] {
 unsafe fn set_dims<const NDIM: usize>(sexp: SEXP, dims: &[usize; NDIM]) {
     unsafe {
         let (dim_sexp, dim_slice) = crate::into_r::alloc_r_vector::<i32>(NDIM);
-        sys::Rf_protect(dim_sexp);
+        let _guard = crate::OwnedProtect::new(dim_sexp);
 
         for (slot, &d) in dim_slice.iter_mut().zip(dims.iter()) {
             *slot = i32::try_from(d).unwrap_or_else(|_| {
@@ -870,7 +870,6 @@ unsafe fn set_dims<const NDIM: usize>(sexp: SEXP, dims: &[usize; NDIM]) {
         }
 
         sexp.set_dim(dim_sexp);
-        sys::Rf_unprotect(1);
     }
 }
 // endregion

--- a/miniextendr-api/src/unwind_protect.rs
+++ b/miniextendr-api/src/unwind_protect.rs
@@ -515,25 +515,31 @@ where
                         data,
                     } => (kind::CONDITION, message, class, data),
                 };
-                return crate::error_value::make_rust_condition_value_with_data(
-                    &message,
-                    kind,
-                    class.as_deref(),
-                    None,
-                    data,
-                );
+                // SAFETY: on the R main thread inside R_UnwindProtect.
+                return unsafe {
+                    crate::error_value::make_rust_condition_value_with_data(
+                        &message,
+                        kind,
+                        class.as_deref(),
+                        None,
+                        data,
+                    )
+                };
             }
             // endregion
 
             // Generic panic path
             let msg = panic_payload_to_string(payload.as_ref());
             crate::panic_telemetry::fire(&msg, crate::panic_telemetry::PanicSource::UnwindProtect);
-            crate::error_value::make_rust_condition_value(
-                &msg,
-                crate::error_value::kind::PANIC,
-                None,
-                None,
-            )
+            // SAFETY: on the R main thread inside R_UnwindProtect.
+            unsafe {
+                crate::error_value::make_rust_condition_value(
+                    &msg,
+                    crate::error_value::kind::PANIC,
+                    None,
+                    None,
+                )
+            }
         }
     }
 }
@@ -591,25 +597,31 @@ where
                     } => (kind::CONDITION, message, class, data),
                 };
                 // No panic telemetry for user-raised conditions — they are intentional.
-                return crate::error_value::make_rust_condition_value_with_data(
-                    &message,
-                    kind,
-                    class.as_deref(),
-                    call,
-                    data,
-                );
+                // SAFETY: on the R main thread inside R_UnwindProtect.
+                return unsafe {
+                    crate::error_value::make_rust_condition_value_with_data(
+                        &message,
+                        kind,
+                        class.as_deref(),
+                        call,
+                        data,
+                    )
+                };
             }
             // endregion
 
             // Generic panic path — unchanged
             let msg = panic_payload_to_string(payload.as_ref());
             crate::panic_telemetry::fire(&msg, crate::panic_telemetry::PanicSource::UnwindProtect);
-            crate::error_value::make_rust_condition_value(
-                &msg,
-                crate::error_value::kind::PANIC,
-                None,
-                call,
-            )
+            // SAFETY: on the R main thread inside R_UnwindProtect.
+            unsafe {
+                crate::error_value::make_rust_condition_value(
+                    &msg,
+                    crate::error_value::kind::PANIC,
+                    None,
+                    call,
+                )
+            }
         }
     }
 }

--- a/miniextendr-bench/benches/error_path_attribution.rs
+++ b/miniextendr-bench/benches/error_path_attribution.rs
@@ -30,19 +30,22 @@ fn main() {
 
 #[divan::bench]
 fn l1_make_condition_simple() -> SEXP {
-    let s = make_rust_condition_value("oops", kind::ERROR, None, None);
+    // SAFETY: the bench harness runs single-threaded on the R main thread.
+    let s = unsafe { make_rust_condition_value("oops", kind::ERROR, None, None) };
     divan::black_box(s)
 }
 
 #[divan::bench]
 fn l1_make_condition_with_class() -> SEXP {
-    let s = make_rust_condition_value("oops", kind::ERROR, Some("my_class"), None);
+    // SAFETY: the bench harness runs single-threaded on the R main thread.
+    let s = unsafe { make_rust_condition_value("oops", kind::ERROR, Some("my_class"), None) };
     divan::black_box(s)
 }
 
 #[divan::bench]
 fn l1_make_condition_warning() -> SEXP {
-    let s = make_rust_condition_value("hmm", kind::WARNING, None, None);
+    // SAFETY: the bench harness runs single-threaded on the R main thread.
+    let s = unsafe { make_rust_condition_value("hmm", kind::WARNING, None, None) };
     divan::black_box(s)
 }
 

--- a/miniextendr-macros/src/c_wrapper_builder.rs
+++ b/miniextendr-macros/src/c_wrapper_builder.rs
@@ -418,12 +418,12 @@ impl CWrapperContext {
             // RNG variant: wrap in catch_unwind so we can call PutRNGstate before error handling.
             // The wrapper always returns a tagged condition SEXP on panic; the R-side wrapper raises.
             let rng_panic_handler = quote! {
-                ::miniextendr_api::error_value::make_rust_condition_value(
+                unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &::miniextendr_api::unwind_protect::panic_payload_to_string(&*payload),
                     ::miniextendr_api::error_value::kind::PANIC,
                     ::core::option::Option::None,
                     Some(__miniextendr_call),
-                )
+                ) }
             };
             quote! {
                 #[doc = #doc]
@@ -531,12 +531,12 @@ impl CWrapperContext {
 
         // Panic error handling: return tagged error value (the only mode).
         let panic_error_handling = quote! {
-            ::miniextendr_api::error_value::make_rust_condition_value(
+            unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                 &::miniextendr_api::unwind_protect::panic_payload_to_string(&*payload),
                 ::miniextendr_api::error_value::kind::PANIC,
                 ::core::option::Option::None,
                 Some(__miniextendr_call),
-            )
+            ) }
         };
 
         // run_on_worker returns Result; Err → tagged error value.
@@ -562,9 +562,9 @@ impl CWrapperContext {
                             #return_conversion
                         }
                         Err(__panic_msg) => {
-                            ::miniextendr_api::error_value::make_rust_condition_value(
+                            unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                 &__panic_msg, ::miniextendr_api::error_value::kind::PANIC, ::core::option::Option::None, Some(__miniextendr_call),
-                            )
+                            ) }
                         }
                     }
                 }));
@@ -631,9 +631,9 @@ impl CWrapperContext {
                 quote! {
                     let __result = #call_expr;
                     if __result.is_none() {
-                        return ::miniextendr_api::error_value::make_rust_condition_value(
+                        return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        );
+                        ) };
                     }
                     ::miniextendr_api::SEXP::nil()
                 }
@@ -644,9 +644,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     match __result {
                         Some(v) => v,
-                        None => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 }
             }
@@ -672,9 +672,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     let #result_ident = match __result {
                         Some(v) => v,
-                        None => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     };
                     #conversion
                 }
@@ -687,9 +687,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     let __result = match __result {
                         Some(v) => v,
-                        None => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     };
                     ::miniextendr_api::into_r::IntoR::into_sexp(
                         ::miniextendr_api::externalptr::ExternalPtr::new(__result)
@@ -700,9 +700,9 @@ impl CWrapperContext {
                 quote! {
                     let __result = #call_expr;
                     if let Err(e) = __result {
-                        return ::miniextendr_api::error_value::make_rust_condition_value(
+                        return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        );
+                        ) };
                     }
                     ::miniextendr_api::SEXP::nil()
                 }
@@ -712,9 +712,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     match __result {
                         Ok(v) => v,
-                        Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 }
             }
@@ -725,9 +725,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     let #result_ident = match __result {
                         Ok(v) => v,
-                        Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     };
                     #conversion
                 }
@@ -751,9 +751,9 @@ impl CWrapperContext {
                     let __result = #call_expr;
                     let __result = match __result {
                         Ok(v) => v,
-                        Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     };
                     ::miniextendr_api::into_r::IntoR::into_sexp(
                         ::miniextendr_api::externalptr::ExternalPtr::new(__result)
@@ -860,9 +860,9 @@ impl CWrapperContext {
                 let worker = quote! { #call_expr };
                 let convert = quote! {
                     if __miniextendr_result.is_none() {
-                        ::miniextendr_api::error_value::make_rust_condition_value(
+                        unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        )
+                        ) }
                     } else {
                         ::miniextendr_api::SEXP::nil()
                     }
@@ -875,9 +875,9 @@ impl CWrapperContext {
                 let convert = quote! {
                     match __miniextendr_result {
                         Some(v) => v,
-                        None => ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -912,9 +912,9 @@ impl CWrapperContext {
                 let convert = quote! {
                     match __miniextendr_result {
                         Some(#result_ident) => #unwind_fn(|| #conversion, None),
-                        None => ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -933,9 +933,9 @@ impl CWrapperContext {
                             ),
                             None,
                         ),
-                        None => ::miniextendr_api::error_value::make_rust_condition_value(
+                        None => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             #error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -945,9 +945,9 @@ impl CWrapperContext {
                 let convert = quote! {
                     match __miniextendr_result {
                         Ok(()) => ::miniextendr_api::SEXP::nil(),
-                        Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -957,9 +957,9 @@ impl CWrapperContext {
                 let convert = quote! {
                     match __miniextendr_result {
                         Ok(v) => v,
-                        Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -975,9 +975,9 @@ impl CWrapperContext {
                             || #conversion,
                             None,
                         ),
-                        Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)
@@ -1010,9 +1010,9 @@ impl CWrapperContext {
                             ),
                             None,
                         ),
-                        Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                        Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                             &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                        ),
+                        ) },
                     }
                 };
                 (worker, convert)

--- a/miniextendr-macros/src/return_type_analysis.rs
+++ b/miniextendr-macros/src/return_type_analysis.rs
@@ -171,9 +171,10 @@ fn analyze_option_type(
         quote::quote! {
             match #rust_result_ident {
                 Some(()) => ::miniextendr_api::SEXP::nil(),
-                None => ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: runs inside the wrapper's with_r_unwind_protect closure on the R main thread.
+                None => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     #option_none_error_msg, ::miniextendr_api::error_value::kind::NONE_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                ),
+                ) },
             }
         }
     } else if is_sexp_inner {
@@ -261,9 +262,10 @@ fn analyze_result_type(
         quote::quote! {
             match #rust_result_ident {
                 Ok(()) => ::miniextendr_api::SEXP::nil(),
-                Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: runs inside the wrapper's with_r_unwind_protect closure on the R main thread.
+                Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                ),
+                ) },
             }
         }
     } else if ok_is_sexp {
@@ -273,9 +275,10 @@ fn analyze_result_type(
         quote::quote! {
             match #rust_result_ident {
                 Ok(v) => v,
-                Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: runs inside the wrapper's with_r_unwind_protect closure on the R main thread.
+                Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                ),
+                ) },
             }
         }
     } else {
@@ -284,9 +287,10 @@ fn analyze_result_type(
         quote::quote! {
             match #rust_result_ident {
                 Ok(v) => ::miniextendr_api::into_r::IntoR::into_sexp(v),
-                Err(e) => ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: runs inside the wrapper's with_r_unwind_protect closure on the R main thread.
+                Err(e) => unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{:?}", e), ::miniextendr_api::error_value::kind::RESULT_ERR, ::core::option::Option::None, Some(__miniextendr_call),
-                ),
+                ) },
             }
         }
     }

--- a/miniextendr-macros/src/rust_conversion_builder.rs
+++ b/miniextendr-macros/src/rust_conversion_builder.rs
@@ -96,12 +96,13 @@ impl RustConversionBuilder {
         quote_spanned! {span=>
             let #ident: #ty = match #try_expr {
                 Ok(v) => v,
-                Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{}: {e}", #error_msg),
                     ::miniextendr_api::error_value::kind::CONVERSION,
                     ::core::option::Option::None,
                     Some(__miniextendr_call),
-                ),
+                ) },
             };
         }
     }
@@ -117,12 +118,13 @@ impl RustConversionBuilder {
         quote_spanned! {span=>
             let #ident = match #try_expr {
                 Ok(v) => v,
-                Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                     &format!("{}: {e}", #error_msg),
                     ::miniextendr_api::error_value::kind::CONVERSION,
                     ::core::option::Option::None,
                     Some(__miniextendr_call),
-                ),
+                ) },
             };
         }
     }
@@ -256,12 +258,13 @@ impl RustConversionBuilder {
                         quote_spanned! {span=>
                             let mut #storage_ident: #vec_ty = match #try_expr {
                                 Ok(v) => v,
-                                Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                                // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                                Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                     &format!("{}: {e}", #em),
                                     ::miniextendr_api::error_value::kind::CONVERSION,
                                     ::core::option::Option::None,
                                     Some(__miniextendr_call),
-                                ),
+                                ) },
                             };
                         }
                     } else {
@@ -489,21 +492,23 @@ impl RustConversionBuilder {
                             let #ident: #target = {
                                 let __r_val: #r_native = match ::miniextendr_api::TryFromSexp::try_from_sexp(#sexp_ident) {
                                     Ok(v) => v,
-                                    Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                                    // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                                    Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                         &format!("{}: {e}", #error_msg_convert),
                                         ::miniextendr_api::error_value::kind::CONVERSION,
                                         ::core::option::Option::None,
                                         Some(__miniextendr_call),
-                                    ),
+                                    ) },
                                 };
                                 match ::miniextendr_api::TryCoerce::<#target>::try_coerce(__r_val) {
                                     Ok(v) => v,
-                                    Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                                    // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                                    Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                         &format!("{}: {e}", #error_msg_coerce),
                                         ::miniextendr_api::error_value::kind::CONVERSION,
                                         ::core::option::Option::None,
                                         Some(__miniextendr_call),
-                                    ),
+                                    ) },
                                 }
                             };
                         }
@@ -525,24 +530,26 @@ impl RustConversionBuilder {
                             let #ident: Vec<#target_elem> = {
                                 let __r_slice: &[#r_native_elem] = match ::miniextendr_api::TryFromSexp::try_from_sexp(#sexp_ident) {
                                     Ok(v) => v,
-                                    Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                                    // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                                    Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                         &format!("{}: {e}", #error_msg_convert),
                                         ::miniextendr_api::error_value::kind::CONVERSION,
                                         ::core::option::Option::None,
                                         Some(__miniextendr_call),
-                                    ),
+                                    ) },
                                 };
                                 match __r_slice.iter().copied()
                                     .map(::miniextendr_api::TryCoerce::<#target_elem>::try_coerce)
                                     .collect::<Result<Vec<_>, _>>()
                                 {
                                     Ok(v) => v,
-                                    Err(e) => return ::miniextendr_api::error_value::make_rust_condition_value(
+                                    // SAFETY: emitted into the wrapper's with_r_unwind_protect closure (R main thread).
+                                    Err(e) => return unsafe { ::miniextendr_api::error_value::make_rust_condition_value(
                                         &format!("{}: {e}", #error_msg_coerce),
                                         ::miniextendr_api::error_value::kind::CONVERSION,
                                         ::core::option::Option::None,
                                         Some(__miniextendr_call),
-                                    ),
+                                    ) },
                                 }
                             };
                         }

--- a/rpkg/src/rust/gc_stress_fixtures.rs
+++ b/rpkg/src/rust/gc_stress_fixtures.rs
@@ -2484,13 +2484,16 @@ pub fn gc_stress_condition_data() {
             ),
         ];
 
-        let tagged = make_rust_condition_value_with_data(
-            "gc stress condition",
-            miniextendr_api::error_value::kind::ERROR,
-            Some("gc_stress_class"),
-            None,
-            Some(data),
-        );
+        // SAFETY: gc_stress fixtures run on the R main thread under gctorture.
+        let tagged = unsafe {
+            make_rust_condition_value_with_data(
+                "gc stress condition",
+                miniextendr_api::error_value::kind::ERROR,
+                Some("gc_stress_class"),
+                None,
+                Some(data),
+            )
+        };
         // The returned SEXP is unprotected — root it before the readback
         // (string_elt_str etc. do not allocate, but the next loop round does).
         let _guard = unsafe { miniextendr_api::gc_protect::OwnedProtect::new(tagged) };

--- a/rpkg/src/rust/jiff_adapter_tests.rs
+++ b/rpkg/src/rust/jiff_adapter_tests.rs
@@ -3,10 +3,9 @@ use miniextendr_api::cached_class::set_posixct_utc;
 use miniextendr_api::into_r::IntoR;
 use miniextendr_api::miniextendr;
 use miniextendr_api::prelude::SEXP;
-use miniextendr_api::sys::{Rf_protect, Rf_unprotect};
 use miniextendr_api::{
     AltRealData, AltrepLen, JiffDate, JiffDateTime, JiffTime, JiffTimestampVec, JiffZonedVec,
-    SignedDuration, Span, Timestamp, Zoned,
+    OwnedProtect, SignedDuration, Span, Timestamp, Zoned,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -206,9 +205,8 @@ pub fn jiff_altrep_timestamps(n: i32) -> SEXP {
     // Create the ALTREP SEXP and set POSIXct class + UTC tzone.
     let altrep = vec.into_sexp();
     unsafe {
-        Rf_protect(altrep);
+        let _guard = OwnedProtect::new(altrep);
         set_posixct_utc(altrep);
-        Rf_unprotect(1);
     }
     altrep
 }
@@ -568,9 +566,8 @@ pub fn jiff_counted_altrep(n: i32) -> SEXP {
     };
     let altrep = vec.into_sexp();
     unsafe {
-        Rf_protect(altrep);
+        let _guard = OwnedProtect::new(altrep);
         set_posixct_utc(altrep);
-        Rf_unprotect(1);
     }
     altrep
 }

--- a/rpkg/src/rust/native_sexp_altrep_fixture.rs
+++ b/rpkg/src/rust/native_sexp_altrep_fixture.rs
@@ -49,8 +49,8 @@ use std::sync::OnceLock;
 use miniextendr_api::altrep::RegisterAltrep;
 use miniextendr_api::altrep_data::{AltIntegerData, AltrepDataptr, AltrepExtract, AltrepLen};
 use miniextendr_api::into_r::IntoR;
-use miniextendr_api::sys::{DATAPTR_RO, Rf_allocVector, Rf_protect, Rf_unprotect};
-use miniextendr_api::{R_xlen_t, SEXP, SEXPTYPE, SexpExt as _};
+use miniextendr_api::sys::{DATAPTR_RO, Rf_allocVector};
+use miniextendr_api::{OwnedProtect, R_xlen_t, SEXP, SEXPTYPE, SexpExt as _};
 use miniextendr_api::{impl_inferbase_integer, miniextendr};
 
 // region: NativeSexpIntAltrep — ZST, all data in ALTREP data1
@@ -246,7 +246,7 @@ impl IntoR for NativeSexpIntAltrep {
 fn build_native_sexp_altrep(values: &[i32]) -> SEXP {
     let cls = <NativeSexpIntAltrep as RegisterAltrep>::get_or_init_class();
     let n = values.len() as R_xlen_t;
-    // SAFETY: on R's main thread; `Rf_protect` before `new_altrep` which may GC.
+    // SAFETY: on R's main thread; protect data1 before `new_altrep` which may GC.
     unsafe {
         // Allocate and fill data1 (plain INTSXP).
         let data1 = Rf_allocVector(SEXPTYPE::INTSXP, n);
@@ -255,10 +255,8 @@ fn build_native_sexp_altrep(values: &[i32]) -> SEXP {
             data1.set_integer_elt(i as isize, v);
         }
         // Protect data1 across new_altrep, which may allocate.
-        Rf_protect(data1);
-        let altrep = cls.new_altrep(data1, SEXP::nil());
-        Rf_unprotect(1);
-        altrep
+        let _guard = OwnedProtect::new(data1);
+        cls.new_altrep(data1, SEXP::nil())
     }
 }
 


### PR DESCRIPTION
Finishes the raw `Rf_protect`/`Rf_unprotect` → `OwnedProtect`/`ProtectScope` migration beyond the serde modules, so a protect/unprotect miscount is unrepresentable everywhere. The mechanical tail is one commit; `error_value.rs` (the #344-segfault function) is its own commit and also picks up #1106, making the two condition-value producers `pub unsafe fn` to reflect their main-thread contract. No behavior change: every migration preserves the exact set and lifetime of protected objects.

Closes #1023
Closes #1106

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Two commits.

**Commit 1 (#1023 mechanical tail).** Fresh Step-0 inventory confirmed the issue's 2026-06-10 list was stale (`into_r.rs`/`list.rs` already done by #1150). Migrated the remaining code sites, matching the serde/columnar.rs idiom (OwnedProtect for a single carried value, ProtectScope for temporaries):
- `convert.rs` (2 named-vector blocks), `encoding.rs` (l10n_info temporaries), `cached_class.rs` (tzone), `rarray.rs` (set_dims), `into_r/collections.rs` (both map→named-list fns incl. the `_unchecked` twin), `optionals/jiff_impl.rs` (Zoned / Vec / difftime / into_posixct_sexp), and the `impl_realsxp_datetime!` macro body (one edit fixes all datetime expansions).
- `encoding.rs` scopes the temporaries to an inner block so they unprotect before the error branch (a longjmp would otherwise skip Drop); jiff `set_difftime_secs_class` uses two inner blocks to keep the class/units protects sequential.
- Annotated the two intentional keep-raw boundaries with `// keep raw:` comments: `externalptr.rs` (ProtectPool handoff via `root_owned`) and `r_memory.rs` (bootstrap init probe).

**Commit 2 (#1023 error_value + #1106).** Kept separate because `make_rust_condition_value` is the #344-segfault, R-devel-gctorture-sensitive tagged-condition producer.
- Replaced the hand-counted `prot` / `Rf_unprotect(prot)` ladder in `make_rust_condition_value_with_data` with a single `ProtectScope` (identical coverage, RAII-released on every branch).
- #1106: both `make_rust_condition_value` and `make_rust_condition_value_with_data` are now `pub unsafe fn` with `# Safety` docs. Call sites wrapped in `unsafe { }`: `unwind_protect.rs` (4), proc-macro codegen (`return_type_analysis.rs`, `rust_conversion_builder.rs`, `c_wrapper_builder.rs`), `miniextendr-bench` (3), rpkg `gc_stress_fixtures.rs` (1). `externalptr_derive.rs` sidecar accessors already emit into generated `unsafe {}` blocks, so they were left as-is (wrapping would trip `unused_unsafe`).

## Inventory (before → after)

Step-0 grep `Rf_protect(|Rf_unprotect(` in `miniextendr-api/src`, minus infra (`gc_protect`, `protect_pool`, `refcount_protect`, `unwind_protect`, `sys.rs`):
- Before: migrate targets in `error_value.rs` (8), `convert.rs` (4), `encoding.rs` (3), `cached_class.rs` (2), `rarray.rs` (2), `into_r/collections.rs` (6), `optionals/jiff_impl.rs` (14), `optionals/datetime_realsxp.rs` (8) plus keep-raw `externalptr.rs` (3) and `r_memory.rs` (2).
- After: 0 migrate targets. Only the 2 annotated keep-raw boundaries remain.

## Test plan
- [x] `cargo fmt --all`.
- [x] All 4 CI clippy legs, `-D warnings`: clippy_default, clippy_all (`full-codegen` + integration list), clippy_all_s7 (`full-codegen-s7`), clippy_revendor. All pass.
- [x] `cargo test --workspace`: green except the 7 known `derive_dataframe_*` UI-snapshot mismatches (local-rustc vs CI-stable `.stderr` skew, unrelated).
- [x] `just check` (all manifests: main workspace + cross-package + rpkg/src/rust + revendor): compiles, validating the proc-macro-generated code with the new `unsafe {}` wraps.
- [x] `just rcmdinstall`: full rpkg build/install, exercising every touched macro file across all rpkg exports.
- [x] gctorture(TRUE), package loaded first: `gc_stress_condition_data` x8 (the migrated ladder), `gc_stress_protect_discipline` x8 (#344 STRSXP canary), `gc_stress_jiff_zoned_vec` x8 (set_posixct_tz / into_posixct_sexp), plus the real error transport `error_in_r_panic()` x40 (PANIC path through `with_r_unwind_protect` → `make_rust_condition_value`) and `test_condition_parse_int` x40 (Result::Err path). No crashes.
- [x] Full `^gc_stress_` no-arg sweep under gctorture: 73/74 ok (the 1 non-ok is `gc_stress_with_r_thread_stop`, which intentionally raises an R error; caught cleanly, no segfault).
- [x] No `NAMESPACE` / `man/` drift (pure-Rust refactor, no new exports).

## Notes
- #1106's blast radius is the ~30 proc-macro codegen call sites. They all emit into the wrapper's `with_r_unwind_protect` closure or its panic handlers, both of which run on the R main thread, so the `unsafe` precondition holds. The `c_wrapper_builder.rs` wraps were applied with a balanced-paren script (scoped to that one file) and validated by the full rpkg build.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
