### PR TITLE
ci: gate committed Cargo.lock shape in the Rust lint job (#1222)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,19 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
 
+      # Committed-lock shape gate (#1222): the committed rpkg/src/rust/Cargo.lock
+      # must stay in tarball-shape (framework crates carry their canonical
+      # `source = "git+…"` lines — see docs/CARGO_LOCK_SHAPE.md). Local dev
+      # recipes auto-restore drift (`just cargo-lock-restore`), but nothing
+      # gated the *committed* file, and it silently drifted to path-shape on
+      # main for 20+ commits. Pure grep, no toolchain needed — runs first so
+      # a drifted lock fails fast.
+      - name: Lock shape (committed Cargo.lock)
+        id: lock_shape
+        continue-on-error: true
+        run: just lock-shape-check 2>&1 | tee "$RUNNER_TEMP/lock_shape.log"
+        shell: bash
+
       - name: Rustfmt
         id: rustfmt
         continue-on-error: true
@@ -386,6 +399,7 @@ jobs:
           set -uo pipefail
           failed=0
 
+          lock_shape="${{ steps.lock_shape.outcome }}"
           rustfmt="${{ steps.rustfmt.outcome }}"
           clippy_default="${{ steps.clippy_default.outcome }}"
           clippy_all="${{ steps.clippy_all.outcome }}"
@@ -393,6 +407,7 @@ jobs:
           clippy_revendor="${{ steps.clippy_revendor.outcome }}"
           doc_revendor="${{ steps.doc_revendor.outcome }}"
 
+          echo "lock_shape:       $lock_shape"
           echo "rustfmt:          $rustfmt"
           echo "clippy_default:   $clippy_default"
           echo "clippy_all:       $clippy_all"
@@ -415,6 +430,7 @@ jobs:
             fi
           }
 
+          dump_failed lock_shape       "$lock_shape"
           dump_failed rustfmt          "$rustfmt"
           dump_failed clippy_default   "$clippy_default"
           dump_failed clippy_all       "$clippy_all"

--- a/docs/CARGO_LOCK_SHAPE.md
+++ b/docs/CARGO_LOCK_SHAPE.md
@@ -162,6 +162,10 @@ these `just` recipes, `git status` shows the lock clean with no manual
 `just vendor`, which re-stamp tarball-shape. Raw `R CMD INSTALL` (no `just`)
 still drifts and relies on the pre-commit hook + `lock-shape-check` (#1052).
 
+The *committed* lock is gated remotely too: CI's Rust lint job runs
+`just lock-shape-check` on every rust-touching PR (#1222), so a path-shape
+lock that slips past the local hook turns CI red instead of landing on main.
+
 ## Recovering a drifted lock
 
 ```bash


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Adds `just lock-shape-check` as a fail-fast step in the `rust-lint` CI job, wired into the job's existing `continue-on-error` + outcome-aggregation pattern (`lock_shape` id, log dump on failure). Closes #1222.
- The check is pure grep (no toolchain, no configure), so it runs before Rustfmt and costs seconds.
- The `changes` filter already includes `**/Cargo.lock`, so any PR touching the committed lock triggers the job; verified `just lock-shape-check` exits 0 on current `main` (post-#1221 re-stamp).
- Documents the remote gate in `docs/CARGO_LOCK_SHAPE.md` next to the existing local-hook prose.

## Test plan
- [ ] `rust-lint` job on this PR is green and shows `lock_shape: success` in the aggregation output
- [ ] (negative test, optional) a scratch branch deleting a `source = "git+…"` line from `rpkg/src/rust/Cargo.lock` turns `rust-lint` red with the recipe's remediation hint

## Notes
- The pre-commit hook remains the local layer; this only adds the missing remote gate so a drifted committed lock can no longer land silently (it previously sat on `main` for 20+ commits).

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>