### PR TITLE
ci(webr): enforce image-pin lockstep, derive Imports from DESCRIPTION, keep main-push validation

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -45,7 +45,13 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PRs only. On main pushes, let the in-flight run
+  # finish: with unconditional cancel-in-progress, the next merge killed the
+  # running tier-2/3 job, so rapid merge bursts left intermediate main commits
+  # with no webR validation at all. Queued (not yet started) main runs are
+  # still deduped by GitHub's pending-run handling, so a burst validates its
+  # first and latest commits without piling up runners.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -53,6 +59,35 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  # The webR base-image digest is pinned in three places that must stay
+  # identical: Dockerfile.webr's WEBR_BASE (the source of truth —
+  # mirror-webr.yml reads that pin to mirror upstream), Dockerfile.webr-arm64's
+  # WEBR_AMD64_DONOR (the copied wasm sysroot must come from the same image
+  # bytes), and this workflow's tier-2 container image. "Bump in lockstep" was
+  # previously a comment-only invariant; this job enforces it.
+  pin-lockstep:
+    name: webR image pin lockstep
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare the three pinned digests
+        run: |
+          set -euo pipefail
+          base=$(grep -E '^ARG WEBR_BASE=' Dockerfile.webr | grep -Eo 'sha256:[0-9a-f]{64}' | sort -u)
+          donor=$(grep -E '^ARG WEBR_AMD64_DONOR=' Dockerfile.webr-arm64 | grep -Eo 'sha256:[0-9a-f]{64}' | sort -u)
+          ci=$(grep -E 'image: ghcr\.io/a2-ai/webr-mirror@' .github/workflows/webr.yml | grep -Eo 'sha256:[0-9a-f]{64}' | sort -u)
+          echo "Dockerfile.webr WEBR_BASE:        $base"
+          echo "Dockerfile.webr-arm64 donor pin:  $donor"
+          echo "webr.yml tier-2 container:        $ci"
+          test -n "$base" && test -n "$donor" && test -n "$ci"
+          if [ "$base" != "$donor" ] || [ "$base" != "$ci" ]; then
+            echo "::error::webR base-image digests are out of lockstep — bump all three together: Dockerfile.webr (WEBR_BASE), Dockerfile.webr-arm64 (WEBR_AMD64_DONOR), .github/workflows/webr.yml (tier-2 container image)."
+            exit 1
+          fi
+          echo "All three pins agree."
+
   cargo-check:
     name: wasm32 check
     runs-on: ubuntu-latest
@@ -111,7 +146,8 @@ jobs:
   # here too, until #745 confirmed it redundant and dropped it.)
   #
   # The container image must stay digest-aligned with Dockerfile.webr's
-  # WEBR_BASE — bump both together. The S7 + autoconf installs mirror the
+  # WEBR_BASE — bump both together (enforced by the pin-lockstep job above).
+  # The S7 + autoconf installs mirror the
   # Dockerfile.webr layers (Dockerfile.webr is the local dev image and bakes
   # them in; CI installs inline so we don't need to publish miniextendr-webr-dev).
   webr-install:
@@ -122,7 +158,8 @@ jobs:
       # Pulled from the mirror at ghcr.io/a2-ai/webr-mirror (closes #496),
       # which `.github/workflows/mirror-webr.yml` keeps digest-aligned with
       # upstream ghcr.io/r-wasm/webr — image bytes are identical at this
-      # sha256. Bump in lockstep with Dockerfile.webr's WEBR_BASE.
+      # sha256. Bump in lockstep with Dockerfile.webr's WEBR_BASE (the
+      # pin-lockstep job fails the workflow if the pins diverge).
       image: ghcr.io/a2-ai/webr-mirror@sha256:3fbf3dc3537c5b31bca94dd797dc25364693b18d71b1d0975f318fbfd6269d86
       # The mirror package is currently private; auth via the job's
       # GITHUB_TOKEN (workflow-level `packages: read` permission above).
@@ -156,14 +193,27 @@ jobs:
           # ship it. `autoconf` is needed by rpkg/configure.
           apt-get update && apt-get install -y --no-install-recommends autoconf file
           mkdir -p "$R_LIBS_USER"
-          # Install via the host R that Phase 2 uses, so transitive deps land
-          # in a library Phase 2's lazy-load will see. `dependencies = c(...)`
-          # pulls rlang in via lifecycle/vctrs without us having to enumerate.
-          /opt/webr/host/R-4.6.0/bin/Rscript -e \
-            'install.packages(c("cli","lifecycle","R6","S7","vctrs"), dependencies = c("Depends","Imports","LinkingTo"), repos="https://packagemanager.posit.co/cran/__linux__/noble/latest", lib=Sys.getenv("R_LIBS_USER"))'
-          # Sanity-check the transitive set landed.
-          /opt/webr/host/R-4.6.0/bin/Rscript -e \
-            'pkgs <- c("cli","lifecycle","rlang","R6","S7","vctrs"); miss <- setdiff(pkgs, rownames(installed.packages(lib.loc=Sys.getenv("R_LIBS_USER")))); if (length(miss)) stop("Missing: ", paste(miss, collapse=", "))'
+          # Derive the Imports list from rpkg/DESCRIPTION (minus base-R
+          # packages) instead of hand-enumerating it — tests/webr-node-smoke/
+          # smoke.mjs derives its copy the same way, so DESCRIPTION is the
+          # single source of truth. Install via the host R that Phase 2 uses,
+          # so transitive deps land in a library Phase 2's lazy-load will see;
+          # `dependencies = c(...)` pulls rlang in via lifecycle/vctrs. The
+          # closing requireNamespace() sweep loads each import through
+          # R_LIBS_USER, exercising the full transitive graph (stronger than
+          # the old hand-maintained installed.packages() list check).
+          /opt/webr/host/R-4.6.0/bin/Rscript -e '
+            imports <- trimws(strsplit(read.dcf("rpkg/DESCRIPTION")[1, "Imports"], ",")[[1]])
+            imports <- sub("\\s*\\(.*\\)$", "", imports)
+            imports <- setdiff(imports, rownames(installed.packages(priority = "base")))
+            stopifnot(length(imports) > 0)
+            cat("Derived hard Imports:", paste(imports, collapse = ", "), "\n")
+            install.packages(imports, dependencies = c("Depends", "Imports", "LinkingTo"),
+                             repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest",
+                             lib = Sys.getenv("R_LIBS_USER"))
+            miss <- imports[!vapply(imports, requireNamespace, logical(1), quietly = TRUE)]
+            if (length(miss)) stop("Unloadable after install: ", paste(miss, collapse = ", "))
+          '
 
       - name: Cache cargo registry + git
         uses: actions/cache@v6

--- a/tests/webr-node-smoke/smoke.mjs
+++ b/tests/webr-node-smoke/smoke.mjs
@@ -29,21 +29,54 @@
 // ERR_WORKER_PATH, so the bundle would crash at init building the
 // webr-worker.js worker path off such a baseUrl.)
 //
-// Hard miniextendr Imports (cli/lifecycle/R6/S7/vctrs) are fetched from
-// repo.r-wasm.org via `webR.installPackages` before the library load.
-// If the network fetch fails the smoke aborts loudly — we cannot prove
-// the side-module is healthy without the deps that its NAMESPACE pulls in.
+// Hard miniextendr Imports are derived from rpkg/DESCRIPTION (minus base-R
+// packages) and fetched from repo.r-wasm.org via `webR.installPackages`
+// before the library load. If the network fetch fails the smoke aborts
+// loudly — we cannot prove the side-module is healthy without the deps that
+// its NAMESPACE pulls in. (A newly added Import must exist as a wasm binary
+// on repo.r-wasm.org; this runner surfaces that requirement automatically.)
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { WebR } from "file:///opt/webr/src/dist/webr.mjs";
 
 const WASM_LIB_MOUNT = "/wasm-rlib";
 const HOST_WASM_LIB = "/tmp/wasm-lib";
 
-// Imports listed in rpkg/DESCRIPTION. `methods` is part of base R, so we
-// don't try to install it here. Kept in sync manually — if DESCRIPTION's
-// Imports change, update this list and the matching CI permissions on
-// repo.r-wasm.org availability.
-const HARD_IMPORTS = ["cli", "lifecycle", "R6", "S7", "vctrs"];
+// Base-R packages ship with webR itself — never install them from the repo.
+const R_BASE_PKGS = new Set([
+  "base", "compiler", "datasets", "graphics", "grDevices", "grid", "methods",
+  "parallel", "splines", "stats", "stats4", "tcltk", "tools", "utils",
+]);
+
+// Parse the Imports field out of rpkg/DESCRIPTION so there is no hand-synced
+// copy of the list here; the tier-2 workflow step derives its native-install
+// list from the same file. DCF format: the field's value runs until the next
+// line that starts at column 0.
+function hardImportsFromDescription() {
+  const descPath = join(
+    dirname(fileURLToPath(import.meta.url)), "..", "..", "rpkg", "DESCRIPTION",
+  );
+  const lines = readFileSync(descPath, "utf8").split("\n");
+  const start = lines.findIndex((l) => l.startsWith("Imports:"));
+  if (start === -1) throw new Error(`No Imports field found in ${descPath}`);
+  let field = lines[start].slice("Imports:".length);
+  for (let i = start + 1; i < lines.length && /^[ \t]/.test(lines[i]); i++) {
+    field += ` ${lines[i]}`;
+  }
+  const imports = field
+    .split(",")
+    .map((s) => s.trim().replace(/\s*\(.*\)$/, ""))
+    .filter((s) => s.length > 0 && !R_BASE_PKGS.has(s));
+  if (imports.length === 0) {
+    throw new Error(`Parsed zero non-base Imports from ${descPath}`);
+  }
+  return imports;
+}
+
+const HARD_IMPORTS = hardImportsFromDescription();
 
 function unwrapScalar(rJsResult) {
   if (rJsResult && Array.isArray(rJsResult.values) && rJsResult.values.length > 0) {


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Three CI-hygiene fixes from the same webR/wasm review that produced #1256 (docs drift) — this PR carries the behavior changes so #1256 stays prose-only. The two PRs touch disjoint hunks of `webr.yml` and merge cleanly in either order.

- **New `pin-lockstep` job.** The webR base-image digest is pinned in three hand-synced places: `Dockerfile.webr`'s `WEBR_BASE` (the source of truth `mirror-webr.yml` reads), `Dockerfile.webr-arm64`'s `WEBR_AMD64_DONOR` (the copied wasm sysroot must come from the same image bytes), and the tier-2 container image in `webr.yml`. "Bump in lockstep" was a comment-only invariant; a ~5s job now fails the workflow if the three digests diverge.
- **Hard Imports derived from `rpkg/DESCRIPTION`.** The list existed in three places (DESCRIPTION, the tier-2 install step, `HARD_IMPORTS` in `smoke.mjs`) with "kept in sync manually" comments. Both consumers now parse DESCRIPTION (minus base-R packages), so DESCRIPTION is the single source of truth and a new Import flows through automatically. The tier-2 sanity check is upgraded from a hand-maintained `installed.packages()` list (which had to enumerate transitive deps like rlang by hand) to a `requireNamespace()` sweep, which loads each import through `R_LIBS_USER` and exercises the full transitive graph.
- **`cancel-in-progress` scoped to PRs.** Unconditional cancellation let the next main merge kill the in-flight tier-2/3 run; rapid merge bursts left intermediate main commits with no webR validation (observed on 2026-07-10: #1230's main run was cancelled 3 seconds after starting when the next push landed). Main pushes now let the running validation finish; GitHub still dedupes queued runs, so a burst validates its first and latest commits without piling up runners.

## Test plan
- [x] Both parsers tested verbatim against `rpkg/DESCRIPTION` from the on-disk files (sed-extracted, not retyped): each yields `cli, lifecycle, R6, S7, vctrs`, identical to the previous hardcoded lists (`methods`/`utils` correctly excluded as base).
- [x] Digest-lockstep extraction tested locally against all three files: passes on the current aligned pin (`3fbf3dc3…`).
- [x] `node --check smoke.mjs` clean; workflow YAML parses.
- [ ] `pin-lockstep`, tier 1, and tier 2/3 green on this PR (the workflow triggers on its own path filter).

## Notes
- The DESCRIPTION parse in `smoke.mjs` is line-wise DCF (field runs until the next column-0 line) rather than a multiline regex — the first regex attempt failed silently because `$` under the `m` flag matches at every line end.
- `installPackages` against repo.r-wasm.org means a newly added Import must exist there as a wasm binary; deriving the list surfaces that requirement automatically instead of when someone remembers to update the hardcoded copy.
- Related: #747 (dropping the mirror-credentials block once the GHCR package is public) is unchanged here.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)