### PR TITLE
ci: run gctorture stress files once per PR (sharded), not in every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only PRs cancel their superseded runs. Main-push runs queue instead:
+  # with cancel-on-main, every merge cancelled the previous merge's run, so
+  # on busy days the main-tip guard (heap-check, devel/oldrel legs) never
+  # actually completed (observed 2026-07-10: all recent main runs cancelled).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -193,6 +197,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.r == 'true'
+    env:
+      # wrappers-sync-check does a full source-mode `R CMD INSTALL` (Rust
+      # compile) — without sccache it was the job's dominant cost (~13 min
+      # cold vs ~5 min warm in the identically-shaped r-tests job).
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -208,12 +218,22 @@ jobs:
           use-public-rspm: true
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rpkg/src/rust -> target
+          shared-key: sync-checks
+          cache-on-failure: true
 
       - name: Set up cargo-revendor (install only)
         uses: ./.github/actions/setup-vendor
@@ -513,18 +533,25 @@ jobs:
     if: needs.changes.outputs.r == 'true'
     strategy:
       fail-fast: false
+      # PRs check on R release only. devel (advisory — continue-on-error) and
+      # oldrel-1 rarely catch anything release doesn't on a per-PR basis but
+      # cost ~2x45 min of runners per push; they still run on push-to-main,
+      # the weekly schedule, and workflow_dispatch, so a genuine devel/oldrel
+      # breakage surfaces within one merge.
       matrix:
-        include:
-          - r: release
-          - r: devel
-            allow_failure: true # R-devel may break for upstream reasons
-          - r: oldrel-1
+        include: ${{ github.event_name == 'pull_request'
+          && fromJSON('[{"r":"release"}]')
+          || fromJSON('[{"r":"release"},{"r":"devel","allow_failure":true},{"r":"oldrel-1"}]') }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      # The gctorture-heavy test files (~31 of the suite's ~34 min) run once
+      # per PR in the dedicated r-stress-tests job — not in every check leg.
+      # See rpkg/tests/testthat/helper-gc-stress.R.
+      MINIEXTENDR_SKIP_STRESS: "1"
 
     steps:
       - uses: actions/checkout@v7
@@ -548,9 +575,10 @@ jobs:
           needs: check
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -926,13 +954,12 @@ jobs:
   r-tests:
     name: R tests / Linux
     runs-on: ubuntu-latest
-    # This job bundles unit tests + the 3-round randomized gctorture heap-check
-    # + the Valgrind ALTREP pass; the total runs ~47 min and outgrew the prior
-    # 45-min cap (itself a 30->45 bump in #732), so the tip-of-main run was
-    # being cancelled by timeout. Use the 90 min the other heavy jobs here use.
-    # If it overruns again, split the heap-check/Valgrind into their own job(s)
-    # rather than bumping a third time.
-    timeout-minutes: 90
+    # Fast source-mode leg: full suite minus the gctorture-heavy files (those
+    # run once per PR in r-stress-tests below), plus the heap-check rounds
+    # (main/label) and the Valgrind ALTREP pass. Before the stress split this
+    # job bundled everything and had outgrown even a 90-min cap on main pushes
+    # (suite 34 min + 3 heap-check rounds = ~140 min -> guaranteed timeout).
+    timeout-minutes: 60
     needs: changes
     if: needs.changes.outputs.r == 'true'
 
@@ -940,6 +967,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      # Stress files run in r-stress-tests; this also keeps the 3x heap-check
+      # rounds below within the job budget (they re-run the whole suite).
+      MINIEXTENDR_SKIP_STRESS: "1"
 
     steps:
       - uses: actions/checkout@v7
@@ -984,11 +1014,14 @@ jobs:
 
       - name: Run tests with heap checking (3 rounds, randomized order)
         # Heap checking (glibc MALLOC_CHECK_, 3 randomized rounds) is the
-        # GC-discipline guard, but it runs ~30+ min and reliably overruns the
-        # 45-min job budget (bumped 30 -> 45 in #732 and still cancelling).
-        # Gate it on PRs behind the `heap-check` label so routine PRs stay fast;
-        # still run it unconditionally on push-to-main, the weekly schedule, and
-        # manual dispatch so merged code keeps its GC safety net.
+        # malloc-discipline guard. Gate it on PRs behind the `heap-check` label
+        # so routine PRs stay fast; still run it unconditionally on
+        # push-to-main, the weekly schedule, and manual dispatch so merged code
+        # keeps its safety net. The rounds inherit MINIEXTENDR_SKIP_STRESS
+        # (~5 min each, not ~35): heap-check hunts malloc/free corruption
+        # across the whole suite, while the gctorture files have their own
+        # dedicated job — running torture under MALLOC_CHECK_ three extra
+        # times is what used to push this job past any timeout.
         if: >-
           github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'heap-check')
@@ -1024,6 +1057,83 @@ jobs:
           else
             echo "Valgrind not available, skipping"
           fi
+
+  # ===========================================================================
+  # R Package: GC-stress tests (gctorture) — sharded
+  # ===========================================================================
+  # The single place the gctorture-heavy test files run per PR (every other
+  # suite-running job sets MINIEXTENDR_SKIP_STRESS=1 — they were all running
+  # the same ~31 min of torture, five times per push). The dominant cost is
+  # the dynamic no-arg fixture sweep in test-gc-stress-fixtures.R; it splits
+  # across the shards by fixture index (MINIEXTENDR_STRESS_SHARD=k/n, see
+  # helper-gc-stress.R), and the other stress files are distributed via the
+  # testthat filter so the shards stay balanced. Per-PR coverage is unchanged:
+  # same fixtures, same iteration counts, run once instead of five times. The
+  # nightly gctorture-nightly.yml step=100 full-suite sweep remains the deep net.
+  r-stress-tests:
+    name: R GC-stress tests / shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: changes
+    if: needs.changes.outputs.r == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Shard 1: sweep half 1 + the ExternalPtr self-root file.
+          - shard: "1/2"
+            filter: "gc-stress-fixtures|externalptr-self-root"
+          # Shard 2: sweep half 2 + the two dataframe stress files.
+          - shard: "2/2"
+            filter: "gc-stress-fixtures|iter-to-dataframe|dataframe-deserialize"
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      MINIEXTENDR_STRESS_SHARD: ${{ matrix.shard }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          lfs: true
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: rpkg
+          extra-packages: any::testthat
+          needs: check
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rpkg/src/rust -> target
+          # Same source-mode build as r-tests — share its cache rather than
+          # keeping per-shard copies of an identical target dir.
+          shared-key: r-tests
+          cache-on-failure: true
+
+      - name: Install package (source mode)
+        # Same source-mode install as r-tests: no vendor tarball, configure.ac
+        # detects source install and resolves the workspace via path overrides.
+        run: R CMD INSTALL rpkg
+
+      - name: Run GC-stress tests
+        working-directory: rpkg
+        shell: bash
+        run: Rscript -e 'testthat::test_local(filter = "${{ matrix.filter }}")'
 
   # ===========================================================================
   # Feature runtime legs (scheduled only)
@@ -1097,7 +1207,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -1188,9 +1298,10 @@ jobs:
           needs: check
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -1251,9 +1362,10 @@ jobs:
           needs: check
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -1296,6 +1408,12 @@ jobs:
       # inst/vendor.tar.xz (produced by `just vendor` below). No NOT_CRAN needed.
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      # Skip the gctorture files here for CRAN realism as much as speed: their
+      # helper also calls skip_on_cran(), because a half-hour test suite would
+      # be rejected by real CRAN. The explicit env var is still needed —
+      # r-lib's setup actions export NOT_CRAN=true into every job, so
+      # skip_on_cran() alone never fires in CI. See helper-gc-stress.R.
+      MINIEXTENDR_SKIP_STRESS: "1"
 
     steps:
       - uses: actions/checkout@v7
@@ -1319,9 +1437,10 @@ jobs:
           needs: check
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -1514,9 +1633,10 @@ jobs:
           needs: check
 
       - name: Install autoconf
+        # ubuntu-latest images ship autoconf; the apt path is only a fallback
+        # for image changes (saves ~30-60 s of apt-get update per job).
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf
+          command -v autoconf >/dev/null || { sudo apt-get update && sudo apt-get install -y autoconf; }
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -1556,6 +1676,7 @@ jobs:
       # - r-check-macos   # non-gating: runs only on workflow_dispatch + weekly cron, see #95
       # - r-check-windows # DISABLED — re-enable when Windows job is uncommented above
       - r-tests
+      - r-stress-tests
       - cross-package-tests
       - minirextendr
       - cran-check
@@ -1577,6 +1698,7 @@ jobs:
             # "${{ needs.r-check-macos.result }}"   # non-gating, see #95
             # "${{ needs.r-check-windows.result }}" # DISABLED
             "${{ needs.r-tests.result }}"
+            "${{ needs.r-stress-tests.result }}"
             "${{ needs.cross-package-tests.result }}"
             "${{ needs.minirextendr.result }}"
             "${{ needs.cran-check.result }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,12 @@ other runners silently corrupt and "pass." See `docs/GCTORTURE_TESTING.md`
 for the harness pattern (load package first, *then* enable gctorture;
 per-function loop is fastest; full `test_dir` sweep is for nightly).
 
+In CI the gctorture-heavy testthat files run once per PR in the sharded
+`r-stress-tests` job; every other suite-running job sets
+`MINIEXTENDR_SKIP_STRESS=1` (see `rpkg/tests/testthat/helper-gc-stress.R` and
+`docs/GCTORTURE_TESTING.md` → "How CI runs the gctorture tests"). Locally both
+env vars are unset and `just devtools-test` runs everything.
+
 **Convention: ship a no-arg fixture with new SEXP-storage features.** The fast
 gctorture sweep over `rpkg/`'s exports only exercises functions callable with
 no arguments — argument synthesis for arbitrary `#[miniextendr]` signatures

--- a/docs/GCTORTURE_TESTING.md
+++ b/docs/GCTORTURE_TESTING.md
@@ -137,7 +137,29 @@ For a tighter feedback loop while bisecting:
 - Pool variant for any-order release: `miniextendr-api/src/protect_pool.rs`
   (`ProtectPool` — VECSXP-backed, generational keys).
 
-## Adding to CI
+## How CI runs the gctorture tests (per-PR)
+
+The gctorture-heavy testthat files (`test-gc-stress-fixtures.R`,
+`test-externalptr-self-root.R`, `test-iter-to-dataframe.R`,
+`test-dataframe-deserialize.R`) are ~31 of the suite's ~34 minutes, so CI runs
+them **exactly once per PR**, in the sharded `r-stress-tests` job, instead of
+inside every job that happens to execute the suite. Two env vars, both handled
+by `rpkg/tests/testthat/helper-gc-stress.R`, orchestrate this:
+
+- `MINIEXTENDR_SKIP_STRESS=1` — skips the torture blocks (cheap structure /
+  value assertions in the same files keep running). Set by the `R CMD check`
+  legs, the CRAN-like check, and the `r-tests` job (including its heap-check
+  rounds). The helper also calls `skip_on_cran()`: a half-hour suite is far
+  beyond real CRAN's check budget. Note `skip_on_cran()` alone can't gate CI —
+  r-lib's setup actions export `NOT_CRAN=true` into every job.
+- `MINIEXTENDR_STRESS_SHARD=k/n` — splits the dynamic no-arg fixture sweep in
+  `test-gc-stress-fixtures.R` across the parallel `r-stress-tests` shards by
+  fixture index. Unset locally, so `just devtools-test` always runs everything.
+
+Per-PR coverage is unchanged by this layout — same fixtures, same iteration
+counts, run once instead of five times.
+
+## Adding to CI (nightly deep sweep)
 
 A nightly `gctorture nightly` job invokes the full-suite recipe at `step = 100` on the
 Linux R-release runner, catching this class of bug before it reaches a release. It is

--- a/plans/2026-07-10-ci-speed-audit.md
+++ b/plans/2026-07-10-ci-speed-audit.md
@@ -1,0 +1,88 @@
+# CI speed audit — dedupe stress tests, revive main-push CI
+
+Date: 2026-07-10. Audited run: `29070047852` (PR CI, success, ~49 min wall).
+
+## Measurements
+
+Per-PR job durations (wall):
+
+| Job | Duration | Dominant cost |
+|---|---|---|
+| R CMD check / Linux devel | 48.5 min | `checking tests` ≈ 31 min |
+| R CMD check / Linux oldrel-1 | 45.0 min | same |
+| R tests / Linux | 44.0 min | `testthat::test_local()` = 34.5 min |
+| R CMD check / Linux release | 39.9 min | `checking tests [31m/30m]` |
+| CRAN-like check | 39.1 min | check step 36 min (same tests) |
+| Sync Checks | 17.0 min | `wrappers-sync-check` 13.2 min (no sccache!) |
+| everything else | ≤ 4 min each | — |
+
+Test-suite breakdown (2051 s total, 7084 tests):
+
+| File | Time | Share |
+|---|---|---|
+| gc-stress-fixtures | 1360 s | 66% |
+| externalptr-self-root | 233 s | 11% |
+| iter-to-dataframe | 194 s | 9% |
+| dataframe-deserialize | 147 s | 7% |
+| all ~90 other files | ~117 s | 6% |
+
+Key facts:
+- Rust compile is NOT the bottleneck: sccache-warm install ≈ 5 min elapsed
+  (`checking whether package can be installed ... [66s/301s]`).
+- The four gctorture files (~32 min) run identically in **five** jobs
+  → ~2.6 h of duplicated runner time per push event.
+- Main-push `r-tests` = suite + 3× heap-check rounds ≈ 140 min > 90-min
+  timeout → the last several main-push runs all cancelled at ~90+ min.
+  The heap-check guard on main effectively never completes.
+- `cancel-in-progress: true` applies to main pushes too, so merge trains
+  cancel main-tip CI serially.
+- Nightly `gctorture-nightly.yml` already runs the full suite under
+  `gctorture2(step=100)` — the deep GC net exists independently of PR CI.
+- `NOT_CRAN=true` is exported by r-lib actions in every job (including
+  CRAN-like check), so `skip_on_cran()` alone cannot gate CI; an explicit
+  env var is required.
+
+## Changes (flat priority)
+
+1. **Gate the four gctorture-heavy test files** behind
+   `MINIEXTENDR_SKIP_STRESS` (new `helper-gc-stress.R`; gates only the
+   torture blocks — cheap structure/value assertions keep running
+   everywhere). Helper also calls `skip_on_cran()`: a 31-min test suite
+   would be rejected by real CRAN anyway.
+2. **New `r-stress-tests` job** (2 shards) is now the single place the
+   gctorture files run per-PR. The dynamic no-arg-fixture sweep (77
+   fixtures × 5 iters) splits by fixture index via
+   `MINIEXTENDR_STRESS_SHARD=k/n`; the three other files are distributed
+   across the shards by testthat `filter`. Coverage per PR is unchanged —
+   same fixtures, same iteration counts, just not repeated 5×.
+3. `r-check-linux`, `cran-check`, `r-tests` set `MINIEXTENDR_SKIP_STRESS=1`.
+   Their `checking tests` drops ~31 min → ~4 min.
+4. **`r-check-linux` matrix trims to `release` on PRs**; devel + oldrel-1
+   still run on push-to-main / schedule / dispatch (dynamic matrix via
+   `fromJSON`). devel is advisory (`continue-on-error`) and oldrel-1
+   rarely diverges — post-merge signal is enough.
+5. **Main-push r-tests fits its budget again**: heap-check rounds inherit
+   the stress skip (3 × ~5 min instead of 3 × ~35 min). Main guard is alive.
+6. **Concurrency: only PRs cancel in-progress runs** — main-push runs now
+   queue instead of cancelling each other.
+7. **Sync Checks gets sccache + rust-cache** (was completely uncached):
+   13 min install → ~5 min.
+8. Housekeeping: autoconf install steps skip apt-get when preinstalled;
+   feature-legs' sccache-action pinned to v0.0.10 like everywhere else.
+
+## Expected outcome
+
+- PR wall-clock: ~50 min → ~30 min (critical path: stress shard).
+- PR runner time: ~240 min → ~135 min.
+- Main-push CI completes instead of timing out/cancelling.
+- Per-PR GC guard preserved (all fixtures, same iterations, once).
+- Real-CRAN test time drops below CRAN's patience threshold.
+
+## Explicitly out of scope (tracked separately)
+
+- The 4 standing `R CMD check` WARNINGs visible in every check log
+  (R code for possible problems / Rd usage / compiled code / unstated
+  test deps) — pre-existing, gated by `error-on: "error"`. → issue.
+- webr.yml duration (~27 min) — under active work in PRs #1256–#1258.
+- devel/oldrel-1 lose per-PR (not post-merge) stress coverage — accepted
+  trade; nightly + main-push retain it on release R.

--- a/rpkg/tests/testthat/helper-gc-stress.R
+++ b/rpkg/tests/testthat/helper-gc-stress.R
@@ -1,0 +1,50 @@
+# CI orchestration for the gctorture-heavy test blocks.
+#
+# The gctorture blocks in test-gc-stress-fixtures.R, test-externalptr-self-root.R,
+# test-iter-to-dataframe.R and test-dataframe-deserialize.R account for ~94% of
+# the suite's runtime (~32 of ~34 min). CI runs them exactly once per PR, in the
+# dedicated sharded `r-stress-tests` job; every other job that runs the suite
+# (R CMD check legs, CRAN-like check, r-tests, heap-check rounds) sets
+# MINIEXTENDR_SKIP_STRESS=1 so it only pays for the fast tests. Local
+# `just devtools-test` sets neither variable and runs everything, unsharded.
+# The nightly gctorture2(step=100) full-suite sweep also runs everything.
+# See docs/GCTORTURE_TESTING.md.
+
+# Skip the calling test when GC-stress work is delegated to another CI job.
+# Also skips on CRAN: a half-hour gctorture pass is far beyond CRAN's check
+# time budget, and the nightly sweep is the real deep net.
+skip_gc_stress_if_disabled <- function() {
+  skip_on_cran()
+  if (nzchar(Sys.getenv("MINIEXTENDR_SKIP_STRESS"))) {
+    skip("GC-stress block skipped: MINIEXTENDR_SKIP_STRESS is set (runs in the r-stress-tests CI job)")
+  }
+}
+
+# Parse MINIEXTENDR_STRESS_SHARD="k/n" into c(k, n), or NULL when unset.
+# Used by the dynamic fixture sweep to split its fixture list across the
+# parallel r-stress-tests shards. Malformed values error loudly rather than
+# silently running everything (a typo'd shard spec must not double coverage
+# in one shard and drop it in another).
+gc_stress_shard <- function() {
+  spec <- Sys.getenv("MINIEXTENDR_STRESS_SHARD", "")
+  if (!nzchar(spec)) {
+    return(NULL)
+  }
+  parts <- strsplit(spec, "/", fixed = TRUE)[[1]]
+  k <- suppressWarnings(as.integer(parts[[1]]))
+  n <- suppressWarnings(as.integer(parts[[length(parts)]]))
+  if (length(parts) != 2L || is.na(k) || is.na(n) || n < 1L || k < 1L || k > n) {
+    stop("MINIEXTENDR_STRESS_SHARD must be 'k/n' with 1 <= k <= n, got: ", spec)
+  }
+  c(k, n)
+}
+
+# Subset a vector to this process's shard (round-robin by index), or return
+# it unchanged when sharding is inactive.
+gc_stress_shard_subset <- function(x) {
+  shard <- gc_stress_shard()
+  if (is.null(shard)) {
+    return(x)
+  }
+  x[seq_along(x) %% shard[[2]] == shard[[1]] %% shard[[2]]]
+}

--- a/rpkg/tests/testthat/test-dataframe-deserialize.R
+++ b/rpkg/tests/testthat/test-dataframe-deserialize.R
@@ -18,6 +18,7 @@ test_that("gc_stress_dataframe_to_vec — returns expected row count", {
 })
 
 test_that("gc_stress_dataframe_to_vec — survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_dataframe_to_vec", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_dataframe_to_vec not compiled (serde feature missing)"
@@ -43,6 +44,7 @@ test_that("gc_stress_dataframe_to_vec_nested — returns expected row count", {
 })
 
 test_that("gc_stress_dataframe_to_vec_nested — survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_dataframe_to_vec_nested", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_dataframe_to_vec_nested not compiled (serde feature missing)"
@@ -69,6 +71,7 @@ test_that("gc_stress_with_dataframe_rows — returns expected sum", {
 })
 
 test_that("gc_stress_with_dataframe_rows — survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_with_dataframe_rows", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_with_dataframe_rows not compiled (serde feature missing)"
@@ -96,6 +99,7 @@ test_that("gc_stress_factor_labels — round-trips factor column to labels", {
 })
 
 test_that("gc_stress_factor_labels — survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_factor_labels", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_factor_labels not compiled (serde feature missing)"

--- a/rpkg/tests/testthat/test-externalptr-self-root.R
+++ b/rpkg/tests/testthat/test-externalptr-self-root.R
@@ -20,6 +20,7 @@ test_that("naive Vec<ExternalPtr> construction runs without corruption", {
 })
 
 test_that("naive Vec<ExternalPtr> construction survives gctorture", {
+  skip_gc_stress_if_disabled()
   # The real coverage is the gctorture sweep over no-arg exports (see
   # docs/GCTORTURE_TESTING.md), but a few torture iterations here give CI a
   # direct regression guard. The fixture is small, so this stays cheap.
@@ -35,6 +36,7 @@ test_that("collect_into_r_list bulk build runs without corruption", {
 })
 
 test_that("collect_into_r_list bulk build survives gctorture", {
+  skip_gc_stress_if_disabled()
   gctorture(TRUE)
   on.exit(gctorture(FALSE), add = TRUE)
   for (i in seq_len(3)) {

--- a/rpkg/tests/testthat/test-gc-stress-fixtures.R
+++ b/rpkg/tests/testthat/test-gc-stress-fixtures.R
@@ -8,6 +8,7 @@
 # region: NamedDataFrameListBuilder -------------------------------------------
 
 test_that("gc_stress_named_df_list_builder returns a valid named list under gctorture", {
+  skip_gc_stress_if_disabled()
   # Load the package first, then enable gctorture — see docs/GCTORTURE_TESTING.md.
   # Flip gctorture on for the loop, off when done regardless of failure.
   gctorture(TRUE)
@@ -57,6 +58,7 @@ test_that("str_borrow_len round-trips a zero-copy &str argument", {
 })
 
 test_that("gc_stress_str_borrow keeps zero-copy &str views intact under gctorture", {
+  skip_gc_stress_if_disabled()
   gctorture(TRUE)
   on.exit(gctorture(FALSE), add = TRUE)
 
@@ -85,6 +87,7 @@ test_that("gc_stress_str_borrow keeps zero-copy &str views intact under gctortur
 # sweep below does not enumerate them — exercise them explicitly, with the
 # structure assertions the sweep can't make.
 test_that("List::from_values / from_pairs string fixtures survive gctorture", {
+  skip_gc_stress_if_disabled()
   gctorture(TRUE)
   on.exit(gctorture(FALSE), add = TRUE)
 
@@ -111,6 +114,7 @@ test_that("List::from_values / from_pairs string fixtures survive gctorture", {
 # compiled, they are not in the namespace. Iterations stay low (5) because
 # this runs in PR CI — nightly's gctorture2 sweep amplifies it.
 test_that("every no-arg gc_stress_* fixture survives gctorture", {
+  skip_gc_stress_if_disabled()
   ns <- getNamespace("miniextendr")
   fixtures <- ls(ns, pattern = "^gc_stress_")
   fixtures <- Filter(function(f) length(formals(get(f, ns))) == 0L, fixtures)
@@ -118,6 +122,10 @@ test_that("every no-arg gc_stress_* fixture survives gctorture", {
   # Rf_error longjmp path; test-worker-longjmp.R expect_error()s it). Every
   # other fixture's contract is an error-free return.
   fixtures <- setdiff(fixtures, "gc_stress_with_r_thread_stop")
+  # CI's r-stress-tests job splits this sweep across parallel shards via
+  # MINIEXTENDR_STRESS_SHARD=k/n (helper-gc-stress.R); locally the env var
+  # is unset and the full fixture list runs.
+  fixtures <- gc_stress_shard_subset(fixtures)
   expect_gt(length(fixtures), 0L)
 
   gctorture(TRUE)
@@ -154,6 +162,7 @@ test_that("every no-arg gc_stress_* fixture survives gctorture", {
 # region: expression RCall builder (#430) -------------------------------------
 
 test_that("gc_stress_expression_call survives gctorture and returns the right value", {
+  skip_gc_stress_if_disabled()
   # Load the package first, then enable gctorture — see docs/GCTORTURE_TESTING.md.
   gctorture(TRUE)
   on.exit(gctorture(FALSE), add = TRUE)

--- a/rpkg/tests/testthat/test-iter-to-dataframe.R
+++ b/rpkg/tests/testthat/test-iter-to-dataframe.R
@@ -17,6 +17,7 @@ test_that("gc_stress_iter_to_dataframe returns a valid data.frame", {
 })
 
 test_that("gc_stress_iter_to_dataframe survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_iter_to_dataframe", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_iter_to_dataframe not compiled (serde feature missing)"
@@ -49,6 +50,7 @@ test_that("gc_stress_builder_with_schema returns a valid data.frame", {
 })
 
 test_that("gc_stress_builder_with_schema survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_builder_with_schema", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_builder_with_schema not compiled (serde feature missing)"
@@ -78,6 +80,7 @@ test_that("gc_stress_builder_grow_schema returns a valid data.frame", {
 })
 
 test_that("gc_stress_builder_grow_schema survives gctorture(TRUE)", {
+  skip_gc_stress_if_disabled()
   skip_if_not(
     exists("gc_stress_builder_grow_schema", envir = getNamespace("miniextendr"), mode = "function", inherits = FALSE),
     "gc_stress_builder_grow_schema not compiled (serde feature missing)"


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Audit of a representative PR run (`29070047852`, ~49 min wall, ~240 runner-min) found the cost is not Rust compilation (sccache-warm installs are ~5 min) but the testthat suite: ~34 min, of which ~31 min is four gctorture files (`test-gc-stress-fixtures.R` alone is 22.7 min), executed identically in five jobs per push. Separately, main-push `r-tests` (suite + 3 heap-check rounds, ~140 min) could never finish its 90-min timeout, and `cancel-in-progress` on main meant merge trains cancelled the main-tip guard serially, so the last several main-push runs never completed.

- New `rpkg/tests/testthat/helper-gc-stress.R`: `MINIEXTENDR_SKIP_STRESS` skips the torture blocks (cheap structure/value assertions in the same files keep running everywhere), and it also calls `skip_on_cran()`, since a half-hour suite would be rejected by real CRAN. `MINIEXTENDR_STRESS_SHARD=k/n` splits the dynamic no-arg fixture sweep (77 fixtures) by index. Both are unset locally, so `just devtools-test` still runs everything.
- New sharded `r-stress-tests` job (2 shards, gating via `ci-success`) is the one place per PR the stress files run. `r-check-linux`, `cran-check`, and `r-tests` (including its heap-check rounds) set `MINIEXTENDR_SKIP_STRESS=1`. Per-PR coverage is unchanged: same fixtures, same iteration counts, run once instead of five times. The nightly `gctorture2(step=100)` full-suite sweep remains the deep net.
- `r-check-linux`: PRs check on R release only; devel (advisory) and oldrel-1 still run on push-to-main, weekly schedule, and dispatch via a dynamic matrix.
- Concurrency: only PRs cancel superseded runs; main pushes now queue, so the main-tip guard actually completes.
- `sync-checks` gains sccache + rust-cache (its full `R CMD INSTALL` was the only uncached Rust build in CI, 13.2 min cold vs ~5 min warm elsewhere).
- Housekeeping: autoconf steps skip `apt-get update` when autoconf is preinstalled; `feature-legs` sccache action pinned to v0.0.10 like every other job.

Expected effect: PR wall-clock ~50 min to ~30 min (new critical path is a stress shard), per-PR runner time ~240 min to ~135 min, and main-push CI (heap-check guard, devel/oldrel legs) completes instead of timing out or being cancelled.

Full measurements and rationale: `plans/2026-07-10-ci-speed-audit.md`.

## Test plan
- [x] All edited R files parse (`Rscript -e 'parse(...)'`)
- [x] `actionlint` on the modified `ci.yml`: finding set identical to main (all pre-existing infos)
- [x] Skip path: with `NOT_CRAN=true MINIEXTENDR_SKIP_STRESS=1`, all torture blocks skip with the env-var reason; structure tests still pass (verified on `test-gc-stress-fixtures.R` and `test-externalptr-self-root.R` against the installed package)
- [x] Shard logic unit-tested: `1/2` + `2/2` partition 77 fixtures (39+38, disjoint, complete); unset env returns the full list; malformed specs (`3/2`, `bogus`) error loudly instead of silently mis-sharding
- [x] Positive control: full `test-gc-stress-fixtures.R` run un-gated with `MINIEXTENDR_STRESS_SHARD=1/77`, all torture blocks + sharded sweep green (270 s)
- [ ] Observe this PR's own CI: `r-stress-tests` shards green, check legs' `checking tests` drops to ~3-4 min, only the release leg runs

## Notes
- Trade-off: devel and oldrel-1 no longer run per-PR, and no R version other than release runs the gctorture files in CI. Both still run on every push to main, so a genuine breakage surfaces within one merge.
- The explicit (non-sweep) torture tests in `test-gc-stress-fixtures.R` run in both shards (~3 min duplication); sharding them individually was not worth the extra helper complexity.
- The standing `Status: 4 WARNINGs` in every R CMD check log (masked by `error-on: "error"`) predates this PR and is filed separately.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>