### PR TITLE
fix(rpkg): gate panic_location_tests on the worker-thread feature

### DIFF
--- a/rpkg/src/rust/lib.rs
+++ b/rpkg/src/rust/lib.rs
@@ -239,6 +239,7 @@ mod num_traits_adapter_tests;
 mod option_self_tests;
 #[cfg(feature = "ordered-float")]
 mod ordered_float_adapter_tests;
+#[cfg(feature = "worker-thread")]
 mod panic_location_tests;
 mod panic_telemetry_tests;
 mod panic_tests;


### PR DESCRIPTION
TODO: after this, the remaining gap in this area is #1239 (the 5 trybuild mismatches that short-circuit `just test`'s rpkg leg, documented in #1293) — this PR fixes only the missing cfg guard.

## Summary
`rpkg/src/rust/lib.rs` declared `mod panic_location_tests;` unconditionally, but the module's worker fixtures use `#[miniextendr(worker)]`, which requires the `worker-thread` cargo feature. Since #1281 landed, a bare `cargo test` / `cargo check` inside `rpkg/src/rust` (no explicit `--features`, matching `just test`'s rpkg leg) failed to compile. Found during #1206 validation; surfaced by the #1296 review as a land-immediately one-liner.

One line: `#[cfg(feature = "worker-thread")]` on the mod declaration, mirroring the other feature-gated fixture modules in the same file.

Normal builds are unaffected: `R CMD INSTALL` / `devtools::test()` auto-detect `worker-thread` on, so the module (and its R-visible fixtures + `test-panic-location.R`) compile exactly as before; NAMESPACE/wrapper output is unchanged.

## Validation
- `cargo check --all-targets` inside `rpkg/src/rust` with no features (the previously failing invocation): compiles clean with the guard.
- No other tracked files changed (Cargo.lock churn from the check restored).

Fixes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)