### PR TITLE
ci: split r-stress-tests into three shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1078,14 +1078,23 @@ jobs:
     if: needs.changes.outputs.r == 'true'
     strategy:
       fail-fast: false
+      # Three shards, balanced from measured timings (run 29073963629: the
+      # 2-shard layout ran 20.0 / 20.9 min of tests; the sweep is ~24 min of
+      # that total, the explicit fixture-file blocks ~3 min, the three whole
+      # files ~4 / ~3 / ~2.5 min). Each shard = one sweep third (~8 min) +
+      # the explicit blocks (~3 min, run per-shard — the sweep file is in
+      # every filter) + one whole stress file, so ~14-15 min of tests each.
       matrix:
         include:
-          # Shard 1: sweep half 1 + the ExternalPtr self-root file.
-          - shard: "1/2"
+          # Shard 1: sweep third 1 + the ExternalPtr self-root file.
+          - shard: "1/3"
             filter: "gc-stress-fixtures|externalptr-self-root"
-          # Shard 2: sweep half 2 + the two dataframe stress files.
-          - shard: "2/2"
-            filter: "gc-stress-fixtures|iter-to-dataframe|dataframe-deserialize"
+          # Shard 2: sweep third 2 + the iter-to-dataframe file.
+          - shard: "2/3"
+            filter: "gc-stress-fixtures|iter-to-dataframe"
+          # Shard 3: sweep third 3 + the dataframe-deserialize file.
+          - shard: "3/3"
+            filter: "gc-stress-fixtures|dataframe-deserialize"
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Follow-up to #1260, which made the GC-stress shards the new CI critical path: its own run (`29073963629`, all green, 23.4 min wall vs ~50 before) measured 20.0 / 20.9 min of test time per shard with only ~2.5 min of job overhead.
- This adds a third shard: each runs one sweep third (~8 min) + the explicit fixture-file blocks (~3 min) + one whole stress file (self-root / iter-to-dataframe / dataframe-deserialize), so ~14-15 min of tests per shard and roughly ~18 min PR wall-clock.
- Pure parallelization, no coverage change: the `MINIEXTENDR_STRESS_SHARD=k/n` helper from #1260 is generic, so this is a matrix-only diff. Verified the 3-way partition covers all 77 fixtures exactly once (26 + 26 + 25).

## Test plan
- [x] `actionlint`: finding set identical to main (all pre-existing)
- [x] Shard partition unit check: `1/3` + `2/3` + `3/3` over 77 fixtures is disjoint and complete
- [ ] Observe this PR's CI: three shard jobs, each test step ~14-15 min

## Notes
- The explicit (non-sweep) torture blocks in `test-gc-stress-fixtures.R` now run in three shards instead of two (~3 min duplicated per extra shard). Making them shard-aware would save that but needs per-block helper calls; not worth it at this size.
- One more runner-job of fixed overhead per push event: roughly +5-6 min runner time against a ~5 min wall-clock win.
- Unrelated observation from #1260's run, flagging for visibility: Sync Checks' `Install R packages (devtools, roxygen2)` step took 15.9 min (looked like a pak cache miss); its Rust half dropped 13.2 -> 2.3 min as intended. Worth watching on this PR's run before assuming it needs action.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>