### PR TITLE
docs: fold #596 upstream-pin rebase into the quarterly audit routine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,14 @@ cited paths (BLOCKING, exits non-zero so it can gate CI), symbols that grep
 finds nowhere in the repo (WARN), and out-of-range `file.rs:NNN` line cites
 (WARN). The script's header documents its known false-positive modes.
 
+The same quarterly pass also rebases two upstream release pins (folded from
+#596): the `r-universe-org/macos-libs` `cranlibs-everything.tar.xz` date
+pinned in `minirextendr/inst/templates/r-release.yml` (Gotcha 6) and
+`docs/RELEASE_WORKFLOW.md`, and the r-windows rtools release number in
+`docs/CRAN_COMPATIBILITY.md`'s Layer 3 table. Also force-rebase both before
+any release tag, and smoke-test a bumped tarball URL via a real CI run
+(download + extract paths drift upstream).
+
 ## Reviews
 
 - **Reviews** (`reviews/*.md`): when things go wrong (test/CI failure, runtime error, unexpected behavior), write a short file: *what was attempted*, *what went wrong*, *root cause*, *fix*. Accumulates institutional knowledge on non-obvious failure modes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,6 +535,14 @@ gitignored artifacts, scaffolded-package layout paths). CLAUDE.md ↔ skill
 contradictions are not auto-detected — eyeball any skill that restates a
 CLAUDE.md fact when triaging.
 
+The same quarterly pass also rebases two upstream release pins (folded from
+#596): the `r-universe-org/macos-libs` `cranlibs-everything.tar.xz` date
+pinned in `minirextendr/inst/templates/r-release.yml` (Gotcha 6) and
+`docs/RELEASE_WORKFLOW.md`, and the r-windows rtools release number in
+`docs/CRAN_COMPATIBILITY.md`'s Layer 3 table. Also force-rebase both before
+any release tag, and smoke-test a bumped tarball URL via a real CI run
+(download + extract paths drift upstream).
+
 ### Reviews
 
 - **Reviews** (`reviews/*.md`): when things go wrong (test/CI failure, runtime error, unexpected behavior), write a short file: *what was attempted*, *what went wrong*, *root cause*, *fix*. Accumulates institutional knowledge on non-obvious failure modes.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Folds #596 (upstream r-windows rtools / r-universe macos-libs release tracking) into the existing quarterly skill-freshness audit section in `CLAUDE.md`, per the 2026-07-11 decision review: the two pin rebases are small and infrequent, so they ride the quarterly pass instead of a standalone tracking issue.
- Names the exact pins: the `cranlibs-everything.tar.xz` date in `minirextendr/inst/templates/r-release.yml` (Gotcha 6) + `docs/RELEASE_WORKFLOW.md`, and the rtools release number in `docs/CRAN_COMPATIBILITY.md`'s Layer 3 table; plus the force-rebase-before-release-tag and CI smoke-test steps from #596's definition of done.
- Mirrored verbatim in the root `AGENTS.md` (hand-kept mirror rule).

Fixes #596.

## Test plan
- [x] Docs-only change; no build. Both files render; section text matches #596's definition of done.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
