### PR TITLE
ci: enforce the CLAUDE.md <-> AGENTS.md sibling invariant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
       - name: Check templates sync
         run: just templates-check
 
+      - name: AGENTS.md sibling check
+        run: just agents-md-check
+
       - name: Check end-user Claude skills vs scaffold layout
         run: just user-skills-check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,16 @@ site/                 # Zola docs → GitHub Pages
 background/           # Reference docs (gitignored)
 ```
 
+Every directory that has a `CLAUDE.md` has a sibling `AGENTS.md`: each
+**subdirectory** one is a one-line `@CLAUDE.md` import (codex's include
+mechanism), so it inherits that `CLAUDE.md` verbatim with no drift — when a new
+`CLAUDE.md` is added, drop a matching `@CLAUDE.md` `AGENTS.md` beside it. This
+**root** `AGENTS.md` is a hand-kept mirror of the root `CLAUDE.md`, not an
+import: a project-wide rule changed there must be mirrored here by hand. CI
+enforces the structural invariant (sibling presence, no orphans, the
+`@CLAUDE.md` import line) via `just agents-md-check` (Sync Checks job); prose
+parity of this root mirror stays hand-maintained.
+
 ## Build Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,10 @@ one-line `@CLAUDE.md` import (codex's include mechanism), so it inherits that
 `CLAUDE.md` verbatim with no drift — when you add a new `CLAUDE.md`, drop a matching
 `@CLAUDE.md` `AGENTS.md` beside it. The **root** `AGENTS.md` is a hand-kept mirror,
 not an import: it shares most content with this file, so if you change a
-project-wide rule here, mirror it there.
+project-wide rule here, mirror it there. CI enforces the structural invariant
+(sibling presence, no orphans, the `@CLAUDE.md` import line) via
+`just agents-md-check` (Sync Checks job); prose parity of the root mirror stays
+hand-maintained.
 
 ## Principles
 

--- a/justfile
+++ b/justfile
@@ -1129,6 +1129,10 @@ templates-check:
 
     diff -ruN "$tmp" "$tmp2"
 
+# Check the CLAUDE.md <-> AGENTS.md sibling invariant (exits nonzero on violation)
+agents-md-check:
+    bash scripts/agents-md-check.sh
+
 # ==============================================================================
 # Vendor sync check (ensure vendored crates match workspace)
 # ==============================================================================

--- a/plans/2026-07-11-issue-1253-agents-md-check.md
+++ b/plans/2026-07-11-issue-1253-agents-md-check.md
@@ -1,0 +1,89 @@
+# Plan: #1253 — CI check for the CLAUDE.md ↔ AGENTS.md sibling invariant
+
+Date: 2026-07-11. Anchors verified against main @ 17f634d8.
+Branch: `ci/1253-agents-md-check`.
+
+## Invariant (from PR #1236, restated in root CLAUDE.md)
+
+1. Every tracked `CLAUDE.md` has a sibling `AGENTS.md` in the same directory.
+2. Every tracked `AGENTS.md` has a sibling `CLAUDE.md` (no orphans).
+3. Every **subdirectory** `AGENTS.md` contains the `@CLAUDE.md` import line
+   (a line that is exactly `@CLAUDE.md`); the ROOT `AGENTS.md` is exempt
+   (hand-kept mirror).
+
+Current state (verified): 13 perfectly-paired directories; every
+subdirectory AGENTS.md is a one-comment-line + `@CLAUDE.md` file (see
+`miniextendr-api/AGENTS.md` for the canonical shape).
+
+## Work items
+
+1. New `scripts/agents-md-check.sh` (bash, `set -euo pipefail`; mirror the
+   header style of `scripts/skill-freshness-audit.sh` — purpose comment,
+   exit-nonzero-on-violation contract). Logic over `git ls-files` ONLY (never
+   the working tree — untracked/ignored files like `background/` must not
+   trip it):
+   ```bash
+   claude=$(git ls-files '*CLAUDE.md' | grep -E '(^|/)CLAUDE\.md$' | sed 's|CLAUDE\.md$||' | sort)
+   agents=$(git ls-files '*AGENTS.md' | grep -E '(^|/)AGENTS\.md$' | sed 's|AGENTS\.md$||' | sort)
+   comm -23 <(echo "$claude") <(echo "$agents")   # dirs missing AGENTS.md → violation
+   comm -13 <(echo "$claude") <(echo "$agents")   # orphan AGENTS.md → violation
+   ```
+   (The `grep -E '(^|/)CLAUDE\.md$'` guard keeps a hypothetical
+   `FOO-CLAUDE.md` from matching.) For rule 3: for every tracked AGENTS.md
+   except the root one, require `grep -qx '@CLAUDE.md'`; violations named
+   individually. Print each violation with a one-line fix hint (the root
+   CLAUDE.md "Orientation" section documents the convention) and exit 1 if
+   any rule fired; exit 0 silently otherwise (CI-friendly).
+2. `justfile`: add an `agents-md-check` recipe (`bash scripts/agents-md-check.sh`)
+   near `templates-check` (`justfile:1097`). Follow the file's existing
+   single-line recipe style; mind the recipe-line-isolation gotcha (each line
+   is its own `bash -c` unless `[script("bash")]` — a single command line
+   needs nothing special).
+3. `.github/workflows/ci.yml`, Sync Checks job (`:195-265`): add a step
+   `- name: AGENTS.md sibling check` / `run: just agents-md-check`
+   immediately after the `just templates-check` step (`:265`). No new deps —
+   pure git+coreutils.
+4. Self-test the three failure modes locally (create violation, run script,
+   assert exit 1, revert — do NOT commit the violations):
+   (a) delete a sibling: `git rm --cached miniextendr-bench/AGENTS.md` form —
+   use a scratch `git stash`-able edit, or simpler: run the script in a
+   throwaway clone under `/tmp`; (b) add an orphan `AGENTS.md`;
+   (c) replace a subdir AGENTS.md body with prose lacking `@CLAUDE.md`.
+   Record the three observed failure outputs in the PR body.
+5. Root `CLAUDE.md` + root `AGENTS.md` (hand-kept mirror — project rule: a
+   project-wide rule changed in one must be mirrored in the other): add one
+   sentence to the existing AGENTS.md convention paragraph noting CI enforces
+   the invariant via `just agents-md-check`.
+
+## Exact commands (worktree)
+
+```bash
+just worktree-sync            # FIRST (not strictly needed — no R/Rust builds — but keep the invariant)
+bash scripts/agents-md-check.sh; echo "exit=$?"     # expect exit=0 on clean tree
+just agents-md-check                                 # recipe wiring works
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'
+shellcheck scripts/agents-md-check.sh || true        # advisory; fix what it flags if installed
+```
+
+No Rust/R builds, no regen loop, no snapshots.
+
+## Must NOT touch
+
+- Any existing CLAUDE.md/AGENTS.md content beyond item 5's one sentence
+  (both root files, mirrored).
+- `minirextendr/inst/templates/**` (scaffolded-package files are out of
+  scope; none are tracked CLAUDE.md today — the git-ls-files basis keeps it
+  that way by construction).
+- Other Sync Checks steps.
+
+## Done criteria
+
+- Clean tree passes; each of the three violation classes turns the script
+  red with a named path (evidence in PR body); CI Sync Checks runs the new
+  step; `Fixes #1253`.
+
+## Escalation rule
+
+If reality diverges from this plan — the tracked-file inventory contains a
+legitimate exception the rules can't express, the Sync Checks job structure
+changed — **stop, commit nothing further, and report back. Do not improvise.**

--- a/scripts/agents-md-check.sh
+++ b/scripts/agents-md-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# CI check for the CLAUDE.md <-> AGENTS.md sibling invariant (issue #1253).
+#
+# PR #1236 put an AGENTS.md beside every CLAUDE.md so non-Claude agents
+# (codex/cursor) inherit the same per-directory guidance. The convention is
+# documented in the root CLAUDE.md "Orientation" section; this script keeps
+# it from silently regressing.
+#
+# WHAT IT CHECKS
+# --------------
+# All file inventory comes from `git ls-files` ONLY — never the working
+# tree — so untracked/ignored trees (background/, rv/, target/) can never
+# trip it, and scaffolded-package files under minirextendr/inst/templates/
+# stay out of scope by construction (none are tracked CLAUDE.md/AGENTS.md).
+#
+#   1. SIBLING PRESENCE: every tracked CLAUDE.md has a tracked AGENTS.md in
+#      the same directory.
+#   2. NO ORPHANS: every tracked AGENTS.md has a tracked CLAUDE.md in the
+#      same directory.
+#   3. IMPORT LINE: every tracked *subdirectory* AGENTS.md contains a line
+#      that is exactly `@CLAUDE.md` (codex's include mechanism — the file
+#      inherits its sibling CLAUDE.md verbatim, no drift). The ROOT
+#      AGENTS.md is exempt: it is a hand-kept mirror, not an import.
+#
+# NOT CHECKED: prose parity of the root AGENTS.md mirror against the root
+# CLAUDE.md. That is inherently hand-maintained (see the root CLAUDE.md
+# "Orientation" section — a project-wide rule changed in one must be
+# mirrored in the other by hand).
+#
+# EXIT CODE
+# ---------
+# Non-zero iff any rule fired; every violation is printed with a one-line
+# fix hint. A clean tree exits 0 silently (CI-friendly).
+#
+# USAGE
+#   bash scripts/agents-md-check.sh       # or: just agents-md-check
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+violations=0
+
+# Directory prefixes ("" for the repo root, "dir/" otherwise) holding each
+# file. The `grep -E '(^|/)CLAUDE\.md$'` guard keeps a hypothetical
+# FOO-CLAUDE.md from matching; `|| true` keeps an empty match set from
+# tripping pipefail.
+claude_dirs="$(git ls-files '*CLAUDE.md' | { grep -E '(^|/)CLAUDE\.md$' || true; } | sed 's|CLAUDE\.md$||' | sort)"
+agents_dirs="$(git ls-files '*AGENTS.md' | { grep -E '(^|/)AGENTS\.md$' || true; } | sed 's|AGENTS\.md$||' | sort)"
+
+# Rule 1: dirs with a CLAUDE.md but no AGENTS.md.
+while IFS= read -r dir; do
+    echo "VIOLATION: ${dir}CLAUDE.md has no sibling ${dir}AGENTS.md" \
+        "— add one (subdirectory: a one-line @CLAUDE.md import; see the root CLAUDE.md 'Orientation' section)."
+    violations=1
+done < <(comm -23 <(printf '%s\n' "$claude_dirs") <(printf '%s\n' "$agents_dirs") | sed '/^$/d')
+
+# Rule 2: orphan AGENTS.md (no sibling CLAUDE.md).
+while IFS= read -r dir; do
+    echo "VIOLATION: ${dir}AGENTS.md has no sibling ${dir}CLAUDE.md" \
+        "— every AGENTS.md pairs with a CLAUDE.md; add the CLAUDE.md or remove the orphan (see the root CLAUDE.md 'Orientation' section)."
+    violations=1
+done < <(comm -13 <(printf '%s\n' "$claude_dirs") <(printf '%s\n' "$agents_dirs") | sed '/^$/d')
+
+# Rule 3: every subdirectory AGENTS.md carries the literal import line.
+# The root AGENTS.md (hand-kept mirror) is exempt.
+while IFS= read -r f; do
+    [ "$f" = "AGENTS.md" ] && continue
+    if ! grep -qx '@CLAUDE.md' "$f"; then
+        echo "VIOLATION: $f lacks the exact import line '@CLAUDE.md'" \
+            "— subdirectory AGENTS.md must import its sibling CLAUDE.md verbatim (see the root CLAUDE.md 'Orientation' section)."
+        violations=1
+    fi
+done < <(git ls-files '*AGENTS.md' | { grep -E '(^|/)AGENTS\.md$' || true; })
+
+exit "$violations"


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details><summary><h3>AI-written details</h3></summary>

## Summary

Implements #1253 per `plans/2026-07-11-issue-1253-agents-md-check.md`: a CI gate for the CLAUDE.md ↔ AGENTS.md sibling convention established by #1236.

- **`scripts/agents-md-check.sh`** (new): checks three rules over `git ls-files` ONLY — never the working tree, so untracked/ignored trees (`background/`, `rv/`, `target/`) can never trip it, and `minirextendr/inst/templates/**` stays out of scope by construction:
  1. every tracked `CLAUDE.md` has a sibling tracked `AGENTS.md`;
  2. every tracked `AGENTS.md` has a sibling tracked `CLAUDE.md` (no orphans);
  3. every tracked **subdirectory** `AGENTS.md` contains a line that is exactly `@CLAUDE.md`; the root `AGENTS.md` (hand-kept mirror) is exempt.

  Each violation prints with a one-line fix hint pointing at the root CLAUDE.md "Orientation" section; exit 1 if any rule fired, silent exit 0 otherwise. A `(^|/)CLAUDE\.md$` guard keeps a hypothetical `FOO-CLAUDE.md` from matching.
- **`justfile`**: `agents-md-check` recipe (single-line style, next to `templates-check`).
- **`.github/workflows/ci.yml`**: `AGENTS.md sibling check` step in the Sync Checks job, immediately after `just templates-check`. No new dependencies — pure git + coreutils.
- **Root `CLAUDE.md` + root `AGENTS.md`**: one sentence added to the convention paragraph noting CI now enforces the structural invariant via `just agents-md-check`.

### Backfill note

The convention paragraph itself was **missing from the root `AGENTS.md`**: #1236 (c0fc5875) added it to root CLAUDE.md's Orientation section and — per its own commit message — updated only CLAUDE.md, never mirroring it, violating the hand-kept-mirror rule it documents. That is exactly the drift class this PR targets, so this PR repairs the instance (backfills the paragraph, adapted to AGENTS.md's reader, adjacent to its "Project Structure" section) and adds the checker that prevents structural recurrence. Scope note: the checker validates **structure only** (sibling presence, orphans, the `@CLAUDE.md` import line) — prose parity of the root mirror remains hand-maintained, consistent with the plan.

## Test plan

All run locally on this branch.

**Pass case (clean tree):**

```
$ bash scripts/agents-md-check.sh; echo "exit=$?"
exit=0                                  # silent, CI-friendly
$ just agents-md-check                  # recipe wiring
exit=0
$ python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'
yaml OK
$ shellcheck scripts/agents-md-check.sh
(clean)
```

The pass case also exercises the root exemption: the repo's root `AGENTS.md` has no bare `@CLAUDE.md` line (its first line is an absolute-path RTK import) and rule 3 correctly skips it.

**Induced-fail cases** (in a throwaway `git archive`+`git init` clone under the session scratchpad; violations never staged in this repo):

(a) missing sibling — `git rm --cached miniextendr-bench/AGENTS.md`:
```
VIOLATION: miniextendr-bench/CLAUDE.md has no sibling miniextendr-bench/AGENTS.md — add one (subdirectory: a one-line @CLAUDE.md import; see the root CLAUDE.md 'Orientation' section).
exit=1
```

(b) orphan — tracked `scripts/AGENTS.md` with no sibling CLAUDE.md:
```
VIOLATION: scripts/AGENTS.md has no sibling scripts/CLAUDE.md — every AGENTS.md pairs with a CLAUDE.md; add the CLAUDE.md or remove the orphan (see the root CLAUDE.md 'Orientation' section).
exit=1
```

(c) subdir AGENTS.md body replaced with prose lacking `@CLAUDE.md`:
```
VIOLATION: miniextendr-api/AGENTS.md lacks the exact import line '@CLAUDE.md' — subdirectory AGENTS.md must import its sibling CLAUDE.md verbatim (see the root CLAUDE.md 'Orientation' section).
exit=1
```

After reverting each induced violation, the clone returned to silent `exit=0`.

Fixes #1253

_Drafted by Claude (claude-sonnet-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)