### PR TITLE
perf(minirextendr): jsonlite fast path for parse_cargo_metadata_json (#1064)

### DIFF
--- a/minirextendr/DESCRIPTION
+++ b/minirextendr/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     usethis (>= 2.0.0)
 Suggests:
     devtools,
+    jsonlite,
     knitr,
     pkgbuild,
     pkgload,

--- a/minirextendr/R/feature-detect-configure.R
+++ b/minirextendr/R/feature-detect-configure.R
@@ -324,7 +324,7 @@ print.miniextendr_cargo_features <- function(x, ...) {
       feat_str <- if (length(dep$features) > 0) {
         paste0(" [", paste(dep$features, collapse = ", "), "]")
       } else ""
-      cli::cli_li("{.val {name}} {dep$req}{feat_str}")
+      cli::cli_li("{.val {name}} {dep$version}{feat_str}")
     }
   }
 

--- a/minirextendr/R/feature-detect-configure.R
+++ b/minirextendr/R/feature-detect-configure.R
@@ -349,13 +349,58 @@ print.miniextendr_cargo_features <- function(x, ...) {
 
 #' Parse cargo metadata JSON to extract features and optional deps
 #'
-#' Minimal JSON parser using regex — handles the specific structure of
-#' `cargo metadata --no-deps` output without requiring jsonlite.
+#' Dispatcher: uses [jsonlite::fromJSON()] when the package is available
+#' (the common case in a dev environment — jsonlite is transitively present
+#' almost everywhere), otherwise falls back to the dependency-free regex
+#' parser. Both paths return the same shape. This runs maintainer-side only
+#' (via [list_cargo_features()]); it is NOT part of the configure-time
+#' feature detection, which stays base-R.
 #'
 #' @param json Raw JSON string from cargo metadata
 #' @return List with `features` and `optional_deps`
 #' @noRd
 parse_cargo_metadata_json <- function(json) {
+  if (requireNamespace("jsonlite", quietly = TRUE)) {
+    parse_cargo_metadata_jsonlite(json)
+  } else {
+    parse_cargo_metadata_regex(json)
+  }
+}
+
+#' Parse cargo metadata JSON via jsonlite (fast path)
+#'
+#' @param json Raw JSON string from cargo metadata
+#' @return List with `features` and `optional_deps`, matching
+#'   [parse_cargo_metadata_regex()]'s shape.
+#' @noRd
+parse_cargo_metadata_jsonlite <- function(json) {
+  pkg <- jsonlite::fromJSON(json, simplifyVector = FALSE)$packages[[1]]
+  features <- lapply(pkg$features, function(specs) as.character(unlist(specs)))
+  # An empty features object yields a *named* empty list from jsonlite; the
+  # regex fallback yields a plain one. Normalise so both paths are identical.
+  if (length(features) == 0L) features <- list()
+  optional_deps <- list()
+  for (dep in pkg$dependencies) {
+    if (isTRUE(dep$optional)) {
+      optional_deps[[dep$name]] <- list(
+        version = if (!is.null(dep$req)) dep$req else "*",
+        features = as.character(unlist(dep$features))
+      )
+    }
+  }
+  list(features = features, optional_deps = optional_deps)
+}
+
+#' Parse cargo metadata JSON to extract features and optional deps (regex)
+#'
+#' Minimal JSON parser using regex — handles the specific structure of
+#' `cargo metadata --no-deps` output without requiring jsonlite. Kept as the
+#' dependency-free fallback for [parse_cargo_metadata_json()].
+#'
+#' @param json Raw JSON string from cargo metadata
+#' @return List with `features` and `optional_deps`
+#' @noRd
+parse_cargo_metadata_regex <- function(json) {
   # Extract the first package's features object:
   #   "features": { "name": ["spec1", "spec2"], ... }
   features <- list()

--- a/minirextendr/tests/testthat/test-feature-detect-configure.R
+++ b/minirextendr/tests/testthat/test-feature-detect-configure.R
@@ -531,3 +531,23 @@ test_that("parse_cargo_metadata_json dispatcher returns the correct shape", {
   check_features_case(minirextendr:::parse_cargo_metadata_json(cargo_metadata_cases$features))
   check_multiple_case(minirextendr:::parse_cargo_metadata_json(cargo_metadata_cases$multiple))
 })
+
+test_that("print.miniextendr_cargo_features shows each optional dep's version", {
+  # Regression: the parser stores the version requirement under `version`, so
+  # the print method must read `dep$version`. Reading a non-existent field
+  # (e.g. `dep$req`) silently drops the version from the bullet.
+  x <- structure(
+    list(
+      features = list(default = character(), rayon = "miniextendr-api/rayon"),
+      optional_deps = list(
+        serde = list(version = "^1.0", features = "derive"),
+        log = list(version = "*", features = character())
+      ),
+      without_rules = character()
+    ),
+    class = "miniextendr_cargo_features"
+  )
+  out <- cli::cli_fmt(print(x))
+  expect_true(any(grepl("serde", out) & grepl("\\^1\\.0", out)))
+  expect_true(any(grepl("\\blog\\b", out) & grepl("\\*", out)))
+})

--- a/minirextendr/tests/testthat/test-feature-detect-configure.R
+++ b/minirextendr/tests/testthat/test-feature-detect-configure.R
@@ -434,42 +434,100 @@ test_that("add_feature_rule with optional_dep string uses it as dep spec", {
 
 # =============================================================================
 # parse_cargo_metadata_json tests
+#
+# The public helper `parse_cargo_metadata_json()` dispatches to jsonlite when
+# available, else to the dependency-free regex parser. The cases below pin the
+# expected shape against the regex fallback directly (`parse_cargo_metadata_regex`),
+# so they run without jsonlite. A parallel block re-runs each case through the
+# jsonlite fast path (skipped when jsonlite is absent) to prove the two paths
+# agree, plus a dispatcher test.
 # =============================================================================
 
-test_that("parse_cargo_metadata_json extracts features", {
-  json <- '{"packages":[{"features":{"default":[],"rayon":["miniextendr-api/rayon"],"serde":["miniextendr-api/serde","dep:serde"]},"dependencies":[]}]}'
-  result <- minirextendr:::parse_cargo_metadata_json(json)
+# Shared fixtures for both parser paths.
+cargo_metadata_cases <- list(
+  features = '{"packages":[{"features":{"default":[],"rayon":["miniextendr-api/rayon"],"serde":["miniextendr-api/serde","dep:serde"]},"dependencies":[]}]}',
+  optional_deps = '{"packages":[{"features":{},"dependencies":[{"name":"serde","req":"^1","optional":true,"features":["derive"]},{"name":"miniextendr-api","req":"*","optional":false,"features":[]}]}]}',
+  empty = '{"packages":[{"features":{},"dependencies":[]}]}',
+  multiple = '{"packages":[{"features":{"bitflags":["dep:bitflags"],"time":["dep:time"]},"dependencies":[{"name":"bitflags","req":"^2","optional":true,"features":[]},{"name":"time","req":"^0.3","optional":true,"features":["macros","formatting"]},{"name":"core-dep","req":"*","optional":false,"features":[]}]}]}'
+)
 
+# expect_* assertions shared by both parser paths, given a parsed result.
+check_features_case <- function(result) {
   expect_equal(result$features$default, character())
   expect_equal(result$features$rayon, "miniextendr-api/rayon")
   expect_equal(result$features$serde, c("miniextendr-api/serde", "dep:serde"))
   expect_equal(length(result$optional_deps), 0)
-})
-
-test_that("parse_cargo_metadata_json extracts optional deps", {
-  json <- '{"packages":[{"features":{},"dependencies":[{"name":"serde","req":"^1","optional":true,"features":["derive"]},{"name":"miniextendr-api","req":"*","optional":false,"features":[]}]}]}'
-  result <- minirextendr:::parse_cargo_metadata_json(json)
-
+}
+check_optional_deps_case <- function(result) {
   expect_equal(length(result$optional_deps), 1)
   expect_equal(result$optional_deps$serde$version, "^1")
   expect_equal(result$optional_deps$serde$features, "derive")
-})
-
-test_that("parse_cargo_metadata_json handles empty features and deps", {
-  json <- '{"packages":[{"features":{},"dependencies":[]}]}'
-  result <- minirextendr:::parse_cargo_metadata_json(json)
-
+}
+check_empty_case <- function(result) {
   expect_equal(length(result$features), 0)
   expect_equal(length(result$optional_deps), 0)
-})
-
-test_that("parse_cargo_metadata_json handles multiple optional deps", {
-  json <- '{"packages":[{"features":{"bitflags":["dep:bitflags"],"time":["dep:time"]},"dependencies":[{"name":"bitflags","req":"^2","optional":true,"features":[]},{"name":"time","req":"^0.3","optional":true,"features":["macros","formatting"]},{"name":"core-dep","req":"*","optional":false,"features":[]}]}]}'
-  result <- minirextendr:::parse_cargo_metadata_json(json)
-
+}
+check_multiple_case <- function(result) {
   expect_equal(length(result$optional_deps), 2)
   expect_equal(result$optional_deps$bitflags$version, "^2")
   expect_equal(result$optional_deps$bitflags$features, character())
   expect_equal(result$optional_deps$time$version, "^0.3")
   expect_equal(result$optional_deps$time$features, c("macros", "formatting"))
+}
+
+# --- regex fallback path (no jsonlite required) ------------------------------
+
+test_that("parse_cargo_metadata_regex extracts features", {
+  check_features_case(minirextendr:::parse_cargo_metadata_regex(cargo_metadata_cases$features))
+})
+
+test_that("parse_cargo_metadata_regex extracts optional deps", {
+  check_optional_deps_case(minirextendr:::parse_cargo_metadata_regex(cargo_metadata_cases$optional_deps))
+})
+
+test_that("parse_cargo_metadata_regex handles empty features and deps", {
+  check_empty_case(minirextendr:::parse_cargo_metadata_regex(cargo_metadata_cases$empty))
+})
+
+test_that("parse_cargo_metadata_regex handles multiple optional deps", {
+  check_multiple_case(minirextendr:::parse_cargo_metadata_regex(cargo_metadata_cases$multiple))
+})
+
+# --- jsonlite fast path (skipped when jsonlite absent) -----------------------
+
+test_that("parse_cargo_metadata_jsonlite extracts features", {
+  skip_if_not_installed("jsonlite")
+  check_features_case(minirextendr:::parse_cargo_metadata_jsonlite(cargo_metadata_cases$features))
+})
+
+test_that("parse_cargo_metadata_jsonlite extracts optional deps", {
+  skip_if_not_installed("jsonlite")
+  check_optional_deps_case(minirextendr:::parse_cargo_metadata_jsonlite(cargo_metadata_cases$optional_deps))
+})
+
+test_that("parse_cargo_metadata_jsonlite handles empty features and deps", {
+  skip_if_not_installed("jsonlite")
+  check_empty_case(minirextendr:::parse_cargo_metadata_jsonlite(cargo_metadata_cases$empty))
+})
+
+test_that("parse_cargo_metadata_jsonlite handles multiple optional deps", {
+  skip_if_not_installed("jsonlite")
+  check_multiple_case(minirextendr:::parse_cargo_metadata_jsonlite(cargo_metadata_cases$multiple))
+})
+
+test_that("both parser paths agree on identical input", {
+  skip_if_not_installed("jsonlite")
+  for (json in cargo_metadata_cases) {
+    expect_equal(
+      minirextendr:::parse_cargo_metadata_jsonlite(json),
+      minirextendr:::parse_cargo_metadata_regex(json)
+    )
+  }
+})
+
+test_that("parse_cargo_metadata_json dispatcher returns the correct shape", {
+  # With jsonlite present in the test env, the dispatcher takes the fast path;
+  # either way it must return the documented shape.
+  check_features_case(minirextendr:::parse_cargo_metadata_json(cargo_metadata_cases$features))
+  check_multiple_case(minirextendr:::parse_cargo_metadata_json(cargo_metadata_cases$multiple))
 })


### PR DESCRIPTION
Adds a jsonlite fast path to `parse_cargo_metadata_json()` in minirextendr, keeping the dependency-free regex parser as the fallback. Closes #1064.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Renamed the existing hand-rolled regex parser to `parse_cargo_metadata_regex()` (behavior unchanged).
- Added `parse_cargo_metadata_jsonlite()`, a ~10-line parser built on `jsonlite::fromJSON(..., simplifyVector = FALSE)`.
- Turned `parse_cargo_metadata_json()` into a dispatcher: it uses jsonlite when `requireNamespace("jsonlite", quietly = TRUE)` succeeds, otherwise the regex fallback. Both paths return byte-identical output (verified with `identical()`) across the four cargo-metadata shapes the code parses (features, single/multiple optional deps, empty).
- Maintainer-side only: this is reached via `list_cargo_features()`. The configure-time `parse_cargo_features()` line-scanner is untouched and stays base-R, so no new dependency leaks into `./configure`.
- Added `jsonlite` to `Suggests`.

## Tests
- Existing parser cases now call `parse_cargo_metadata_regex()` directly, so they run without jsonlite.
- A parallel block exercises the jsonlite path under `skip_if_not_installed("jsonlite")`, plus a test asserting both paths agree on identical input and a dispatcher shape test.
- `test-feature-detect-configure.R` (jsonlite present, so both paths executed, not skipped): `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 85 ]`
- `test-exports-exist.R` (guards against a rename regressing the `list_cargo_features` export): `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]`

## `list_cargo_features()` / `print.miniextendr_cargo_features` assessment
Per the issue, evaluated whether these earn their keep. Recommendation: keep, no removal commit. Both are exported, documented (`man/list_cargo_features.Rd`), covered by `test-exports-exist.R`, and provide real maintainer value (the `$without_rules` view surfaces which Cargo features still lack a detection rule). Not dead code.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
