### PR TITLE
refactor: post-review cleanups for thread-pool control (#1133)

### DIFF
--- a/docs/RAYON.md
+++ b/docs/RAYON.md
@@ -597,14 +597,24 @@ rule:
 |---|---|---|
 | 1 | `MINIEXTENDR_NUM_THREADS` env var | Explicit override — wins over everything |
 | 2 | `RAYON_NUM_THREADS` env var | Rayon's own convention, respected as-is |
-| 3 | `_R_CHECK_LIMIT_CORES_` env var (truthy) | Caps at `min(2, available_parallelism())` — CRAN's `--as-cran` policy sets this to `"TRUE"` |
-| 4 | (none of the above) | `std::thread::available_parallelism()` |
+| 3 | `RAYON_RS_NUM_CPUS` env var | Rayon's deprecated fallback, still honored (after `RAYON_NUM_THREADS`) |
+| 4 | `_R_CHECK_LIMIT_CORES_` env var (truthy) | Caps at `min(2, available_parallelism())` — CRAN's `--as-cran` policy sets this to `"TRUE"` |
+| 5 | (none of the above) | `std::thread::available_parallelism()` |
 
-`_R_CHECK_LIMIT_CORES_` truthiness follows R's own convention: unset, empty,
-or `"false"`/`"FALSE"` count as not-limited; anything else (including R's
-`"TRUE"`) caps at 2. Because rayon's global pool cannot be resized once
-built, this resolution happens exactly once per process — the first
+`_R_CHECK_LIMIT_CORES_` truthiness follows R's own `config_val_to_logical`
+convention: unset, empty, or `"no"`/`"false"`/`"0"`/`"off"` count as
+not-limited; `"yes"`/`"true"`/`"1"`/`"on"` (and, failing safe, any
+unrecognized value) cap at 2. Because rayon's global pool cannot be resized
+once built, this resolution happens exactly once per process — the first
 parallel call locks it in.
+
+The two `RAYON_*` vars are parsed exactly as `rayon-core` parses them
+(`usize::from_str`, no whitespace trimming), so a value rayon would reject we
+reject too. Two deliberate exceptions: (1) we treat `RAYON_NUM_THREADS=0` as
+*unset* — falling through to the `_R_CHECK_LIMIT_CORES_` cap — rather than
+rayon-core's "0 means use the default (all cores)", so a stray `0` can never
+bypass CRAN's core limit; (2) `MINIEXTENDR_NUM_THREADS`, being our own var, is
+lenient and trims surrounding whitespace.
 
 If your own code calls `rayon::ThreadPoolBuilder::build_global()` before any
 miniextendr rayon call, that wins outright: `ensure_pool()` sees the pool

--- a/miniextendr-api/src/backtrace.rs
+++ b/miniextendr-api/src/backtrace.rs
@@ -21,10 +21,11 @@ static INSTALLED: AtomicBool = AtomicBool::new(false);
 
 /// Register the miniextendr panic hook.
 ///
-/// If `MINIEXTENDR_BACKTRACE` is set to `true` or `1`, the default Rust
-/// panic hook runs (full traceback printed to stderr); otherwise the hook
-/// swallows the panic output silently so the R error (emitted by
-/// `panic_message_to_r_error`) is what users see.
+/// If `MINIEXTENDR_BACKTRACE` is truthy (`yes`/`true`/`1`/`on`, per
+/// [`crate::env_flag::parse_bool`]), the default Rust panic hook runs (full
+/// traceback printed to stderr); otherwise the hook swallows the panic output
+/// silently so the R error (emitted by `panic_message_to_r_error`) is what
+/// users see. Unrecognized values default to off.
 ///
 /// Idempotent within a DLL instance: the first call installs, subsequent
 /// calls are no-ops. If the DLL is unloaded and loaded again, the new
@@ -41,7 +42,8 @@ pub extern "C-unwind" fn miniextendr_panic_hook() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |x| {
         let show_traceback = std::env::var("MINIEXTENDR_BACKTRACE")
-            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .ok()
+            .and_then(|v| crate::env_flag::parse_bool(&v))
             .unwrap_or(false);
         if show_traceback {
             default_hook(x)

--- a/miniextendr-api/src/env_flag.rs
+++ b/miniextendr-api/src/env_flag.rs
@@ -1,0 +1,55 @@
+//! Shared truthiness parsing for environment-variable flags.
+//!
+//! Two flags in this crate read boolean-ish env vars — `MINIEXTENDR_BACKTRACE`
+//! (`backtrace.rs`) and `_R_CHECK_LIMIT_CORES_` (`optionals/parallel.rs`) — and
+//! they used to disagree on what counts as "on" (`true`/`1` vs. anything but
+//! `false`). [`parse_bool`] is the single source of truth, deliberately aligned
+//! with R's own `config_val_to_logical` (`tools/R/utils.R`): a case-insensitive,
+//! whitespace-trimmed match against explicit truthy/falsy sets.
+//!
+//! Recognized values (case-insensitive, surrounding whitespace trimmed):
+//! - truthy: `yes`, `true`, `1`, `on`
+//! - falsy: `no`, `false`, `0`, `off`, `` (empty)
+//!
+//! Anything else is unrecognized (`None`) — the caller supplies the default,
+//! so each flag keeps control of its own "garbage" policy (see the two call
+//! sites for their deliberately different defaults).
+
+/// Parse an environment-flag value as a boolean, using R's
+/// `config_val_to_logical` rules (see module docs). Returns `None` for values
+/// outside the recognized truthy/falsy sets so the caller picks the default.
+pub(crate) fn parse_bool(v: &str) -> Option<bool> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "yes" | "true" | "1" | "on" => Some(true),
+        "no" | "false" | "0" | "off" | "" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_truthy_values_case_insensitively() {
+        for v in [
+            "yes", "YES", "true", "TRUE", "True", "1", "on", "ON", " true ",
+        ] {
+            assert_eq!(parse_bool(v), Some(true), "{v:?}");
+        }
+    }
+
+    #[test]
+    fn recognizes_falsy_values_case_insensitively() {
+        for v in ["no", "NO", "false", "FALSE", "0", "off", "OFF", "", "  "] {
+            assert_eq!(parse_bool(v), Some(false), "{v:?}");
+        }
+    }
+
+    #[test]
+    fn returns_none_for_unrecognized() {
+        for v in ["garbage", "2", "tru", "yesno"] {
+            assert_eq!(parse_bool(v), None, "{v:?}");
+        }
+    }
+}

--- a/miniextendr-api/src/lib.rs
+++ b/miniextendr-api/src/lib.rs
@@ -701,6 +701,9 @@ pub mod s4_helpers;
 
 pub mod backtrace;
 
+/// Shared truthiness parsing for boolean-ish environment-variable flags.
+pub(crate) mod env_flag;
+
 pub mod coerce;
 pub use coerce::{Coerce, CoerceError, Coerced, TryCoerce};
 

--- a/miniextendr-api/src/optionals/parallel.rs
+++ b/miniextendr-api/src/optionals/parallel.rs
@@ -7,9 +7,25 @@
 //! effective_threads() =
 //!   MINIEXTENDR_NUM_THREADS env        (explicit user/admin override)
 //!   else RAYON_NUM_THREADS env         (rayon convention, respected as-is)
+//!   else RAYON_RS_NUM_CPUS env         (rayon's deprecated fallback, still honored)
 //!   else if _R_CHECK_LIMIT_CORES_ is truthy → min(2, available_parallelism())
 //!   else available_parallelism()       (cgroup-quota aware already, Rust >=1.61)
 //! ```
+//!
+//! # Divergence from rayon-core
+//!
+//! The two `RAYON_*` vars are parsed *exactly* as `rayon-core` parses them
+//! (`usize::from_str`, no whitespace trim) so "respected as-is" is literally
+//! true — a value rayon would reject, we reject too. Two deliberate exceptions:
+//!
+//! - **Zero is treated as unset, not "use the default".** rayon-core reads
+//!   `RAYON_NUM_THREADS=0` as an explicit request for its default (all cores)
+//!   and short-circuits. We instead fall through to the `_R_CHECK_LIMIT_CORES_`
+//!   cap and `available_parallelism()`, so a stray `0` can never bypass CRAN's
+//!   core limit.
+//! - **`MINIEXTENDR_NUM_THREADS` (our own var) is lenient:** surrounding
+//!   whitespace is trimmed before parsing. The `RAYON_*` vars are not — they
+//!   match rayon byte-for-byte.
 //!
 //! [`ensure_pool`] builds the global rayon pool exactly once, sized by
 //! [`effective_threads`]. If a global pool already exists (built by user
@@ -29,6 +45,7 @@ pub fn effective_threads() -> usize {
     resolve(
         std::env::var("MINIEXTENDR_NUM_THREADS").ok().as_deref(),
         std::env::var("RAYON_NUM_THREADS").ok().as_deref(),
+        std::env::var("RAYON_RS_NUM_CPUS").ok().as_deref(),
         std::env::var("_R_CHECK_LIMIT_CORES_").ok().as_deref(),
         std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
@@ -38,17 +55,22 @@ pub fn effective_threads() -> usize {
 
 /// Pure resolution logic, factored out of [`effective_threads`] so it's
 /// testable without mutating real process environment variables (which
-/// would race across parallel `#[test]` fns).
+/// would race across parallel `#[test]` fns). See the module-level
+/// "Divergence from rayon-core" note for the parse semantics.
 fn resolve(
     mx_num_threads: Option<&str>,
     rayon_num_threads: Option<&str>,
+    rayon_rs_num_cpus: Option<&str>,
     r_check_limit_cores: Option<&str>,
     available: usize,
 ) -> usize {
+    // Our own override — lenient (surrounding whitespace trimmed).
     if let Some(n) = parse_positive(mx_num_threads) {
         return n;
     }
-    if let Some(n) = parse_positive(rayon_num_threads) {
+    // rayon's own convention: RAYON_NUM_THREADS, then the deprecated
+    // RAYON_RS_NUM_CPUS fallback, parsed byte-for-byte as rayon-core does.
+    if let Some(n) = parse_rayon(rayon_num_threads).or_else(|| parse_rayon(rayon_rs_num_cpus)) {
         return n;
     }
     if is_truthy(r_check_limit_cores) {
@@ -58,21 +80,30 @@ fn resolve(
     }
 }
 
+/// Lenient positive-integer parse for our own `MINIEXTENDR_NUM_THREADS`:
+/// trims surrounding whitespace, rejects zero and non-numeric input.
 fn parse_positive(v: Option<&str>) -> Option<usize> {
     v.and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|&n| n > 0)
 }
 
-/// `_R_CHECK_LIMIT_CORES_` truthiness: R sets it to `"TRUE"` under
-/// `--as-cran`. Treat unset, empty, or `false`/`FALSE` as not-limited —
-/// anything else (including R's `"TRUE"`) caps at 2 cores.
+/// Parse a `RAYON_*` var exactly as `rayon-core` does (`usize::from_str`, no
+/// trim), keeping only positive values. Zero and unparseable input yield
+/// `None` so the resolver falls through — see the module "Divergence" note on
+/// why we do *not* mirror rayon's "0 = use the default" short-circuit.
+fn parse_rayon(v: Option<&str>) -> Option<usize> {
+    v.and_then(|v| v.parse::<usize>().ok()).filter(|&n| n > 0)
+}
+
+/// `_R_CHECK_LIMIT_CORES_` truthiness. R sets it to `"TRUE"` under
+/// `--as-cran`. Unset defaults to not-limited; otherwise
+/// [`crate::env_flag::parse_bool`] decides, and any *unrecognized* value
+/// (e.g. garbage) fails safe toward limiting — under a CRAN check we would
+/// rather cap cores than not.
 fn is_truthy(v: Option<&str>) -> bool {
     match v {
         None => false,
-        Some(v) => {
-            let v = v.trim();
-            !(v.is_empty() || v.eq_ignore_ascii_case("false"))
-        }
+        Some(v) => crate::env_flag::parse_bool(v).unwrap_or(true),
     }
 }
 
@@ -147,35 +178,65 @@ mod tests {
 
     #[test]
     fn resolve_prefers_mx_num_threads() {
-        assert_eq!(resolve(Some("3"), Some("7"), Some("TRUE"), 16), 3);
+        assert_eq!(
+            resolve(Some("3"), Some("7"), Some("9"), Some("TRUE"), 16),
+            3
+        );
     }
 
     #[test]
     fn resolve_falls_back_to_rayon_num_threads() {
-        assert_eq!(resolve(None, Some("5"), None, 16), 5);
+        assert_eq!(resolve(None, Some("5"), None, None, 16), 5);
     }
 
     #[test]
     fn resolve_ignores_zero_and_garbage() {
-        assert_eq!(resolve(Some("0"), Some("nope"), None, 16), 16);
+        assert_eq!(resolve(Some("0"), Some("nope"), None, None, 16), 16);
     }
 
     #[test]
     fn resolve_caps_under_cran_check() {
-        assert_eq!(resolve(None, None, Some("TRUE"), 16), 2);
-        assert_eq!(resolve(None, None, Some("TRUE"), 1), 1);
+        assert_eq!(resolve(None, None, None, Some("TRUE"), 16), 2);
+        assert_eq!(resolve(None, None, None, Some("TRUE"), 1), 1);
     }
 
     #[test]
     fn resolve_cran_flag_treats_false_and_empty_as_unset() {
-        assert_eq!(resolve(None, None, Some(""), 16), 16);
-        assert_eq!(resolve(None, None, Some("false"), 16), 16);
-        assert_eq!(resolve(None, None, Some("FALSE"), 16), 16);
+        assert_eq!(resolve(None, None, None, Some(""), 16), 16);
+        assert_eq!(resolve(None, None, None, Some("false"), 16), 16);
+        assert_eq!(resolve(None, None, None, Some("FALSE"), 16), 16);
     }
 
     #[test]
     fn resolve_no_env_uses_available() {
-        assert_eq!(resolve(None, None, None, 16), 16);
+        assert_eq!(resolve(None, None, None, None, 16), 16);
+    }
+
+    #[test]
+    fn resolve_honors_deprecated_rayon_rs_num_cpus() {
+        // Used when RAYON_NUM_THREADS is unset, matching rayon-core.
+        assert_eq!(resolve(None, None, Some("6"), None, 16), 6);
+        // ...but RAYON_NUM_THREADS wins over it (rayon's own priority).
+        assert_eq!(resolve(None, Some("4"), Some("6"), None, 16), 4);
+    }
+
+    #[test]
+    fn resolve_rayon_vars_match_rayon_no_trim() {
+        // Our own var trims surrounding whitespace...
+        assert_eq!(resolve(Some(" 3 "), None, None, None, 16), 3);
+        // ...but the rayon vars are parsed byte-for-byte, so whitespace is a
+        // parse failure that falls through (exactly as rayon-core would).
+        assert_eq!(resolve(None, Some(" 5 "), None, None, 16), 16);
+        assert_eq!(resolve(None, None, Some(" 6 "), None, 16), 16);
+    }
+
+    #[test]
+    fn resolve_rayon_zero_falls_through_to_cap() {
+        // Deliberate divergence from rayon-core (which reads 0 as "use the
+        // default", all cores): we treat 0 as unset so the CRAN core cap still
+        // applies and can never be bypassed.
+        assert_eq!(resolve(None, Some("0"), None, Some("TRUE"), 16), 2);
+        assert_eq!(resolve(None, Some("0"), None, None, 16), 16);
     }
 
     #[test]

--- a/miniextendr-api/src/optionals/rayon_bridge.rs
+++ b/miniextendr-api/src/optionals/rayon_bridge.rs
@@ -863,15 +863,6 @@ pub trait RParallelIterator {
     /// Implementations should return an iterator that yields `Self::Item` values.
     fn par_iter(&self) -> impl rayon::iter::ParallelIterator<Item = Self::Item> + '_;
 
-    /// [`Self::par_iter`], but first ensures the rayon pool is sized per
-    /// `docs/RAYON.md`'s precedence table. Every default method below calls
-    /// this instead of `par_iter` directly — the single choke point that
-    /// makes this trait's R-callable methods CRAN-core-limit compliant.
-    fn par_iter_ready(&self) -> impl rayon::iter::ParallelIterator<Item = Self::Item> + '_ {
-        super::parallel::ensure_pool();
-        self.par_iter()
-    }
-
     /// Returns the number of elements, if known.
     ///
     /// Default implementation returns -1 (unknown).
@@ -886,7 +877,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into()).sum()
+        par_iter_ready(self).map(|x| x.into()).sum()
     }
 
     /// Computes the parallel sum of i32 elements.
@@ -894,7 +885,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<i32>,
     {
-        self.par_iter_ready().map(|x| x.into()).sum()
+        par_iter_ready(self).map(|x| x.into()).sum()
     }
 
     /// Computes the parallel sum of i64 elements (returned as f64 for R).
@@ -902,7 +893,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<i64>,
     {
-        self.par_iter_ready().map(|x| x.into()).sum::<i64>() as f64
+        par_iter_ready(self).map(|x| x.into()).sum::<i64>() as f64
     }
 
     /// Computes the parallel mean of f64 elements.
@@ -910,8 +901,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        let (sum, count) = self
-            .par_iter_ready()
+        let (sum, count) = par_iter_ready(self)
             .map(|x| (x.into(), 1usize))
             .reduce(|| (0.0, 0), |(s1, c1), (s2, c2)| (s1 + s2, c1 + c2));
 
@@ -927,7 +917,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Ord,
     {
-        self.par_iter_ready().min()
+        par_iter_ready(self).min()
     }
 
     /// Finds the parallel maximum.
@@ -935,7 +925,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Ord,
     {
-        self.par_iter_ready().max()
+        par_iter_ready(self).max()
     }
 
     /// Finds the parallel minimum f64 (handles NaN).
@@ -943,7 +933,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready()
+        par_iter_ready(self)
             .map(|x| x.into())
             .reduce(|| f64::INFINITY, |a, b| a.min(b))
     }
@@ -953,7 +943,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready()
+        par_iter_ready(self)
             .map(|x| x.into())
             .reduce(|| f64::NEG_INFINITY, |a, b| a.max(b))
     }
@@ -963,7 +953,7 @@ pub trait RParallelIterator {
     /// The count is returned to R as an `int`; collections larger than
     /// `i32::MAX` saturate rather than silently wrapping.
     fn par_count(&self) -> i32 {
-        i32::try_from(self.par_iter_ready().count()).unwrap_or(i32::MAX)
+        i32::try_from(par_iter_ready(self).count()).unwrap_or(i32::MAX)
     }
 
     /// Computes the parallel product of f64 elements.
@@ -971,7 +961,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into()).product()
+        par_iter_ready(self).map(|x| x.into()).product()
     }
 
     /// Returns true if any element satisfies the predicate (greater than threshold).
@@ -979,7 +969,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().any(|x| x.into() > threshold)
+        par_iter_ready(self).any(|x| x.into() > threshold)
     }
 
     /// Returns true if all elements satisfy the predicate (greater than threshold).
@@ -987,7 +977,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().all(|x| x.into() > threshold)
+        par_iter_ready(self).all(|x| x.into() > threshold)
     }
 
     /// Returns true if any element satisfies the predicate (less than threshold).
@@ -995,7 +985,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().any(|x| x.into() < threshold)
+        par_iter_ready(self).any(|x| x.into() < threshold)
     }
 
     /// Returns true if all elements satisfy the predicate (less than threshold).
@@ -1003,7 +993,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().all(|x| x.into() < threshold)
+        par_iter_ready(self).all(|x| x.into() < threshold)
     }
 
     /// Counts elements greater than threshold.
@@ -1012,7 +1002,7 @@ pub trait RParallelIterator {
         Self::Item: Into<f64>,
     {
         i32::try_from(
-            self.par_iter_ready()
+            par_iter_ready(self)
                 .filter(|&x| x.into() > threshold)
                 .count(),
         )
@@ -1025,7 +1015,7 @@ pub trait RParallelIterator {
         Self::Item: Into<f64>,
     {
         i32::try_from(
-            self.par_iter_ready()
+            par_iter_ready(self)
                 .filter(|&x| x.into() < threshold)
                 .count(),
         )
@@ -1038,7 +1028,7 @@ pub trait RParallelIterator {
         Self::Item: Into<f64>,
     {
         i32::try_from(
-            self.par_iter_ready()
+            par_iter_ready(self)
                 .filter(|&x| (x.into() - value).abs() <= epsilon)
                 .count(),
         )
@@ -1055,8 +1045,7 @@ pub trait RParallelIterator {
             return f64::NAN;
         }
 
-        let (sum_sq_diff, count) = self
-            .par_iter_ready()
+        let (sum_sq_diff, count) = par_iter_ready(self)
             .map(|x| {
                 let diff = x.into() - mean;
                 (diff * diff, 1usize)
@@ -1083,7 +1072,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready()
+        par_iter_ready(self)
             .filter(|&x| x.into() > threshold)
             .map(|x| x.into())
             .collect()
@@ -1094,7 +1083,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready()
+        par_iter_ready(self)
             .filter(|&x| x.into() < threshold)
             .map(|x| x.into())
             .collect()
@@ -1105,7 +1094,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into() * factor).collect()
+        par_iter_ready(self).map(|x| x.into() * factor).collect()
     }
 
     /// Applies offset and collects results (add offset).
@@ -1113,7 +1102,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into() + offset).collect()
+        par_iter_ready(self).map(|x| x.into() + offset).collect()
     }
 
     /// Clamps values to range and collects results.
@@ -1121,7 +1110,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready()
+        par_iter_ready(self)
             .map(|x| x.into().clamp(min, max))
             .collect()
     }
@@ -1131,7 +1120,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into().abs()).collect()
+        par_iter_ready(self).map(|x| x.into().abs()).collect()
     }
 
     /// Applies square root and collects results.
@@ -1139,7 +1128,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into().sqrt()).collect()
+        par_iter_ready(self).map(|x| x.into().sqrt()).collect()
     }
 
     /// Applies power and collects results.
@@ -1147,7 +1136,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into().powf(exp)).collect()
+        par_iter_ready(self).map(|x| x.into().powf(exp)).collect()
     }
 
     /// Applies natural log and collects results.
@@ -1155,7 +1144,7 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into().ln()).collect()
+        par_iter_ready(self).map(|x| x.into().ln()).collect()
     }
 
     /// Applies exp and collects results.
@@ -1163,8 +1152,22 @@ pub trait RParallelIterator {
     where
         Self::Item: Into<f64>,
     {
-        self.par_iter_ready().map(|x| x.into().exp()).collect()
+        par_iter_ready(self).map(|x| x.into().exp()).collect()
     }
+}
+
+/// Size the rayon pool per `docs/RAYON.md`'s precedence table, then hand back
+/// the source's parallel iterator. Module-private free fn — deliberately *not*
+/// an overridable [`RParallelIterator`] method — so this single choke point
+/// (the `ensure_pool()` call that keeps every default aggregation below
+/// CRAN-core-limit compliant) cannot be bypassed by a downstream trait impl.
+#[cfg(feature = "rayon")]
+fn par_iter_ready<T>(source: &T) -> impl rayon::iter::ParallelIterator<Item = T::Item> + '_
+where
+    T: RParallelIterator + ?Sized,
+{
+    super::parallel::ensure_pool();
+    source.par_iter()
 }
 
 /// Adapter trait for parallel collection extension.

--- a/minirextendr/R/use-feature.R
+++ b/minirextendr/R/use-feature.R
@@ -195,10 +195,9 @@ use_s4 <- function(path = ".") {
 #'
 #' Thread count is CRAN- and cgroup-aware by default: call
 #' `miniextendr_api::optionals::parallel::ensure_pool()` at the top of your
-#' rayon-backed functions (the bundled `rayon_bridge` helpers already do this)
-#' to honor `MINIEXTENDR_NUM_THREADS` / `RAYON_NUM_THREADS` / CRAN's
-#' `_R_CHECK_LIMIT_CORES_`. See `docs/RAYON.md` ("Controlling parallelism
-#' from R") for the precedence table.
+#' rayon-backed functions (the bundled `rayon_bridge` helpers already do this).
+#' See `docs/RAYON.md` ("Controlling parallelism from R") for the thread-count
+#' precedence table.
 #'
 #' @param path Path to the R package root, or `"."` to use the current directory.
 #' @return Invisibly returns TRUE

--- a/minirextendr/man/use_rayon.Rd
+++ b/minirextendr/man/use_rayon.Rd
@@ -20,10 +20,9 @@ easy parallelization of Rust code.
 \details{
 Thread count is CRAN- and cgroup-aware by default: call
 \verb{miniextendr_api::optionals::parallel::ensure_pool()} at the top of your
-rayon-backed functions (the bundled \code{rayon_bridge} helpers already do this)
-to honor \code{MINIEXTENDR_NUM_THREADS} / \code{RAYON_NUM_THREADS} / CRAN's
-\verb{_R_CHECK_LIMIT_CORES_}. See \code{docs/RAYON.md} ("Controlling parallelism
-from R") for the precedence table.
+rayon-backed functions (the bundled \code{rayon_bridge} helpers already do this).
+See \code{docs/RAYON.md} ("Controlling parallelism from R") for the thread-count
+precedence table.
 }
 \examples{
 \dontrun{

--- a/rpkg/man/thread_control.Rd
+++ b/rpkg/man/thread_control.Rd
@@ -18,7 +18,7 @@ miniextendr_set_threads(n)
 \item{n}{Number of threads to request (positive integer).}
 }
 \description{
-Report the effective rayon thread count. Follows the precedence in \code{docs/RAYON.md} ("Controlling parallelism from R"): \code{MINIEXTENDR_NUM_THREADS} env > \code{RAYON_NUM_THREADS} env > CRAN \verb{_R_CHECK_LIMIT_CORES_} cap (2) > \code{available_parallelism()}. Builds the pool on first call, same as any other rayon entry point.
+Report the effective rayon thread count. Builds the pool on first call, same as any other rayon entry point; the thread-count precedence table is in \code{docs/RAYON.md} ("Controlling parallelism from R").
 
 Build the rayon thread pool with exactly \code{n} threads, immediately. Must be called before the first parallel operation — rayon's global pool cannot be resized once built, so this errors if any pool already exists (whether built by miniextendr or outside it).
 }

--- a/rpkg/src/rust/thread_control.rs
+++ b/rpkg/src/rust/thread_control.rs
@@ -7,11 +7,9 @@
 #[cfg(feature = "rayon")]
 use miniextendr_api::miniextendr;
 
-/// Report the effective rayon thread count. Follows the precedence in
-/// `docs/RAYON.md` ("Controlling parallelism from R"):
-/// `MINIEXTENDR_NUM_THREADS` env > `RAYON_NUM_THREADS` env > CRAN
-/// `_R_CHECK_LIMIT_CORES_` cap (2) > `available_parallelism()`. Builds the
-/// pool on first call, same as any other rayon entry point.
+/// Report the effective rayon thread count. Builds the pool on first call,
+/// same as any other rayon entry point; the thread-count precedence table is
+/// in `docs/RAYON.md` ("Controlling parallelism from R").
 #[cfg(feature = "rayon")]
 #[miniextendr]
 pub fn miniextendr_num_threads() -> i32 {

--- a/rpkg/tests/testthat/helper-subprocess.R
+++ b/rpkg/tests/testthat/helper-subprocess.R
@@ -1,0 +1,32 @@
+# Shared helper for tests that must run in a fresh R subprocess.
+#
+# Several suites need to evaluate an expression in a clean R process with
+# `miniextendr` freshly loaded — hazardous panic/thread/unwind paths that can
+# corrupt the parent (test-subprocess-isolated.R) and the rayon thread-pool
+# control tests, whose global pool builds once per process so each scenario
+# needs its own process (test-rayon.R). This is the single implementation both
+# use; `env_vars` lets callers pin/override environment variables (merged over
+# `callr::rcmd_safe_env()`).
+#
+# NOT used by test-encoding.R's `run_load_in_locale`: that helper tests whether
+# `library(miniextendr)` itself *fails* under a bad locale, so it wraps the load
+# in tryCatch and returns a structured result — the opposite contract from
+# "load succeeds, then eval expr". Folding it in would need a second code path
+# and lose clarity, so it stays separate.
+run_isolated <- function(expr, env_vars = character(), timeout = 30) {
+  skip_if_not_installed("callr")
+  env <- callr::rcmd_safe_env()
+  if (length(env_vars)) {
+    env[names(env_vars)] <- env_vars
+  }
+  callr::r(
+    function(expr_to_eval) {
+      library(miniextendr)
+      eval(expr_to_eval)
+    },
+    args = list(expr_to_eval = substitute(expr)),
+    env = env,
+    timeout = timeout,
+    error = "error"
+  )
+}

--- a/rpkg/tests/testthat/test-rayon.R
+++ b/rpkg/tests/testthat/test-rayon.R
@@ -144,83 +144,79 @@ test_that("rayon_in_thread returns FALSE when called from R", {
 
 # ---------------------------------------------------------------------------
 # Thread pool control (docs/RAYON.md "Controlling Parallelism from R"):
-# MINIEXTENDR_NUM_THREADS > RAYON_NUM_THREADS > _R_CHECK_LIMIT_CORES_ cap >
-# available_parallelism(). The global rayon pool builds once per process, so
-# each scenario needs its own fresh subprocess. callr merges `env` over the
-# inherited environment, so every scenario pins all three resolver vars
-# (blank = unset to the resolver) — otherwise values inherited from the
-# calling process skew baselines: R CMD check --as-cran exports
+# MINIEXTENDR_NUM_THREADS > RAYON_NUM_THREADS > RAYON_RS_NUM_CPUS >
+# _R_CHECK_LIMIT_CORES_ cap > available_parallelism(). The global rayon pool
+# builds once per process, so each scenario that must resolve a *different*
+# thread count needs its own fresh subprocess (via run_isolated() from
+# helper-subprocess.R). To keep the spawn count down, scenarios that share a
+# process are merged (defaults + falsy-flag comparison; set-succeeds +
+# errors-once-built), and the per-value truthiness matrix is left to the Rust
+# unit tests in parallel.rs (`resolve_cran_flag_treats_false_and_empty_as_unset`)
+# rather than one subprocess per value.
+#
+# `rayon_env()` blanks all four resolver env vars (blank = unset to the
+# resolver) and applies the caller's overrides — otherwise values inherited
+# from the calling process skew baselines: R CMD check --as-cran exports
 # _R_CHECK_LIMIT_CORES_=TRUE into this very test run.
 # ---------------------------------------------------------------------------
 
-run_with_env <- function(expr, env_vars = character()) {
-  skip_if_not_installed("callr")
+rayon_env <- function(overrides = character()) {
   vars <- c(
     MINIEXTENDR_NUM_THREADS = "",
     RAYON_NUM_THREADS = "",
+    RAYON_RS_NUM_CPUS = "",
     `_R_CHECK_LIMIT_CORES_` = ""
   )
-  vars[names(env_vars)] <- env_vars
-  callr::r(
-    function(expr_to_eval) {
-      library(miniextendr)
-      eval(expr_to_eval)
-    },
-    args = list(expr_to_eval = substitute(expr)),
-    env = c(callr::rcmd_safe_env(), vars),
-    timeout = 30
-  )
+  vars[names(overrides)] <- overrides
+  vars
 }
 
 test_that("miniextendr_num_threads honors MINIEXTENDR_NUM_THREADS", {
-  result <- run_with_env(
+  result <- run_isolated(
     miniextendr_num_threads(),
-    c(MINIEXTENDR_NUM_THREADS = "3")
+    rayon_env(c(MINIEXTENDR_NUM_THREADS = "3"))
   )
   expect_equal(result, 3L)
 })
 
 test_that("miniextendr_num_threads caps at 2 under _R_CHECK_LIMIT_CORES_", {
-  result <- run_with_env(
+  result <- run_isolated(
     miniextendr_num_threads(),
-    c(`_R_CHECK_LIMIT_CORES_` = "TRUE")
+    rayon_env(c(`_R_CHECK_LIMIT_CORES_` = "TRUE"))
   )
   expect_true(result <= 2L)
 })
 
-test_that("miniextendr_num_threads ignores _R_CHECK_LIMIT_CORES_ = FALSE/empty", {
-  uncapped <- run_with_env(miniextendr_num_threads())
-  for (v in c("FALSE", "false", "")) {
-    result <- run_with_env(
-      miniextendr_num_threads(),
-      c(`_R_CHECK_LIMIT_CORES_` = v)
-    )
-    expect_equal(result, uncapped)
-  }
+test_that("miniextendr_num_threads default is uncapped and ignores a falsy _R_CHECK_LIMIT_CORES_", {
+  # One process establishes the uncapped default (also covers "defaults to
+  # available parallelism"); a second confirms a falsy flag does not cap.
+  uncapped <- run_isolated(miniextendr_num_threads(), rayon_env())
+  expect_true(uncapped >= 1L)
+
+  falsy <- run_isolated(
+    miniextendr_num_threads(),
+    rayon_env(c(`_R_CHECK_LIMIT_CORES_` = "FALSE"))
+  )
+  expect_equal(falsy, uncapped)
 })
 
-test_that("miniextendr_num_threads defaults to available parallelism", {
-  result <- run_with_env(miniextendr_num_threads())
-  expect_true(result >= 1L)
-})
-
-test_that("miniextendr_set_threads changes the reported count before first use", {
-  result <- run_with_env({
-    miniextendr_set_threads(2L)
-    miniextendr_num_threads()
-  })
-  expect_equal(result, 2L)
-})
-
-test_that("miniextendr_set_threads errors once the pool is already built", {
-  msg <- run_with_env({
-    miniextendr_num_threads() # builds the pool
-    tryCatch(
-      miniextendr_set_threads(4L),
-      error = function(e) conditionMessage(e)
-    )
-  })
-  expect_match(msg, "already built", fixed = TRUE)
+test_that("miniextendr_set_threads sets the count before first use, then errors once built", {
+  # Both set-succeeds and errors-once-built exercised in one process: set(2)
+  # builds the pool, so the follow-up set(4) must fail with "already built".
+  result <- run_isolated(
+    {
+      miniextendr_set_threads(2L)
+      before <- miniextendr_num_threads()
+      err <- tryCatch(
+        miniextendr_set_threads(4L),
+        error = function(e) conditionMessage(e)
+      )
+      list(threads = before, err = err)
+    },
+    rayon_env()
+  )
+  expect_equal(result$threads, 2L)
+  expect_match(result$err, "already built", fixed = TRUE)
 })
 
 test_that("miniextendr_set_threads rejects non-positive input", {

--- a/rpkg/tests/testthat/test-subprocess-isolated.R
+++ b/rpkg/tests/testthat/test-subprocess-isolated.R
@@ -14,20 +14,8 @@ skip_if_not_installed("callr")
 # covered on Linux/macOS.
 skip_on_os("windows")
 
-# ---------------------------------------------------------------------------
-# Helper: run an expression in a subprocess with miniextendr loaded
-# ---------------------------------------------------------------------------
-run_isolated <- function(expr, timeout = 30) {
-  callr::r(
-    function(expr_to_eval) {
-      library(miniextendr)
-      eval(expr_to_eval)
-    },
-    args = list(expr_to_eval = substitute(expr)),
-    timeout = timeout,
-    error = "error"
-  )
-}
+# `run_isolated()` (run an expression in a fresh subprocess with miniextendr
+# loaded) lives in helper-subprocess.R, shared with test-rayon.R.
 
 # ===========================================================================
 # From test-errors-more.R: Thread panic propagation


### PR DESCRIPTION
Post-review cleanups for the thread-pool control work (#1131), tracked in #1133. Six independent items; each is a separate commit so they're individually reviewable.

<details>
<summary>AI-generated summary of the six items (landed/declined + verification)</summary>

### Items

**1. Trim callr over-spawning in `test-rayon.R` — LANDED.**
9 subprocess spawns → **5**, with equivalent coverage:
- "defaults to available parallelism" folded into the uncapped-baseline spawn.
- "errors once built" piggybacked onto the `set_threads` spawn (`set(2)` builds the pool, so the follow-up `set(4)` must fail with "already built" in the same process — also asserts set-succeeds → 2).
- The `FALSE`/`false`/`""` falsy matrix collapsed to one representative (`"FALSE"`); the per-value set is already covered by the Rust unit test `resolve_cran_flag_treats_false_and_empty_as_unset`.

Wall-clock (local, whole file): **~3.09s → ~2.10s (~1.0s, ~32% faster)** for the 4 fewer spawns (~0.25s/spawn locally; larger on CI where cold R startup dominates each `callr::r`).

**2. Dedupe the fresh-subprocess helpers — LANDED (partial by design).**
Promoted `run_isolated(expr, env_vars = character(), timeout = 30)` to `rpkg/tests/testthat/helper-subprocess.R` (auto-sourced by testthat), extended with an `env_vars` param. `test-rayon.R` now builds its resolver-var blanking via a trivial `rayon_env()` and calls the shared helper (dropped the duplicate `run_with_env`); `test-subprocess-isolated.R` dropped its local copy.
`run_load_in_locale` (`test-encoding.R`) **intentionally left separate**: it tests whether `library(miniextendr)` itself *fails* under a bad locale (library-load wrapped in `tryCatch`, structured return) — the opposite contract from `run_isolated`'s "load succeeds, then eval". Folding it in would need a second code path and lose clarity; the plan explicitly said to fold only if clean.

**3. Precedence table 4 → 2 copies — LANDED.**
Kept the two canonical copies (`parallel.rs` rustdoc for docs.rs; `docs/RAYON.md` for the site). Reduced the other two to one-line pointers: `thread_control.rs`'s `miniextendr_num_threads` roxygen, and minirextendr's `use_rayon()` roxygen (kept the actionable `ensure_pool()` guidance, dropped the env-var enumeration). Regenerated `rpkg/man/thread_control.Rd` + `minirextendr/man/use_rayon.Rd`; no `NAMESPACE` change.

**4. One env-flag truthiness helper — LANDED.**
`MINIEXTENDR_BACKTRACE` (`backtrace.rs`, `true`/`1` only) and `_R_CHECK_LIMIT_CORES_` (`parallel.rs`, "anything but false") had divergent ad-hoc checks. Added `env_flag::parse_bool`, aligned with R's `config_val_to_logical`: case-insensitive, whitespace-trimmed `yes`/`true`/`1`/`on` vs `no`/`false`/`0`/`off`/empty; unrecognized → `None` so each caller keeps its own default. `backtrace.rs` → default off on unrecognized (now also honors `yes`/`on`); `is_truthy` → **fails safe toward limiting** on unrecognized (documented divergence — under a CRAN check we'd rather cap cores).

**5. De-publicize the pool choke point — LANDED.**
`par_iter_ready` was an overridable provided trait method, so a downstream `impl RParallelIterator` could silently skip `ensure_pool()`. Replaced it with a module-private free fn `par_iter_ready(&source)`; the trait now exposes only `par_iter`, and the CRAN-compliance guarantee can't be bypassed. Confirmed no downstream override (grep of `rpkg` + `tests/cross-package`).

**6. `RAYON_NUM_THREADS` parse parity — LANDED.**
Verified rayon-core 1.13.0's actual behavior. The `RAYON_*` vars are now parsed exactly as rayon-core (`usize::from_str`, **no whitespace trim**), and the deprecated `RAYON_RS_NUM_CPUS` fallback is now honored (after `RAYON_NUM_THREADS`, matching rayon-core). Two deliberate, documented divergences: `MINIEXTENDR_NUM_THREADS` (our own var) stays lenient and trims; `RAYON_NUM_THREADS=0` is treated as *unset* (falls through to the CRAN cap) rather than rayon's "0 = all cores", so a stray `0` can never bypass `_R_CHECK_LIMIT_CORES_`. New unit tests cover each case; precedence docs updated with the new row + a "Divergence from rayon-core" note.

### Verification
- `just fmt` — clean.
- Clippy `-D warnings`, all three CI legs: `clippy_default`, `clippy_all` (`full-codegen` + integration list), `clippy_all_s7` (`full-codegen-s7`) — all pass.
- `just check` — pass (all manifests).
- Rust unit tests: `env_flag::tests` (3) + `optionals::parallel::tests` (12, incl. the new item-6 cases) — 15 passed / 0 failed.
- `just rcmdinstall` + `just force-document` — clean; only `thread_control.Rd` / `use_rayon.Rd` regenerated (intended), `NAMESPACE` unchanged.
- `test-rayon.R` (item 1/2 load-bearing): all thread-control tests green.
- `test-subprocess-isolated.R` (shared helper, `NOT_CRAN=true`): 14 tests green.
- `just devtools-test` (full suite): the affected files pass (see the two targeted lines above). The full-suite run hung on an unrelated worker-thread panic fixture (`rpkg/src/rust/worker_tests.rs`, `"Worker: about to panic"`) — a pre-existing hazard-class test, the very kind `test-subprocess-isolated.R` was created to isolate — and was killed. It touches none of the files in this PR, and the `backtrace.rs` change is behaviorally identical when `MINIEXTENDR_BACKTRACE` is unset (the test case), so it cannot introduce the hang.
- The 7 known `derive_dataframe_*` UI trybuild skews are unrelated to this PR and were not touched.

No items declined; no deferrals.

</details>
