### PR TITLE
docs(skills): consumer wrapper friction (per-param ergonomics, @rdname default, dev-loop removal case, column-major, ExternalPtr serialization)

### DIFF
--- a/.claude/skills/miniextendr-class-systems/SKILL.md
+++ b/.claude/skills/miniextendr-class-systems/SKILL.md
@@ -482,6 +482,13 @@ later, unpredictably.
   to a hand-written sidecar wrapper causes "Incorrect number of arguments" at runtime.
   See the `miniextendr-macros` skill for details on the two codegen paths.
 
+- **Pointer-backed class objects look serializable but are not**: an R6/S7/env
+  object wrapping an `ExternalPtr` round-trips `saveRDS()`/`readRDS()` with its
+  class intact, then fails on the first method or accessor call ("expected
+  ExternalPtr<T>") — the pointer is dead in the new session. See the
+  serialization pitfall in the `miniextendr-externalptr` skill for the
+  closure-over-plain-data escape hatch.
+
 ## Related skills
 
 - `miniextendr-macros` — the full `#[miniextendr]` codegen pipeline: C wrapper

--- a/.claude/skills/miniextendr-conversions/SKILL.md
+++ b/.claude/skills/miniextendr-conversions/SKILL.md
@@ -252,6 +252,16 @@ Avoid strict mode when:
   Scalar `Option<i32>` produces `NA_integer_`. The distinction matters for
   downstream R code that uses `is.null()` vs `is.na()`.
 
+- **R arrays are column-major; conversion never reorders them**: a `Vec<f64>`
+  or `&[f64]` received from an R `matrix`/`array` is the flat column-major
+  (Fortran-order) buffer as R stores it — `dim` is just an attribute, and
+  `TryFromSexp` does not permute data. Rust numeric crates typically expect
+  row-major / C-order flat buffers, so a wrapper must transpose explicitly.
+  Cheapest is on the R side before the `.Call`:
+  `as.double(aperm(x, rev(seq_along(dim(x)))))`, and the inverse on return:
+  `aperm(array(v, rev(dims)), rev(seq_along(dims)))`. For 1-D vectors the two
+  orders coincide and no transform is needed.
+
 ## Related skills
 
 - `miniextendr-getting-started` — how to write and register a first function.

--- a/.claude/skills/miniextendr-externalptr/SKILL.md
+++ b/.claude/skills/miniextendr-externalptr/SKILL.md
@@ -233,6 +233,10 @@ Returning Rust data to R where R needs to inspect, modify, or serialize it:
 - Consider `#[derive(IntoList)]` (converts to a named R list) or
   `miniextendr-serde` (via serde Serialize/Deserialize).
 
+If the object must survive `saveRDS()`/`readRDS()` or a session restart:
+- An `ExternalPtr` cannot (see the pitfall below). Return plain data, a serde
+  list, or an R closure that captures plain R data instead.
+
 If the data is array-like and benefits from lazy evaluation:
 - Consider ALTREP (`miniextendr-altrep` skill).
 
@@ -311,6 +315,17 @@ receive it:
   a vector or use it in vectorized operations. This is an R limitation, not a
   miniextendr limitation. If you need R-vectorized behavior over Rust data,
   use ALTREP.
+
+- **ExternalPtr does not survive `saveRDS()` / session restarts**: the pointer
+  address cannot be serialized, so a round-tripped object keeps its R class
+  but its pointer is dead — every subsequent access fails the `Any::downcast`
+  with an "expected ExternalPtr<T>" error. This is inherent to `EXTPTRSXP`,
+  not a miniextendr bug, and it is easy to miss because `readRDS()` itself
+  succeeds. If users need a persistable interface, expose a base-R-style
+  closure that captures plain R data (which serializes fine and can rebuild
+  the pointer-backed object lazily), or provide getters for the plain data so
+  the object can be reconstructed after reload. At minimum, document the
+  limitation on the constructor.
 
 - **Cross-package type safety requires the same crate version**: the `TypeId`
   in `Any::downcast` is per-compilation. Two separate compilations of the same

--- a/.claude/skills/miniextendr-getting-started/SKILL.md
+++ b/.claude/skills/miniextendr-getting-started/SKILL.md
@@ -202,13 +202,24 @@ The iteration loop for Rust changes is:
    `NAMESPACE` from the freshly generated `R/miniextendr-wrappers.R`, so the
    installed image lags the on-disk `NAMESPACE` by one build and the new export
    isn't callable yet (`could not find function "..."`).
-   - `minirextendr::miniextendr_build()` **handles this for you in a single
-     call**: it snapshots `NAMESPACE` before and after `document()` and, if the
-     export set changed, reinstalls once so the installed image matches. No
-     second pass needed.
+   - `minirextendr::miniextendr_build()` **handles the additive case for you
+     in a single call**: it snapshots `NAMESPACE` before and after `document()`
+     and, if the export set changed, reinstalls once so the installed image
+     matches. No second pass needed.
    - The monorepo raw recipes do *not* self-heal — after `just rcmdinstall &&
      just force-document` you must run `just rcmdinstall` once more so the new
      export becomes runtime-callable.
+   - **Removing or renaming an export fails harder**
+     (A2-ai/miniextendr#1288): the first install validates the stale
+     `NAMESPACE` — now a *superset* of the regenerated wrappers — and aborts
+     with `undefined exports: <old_name>` *before* `document()` can reconcile
+     it. (The additive case self-heals because a subset `NAMESPACE` still
+     installs; closed #860 covered only that side.) The aborting install has
+     already regenerated `R/<pkg>-wrappers.R`, so recovery is: run
+     `devtools::document()` / `roxygen2::roxygenize()` directly — it loads via
+     `pkgload::load_all()`, which only *warns* on the mismatch — then install
+     again. Alternatively, reset `NAMESPACE` to the roxygen header plus the
+     `useDynLib` line before the first install.
    Pure signature/body edits to *existing* exports need neither — only changes
    to the set of exported names do.
 4. Restart R (or reload the package) and test.
@@ -314,6 +325,15 @@ For CRAN submission:
 - **Modules must be reachable from `lib.rs`**: if you add a new `.rs` file with
   `#[miniextendr]` functions, you must add `mod my_module;` to `lib.rs`.
   Functions in unreachable modules are silently excluded from registration.
+
+- **Tests stay green under a stale superset `NAMESPACE`**: after removing or
+  renaming an export, `pkgload::load_all()` — used by `devtools::document()`
+  and `testthat::test_local()` — only *warns* ("Objects listed as exports, but
+  not present in namespace"), while `R CMD INSTALL` / `library()` hard-fail on
+  the same mismatch. So the test suite can pass while `R CMD check` and fresh
+  installs break. If you removed or renamed a `#[miniextendr]` export, confirm
+  `NAMESPACE` was regenerated (see the dev-loop step above and
+  A2-ai/miniextendr#1288).
 
 - **`configure.ac` must not be called via `minirextendr::*`**: configure-time
   helpers belong in `tools/*.R` and are invoked via `Rscript tools/foo.R`. Do

--- a/.claude/skills/miniextendr-macros/SKILL.md
+++ b/.claude/skills/miniextendr-macros/SKILL.md
@@ -162,6 +162,18 @@ generators.
 For multi-line tag support (`@examples`, `@description`, `@return`, `@param`,
 `@prop`), the `DESCRIPTION` file must include `Roxygen: list(markdown = TRUE)`.
 
+**Free functions default to `@rdname <source-file-stem>`.** During wrapper
+collection (`collect_r_wrappers` in `miniextendr-api/src/registry.rs`), any
+`RWrapperPriority::Function` entry without an explicit `@rdname` or `@noRd`
+gets `#' @rdname <file-stem>` injected (`rdname_from_source_file`; `lib.rs` /
+`mod.rs` stems are exempt, and a `@title` is injected if missing). Consequence:
+all exported free functions in one `.rs` file silently share a single `.Rd`
+page — the extras become aliases with concatenated usage/params, with no
+diagnostic. Impl-block/class entries group by class name instead. For one man
+page per function, put an explicit `#' @rdname <fn_name>` on each free
+function. Making per-function pages the default (grouping opt-in) is proposed
+in A2-ai/miniextendr#1289.
+
 ### Trait ABI shims
 
 `#[miniextendr]` applied to a trait definition (not an impl block) is processed
@@ -217,6 +229,72 @@ miniextendr-externalptr and miniextendr-ffi skills.
 Attributes for impl block methods are the same, with class-system–specific
 additions (e.g., `r6(prop = "name")`, `r6(finalize)`, `r6(private)`,
 `constructor`, `label`).
+
+A separate family of **per-parameter** attributes (`choices`, `match_arg`,
+`several_ok`, `default`) goes on individual parameters, not the function —
+see the next section.
+
+### Per-parameter argument ergonomics: `choices`, `match_arg`, `default`
+
+Standalone functions accept `#[miniextendr(...)]` attributes on individual
+parameters that generate R argument defaults and `match.arg()` validation,
+single-sourced from the Rust signature — no hand-written R:
+
+```rust
+#[miniextendr]
+pub fn interp(
+    #[miniextendr(choices("linear", "cubic", "nearest"))] method: &str,
+    #[miniextendr(default = "NULL")] grid_kind: Option<&str>,
+    #[miniextendr(default = "TRUE")] check_bounds: bool,
+) -> Vec<f64> { ... }
+```
+
+generates the R formals `method = c("linear", "cubic", "nearest"),
+grid_kind = NULL, check_bounds = TRUE` plus `method <- match.arg(method)` in
+the wrapper body. Per `match.arg` semantics, the **first choice is the
+effective default**. Details:
+
+- `default = "<expr>"` splices the string verbatim as the R formal default:
+  `"NULL"`, `"TRUE"`, `"0L"`, `"\"World\""` (escaped quotes for string
+  defaults).
+- `choices("a", "b", "c")` is for string parameters (`&str` / `String`). Add
+  `several_ok` (with a `Vec<String>` parameter) to get
+  `match.arg(..., several.ok = TRUE)`.
+- Enum alternative: `#[derive(MatchArg)]` on a fieldless enum plus
+  `#[miniextendr(match_arg)]` on the parameter. Choices come from
+  `MatchArg::CHOICES` (`miniextendr-api/src/match_arg.rs`) at wrapper-write
+  time via the `MX_MATCH_ARG_CHOICES` distributed slice — the placeholder in
+  the R formal default is substituted in `write_r_wrappers_to_file`. Adding
+  `default = "\"Variant\""` alongside `match_arg` rotates that choice to
+  position 0 so it becomes the `match.arg` default.
+- Invalid combinations are compile errors (`validate_per_param_attr_conflicts`
+  in `miniextendr-macros/src/miniextendr_fn.rs`): `choices` + `default`
+  (choices derives its default from the first choice), `coerce` + `choices`,
+  `default` on a `&Dots` or `Missing<T>` parameter (use `Option<T>` +
+  `default` instead), `several_ok` without `choices`/`match_arg`.
+- If a `match_arg`/`choices` parameter has no user-written `@param` doc, a
+  "One of …" / "One or more of …" description is generated
+  (`MX_MATCH_ARG_PARAM_DOCS`).
+
+**Impl methods use a different, method-level grammar.** Rust rejects attribute
+macros on method parameters inside an impl block ("expected non-macro
+attribute"), so the surface moves onto the method attribute with
+`param = "comma, separated"` values:
+
+```rust
+#[miniextendr(match_arg(mode))]
+#[miniextendr(choices(level = "low, medium, high"))]
+#[miniextendr(match_arg_several_ok(modes))]
+```
+
+(parsed in `miniextendr-macros/src/miniextendr_impl.rs`; annotated parameter
+names are validated against the signature, so typos fail at compile time).
+Do not mix the grammars: `choices(...)` placed on a standalone *function*
+(rather than on its parameter) is not a recognized fn-level option and errors
+with "`choices` does not accept parenthesized arguments".
+
+Live fixtures: `rpkg/src/rust/match_arg_tests.rs`,
+`rpkg/src/rust/default_tests.rs`, `rpkg/src/rust/match_arg_impl_tests.rs`.
 
 ## Decision trees
 
@@ -301,10 +379,17 @@ are violated, the macro falls back silently to main-thread execution. See the
   at the `miniextendr_api` crate root. `use miniextendr_api::{error, condition}`
   resolves to the modules. Always invoke via `miniextendr_api::error!(...)`.
 
-- **Lifetime params are rejected on `#[miniextendr]` fns/impl blocks (MXL112)**:
-  `extern "C-unwind" #[no_mangle]` is incompatible with any generic or lifetime
-  parameter. Use `Vec<T>` / `String` in place of `&[T]` / `&str`. For
-  `#[derive(DataFrameRow)]` structs, borrowed fields do work.
+- **Type/const generic params are rejected; lifetimes are allowed**: type and
+  const parameters require monomorphization (one symbol per instantiation),
+  which is incompatible with the single `extern "C-unwind" #[no_mangle]`
+  symbol — the proc-macro rejects them (validation block in
+  `miniextendr-macros/src/lib.rs`). Lifetimes are erased at codegen, so
+  `&[T]` / `&str` arguments and explicit `<'a>` params are fine. (The former
+  MXL112 lifetime lint is retired.) To wrap an upstream API that is generic
+  over `const N: usize`, keep the exported fn non-generic over a runtime value
+  and monomorphize *inside* it — a `match` over the supported `N` values, or
+  the upstream crate's own dispatch macro if it exposes one (e.g. interpn's
+  `dispatch_ndims!(ndims, "err msg", [1, 2, ..., 8], |N| { ... })`).
 
 - **`#[miniextendr]` on 1-field structs is removed**: The shorthand for wrapping
   a newtype struct is gone. Use ALTREP derives instead.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Skill-docs only. These additions come from friction found while building an external wrapper package (interpnow) against miniextendr; every fact was re-verified against current source before writing.

- `miniextendr-macros`: new "Per-parameter argument ergonomics" section documenting `choices(...)`, `match_arg`, `several_ok`, and `default = "..."` on standalone-fn parameters (generated `match.arg()` call, first choice as effective default, verbatim R default splicing, compile-time conflict checks in `validate_per_param_attr_conflicts`, the `MX_MATCH_ARG_CHOICES` placeholder substitution), including the grammar split versus impl methods (method-level `choices(param = "a, b")`, required because Rust rejects attribute macros on method parameters) and the "`choices` does not accept parenthesized arguments" error when the forms are mixed. Cites the live fixtures in `rpkg/src/rust/match_arg_tests.rs`, `default_tests.rs`, and `match_arg_impl_tests.rs`.
- `miniextendr-macros`: documented the `@rdname <source-file-stem>` default for free functions (`collect_r_wrappers` / `rdname_from_source_file` in `miniextendr-api/src/registry.rs`, gated on `RWrapperPriority::Function`), its consequence (same-file exports silently merge onto one Rd page), and the explicit per-function `@rdname` workaround. References #1289 for the proposed opt-in grouping default.
- `miniextendr-macros`: corrected a stale pitfall that claimed lifetime params are rejected (citing the retired MXL112 lint). Source and root CLAUDE.md agree lifetimes are erased at codegen and only type/const generic params are rejected (validation block in `miniextendr-macros/src/lib.rs`). Added the wrapper-author pattern for const-generic upstream APIs: keep the export non-generic and monomorphize inside via a match over N or the upstream crate's dispatch macro.
- `miniextendr-getting-started`: documented that removing or renaming a `#[miniextendr]` export hard-fails the first install on the stale superset NAMESPACE (`undefined exports: <old>`) before `document()` can reconcile it, unlike the additive case which self-heals. Added recovery steps (run roxygenize directly, or reset NAMESPACE to header plus `useDynLib`) and a pitfall on the `pkgload::load_all()` warn-only behavior that keeps tests green while `R CMD check` breaks. References #1288.
- `miniextendr-conversions`: new pitfall on column-major R arrays versus row-major/C-order Rust buffers. `TryFromSexp` never permutes data, so wrappers must transform explicitly (`aperm(x, rev(seq_along(dim(x))))` before flattening, and the inverse on return).
- `miniextendr-externalptr`: new pitfall plus decision-tree entry: ExternalPtr-backed objects do not survive `saveRDS()`/`readRDS()` or session restarts (the reloaded object keeps its class but every access fails the downcast), with the closure-over-plain-data escape hatch for a serializable API.
- `miniextendr-class-systems`: short cross-reference pitfall, since the failure surfaces as an R6/S7 object that round-trips `saveRDS` with class intact and only errors on the first method call.

## Test plan

- [x] `bash scripts/skill-freshness-audit.sh` passes: 0 BLOCKING, 18 WARN, identical to the main baseline (all pre-existing documented false-positive classes)
- [x] Cited paths and symbols exist in current source (`validate_per_param_attr_conflicts`, `MX_MATCH_ARG_CHOICES`, `MatchArg::CHOICES`, `collect_r_wrappers`, `rdname_from_source_file`, the generics validation in `miniextendr-macros/src/lib.rs`, and the rpkg fixture files)

## Notes

- The additive export-set lag (new export needs a second install) was already documented in `miniextendr-getting-started` Step 4; only the removal/rename hard-fail case was added, and the "handles this in a single call" claim was narrowed to the additive case to match `minirextendr/R/workflow.R` behavior.
- The vendor-tarball latch leak from the same friction log was not added anywhere: it is already covered by the getting-started and build skills and handled upstream (`clean_vendor_leak`, `minirextendr_doctor()`).
- `miniextendr-dots` already points at `miniextendr-macros` for "the broader match.arg gotcha"; that reference now resolves to the new section instead of dangling.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>
