### PR TITLE
docs(skills): use prelude glob in ALTREP skill example (#1229)

### DIFF
--- a/docs/ALTREP.md
+++ b/docs/ALTREP.md
@@ -22,10 +22,10 @@ ALTREP allows you to create R vectors with custom internal representations. Inst
 Here's a minimal ALTREP example - a constant integer vector using the field-based derive (simplest approach):
 
 ```rust
-use miniextendr_api::{miniextendr, SEXP, IntoR};
+use miniextendr_api::prelude::*;
 
 // 1. Define your data type with derive - generates everything
-#[derive(miniextendr_api::AltrepInteger)]
+#[derive(AltrepInteger)]
 #[altrep(len = "len", elt = "value", class = "ConstantInt")]
 pub struct ConstantIntData {
     value: i32,
@@ -79,7 +79,7 @@ fn get_data() -> Vec<i32> {
 ### ALTREP Conversion (IntoRAltrep) - Zero-Copy
 
 ```rust
-use miniextendr_api::IntoRAltrep;
+use miniextendr_api::prelude::*;
 
 #[miniextendr]
 fn get_data() -> SEXP {
@@ -140,7 +140,7 @@ Is your data > 1000 elements?
 ### Examples
 
 ```rust
-use miniextendr_api::{miniextendr, IntoRAltrep, SEXP};
+use miniextendr_api::prelude::*;
 
 // Small data - copy is fine
 #[miniextendr]
@@ -353,9 +353,10 @@ pub fn arith_seq(from: f64, to: f64, length_out: i32) -> SEXP {
 For cases where you want lazy computation but also need to support `DATAPTR`:
 
 ```rust
+use miniextendr_api::prelude::*;
 use miniextendr_api::altrep_data::AltrepDataptr;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "LazyIntSeq")]
 pub struct LazyIntSeqData {
     start: i32,
@@ -417,7 +418,8 @@ impl AltrepSerialize for LazyIntSeqData {
     fn serialized_state(&self) -> SEXP {
         // Return a serializable representation (typically a simple vector)
         unsafe {
-            use miniextendr_api::sys::{Rf_allocVector, SET_INTEGER_ELT, SEXPTYPE};
+            use miniextendr_api::SEXPTYPE;
+            use miniextendr_api::sys::{Rf_allocVector, SET_INTEGER_ELT};
             let state = Rf_allocVector(SEXPTYPE::INTSXP, 3);
             SET_INTEGER_ELT(state, 0, self.start);
             SET_INTEGER_ELT(state, 1, self.step);
@@ -574,6 +576,13 @@ framework guarantees unique, so the collision is always in your own code.
 
 ## Mutable Vectors (Set_elt)
 
+> **Known drift (#1266)**: the data-trait `set_elt` shown in this section has
+> been removed — `AltStringData`/`AltListData` no longer have a `set_elt`
+> method and `impl_alt*_from_data!` has no `set_elt` option. Mutation currently
+> requires implementing the low-level `AltString`/`AltList` traits with
+> `HAS_SET_ELT = true`. The examples below do **not** compile against current
+> main; this section is pending a rewrite.
+
 String and List vectors can be made mutable by implementing the `set_elt()` method. This allows R code to modify elements in-place.
 
 **Important**: Only String and List types support `set_elt`. Numeric vectors (Integer, Real, Logical, Raw, Complex) cannot be mutated through ALTREP.
@@ -581,11 +590,10 @@ String and List vectors can be made mutable by implementing the `set_elt()` meth
 ### Mutable String Vectors
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltStringData};
-use miniextendr_api::sys::SEXP;
+use miniextendr_api::prelude::*;
 use std::cell::RefCell;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "MutableString")]
 pub struct MutableStringData {
     strings: RefCell<Vec<Option<String>>>,
@@ -629,11 +637,10 @@ miniextendr_api::impl_altstring_from_data!(MutableStringData, set_elt);
 Lists are easier to make mutable since they already store SEXPs:
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltListData};
-use miniextendr_api::sys::SEXP;
+use miniextendr_api::prelude::*;
 use std::cell::RefCell;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "MutableList")]
 pub struct MutableListData {
     // SEXPs need to be protected from GC
@@ -732,10 +739,10 @@ pub fn static_ints() -> SEXP {
 ## Complex Numbers
 
 ```rust
-use miniextendr_api::sys::Rcomplex;
-use miniextendr_api::altrep_data::AltComplexData;
+use miniextendr_api::prelude::*;
+use miniextendr_api::Rcomplex;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "UnitCircle")]
 pub struct UnitCircleData {
     n: usize,  // Number of points on unit circle
@@ -767,9 +774,10 @@ pub fn unit_circle(n: i32) -> SEXP {
 Use the `Logical` enum for proper NA handling:
 
 ```rust
-use miniextendr_api::altrep_data::{AltLogicalData, Logical};
+use miniextendr_api::prelude::*;
+use miniextendr_api::altrep_data::Logical;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "LogicalVec")]
 pub struct LogicalVecData {
     data: Vec<Logical>,
@@ -812,9 +820,9 @@ miniextendr_api::impl_altlogical_from_data!(LogicalVecData);
 String ALTREPs return `Option<&str>` where `None` represents `NA`:
 
 ```rust
-use miniextendr_api::altrep_data::AltStringData;
+use miniextendr_api::prelude::*;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "StringVec")]
 pub struct StringVecData {
     data: Vec<Option<String>>,
@@ -842,9 +850,9 @@ miniextendr_api::impl_altstring_from_data!(StringVecData);
 ## Raw Vectors
 
 ```rust
-use miniextendr_api::altrep_data::AltRawData;
+use miniextendr_api::prelude::*;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "RepeatingRaw")]
 pub struct RepeatingRawData {
     pattern: Vec<u8>,
@@ -871,11 +879,10 @@ miniextendr_api::impl_altraw_from_data!(RepeatingRawData);
 List vectors (R's `list` type / VECSXP) can contain any R objects. The `AltListData` trait allows you to create lists that compute or fetch elements on demand.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltListData};
-use miniextendr_api::sys::SEXP;
-use miniextendr_api::{IntoR, Rf_ScalarInteger};
+use miniextendr_api::prelude::*;
+use miniextendr_api::sys::Rf_ScalarInteger;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "IntegerSequenceList")]
 pub struct IntegerSequenceListData {
     n: usize,  // Number of elements in the list
@@ -1049,8 +1056,8 @@ R calls `extract_subset(x, indices, call)` when:
 ### Basic Example: Range Subsetting
 
 ```rust
+use miniextendr_api::prelude::*;
 use miniextendr_api::altrep_traits::AltVec;
-use miniextendr_api::sys::{SEXP, R_xlen_t};
 
 impl AltVec for RangeData {
     const HAS_EXTRACT_SUBSET: bool = true;
@@ -1082,7 +1089,7 @@ impl AltVec for ConstantIntData {
     const HAS_EXTRACT_SUBSET: bool = true;
 
     fn extract_subset(x: SEXP, indices: SEXP, _call: SEXP) -> SEXP {
-        use miniextendr_api::sys::{Rf_xlength, TYPEOF, SEXPTYPE};
+        use miniextendr_api::sys::Rf_xlength;
 
         let data = unsafe { altrep_data1_as::<ConstantIntData>(x) }?;
 
@@ -1136,7 +1143,8 @@ With `extract_subset`:
 
 ```rust
 fn extract_subset(x: SEXP, indices: SEXP, _call: SEXP) -> SEXP {
-    use miniextendr_api::sys::{TYPEOF, SEXPTYPE};
+    use miniextendr_api::SEXPTYPE;
+    use miniextendr_api::sys::TYPEOF;
 
     unsafe {
         match TYPEOF(indices) {

--- a/docs/ALTREP_EXAMPLES.md
+++ b/docs/ALTREP_EXAMPLES.md
@@ -17,11 +17,10 @@ Real-world examples of ALTREP usage patterns in miniextendr.
 **Use case**: Lazy loading of database query results without materializing all rows.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltListData};
-use miniextendr_api::sys::SEXP;
+use miniextendr_api::prelude::*;
 use std::cell::RefCell;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "DatabaseResultSet")]
 pub struct DatabaseResultSet {
     connection_id: usize,
@@ -77,11 +76,12 @@ summary <- results[[1:100]]    # Fetches first 100 rows
 **Use case**: Zero-copy access to large binary files.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltRawData, AltrepDataptr};
+use miniextendr_api::prelude::*;
+use miniextendr_api::altrep_data::AltrepDataptr;
 use memmap2::Mmap;
 use std::fs::File;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "MappedFile")]
 pub struct MappedFile {
     _file: File,
@@ -134,9 +134,9 @@ checksum <- sum(as.integer(file))  # Process entire file
 **Use case**: Generate time series data on-demand from formula.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltRealData};
+use miniextendr_api::prelude::*;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "SinewaveTimeSeries")]
 pub struct SinewaveTimeSeries {
     frequency: f64,
@@ -186,10 +186,10 @@ max(wave)           # Find peak (should be ~1.0)
 **Use case**: Efficient representation of sparse data.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltIntegerData};
+use miniextendr_api::prelude::*;
 use std::collections::HashMap;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "SparseVector")]
 pub struct SparseVector {
     length: usize,
@@ -252,11 +252,11 @@ sparse[1:100]      # Access works normally
 **Use case**: Lazy-load strings from external API with intelligent caching.
 
 ```rust
-use miniextendr_api::altrep_data::{AltrepLen, AltStringData};
+use miniextendr_api::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-#[derive(miniextendr_api::Altrep)]
+#[derive(Altrep)]
 #[altrep(class = "ApiStringCache")]
 pub struct ApiStringCache {
     api_endpoint: String,

--- a/docs/MINIEXTENDR_ATTRIBUTE.md
+++ b/docs/MINIEXTENDR_ATTRIBUTE.md
@@ -12,8 +12,7 @@ Complete reference for `#[miniextendr]` on every Rust item type.
 | `impl` (inherent) | Env-class methods | `#[miniextendr] impl Counter { ... }` |
 | `impl Trait for Type` | Trait ABI shims | `#[miniextendr(s3)] impl Display for Counter { ... }` |
 | `trait` | Vtable + ABI generation | `#[miniextendr] pub trait Counter { ... }` |
-| 1-field `struct` | ALTREP class | `#[miniextendr] struct MyVec(Vec<i32>)` |
-| multi-field `struct` | ExternalPtr | `#[miniextendr] struct Point { x: f64, y: f64 }` |
+| `struct` (any field count) | ExternalPtr | `#[miniextendr] struct Point { x: f64, y: f64 }` |
 | fieldless `enum` | RFactor | `#[miniextendr] enum Color { Red, Green, Blue }` |
 
 ---
@@ -456,34 +455,26 @@ impl<T: AsRef<str>> Display for T { /* ... */ }
 
 ## Structs
 
-### 1-Field Struct → ALTREP (default)
+### ALTREP via `#[miniextendr]` Is Removed
+
+`#[miniextendr]` no longer generates ALTREP classes. Applying the old ALTREP
+attributes (`class`, `base`) to a 1-field struct is a compile error with
+migration guidance. Use the per-family ALTREP derives instead:
 
 ```rust
-#[miniextendr]
-pub struct LazyInts(Vec<i32>);
+use miniextendr_api::prelude::*;
+
+#[derive(AltrepInteger)]
+#[altrep(len = "len", elt = "value", class = "MyInts")]
+pub struct LazyInts {
+    value: i32,
+    len: usize,
+}
 ```
 
-Generates ALTREP class registration + `IntoR` + `TryFromSexp`. The struct wraps
-a single data field and presents it as an R vector via ALTREP's lazy evaluation.
+See [ALTREP.md](ALTREP.md) for the full derive surface.
 
-Override with ALTREP options:
-
-```rust
-#[miniextendr(class = "MyInts", base = "integer")]
-pub struct LazyInts(Vec<i32>);
-```
-
-Override to use a different representation:
-
-```rust
-#[miniextendr(externalptr)]
-pub struct Wrapper(Vec<i32>);   // ExternalPtr instead of ALTREP
-
-#[miniextendr(list)]
-pub struct Wrapper(Vec<i32>);   // List conversion instead of ALTREP
-```
-
-### Multi-Field Struct → ExternalPtr (default)
+### Struct → ExternalPtr (default)
 
 ```rust
 #[miniextendr]
@@ -491,14 +482,24 @@ pub struct Point { x: f64, y: f64 }
 ```
 
 Generates `ExternalPtr` + `TypedExternal` derives. The struct lives as an opaque
-R external pointer.
+R external pointer. This is the default for **any** field count — a bare 1-field
+struct is ExternalPtr too, not ALTREP.
+
+Override with an explicit mode:
+
+```rust
+#[miniextendr(externalptr)]
+pub struct Wrapper(Vec<i32>);   // ExternalPtr (same as the default)
+
+#[miniextendr(list)]
+pub struct Wrapper(Vec<i32>);   // List conversion instead of ExternalPtr
+```
 
 ### Struct Mode Overrides
 
 | Syntax | Result |
 |--------|--------|
-| `#[miniextendr]` on 1-field | ALTREP |
-| `#[miniextendr]` on multi-field | ExternalPtr |
+| `#[miniextendr]` (no mode attr) | ExternalPtr |
 | `#[miniextendr(list)]` | `IntoList` + `TryFromList` + `PreferList` |
 | `#[miniextendr(dataframe)]` | `IntoList` + `DataFrameRow` + companion type |
 | `#[miniextendr(externalptr)]` | `ExternalPtr` + `TypedExternal` |

--- a/docs/NATIVE_SEXP_ALTREP.md
+++ b/docs/NATIVE_SEXP_ALTREP.md
@@ -150,12 +150,11 @@ R tests are in `tests/testthat/test-native-sexp-altrep.R`.
 ## Example Usage
 
 ```rust
-use miniextendr_api::altrep::RegisterAltrep;
-use miniextendr_api::altrep_data::{AltIntegerData, AltrepDataptr, AltrepExtract, AltrepLen};
+use miniextendr_api::prelude::*;
+use miniextendr_api::altrep_data::AltrepDataptr;
 use miniextendr_api::altrep_traits::{AltInteger, AltVec, Altrep, AltrepGuard};
-use miniextendr_api::sys::{DATAPTR_RO, R_xlen_t, Rf_allocVector, Rf_protect, Rf_unprotect, SEXP, SEXPTYPE};
-use miniextendr_api::into_r::IntoR;
-use miniextendr_api::{impl_inferbase_integer, miniextendr};
+use miniextendr_api::sys::DATAPTR_RO;
+use miniextendr_api::{R_xlen_t, impl_inferbase_integer};
 
 pub struct MyNativeSexpAltrep;
 static mut MY_INSTANCE: MyNativeSexpAltrep = MyNativeSexpAltrep;

--- a/docs/SPARSE_ITERATOR_ALTREP.md
+++ b/docs/SPARSE_ITERATOR_ALTREP.md
@@ -86,18 +86,21 @@ This example from `rpkg/src/rust/lib.rs` shows the full pattern for creating a s
 
 ### Step 1: Define a Wrapper Type
 
-The generic `SparseIterIntData<I>` needs a concrete iterator type. Use a boxed trait object for flexibility:
+The generic `SparseIterIntData<I>` needs a concrete iterator type. Use a boxed
+trait object for flexibility. The `#[derive(AltrepInteger)]` with
+`#[altrep(manual)]` registers the ALTREP class and leaves the data traits
+(`AltrepLen` + `AltIntegerData`) for you to implement by hand in the next step:
 
 ```rust
-use miniextendr_api::altrep_data::{
-    AltrepLen, AltIntegerData, SparseIterIntData,
-};
+use miniextendr_api::prelude::*;
+use miniextendr_api::altrep_data::SparseIterIntData;
 
 /// Type alias for boxed iterator producing i32
 type BoxedIntIter = Box<dyn Iterator<Item = i32>>;
 
 /// Wrapper for sparse integer iterator ALTREP
-#[derive(miniextendr_api::ExternalPtr)]
+#[derive(AltrepInteger)]
+#[altrep(class = "SparseIntIter", manual)]
 pub struct SparseIntIterData {
     inner: SparseIterIntData<BoxedIntIter>,
 }
@@ -127,15 +130,12 @@ impl AltIntegerData for SparseIntIterData {
 }
 ```
 
-### Step 3: Generate Low-Level Trait Impls and Create the ALTREP Class
+### Step 3: Registration Is Automatic
 
-```rust
-miniextendr_api::impl_altinteger_from_data!(SparseIntIterData);
-
-/// The ALTREP class wrapper
-#[miniextendr(class = "SparseIntIter")]
-pub struct SparseIntIterClass(pub SparseIntIterData);
-```
+The derive in Step 1 already emitted the low-level trait impls
+(`impl_altinteger_from_data!`), the `RegisterAltrep` impl, and the
+registration entry. There is no macro to call and no wrapper class struct to
+define — `#[miniextendr]` on a 1-field struct is removed.
 
 ### Step 4: Write the Constructor Function
 
@@ -148,11 +148,11 @@ pub fn sparse_iter_int(from: i32, to: i32) -> SEXP {
     let data = SparseIntIterData {
         inner: SparseIterIntData::from_iter(iter, len),
     };
-    SparseIntIterClass(data).into_sexp()
+    data.into_sexp()
 }
 ```
 
-Registration is automatic via `#[miniextendr]` -- no manual module declarations needed.
+Registration is automatic via the derive's registration entry -- no manual module declarations needed.
 
 ---
 
@@ -232,7 +232,8 @@ Real-valued sparse iterators work the same way, with `NaN` (displayed as `NA` in
 ```rust
 type BoxedRealIter = Box<dyn Iterator<Item = f64>>;
 
-#[derive(miniextendr_api::ExternalPtr)]
+#[derive(AltrepReal)]
+#[altrep(class = "SparseRealIter", manual)]
 pub struct SparseRealIterData {
     inner: SparseIterRealData<BoxedRealIter>,
 }
@@ -248,7 +249,7 @@ pub fn sparse_iter_real(from: f64, step: f64, length_out: i32) -> SEXP {
     let data = SparseRealIterData {
         inner: SparseIterRealData::from_iter(iter, len),
     };
-    SparseRealIterClass(data).into_sexp()
+    data.into_sexp()
 }
 ```
 

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -718,8 +718,10 @@ fn build_match_arg_helpers(
 ///
 /// # ALTREP
 ///
-/// Apply `#[miniextendr(class = "...", base = "...")]` to a one-field
-/// wrapper struct. Registration is automatic.
+/// `#[miniextendr]` no longer generates ALTREP classes — `class`/`base`
+/// attributes on a one-field struct are a compile error. Use the per-family
+/// derives (`#[derive(AltrepInteger)]`, …) with `#[altrep(class = "...")]`
+/// instead; registration is automatic there.
 #[proc_macro_attribute]
 pub fn miniextendr(
     attr: proc_macro::TokenStream,

--- a/miniextendr-macros/src/struct_enum_dispatch.rs
+++ b/miniextendr-macros/src/struct_enum_dispatch.rs
@@ -182,7 +182,9 @@ pub fn expand_struct_or_enum(
 /// Dispatches `#[miniextendr]` on a struct to the correct derive path.
 ///
 /// Decision logic:
-/// - 1-field struct with no explicit mode: ALTREP (backwards compatibility)
+/// - 1-field struct with ALTREP attrs (`class`/`base`): compile error with
+///   migration guidance (ALTREP via `#[miniextendr]` is removed — use the
+///   `#[derive(Altrep*)]` family)
 /// - Explicit `list` mode: `IntoList` + `TryFromList` + `PreferList`
 /// - Explicit `dataframe` mode: `IntoList` + `DataFrameRow` + companion `IntoR`
 /// - Default multi-field or explicit `externalptr`: `ExternalPtr`


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## Summary

The skill side of #1229 was already done — #1225 switched the miniextendr-altrep skill example to `use miniextendr_api::prelude::*;` and #1230 landed the re-exports it depends on. This PR closes the loop by (a) compile-verifying that the skill's field-based and manual examples really do build with only the prelude glob, and (b) sweeping the same outdated import style out of the ALTREP docs, where explicit `altrep_data::{...}` imports were still presented as current guidance.

- **`docs/ALTREP.md` / `docs/ALTREP_EXAMPLES.md`**: converted blocks now lead with `use miniextendr_api::prelude::*;`; only genuinely non-prelude items stay explicit (`AltrepDataptr`, `AltrepSerialize`, `Logical`, `Sortedness`, the iterator data types). Fragment blocks without import context keep their fully-qualified `#[derive(miniextendr_api::Altrep)]` form.
- **Broken `sys` type imports fixed**: `use miniextendr_api::sys::{SEXP, SEXPTYPE, R_xlen_t, Rcomplex}` never compiled — those types are *private* imports inside `sys` (E0603; crate root is their canonical home, and `SEXP` is in the prelude). Conversely `Rf_ScalarInteger` is `sys`-only, not at the crate root as `docs/ALTREP.md` claimed.
- **`docs/SPARSE_ITERATOR_ALTREP.md`**: the 4-step walkthrough still showed the **removed** `#[miniextendr(class = "...")]` 1-field class-wrapper pattern plus an explicit `impl_altinteger_from_data!` call, and claimed to mirror `rpkg/src/rust/lib.rs`. Rewritten to match the actual source: per-family derive with `#[altrep(class = "...", manual)]`, automatic registration, `data.into_sexp()`.
- **`docs/NATIVE_SEXP_ALTREP.md`**: import header rewritten (prelude glob + explicit `altrep_traits`/`sys::DATAPTR_RO`/`R_xlen_t` paths); the example block now compiles verbatim.
- **`docs/MINIEXTENDR_ATTRIBUTE.md` + `miniextendr-macros` rustdoc/dispatch comments**: stopped documenting 1-field-struct ALTREP as current behavior — `struct_enum_dispatch.rs` makes `class`/`base` on a 1-field struct a compile error with migration guidance, and a bare struct of any field count defaults to ExternalPtr.
- **`docs/ALTREP.md` "Mutable Vectors"**: added a known-drift admonition — the data-trait `set_elt` API it documents no longer exists (mutation lives at the low-level `AltString`/`AltList` layer via `HAS_SET_ELT`); tracked in #1266.

Follow-ups filed (referenced above where relevant):
- #1266 — Mutable Vectors section documents a removed data-trait API (needs a verified rewrite or an API restoration decision).
- #1267 — modernize remaining ALTREP examples from generic `#[derive(Altrep)]` + explicit `impl_alt*_from_data!` to per-family derives.
- #1268 — `MINIEXTENDR_ATTRIBUTE.md` prefer-rows misdescribe struct dispatch (`prefer = "list"`/`"dataframe"` trigger full mode, not marker-only).

## Verification

- Scratch integration-test target under `rpkg/src/rust/tests/` (removed before commit; `git status` clean) containing the skill's two examples **verbatim** plus every rewritten doc block (Quick Start, decision-guide, lazy+serialize, complex, logical, string, raw, list, extract-subset import paths, all four `ALTREP_EXAMPLES` patterns, the full `NATIVE_SEXP_ALTREP` example, both sparse-iterator walkthroughs, and the `MINIEXTENDR_ATTRIBUTE` migration snippet): `cargo check --test scratch_1229` run **from `rpkg/src/rust`** (so `.cargo/config.toml` patches apply) — clean, zero warnings.
- Negative probes confirmed the drift claims by compilation, not eyeballing: `use miniextendr_api::sys::{SEXP, SEXPTYPE}` → E0603 "private"; `impl_altstring_from_data!(T, set_elt)` → "no rules expected identifier `set_elt`".
- Prelude coverage cross-checked against `miniextendr-api/src/prelude.rs` post-#1230 (7 per-family derives, `Alt*Data`, `AltrepLen`, `AltrepExtract`, `RegisterAltrep`) — the skill's coverage claim matches exactly.
- `bash scripts/skill-freshness-audit.sh`: miniextendr-altrep **OK**, 0 BLOCKING; remaining warnings are the script's documented false-positive modes. No ALTREP skill exists in `minirextendr/inst/claude/skills/`, so no end-user mirror to touch.
- `cargo fmt --all --check` clean; the `miniextendr-macros` comment-only edits compiled during the scratch build. `journal/` entries left untouched (historical records).

Fixes #1229

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
