### PR TITLE
fix(macros): label-aware class-name-entry static; dedup MX_CLASS_NAMES on read (#1242)

### DIFF
--- a/miniextendr-api/src/registry.rs
+++ b/miniextendr-api/src/registry.rs
@@ -287,6 +287,51 @@ pub struct ClassNameEntry {
 // SAFETY: All fields are &'static str — immutable and valid for program lifetime.
 unsafe impl Sync for ClassNameEntry {}
 
+/// Build the `rust_type → ClassNameEntry` lookup used by every placeholder
+/// resolver in `write_r_wrappers_to_file`.
+///
+/// Multiple labeled `#[miniextendr]` impl blocks on one type each register a
+/// `ClassNameEntry` (#1242) — the class name is a property of the *type*, so
+/// identical duplicates collapse here. *Conflicting* registrations (same
+/// `rust_type`, different `r_class_name` or `class_system` — e.g. two labeled
+/// blocks with disagreeing `class = "..."` overrides) panic: silently keeping
+/// whichever entry linkme ordered last would resolve `.__MX_CLASS_REF_*__`
+/// placeholders nondeterministically.
+///
+/// Host-only like `MX_CLASS_NAMES` itself — the consumers all live in the
+/// wrapper-writing path, which never runs on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+fn build_class_name_index<'a>(
+    entries: impl IntoIterator<Item = &'a ClassNameEntry>,
+) -> std::collections::HashMap<&'a str, &'a ClassNameEntry> {
+    use std::collections::hash_map::Entry;
+    let mut index = std::collections::HashMap::new();
+    for e in entries {
+        match index.entry(e.rust_type) {
+            Entry::Vacant(slot) => {
+                slot.insert(e);
+            }
+            Entry::Occupied(slot) => {
+                let prev = *slot.get();
+                if prev.r_class_name != e.r_class_name || prev.class_system != e.class_system {
+                    panic!(
+                        "conflicting class registrations for Rust type `{}`: \
+                         `{}` ({}) vs `{}` ({}). Multiple #[miniextendr] impl blocks \
+                         on one type must agree on the class system and any \
+                         `class = \"...\"` override.",
+                        e.rust_type,
+                        prev.r_class_name,
+                        prev.class_system,
+                        e.r_class_name,
+                        e.class_system,
+                    );
+                }
+            }
+        }
+    }
+    index
+}
+
 /// Entry documenting a sidecar (`#[r_data]`) property on an S7 ExternalPtr type.
 ///
 /// Emitted by `#[derive(ExternalPtr)] #[externalptr(s7)]` for each public `#[r_data]`
@@ -1256,9 +1301,7 @@ pub fn write_r_wrappers_to_file(path: &str) {
     // the content for each placeholder. We avoid pulling in a regex dependency
     // by scanning for the sentinel prefix directly.
     {
-        use std::collections::HashMap;
-        let class_index: HashMap<&'static str, &ClassNameEntry> =
-            MX_CLASS_NAMES.iter().map(|e| (e.rust_type, e)).collect();
+        let class_index = build_class_name_index(MX_CLASS_NAMES.iter());
 
         // Two placeholder forms:
         //   .__MX_CLASS_REF_<RustName>__         → loud fallback on miss
@@ -1336,9 +1379,7 @@ pub fn write_r_wrappers_to_file(path: &str) {
     // false positives, and write time is where we know whether `<RustName>` is
     // registered in this package.
     {
-        use std::collections::HashMap;
-        let class_index: HashMap<&'static str, &ClassNameEntry> =
-            MX_CLASS_NAMES.iter().map(|e| (e.rust_type, e)).collect();
+        let class_index = build_class_name_index(MX_CLASS_NAMES.iter());
 
         const PREFIX: &str = ".__MX_WRAP_RETURN_";
         const ARG_OPEN: &str = "__(";
@@ -1444,9 +1485,7 @@ pub fn write_r_wrappers_to_file(path: &str) {
     // MX_CLASS_NAMES so a `class = "Override"` is honoured, then scan the final
     // content. This runs after all placeholder resolution so names are final.
     {
-        use std::collections::HashMap;
-        let class_index: HashMap<&str, &ClassNameEntry> =
-            MX_CLASS_NAMES.iter().map(|e| (e.rust_type, e)).collect();
+        let class_index = build_class_name_index(MX_CLASS_NAMES.iter());
         let accessor_producers = sidecar_accessor_names(&MX_S7_SIDECAR_PROPS, &class_index);
         if let Err(msg) = detect_duplicate_wrapper_defs(&content, &accessor_producers) {
             panic!("{msg}");
@@ -1880,9 +1919,7 @@ mod tests {
     /// This mirrors the logic in `write_r_wrappers_to_file` but operates on a caller-supplied
     /// slice so it can be called from unit tests without a live distributed_slice.
     fn resolve_class_refs(content: &str, entries: &[ClassNameEntry]) -> String {
-        use std::collections::HashMap;
-        let class_index: HashMap<&str, &ClassNameEntry> =
-            entries.iter().map(|e| (e.rust_type, e)).collect();
+        let class_index = build_class_name_index(entries.iter());
 
         const OR_ANY_PREFIX: &str = ".__MX_CLASS_REF_OR_ANY_";
         const PREFIX: &str = ".__MX_CLASS_REF_";
@@ -1923,12 +1960,52 @@ mod tests {
         result
     }
 
+    /// Two labeled impl blocks on one type register identical entries (#1242);
+    /// the index collapses them instead of treating the duplicate key as an error.
+    #[test]
+    fn class_name_index_dedups_identical_entries() {
+        let entries = [
+            ClassNameEntry {
+                rust_type: "Foo",
+                r_class_name: "Foo",
+                class_system: "env",
+            },
+            ClassNameEntry {
+                rust_type: "Foo",
+                r_class_name: "Foo",
+                class_system: "env",
+            },
+        ];
+        let index = build_class_name_index(entries.iter());
+        assert_eq!(index.len(), 1);
+        assert_eq!(index["Foo"].r_class_name, "Foo");
+    }
+
+    /// Disagreeing `class = "..."` overrides across blocks must fail loudly —
+    /// placeholder resolution would otherwise pick whichever entry linkme
+    /// ordered last.
+    #[test]
+    #[should_panic(expected = "conflicting class registrations for Rust type `Foo`")]
+    fn class_name_index_panics_on_conflicting_override() {
+        let entries = [
+            ClassNameEntry {
+                rust_type: "Foo",
+                r_class_name: "Foo",
+                class_system: "env",
+            },
+            ClassNameEntry {
+                rust_type: "Foo",
+                r_class_name: "FooOverride",
+                class_system: "env",
+            },
+        ];
+        let _ = build_class_name_index(entries.iter());
+    }
+
     /// Run the cross-class return wrapper resolver over `content` using
     /// `entries` as the class registry.
     fn resolve_return_wrappers(content: &str, entries: &[ClassNameEntry]) -> String {
-        use std::collections::HashMap;
-        let class_index: HashMap<&str, &ClassNameEntry> =
-            entries.iter().map(|e| (e.rust_type, e)).collect();
+        let class_index = build_class_name_index(entries.iter());
 
         const PREFIX: &str = ".__MX_WRAP_RETURN_";
         const ARG_OPEN: &str = "__(";

--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -3473,15 +3473,25 @@ pub fn expand_impl(
     // Build MX_CLASS_NAMES entry for cross-reference resolution.
     // r_class_name is the R-visible name (may differ from type_ident when
     // `class = "Override"` was set on the impl block).
+    //
+    // The static name folds the impl label in when present, mirroring
+    // `r_wrappers_const_ident`: keying on the type alone made two labeled
+    // impl blocks on one type collide with E0428 (#1242) — exactly the
+    // multi-block pattern MXL009 directs users toward. The duplicate entries
+    // this registers for one type are collapsed (identical) or rejected
+    // (conflicting `class = "..."` overrides) by `build_class_name_index` in
+    // miniextendr-api's registry. Unlabeled multi-blocks still collide — on
+    // `R_WRAPPERS_IMPL_<TYPE>` too — so no per-block counter is needed here.
     let r_class_name_str = parsed.class_name();
     let class_system_str = parsed.class_system.to_ident().to_string();
-    let class_names_const = syn::Ident::new(
-        &format!(
-            "__mx_class_name_entry_{}",
-            type_ident.to_string().to_lowercase()
-        ),
-        type_ident.span(),
-    );
+    let class_names_const = {
+        let type_lower = type_ident.to_string().to_lowercase();
+        let name = match parsed.label() {
+            Some(label) => format!("__mx_class_name_entry_{type_lower}_{label}"),
+            None => format!("__mx_class_name_entry_{type_lower}"),
+        };
+        syn::Ident::new(&name, type_ident.span())
+    };
 
     let expanded = quote! {
         // Original impl block with doc link to R wrapper

--- a/miniextendr-macros/tests/ui/pass/impl_labeled_blocks_class_name_no_collision.rs
+++ b/miniextendr-macros/tests/ui/pass/impl_labeled_blocks_class_name_no_collision.rs
@@ -1,0 +1,39 @@
+//! Compile-pass regression test for #1242.
+//!
+//! Two *labeled* inherent `#[miniextendr]` impl blocks on the same type — the
+//! documented multi-impl pattern (docs/CLASS_SYSTEMS.md "Multiple Impl
+//! Blocks"; labels are what MXL009 tells the user to add). Before the fix,
+//! both blocks emitted a class-name registration static named
+//! `__mx_class_name_entry_<type>` (keyed on the type alone, ignoring the
+//! label) and collided with `error[E0428]: the name ... is defined multiple
+//! times` — labels cleared the `R_WRAPPERS_IMPL_*` and C-wrapper names but
+//! not this one. The label-aware name makes the pattern compile; the
+//! duplicate (identical) `MX_CLASS_NAMES` entries the two blocks register are
+//! collapsed at consumption by `build_class_name_index` in miniextendr-api.
+
+#![allow(dead_code)]
+
+use miniextendr_api::{ExternalPtr, miniextendr};
+
+#[derive(ExternalPtr)]
+pub struct SplitImpl {
+    value: i32,
+}
+
+/// Constructor-side operations.
+#[miniextendr(env, label = "ctor")]
+impl SplitImpl {
+    fn new(initial: i32) -> Self {
+        Self { value: initial }
+    }
+}
+
+/// Accessor-side operations.
+#[miniextendr(env, label = "ops")]
+impl SplitImpl {
+    fn bump(&self) -> i32 {
+        self.value + 1
+    }
+}
+
+fn main() {}

--- a/miniextendr-macros/tests/ui/pass/impl_method_tag_const_no_collision.rs
+++ b/miniextendr-macros/tests/ui/pass/impl_method_tag_const_no_collision.rs
@@ -9,9 +9,11 @@
 //! The per-block disambiguator (`next_impl_tag_block_id`) makes the names
 //! unique, so this compiles.
 //!
-//! (Two *inherent* impl blocks on one type is not a valid reproduction: they
-//! also collide on the per-type `__mx_class_name_entry_<type>` static, which is
-//! unrelated to the tag-const bug. Inherent + trait is the real-world case.)
+//! (Two *unlabeled* inherent impl blocks on one type is not a valid
+//! reproduction: they also collide on `R_WRAPPERS_IMPL_<TYPE>`, which is
+//! unrelated to the tag-const bug. Two *labeled* inherent blocks compile
+//! since #1242 — see `impl_labeled_blocks_class_name_no_collision.rs`.
+//! Inherent + trait is the real-world case exercised here.)
 
 #![allow(dead_code)]
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Fixes #1242: two labeled `#[miniextendr]` impl blocks on one type (the documented multi-impl pattern, `docs/CLASS_SYSTEMS.md` "Multiple Impl Blocks"; labels are exactly what MXL009 tells users to add) collided with `error[E0428]` on the `__mx_class_name_entry_<type>` static, which was keyed on the type alone.
- The static name now folds the impl label in, mirroring `r_wrappers_const_ident`. Deliberately no per-block counter (the issue floated one for the lint-off case): unlabeled multi-blocks already collide on `R_WRAPPERS_IMPL_<TYPE>`, so label parity makes the class-name static exactly as permissive as its siblings, and the name stays deterministic.
- The issue's preferred "emit once" option is unimplementable at expansion time (impl blocks expand independently, so no block can know it is the second one). Instead, the duplicate `MX_CLASS_NAMES` entries are handled at consumption: a shared `build_class_name_index()` replaces the three inline `HashMap::collect` builds in `registry.rs`, collapsing identical duplicates and panicking with a named-type message when two blocks disagree on class system or `class = "..."` override. Previously `collect` silently kept whichever entry linkme ordered last, which would have resolved `.__MX_CLASS_REF_*__` placeholders nondeterministically.
- New trybuild compile-pass fixture (`impl_labeled_blocks_class_name_no_collision.rs`) pins the two-labeled-blocks pattern; the #1118 fixture's comment documenting this as a known limitation is updated to point at it. Two registry unit tests pin the dedup and conflict-panic semantics.
- No R-side output changes (the static is Rust-internal), so no wrappers.R/NAMESPACE/man regeneration is involved.

## Test plan
- [x] `cargo test -p miniextendr-api --lib registry::` — 39 passed, including the two new index tests
- [x] `cargo test -p miniextendr-macros` — lib 466 passed; new UI fixture compiles; the 5 pre-existing DataFrameRow `.stderr` mismatches are the documented local rust-src false positive (#1239), untouched by this change — CI is authoritative for those
- [x] `cargo clippy -p miniextendr-api -p miniextendr-macros --all-targets -- -D warnings` clean; `cargo fmt --all` applied
- [ ] CI green (clippy_all / clippy_all_s7 legs compile the touched code with full features)

## Notes
- `build_class_name_index` carries `#[cfg(not(target_arch = "wasm32"))]` to match `MX_CLASS_NAMES` (host-only; consumers all live in the wrapper-writing path), avoiding a dead-code warning in wasm32 builds of the api crate.
- A conflicting-override pair (e.g. `class = "A"` vs `class = "B"` across two labeled blocks) previously could not compile at all (the E0428), so the new panic path rejects only configurations that were never valid — nothing that compiles today changes behavior.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>