### PR TITLE
feat(api): re-export the per-family ALTREP derives and data traits from the prelude

### DIFF
--- a/miniextendr-api/src/prelude.rs
+++ b/miniextendr-api/src/prelude.rs
@@ -45,6 +45,13 @@
 pub use crate::{
     // Derive macros
     Altrep,
+    AltrepComplex,
+    AltrepInteger,
+    AltrepList,
+    AltrepLogical,
+    AltrepRaw,
+    AltrepReal,
+    AltrepString,
     ExternalPtr,
     MatchArg,
     RFactor,
@@ -56,7 +63,12 @@ pub use crate::{
 // endregion
 
 // region: Core traits
-pub use crate::{Coerce, IntoR, IntoRAltrep, TryCoerce, TryFromSexp};
+pub use crate::altrep::RegisterAltrep;
+// Round out the ALTREP surface so it matches the DataFrame/serde prelude precedent.
+pub use crate::{
+    AltComplexData, AltIntegerData, AltListData, AltLogicalData, AltRawData, AltRealData,
+    AltStringData, AltrepExtract, AltrepLen, Coerce, IntoR, IntoRAltrep, TryCoerce, TryFromSexp,
+};
 // endregion
 
 // region: Types


### PR DESCRIPTION
## Summary
- Re-export the seven per-family ALTREP derive macros from `miniextendr_api::prelude`.
- Re-export `AltrepLen`, the seven `Alt*Data` traits, `AltrepExtract`, and `RegisterAltrep` from the prelude core-trait surface.
- Addresses golife dogfood hiccup #3 from `journal/2026-07-08-golife-dogfood-hiccups.md` on `docs/golife-dogfood-2026-07-08`.
- Follow-up skill cleanup is tracked in #1229.

## Verification
- `just fmt`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --features full-codegen,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --features full-codegen-s7,rayon,rand,rand_distr,either,ndarray,nalgebra,serde,serde_json,num-bigint,rust_decimal,ordered-float,uuid,regex,indexmap,time,num-traits,bytes,num-complex,url,sha2,bitflags,bitvec,aho-corasick,toml,tabled,raw_conversions,vctrs,tinyvec,borsh,jiff,blake3,md5,globset,zstd -- -D warnings`
- `just check` (redirected to `/tmp/plan-check.log`, read after completion)
- `just test` (redirected to `/tmp/plan-test.log`, read after completion): non-zero only for the documented local-rustc trybuild skew, 7 `derive_dataframe_*` UI stderr mismatches in `miniextendr-macros --test ui`; snapshots were not overwritten.

No new `#[miniextendr]` export was added, so no double install or targeted testthat run was required.