### PR TITLE
chore: pin Rust toolchain to stable via rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add a root `rust-toolchain.toml` pinning `channel = "stable"`.
- Rationale: local sessions sometimes ran nightly, which drifts from CI's stable in trybuild `.stderr` snapshot formatting (E0080 notes) and clippy lint sets. The pin makes local cargo, clippy, and trybuild runs match CI for every manifest under the repo root (workspace, `rpkg/src/rust`, `tests/cross-package`, `cargo-revendor`).
- Preflight checked: no `#![feature(...)]` gates in source, no `+nightly` in justfile/CI/scripts, no rustfmt config requiring nightly. Vendored crates carry their own toolchain files but rustup does not consult those during builds.

## Test plan
- [ ] `rustup show active-toolchain` inside the repo resolves to stable
- [ ] CI (dtolnay/rust-toolchain@stable) unaffected, same channel

## Notes
- End-user scaffolded packages are unaffected: this file is repo-level and is not part of the rpkg tarball.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
