### PR TITLE
fix(macros): match @param comma-lists exactly when deduping generated arg docs (#1261 items 2+4)

### DIFF
--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -1191,9 +1191,7 @@ pub fn miniextendr(
         }
         let rust_name = pat_ident.ident.to_string();
         let r_name = r_wrapper_builder::normalize_r_arg_ident(&pat_ident.ident).to_string();
-        let already_documented = roxygen_tags
-            .iter()
-            .any(|t| t.trim_start().starts_with(&format!("@param {r_name}")));
+        let already_documented = crate::roxygen::param_documented(&roxygen_tags, &r_name);
         if already_documented {
             continue;
         }

--- a/miniextendr-macros/src/miniextendr_impl/r6_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/r6_class.rs
@@ -184,11 +184,8 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
             if param_name == ".ptr" {
                 continue;
             }
-            let already_documented = ctx
-                .method
-                .doc_tags
-                .iter()
-                .any(|t| t.starts_with(&format!("@param {}", param_name)));
+            let already_documented =
+                crate::roxygen::param_documented(&ctx.method.doc_tags, param_name);
             if !already_documented {
                 // Param covered by class-level @param → roxygen2 inherits; emit nothing.
                 if class_param_names.contains(param_name) {
@@ -296,11 +293,8 @@ pub fn generate_r6_r_wrapper(parsed_impl: &ParsedImpl) -> String {
         let r_method_name = ctx.method.r_method_name();
         for param in ctx.params.split(", ").filter(|p| !p.is_empty()) {
             let param_name = param.split('=').next().unwrap_or(param).trim();
-            let already_documented = ctx
-                .method
-                .doc_tags
-                .iter()
-                .any(|t| t.starts_with(&format!("@param {}", param_name)));
+            let already_documented =
+                crate::roxygen::param_documented(&ctx.method.doc_tags, param_name);
             if !already_documented {
                 // Param covered by class-level @param → roxygen2 inherits; emit nothing.
                 if class_param_names.contains(param_name) {

--- a/miniextendr-macros/src/miniextendr_impl/s7_class.rs
+++ b/miniextendr-macros/src/miniextendr_impl/s7_class.rs
@@ -426,18 +426,12 @@ pub fn generate_s7_r_wrapper(parsed_impl: &ParsedImpl) -> String {
                     continue;
                 }
                 // Check if already documented at the class level (impl block doc_tags)
-                let in_class_docs = class_doc_tags
-                    .iter()
-                    .any(|t| t.starts_with(&format!("@param {}", param_name)));
+                let in_class_docs = crate::roxygen::param_documented(class_doc_tags, param_name);
                 if in_class_docs {
                     continue; // Already emitted by ClassDocBuilder
                 }
                 // Check if documented in the constructor method's doc_tags
-                let ctor_tag = ctx
-                    .method
-                    .doc_tags
-                    .iter()
-                    .find(|t| t.starts_with(&format!("@param {}", param_name)));
+                let ctor_tag = crate::roxygen::find_param_tag(&ctx.method.doc_tags, param_name);
                 if let Some(tag) = ctor_tag {
                     lines.push(format!("#' {}", tag));
                 } else if let Some(placeholder) = mx_doc.get(param_name) {

--- a/miniextendr-macros/src/miniextendr_impl_trait/r_wrappers.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/r_wrappers.rs
@@ -742,10 +742,7 @@ fn generate_trait_s7_r_wrapper(
                 if pname == "self" {
                     continue;
                 }
-                let documented = method
-                    .param_tags
-                    .iter()
-                    .any(|t| t.starts_with(&format!("@param {}", pname)));
+                let documented = crate::roxygen::param_documented(&method.param_tags, pname);
                 if documented {
                     continue;
                 }

--- a/miniextendr-macros/src/r_class_formatter.rs
+++ b/miniextendr-macros/src/r_class_formatter.rs
@@ -884,10 +884,8 @@ impl<'a> MethodDocBuilder<'a> {
                 if param_name == ".ptr" || param_name == "..." || param_name == "self" {
                     continue;
                 }
-                let already_documented = self
-                    .doc_tags
-                    .iter()
-                    .any(|t| t.starts_with(&format!("@param {}", param_name)));
+                let already_documented =
+                    crate::roxygen::param_documented(self.doc_tags, param_name);
                 if !already_documented {
                     // match_arg'd params get a placeholder the cdylib write-pass
                     // replaces with the rendered choice description (#210).

--- a/miniextendr-macros/src/roxygen.rs
+++ b/miniextendr-macros/src/roxygen.rs
@@ -741,23 +741,70 @@ pub(crate) fn strip_method_tags(
 
 /// Extract the set of parameter names declared via `@param` in a list of roxygen tags.
 ///
-/// For each `@param <name> <desc>` tag in `tags`, extracts `<name>` and inserts it
-/// into the returned `HashSet`. Used by R6 class generators to build the set of
-/// class-level params so method param loops can suppress `(no documentation available)`
-/// for names already covered at class level (roxygen2 8.0.0 inherits class-level
-/// `@param` tags into all methods automatically).
+/// For each `@param <names> <desc>` tag in `tags`, extracts `<names>` and inserts
+/// each comma-separated name into the returned `HashSet`. roxygen2 supports
+/// documenting several params in one tag (`@param a,b,c desc` documents `a`,
+/// `b`, and `c`) — the name token is split on `,` (and each piece trimmed
+/// defensively, though roxygen2's own syntax has no spaces around the commas)
+/// so multi-name tags don't collapse to a single name. Used by R6 class
+/// generators to build the set of class-level params so method param loops
+/// can suppress `(no documentation available)` for names already covered at
+/// class level (roxygen2 8.0.0 inherits class-level `@param` tags into all
+/// methods automatically).
 pub(crate) fn extract_param_names(tags: &[String]) -> HashSet<String> {
     let mut names = HashSet::new();
     for tag in tags {
-        let trimmed = tag.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("@param ") {
-            let name = rest.split_whitespace().next().unwrap_or("").to_string();
+        let Some(names_token) = param_names_token(tag) else {
+            continue;
+        };
+        for name in names_token.split(',') {
+            let name = name.trim();
             if !name.is_empty() {
-                names.insert(name);
+                names.insert(name.to_string());
             }
         }
     }
     names
+}
+
+/// Returns `true` if `name` is documented by any `@param` tag in `tags`.
+///
+/// A tag documents `name` if `name` is exactly one of the comma-separated
+/// names in its `@param <names> <desc>` name token (see
+/// [`extract_param_names`]). This is an **exact-membership** check, not a
+/// prefix match — `starts_with(&format!("@param {name}"))` was the previous
+/// (buggy) approach: it misses every name after the first in a comma-list
+/// tag (`@param a,b,c desc` "documents" only `a`, so `b`/`c` get a spurious
+/// `(no documentation available)` filler that roxygen2 then merges into a
+/// duplicate `\item{b}` and `\item{c}` in the rendered Rd — an
+/// `R CMD check` `checking Rd \usage sections` WARNING), and it also
+/// false-positives on names that are prefixes of other names (`@param x2
+/// desc` looks like it documents `x` too).
+pub(crate) fn param_documented(tags: &[String], name: &str) -> bool {
+    tags.iter().any(|tag| tag_documents_param(tag, name))
+}
+
+/// Like [`param_documented`] but returns the matching tag itself rather than
+/// a bool, for callers that reuse the tag's rendered text verbatim (S7
+/// constructor param doc forwarding pushes the found tag as-is).
+pub(crate) fn find_param_tag<'a>(tags: &'a [String], name: &str) -> Option<&'a String> {
+    tags.iter().find(|tag| tag_documents_param(tag, name))
+}
+
+/// Shared predicate: does this single `@param` tag document `name`?
+fn tag_documents_param(tag: &str, name: &str) -> bool {
+    let Some(names_token) = param_names_token(tag) else {
+        return false;
+    };
+    names_token.split(',').any(|n| n.trim() == name)
+}
+
+/// Returns the `@param` name token (e.g. `a,b,c` in `@param a,b,c desc`) of a
+/// single tag, or `None` if `tag` isn't an `@param` tag.
+fn param_names_token(tag: &str) -> Option<&str> {
+    let trimmed = tag.trim_start();
+    let rest = trimmed.strip_prefix("@param ")?;
+    rest.split_whitespace().next()
 }
 
 /// Split an R formals/argument string on **top-level** commas only.

--- a/miniextendr-macros/src/roxygen/tests.rs
+++ b/miniextendr-macros/src/roxygen/tests.rs
@@ -797,3 +797,60 @@ fn test_normalize_for_comparison() {
     );
 }
 // endregion
+
+// region: comma-list @param dedup (duplicated \argument Rd entries, #1261 item 2)
+
+#[test]
+fn extract_param_names_splits_comma_list() {
+    // A single `@param a,b,c desc` tag documents three names, not one.
+    let tags = vec!["@param a,b,c Numeric scalars.".to_string()];
+    let names = extract_param_names(&tags);
+    assert_eq!(names.len(), 3);
+    assert!(names.contains("a"));
+    assert!(names.contains("b"));
+    assert!(names.contains("c"));
+}
+
+#[test]
+fn extract_param_names_single_name_unaffected() {
+    let tags = vec!["@param x Input value.".to_string()];
+    let names = extract_param_names(&tags);
+    assert_eq!(names.len(), 1);
+    assert!(names.contains("x"));
+}
+
+#[test]
+fn param_documented_true_for_every_name_in_comma_list() {
+    let tags = vec!["@param a,b,c Numeric scalars.".to_string()];
+    assert!(param_documented(&tags, "a"));
+    assert!(param_documented(&tags, "b"));
+    assert!(param_documented(&tags, "c"));
+}
+
+#[test]
+fn param_documented_false_for_undocumented_name() {
+    let tags = vec!["@param a,b,c Numeric scalars.".to_string()];
+    assert!(!param_documented(&tags, "d"));
+}
+
+#[test]
+fn param_documented_no_prefix_false_positive() {
+    // The old `starts_with(&format!("@param {name}"))` check would wrongly
+    // treat "@param x2 desc" as documenting "x" too, since "@param x2 desc"
+    // starts with "@param x". Exact comma-split membership must not repeat
+    // that false positive.
+    let tags = vec!["@param x2 Second input.".to_string()];
+    assert!(!param_documented(&tags, "x"));
+    assert!(param_documented(&tags, "x2"));
+}
+
+#[test]
+fn find_param_tag_returns_the_comma_list_tag_for_any_covered_name() {
+    let tags = vec!["@param a,b,c Numeric scalars.".to_string()];
+    assert_eq!(
+        find_param_tag(&tags, "b"),
+        Some(&"@param a,b,c Numeric scalars.".to_string())
+    );
+    assert_eq!(find_param_tag(&tags, "d"), None);
+}
+// endregion

--- a/plans/2026-07-11-issue-1261-items-2-4-rd-dedup-int-literal.md
+++ b/plans/2026-07-11-issue-1261-items-2-4-rd-dedup-int-literal.md
@@ -1,0 +1,157 @@
+# Plan: #1261 items 2+4 — Rd duplicate-argument emission bug + 2147483648L test literal
+
+Date: 2026-07-11. Anchors verified against main @ 17f634d8.
+Branch: `fix/1261-rd-arg-dedup-int-literal`.
+
+Scope: two of the four standing `R CMD check` WARNINGs from #1261. Item 1
+(`.mx_gen` leak) rides the #1248 PR (`plans/2026-07-11-issue-1248-s3-nongeneric-collision.md`);
+item 3 (`Rf_findVarInFrame`) has its own plan
+(`plans/2026-07-11-issue-1261-item3-findvarinframe.md`). Do NOT touch those here.
+
+## Item 2 — duplicated `\argument` entries `b`, `c` in `fast_fixtures.Rd`
+
+### Root cause (verified)
+
+`rpkg/man/fast_fixtures.Rd:38-44` currently contains:
+
+```
+\item{x}{Input value.}
+\item{a, b, c}{Numeric scalars.}
+\item{b}{(no documentation available)}
+\item{c}{(no documentation available)}
+```
+
+The user doc on `fast_sum3_default`/`fast_sum3_fast`
+(`rpkg/src/rust/fast_fixtures.rs:57,65`) is `/// @param a,b,c Numeric scalars.`
+— a roxygen comma-list documenting three params in one tag. The macro's
+auto-filler decides "is this param already documented?" by **string prefix
+match**:
+
+- `miniextendr-macros/src/lib.rs:1194-1196`:
+  `.any(|t| t.trim_start().starts_with(&format!("@param {r_name}")))`
+
+For param `b`, `"@param a,b,c Numeric scalars."` does not start with
+`"@param b"` → filler `@param b (no documentation available)` is emitted →
+roxygen2 merges the blocks under the shared Rd page → duplicate `\item{b}`
+→ `checking Rd \usage sections` WARNING. (`a` escapes only because
+`"@param a,b,c…"` happens to start with `"@param a"` — the same mechanism is
+also a false-positive generator: a documented `@param x2` would wrongly count
+param `x` as documented.)
+
+The identical prefix-match appears at 7 sites total (all must be fixed —
+same defect class):
+
+| Site | Form |
+|---|---|
+| `miniextendr-macros/src/lib.rs:1196` | `.any(starts_with)` |
+| `miniextendr-macros/src/r_class_formatter.rs:890` | `.any(starts_with)` |
+| `miniextendr-macros/src/miniextendr_impl_trait/r_wrappers.rs:748` | `.any(starts_with)` |
+| `miniextendr-macros/src/miniextendr_impl/r6_class.rs:191` | `.any(starts_with)` |
+| `miniextendr-macros/src/miniextendr_impl/r6_class.rs:303` | `.any(starts_with)` |
+| `miniextendr-macros/src/miniextendr_impl/s7_class.rs:431` | `.any(starts_with)` |
+| `miniextendr-macros/src/miniextendr_impl/s7_class.rs:440` | `.find(starts_with)` — returns the matched tag, not a bool |
+
+There is already a canonical name extractor:
+`roxygen::extract_param_names` (`miniextendr-macros/src/roxygen.rs:749-761`),
+used by the R6 generators for class-level param suppression — but it takes
+the whole first whitespace token (`a,b,c`) as ONE name, so it shares the
+comma-list defect.
+
+### Fix
+
+1. **`roxygen.rs`**: make `extract_param_names` split the name token on `,`
+   (roxygen2's multi-param syntax is comma-separated names without spaces;
+   trim each piece defensively anyway; skip empties). Update its rustdoc.
+2. **`roxygen.rs`**: add
+   `pub(crate) fn param_documented(tags: &[String], name: &str) -> bool`
+   implemented as exact-membership against the (comma-split) names of each
+   `@param` tag. Do NOT build a HashSet per call inside loops if trivially
+   avoidable, but correctness > micro-perf here; a simple per-call scan that
+   splits each tag's first token on commas and compares exact strings is fine.
+3. Replace the 6 `.any(starts_with)` sites with `param_documented(...)`.
+4. `s7_class.rs:440` (`.find(...)` — it *reuses* the matched tag's text):
+   replace the predicate with "tag's comma-split name list contains
+   `param_name`" so a comma-list tag is found for every name it documents;
+   keep the surrounding logic unchanged.
+5. Unit tests in the macros crate (beside existing roxygen tests — grep
+   `extract_param_names` in `miniextendr-macros/src` for the current test
+   module): `extract_param_names(["@param a,b,c desc"])` yields `{a,b,c}`;
+   `param_documented` true for `b`, false for `d`; false-positive case:
+   `@param x2 desc` does NOT document `x`.
+
+### Regeneration and proof
+
+- Full regen loop (commands below). `rpkg/man/fast_fixtures.Rd` must lose the
+  `\item{b}`/`\item{c}` filler lines (the *committed* diff is the proof).
+  Other `man/*.Rd` files may lose spurious fillers too — that's the same fix
+  working; review the diff, commit all of it.
+- `just r-cmd-check` log: the `checking Rd \usage sections ... WARNING`
+  (duplicated `\argument` entries) line must be gone.
+
+## Item 4 — `2147483648L` parse warning in a test file
+
+`rpkg/tests/testthat/test-fast-fixtures.R:60`:
+
+```r
+e <- tryCatch(fast_i32_default(x = -2147483648L - 1),
+```
+
+`2147483648L` is one past `.Machine$integer.max`; the parser warns
+`non-integer value 2147483648L qualified with L; using numeric value` and
+demotes to double → `checking for unstated dependencies in tests` WARNING
+surface. The expression's *value* (`-2147483649`, a double below i32::MIN)
+is exactly what the test wants. Replace the expression with the literal
+`-2147483649` (no `L`) and keep everything else on that line unchanged.
+This is the only such literal in the repo's R sources (verified:
+`grep -rn '2147483648L' rpkg/` → only this line; the two hits without `L`
+in test comments are prose, untouched).
+
+## Exact commands (worktree)
+
+```bash
+rig default 4.6 && R --version | head -1       # must print 4.6.x
+just worktree-sync                              # FIRST
+just configure && just rcmdinstall && just force-document
+# (no NEW exports — single install suffices; wrappers.R regen is enough)
+cargo test -p miniextendr-macros 2>&1 > /tmp/1261-macros-test.log   # Read it
+just test 2>&1 > /tmp/1261-rust-test.log
+just devtools-test 2>&1 > /tmp/1261-devtools.log
+grep -E '\[ FAIL [0-9]+' /tmp/1261-devtools.log  # devtools::test always exits 0
+just r-cmd-check 2>&1 > /tmp/1261-rcmdcheck.log  # then Read; verify both WARNINGs gone
+cargo clippy --workspace --all-targets --locked -- -D warnings   # + all/all_s7 legs per ci.yml
+cargo fmt --all
+```
+
+Snapshot rebaselining: insta snapshots under `miniextendr-macros/src/**/snapshots/`
+may change where fixtures use comma-list `@param` (also check
+`snapshot_r6_active_bindings.snap` — it contains a filler line). Diff each
+`.snap.new` vs `.snap`; if the only delta is removed spurious fillers, `mv`
+over and re-run. trybuild `.stderr`: not expected to change; if one does,
+stop and report (never `TRYBUILD=overwrite` locally — #1239).
+
+## Must NOT touch
+
+- Do NOT hand-edit `rpkg/man/fast_fixtures.Rd` — it must change only via the
+  regen loop (roxygen2 output).
+- `rpkg/R/miniextendr-wrappers.R` / `wasm_registry.rs` (generated, gitignored).
+- Items 1 and 3 of #1261 (other PRs). Do not "fix" `.mx_gen` or
+  `Rf_findVarInFrame` here even though the same check log shows them.
+- Do not flip CI `error-on:` to `"warning"` — that's #1261's close-out step,
+  decided by the maintainer after all four items land.
+
+## Done criteria
+
+- `fast_fixtures.Rd` regenerates without duplicate `\item{b}`/`\item{c}`;
+  `R CMD check` no longer reports the duplicated-`\argument` WARNING nor the
+  `2147483648L` parse warning (2 of the 4 #1261 WARNINGs gone; the log will
+  still show the other two — expected, reference their PRs in the PR body).
+- Macros unit tests for comma-split param docs pass; all 7 prefix-match
+  sites replaced; suites + three clippy legs green.
+- PR body references #1261 (partial fix — do NOT `Fixes #1261`).
+
+## Escalation rule
+
+If reality diverges from this plan — an anchor doesn't match, the Rd diff
+shows changes beyond removed fillers, a snapshot changes in a way not
+explained by the fix — **stop, commit nothing further, and report back.
+Do not improvise.**

--- a/rpkg/man/fast_fixtures.Rd
+++ b/rpkg/man/fast_fixtures.Rd
@@ -38,10 +38,6 @@ fast_i32_no_call_attribution(x)
 \item{x}{Input value.}
 
 \item{a, b, c}{Numeric scalars.}
-
-\item{b}{(no documentation available)}
-
-\item{c}{(no documentation available)}
 }
 \description{
 Identity (i32) with \code{fast} — bundle of \code{no_preconditions} + \code{no_call_attribution}. Largest single-fn perf win.

--- a/rpkg/tests/testthat/test-fast-fixtures.R
+++ b/rpkg/tests/testthat/test-fast-fixtures.R
@@ -57,7 +57,7 @@ test_that("no_call_attribution: error$call falls back to sys.call()", {
 })
 
 test_that("default wrapper's error$call uses match.call() (named args)", {
-  e <- tryCatch(fast_i32_default(x = -2147483648L - 1),
+  e <- tryCatch(fast_i32_default(x = -2147483649),
                 error = function(e) e)
   # The min-int sentinel is NA_integer_ in R; this triggers the
   # length-1 / numeric check downstream of stopifnot. Just verify the


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## Summary

Partial fix for #1261 — items 2 and 4 of the four standing `R CMD check` WARNINGs (item 1 landed via #1278; item 3 has its own queued PR).

**Item 2 — duplicated `\argument` entries `b`, `c` in `fast_fixtures.Rd`.** The macro's "is this param already documented?" auto-filler check was a string prefix match (`starts_with("@param <name>")`) repeated at 7 codegen sites (`lib.rs`, `r_class_formatter.rs`, `miniextendr_impl_trait/r_wrappers.rs`, `r6_class.rs` x2, `s7_class.rs` x2). roxygen2's comma-list syntax (`@param a,b,c desc`) documents several params in one tag, but the prefix match only recognized the first name — `b` and `c` got spurious `(no documentation available)` fillers that roxygen2 merged into duplicate `\item{b}`/`\item{c}` Rd entries. The prefix match was also a false-positive generator (`@param x2` wrongly counted `x` as documented). All 7 sites now use exact comma-split membership helpers in `roxygen.rs`: `param_documented(tags, name)` and `find_param_tag(tags, name)` (the S7 constructor site reuses the matched tag's text), sharing one `tag_documents_param` predicate; `extract_param_names` splits comma-lists too, so R6 class-level param suppression handles them. `rpkg/man/fast_fixtures.Rd` regenerated — the only change is the removal of the two filler entries.

**Item 4 — `2147483648L` parse warning.** `rpkg/tests/testthat/test-fast-fixtures.R` used `-2147483648L - 1`; `2147483648L` is one past `.Machine$integer.max`, so the parser warned ("non-integer value 2147483648L qualified with L; using numeric value") and surfaced as the `checking for unstated dependencies in tests` WARNING. Replaced with the equal-valued double literal `-2147483649`.

New unit tests in `miniextendr-macros/src/roxygen/tests.rs` cover comma-list splitting, exact membership (true for every listed name, false otherwise), the `x2`-vs-`x` prefix false positive, and `find_param_tag` returning the comma-list tag for any covered name.

## Test plan

- `cargo test -p miniextendr-macros`: 472 passed, 0 failed (lib tests, including the 6 new roxygen tests). The `ui` trybuild target shows only the 5 pre-existing `derive_dataframe_enum_*` `.stderr` mismatches from the local rust-src component (#1239) — untouched, not overwritten.
- `just test`: all workspace suites pass; the sole failure is the same pre-existing #1239 trybuild target.
- `just devtools-test`: `[ FAIL 0 | WARN 0 | SKIP 28 | PASS 7105 ]`
- `just r-cmd-check` (built tarball) WARNING delta:
  - GONE: duplicated `\argument` entries `b`, `c` in `fast_fixtures.Rd` under `checking Rd \usage sections` (item 2).
  - GONE: `checking for unstated dependencies in tests` WARNING (the `2147483648L` parse warning) — now `OK` (item 4).
  - Remaining 4 WARNINGs, all expected on this branch and none in scope here: `.mx_gen` `.Internal(get(...))` (item 1 — fixed on main by #1278, which merged after this branch point), `Rf_findVarInFrame` non-API call (item 3 — own PR), and the two pre-existing doc WARNINGs inventoried in the #1261 comment (`impl_dots_s3_*` undocumented objects; `ImplDotsS3.Rd` undocumented `seed`). The `r-cmd-check` recipe exits non-zero while any WARNING remains — expected until all four items land.
- Insta snapshots: no `.snap.new` produced (no fixture in the snapshot corpus hits the comma-list path). `NAMESPACE`/other `man/*.Rd`: no changes beyond `fast_fixtures.Rd`.
- All three CI clippy legs reproduced locally at `-D warnings`: default, `full-codegen` + curated feature list, `full-codegen-s7` + same list (feature lists read from `.github/workflows/ci.yml`). `cargo fmt --all` clean.

References #1261 (partial: items 2 and 4).

_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>
