### PR TITLE
feat(webr): informational testthat pass in the tier-3 smoke (#1255)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -277,10 +277,17 @@ jobs:
 
       - name: Tier 3 — run Node + webR smoke (library(miniextendr))
         working-directory: tests/webr-node-smoke
+        env:
+          # Informational testthat pass (#1255): after the gating library()
+          # check, run rpkg's suite inside the webR session and report
+          # counts. Never gates — smoke.mjs races it against a 20-min
+          # JS-side budget so a wedged suite can't eat the step timeout.
+          SMOKE_TESTTHAT: "1"
         run: |
           set -euo pipefail
           # Hard wall-clock cap: webR init + Imports install + library load
-          # should take well under 10 min on a clean runner. If we ever hit
-          # 15 min the runner has wedged on something — fail visibly rather
-          # than burning the 90-min job timeout.
-          timeout 900 node smoke.mjs
+          # should take well under 10 min on a clean runner, plus up to 20
+          # min for the informational testthat pass. If we hit 40 min the
+          # runner has wedged on something — fail visibly rather than
+          # burning the 90-min job timeout.
+          timeout 2400 node smoke.mjs

--- a/docs/WEBR.md
+++ b/docs/WEBR.md
@@ -17,13 +17,13 @@ cross-package wasm stubs (#493), side-module `RUSTFLAGS`
 base-image mirror (#496), the redundant `-C relocation-model=pic` flag
 dropped (#745), the base-image pin bumped to a tagged webR v0.6.0 / R 4.6.0
 release (#755), dependency guidance (#752 — see "Dependencies and webR"
-below), and the compiled-imports lint (#925,
-`minirextendr::miniextendr_webr_import_lint()`). Open follow-ups: #495
+below), the compiled-imports lint (#925,
+`minirextendr::miniextendr_webr_import_lint()`), and the informational
+testthat-under-wasm pass (#1255, `SMOKE_TESTTHAT=1`). Open follow-ups: #495
 (cross-crate trait dispatch), #1254 (on-hardware validation of the
 arm64-native dev image — first cut landed as `Dockerfile.webr-arm64` via
 #788 / PR #916; see "arm64-native dev image" below), #747 (drop mirror creds
-once the GHCR package is public), #1255 (testthat-under-wasm coverage,
-dropped when the smoke runners were unified).
+once the GHCR package is public).
 
 ## Target
 
@@ -110,10 +110,12 @@ the container:
    tier 3 uses), which imports `file:///opt/webr/src/dist/webr.mjs` (see
    "Running a webR session in Node" below), NODEFS-mounts the wasm R lib
    tree, installs the hard Imports from repo.r-wasm.org, and drives
-   `library(miniextendr)` + `packageVersion()`. It does **not** run the
-   testthat suite — that coverage was dropped when the local and CI runners
-   were unified onto `smoke.mjs`; restoring an informational testthat pass
-   is tracked in #1255.
+   `library(miniextendr)` + `packageVersion()`. With `SMOKE_TESTTHAT=1`
+   (the local-smoke default; CI sets it too) it then runs an
+   **informational** testthat pass (#1255): suite counts are reported, but
+   many tests legitimately fail or skip under wasm (worker thread / fork /
+   subprocess assumptions), so the pass never affects the exit status, and
+   a 20-minute JS-side budget abandons a wedged suite.
 
 First cold run is **1–2 hours** on Apple Silicon (Rosetta amd64 + cargo
 wasm32 build). Subsequent runs reuse the docker image and most cargo
@@ -406,8 +408,9 @@ install regenerates `wasm_registry.rs`), Phase 2 (emcc wasm install →
 `/tmp/wasm-lib/miniextendr`, the empirical validator for the side-module
 `RUSTFLAGS`), then **tier 3** — the Node + webR session
 (`tests/webr-node-smoke/smoke.mjs`) that NODEFS-mounts the wasm install,
-installs the package's Imports from `repo.r-wasm.org`, and drives
-`library(miniextendr)`. Tier 2 only proves the side-module *links*; tier 3
+installs the package's Imports from `repo.r-wasm.org`, drives
+`library(miniextendr)`, and finishes with the informational testthat pass
+(#1255, never gating). Tier 2 only proves the side-module *links*; tier 3
 is what proves it *loads* in a real webR runtime.
 
 ## See also
@@ -418,8 +421,8 @@ is what proves it *loads* in a real webR runtime.
   (`miniextendr_webr_import_lint()`, shipped);
   #788 — arm64-native dev image (first cut: `Dockerfile.webr-arm64` + the
   `docker-webr-arm64-*` just recipes + the `WEBR_ARM64=1` smoke path;
-  on-hardware validation tracked in #1254); #1255 — testthat-under-wasm
-  coverage (dropped when the smoke runners were unified).
+  on-hardware validation tracked in #1254); #1255 — the informational
+  testthat-under-wasm pass (`SMOKE_TESTTHAT=1`, shipped).
 - Issues #491 / #744 — the base-package variant of the host-R-loads-a-wasm-
   object failure, solved via the install-to-temp-lib pattern (the dependency
   guidance above is the consumer-package-imports variant of the same failure).

--- a/justfile
+++ b/justfile
@@ -1447,8 +1447,8 @@ docker-webr-test: docker-webr-build
 # Run the webR/wasm32 smoke test for rpkg.
 # Builds rpkg as a wasm32 side-module inside the dev container and loads it
 # in a webR Node session via the canonical runner
-# tests/webr-node-smoke/smoke.mjs (library() + packageVersion() only;
-# testthat-under-wasm coverage is tracked in #1255).
+# tests/webr-node-smoke/smoke.mjs, plus an informational testthat pass
+# (#1255; counts reported, never gates — disable with SMOKE_TESTTHAT=0).
 docker-webr-smoke *args: docker-webr-build
     bash tests/webr-smoke.sh {{args}}
 

--- a/tests/webr-node-smoke/smoke.mjs
+++ b/tests/webr-node-smoke/smoke.mjs
@@ -119,7 +119,67 @@ async function main() {
   const version = unwrapScalar(await versionResult.toJs());
   console.log(`[tier3] miniextendr version: ${version}`);
 
+  if (process.env.SMOKE_TESTTHAT === "1") {
+    const budget = new Promise((resolve) =>
+      setTimeout(() => {
+        console.log(
+          "[tier3][testthat] 20-min budget exceeded — abandoning the informational pass.",
+        );
+        resolve();
+      }, TESTTHAT_BUDGET_MS),
+    );
+    await Promise.race([
+      informationalTestthat().catch((e) => {
+        console.log(
+          "[tier3][testthat] informational pass failed (not a gate):",
+          e && e.message ? e.message : e,
+        );
+      }),
+      budget,
+    ]);
+  }
+
   console.log("[tier3] Tier-3 PASSED.");
+}
+
+// ── Informational testthat pass (#1255, opt-in via SMOKE_TESTTHAT=1) ────────
+// Restores the coverage dropped when the local and CI runners were unified:
+// run rpkg's testthat suite inside the webR session and report counts.
+// Strictly informational — many tests legitimately fail or skip under wasm
+// (worker thread / fork / subprocess assumptions), so this NEVER affects the
+// exit status, and the Promise.race budget above keeps a wedged suite from
+// eating the step timeout (the stuck R worker is torn down by webR.close()
+// in the top-level teardown regardless).
+const TESTTHAT_BUDGET_MS = 20 * 60 * 1000;
+
+async function informationalTestthat() {
+  console.log("[tier3][testthat] Installing testthat from repo.r-wasm.org...");
+  await webR.installPackages(["testthat"], { mount: false, quiet: false });
+  // The rpkg source tree (for tests/testthat) — relative to this script's
+  // documented working directory (tests/webr-node-smoke); override with
+  // SMOKE_RPKG_DIR for non-standard layouts.
+  const rpkgDir = process.env.SMOKE_RPKG_DIR || "../../rpkg";
+  await webR.FS.mkdir("/rpkg-src");
+  await webR.FS.mount("NODEFS", { root: rpkgDir }, "/rpkg-src");
+  console.log(
+    `[tier3][testthat] NODEFS-mounted ${rpkgDir} -> /rpkg-src; running test_dir (silent reporter)...`,
+  );
+  const res = await webR.evalR(`
+    tryCatch({
+      res <- testthat::test_dir(
+        "/rpkg-src/tests/testthat",
+        package = "miniextendr",
+        reporter = "silent",
+        stop_on_failure = FALSE
+      )
+      df <- as.data.frame(res)
+      sprintf(
+        "passed=%d failed=%d skipped=%d errors=%d",
+        sum(df$passed), sum(df$failed), sum(df$skipped), sum(df$error)
+      )
+    }, error = function(e) paste0("suite errored: ", conditionMessage(e)))
+  `);
+  console.log("[tier3][testthat] result:", unwrapScalar(await res.toJs()));
 }
 
 // webR boots a dedicated worker (Node `worker_threads`) to host the R runtime.

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -3,8 +3,10 @@
 #
 # Local smoke test: builds rpkg as a wasm32 side-module inside the
 # miniextendr-webr-dev container and loads it in a webR Node.js session
-# via the canonical runner tests/webr-node-smoke/smoke.mjs — library() +
-# packageVersion() only (testthat-under-wasm coverage is tracked in #1255).
+# via the canonical runner tests/webr-node-smoke/smoke.mjs. By default the
+# runner then does an informational testthat pass (#1255): suite counts are
+# reported but never gate (many tests legitimately fail or skip under wasm);
+# disable with SMOKE_TESTTHAT=0.
 #
 # Exit codes:
 #   0  — miniextendr loaded in the webR session
@@ -300,10 +302,13 @@ phase_webr_session() {
     "
 
     log "Running canonical Node smoke runner (tests/webr-node-smoke/smoke.mjs)..."
+    # SMOKE_TESTTHAT defaults ON locally (host env passes through; the CI
+    # workflow sets it explicitly). The 2400s cap = ~10 min smoke + the
+    # runner's 20-min informational-testthat budget.
     docker_run "
         set -euo pipefail
         cd /work/tests/webr-node-smoke
-        timeout 900 node smoke.mjs
+        SMOKE_TESTTHAT=${SMOKE_TESTTHAT:-1} timeout 2400 node smoke.mjs
     "
 
     ok "webR session complete (library(miniextendr) loaded)."


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Implements #1255 (option 1 from the issue): restore the testthat-under-wasm coverage that was dropped when the local and CI runners were unified onto `smoke.mjs`, as a strictly informational pass.

- `tests/webr-node-smoke/smoke.mjs`: with `SMOKE_TESTTHAT=1`, after the gating `library(miniextendr)` check the runner installs testthat from repo.r-wasm.org, NODEFS-mounts the rpkg source tree (`SMOKE_RPKG_DIR` overrides the `../../rpkg` default), runs `test_dir` with the silent reporter and `stop_on_failure = FALSE`, and logs `passed/failed/skipped/errors` counts.
- Hang-proof by construction: the phase is wrapped in a catch that only logs (never sets the exit code), and it races a 20-minute JS-side budget — a suite wedged on a blocked subprocess is simply abandoned, and the stuck R worker dies with `webR.close()` in the existing teardown. The tier-3 gate semantics are unchanged.
- `.github/workflows/webr.yml`: tier-3 step sets `SMOKE_TESTTHAT=1` and the wall-clock cap goes 900s → 2400s to cover the budget.
- `tests/webr-smoke.sh` / justfile / docs/WEBR.md: local smoke defaults the pass ON (`SMOKE_TESTTHAT=0` disables); docs updated from "coverage dropped, tracked in #1255" to the shipped behavior.

**Stacked on #1256** (base branch `review/webr-wasm-support`) because it rewrites doc/header lines that PR just fixed — merge #1256 first, then retarget/merge this. Disjoint from #1257's hunks.

## Test plan
- [x] `node --check smoke.mjs`, workflow YAML parse, `bash -n webr-smoke.sh` all clean.
- [x] The exact R counting snippet validated natively against a synthetic suite (2 pass / 1 fail / 1 skip → `passed=2 failed=1 skipped=1 errors=0`).
- [ ] This PR's own tier-3 job is the end-to-end wasm validation — it runs with `SMOKE_TESTTHAT=1`, so the log should show `[tier3][testthat] result: passed=… failed=… skipped=…` (or a clean informational failure line) followed by `Tier-3 PASSED`.

## Notes
- Expect substantial failed/skipped counts under wasm (worker-thread, fork, and subprocess assumptions); the value is trend visibility, not green-ness. If the first CI run shows the 20-min budget being exceeded routinely, the budget or the CI opt-in can be tuned — that's a knob, not a redesign.
- testthat's wasm binary and its dependency closure come from repo.r-wasm.org via `webR.installPackages`; if that fetch fails the pass logs and steps aside without gating.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)