### PR TITLE
fix(api): batch all element errors in IntoRAs vector conversions (#1097)

### DIFF
--- a/miniextendr-api/src/from_r.rs
+++ b/miniextendr-api/src/from_r.rs
@@ -1986,7 +1986,11 @@ macro_rules! impl_vec_option_try_from_sexp_list {
 
 /// Cap on the number of per-element failures listed in a batched vector
 /// conversion error; the remainder is summarized as `"and N more"`.
-const BATCHED_ERROR_CAP: usize = 10;
+///
+/// `pub(crate)` (rather than file-private) so [`crate::into_r_as`]'s
+/// `StorageCoerceError::Batched` (#1097) shares the exact same cap instead of
+/// drifting from the inbound [`BatchedErrors`] path.
+pub(crate) const BATCHED_ERROR_CAP: usize = 10;
 
 /// Bounded accumulator that folds indexed per-element conversion failures into
 /// one batched [`SexpError::InvalidValue`].

--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -48,6 +48,7 @@
 //! ```
 
 use crate::coerce::{CoerceError, TryCoerce};
+use crate::from_r::BATCHED_ERROR_CAP;
 use crate::into_r::IntoR;
 use crate::{RLogical, SEXP};
 use std::fmt;
@@ -105,6 +106,17 @@ pub enum StorageCoerceError {
     InvalidUtf8 {
         /// Failing element index for vector conversions.
         index: Option<usize>,
+    },
+    /// Aggregated per-element failures from a vector conversion (#1097).
+    /// `listed` holds at most the first `BATCHED_ERROR_CAP` element errors
+    /// (each with `index` set); `total` counts all failures.
+    Batched {
+        /// The vector/slice type that failed to convert, e.g. `"Vec<i64>"`.
+        container: &'static str,
+        /// The first `BATCHED_ERROR_CAP` per-element failures.
+        listed: Vec<StorageCoerceError>,
+        /// Total number of failing elements (`>= listed.len()`).
+        total: usize,
     },
 }
 
@@ -168,6 +180,23 @@ impl fmt::Display for StorageCoerceError {
                     write!(f, "invalid UTF-8")
                 }
             }
+            StorageCoerceError::Batched {
+                container,
+                listed,
+                total,
+            } => {
+                write!(f, "{} conversion failed: ", container)?;
+                for (i, e) in listed.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{}", e)?;
+                }
+                if *total > listed.len() {
+                    write!(f, "; and {} more", total - listed.len())?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -203,6 +232,9 @@ impl StorageCoerceError {
             StorageCoerceError::InvalidUtf8 { .. } => {
                 StorageCoerceError::InvalidUtf8 { index: Some(idx) }
             }
+            // Batched errors already carry per-element indices on their
+            // `listed` entries — indexing the aggregate itself is a no-op.
+            batched @ StorageCoerceError::Batched { .. } => batched,
             other => other,
         }
     }
@@ -592,10 +624,25 @@ macro_rules! impl_vec_into_r_as {
         impl IntoRAs<$target> for Vec<$from> {
             fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
                 let mut result = Vec::with_capacity(self.len());
+                let mut listed: Vec<StorageCoerceError> = Vec::new();
+                let mut total = 0usize;
                 for (i, val) in self.into_iter().enumerate() {
-                    let v: $target = try_coerce_scalar(val, $from_name, $target_name)
-                        .map_err(|e| e.at_index(i))?;
-                    result.push(v);
+                    match try_coerce_scalar::<$from, $target>(val, $from_name, $target_name) {
+                        Ok(v) => result.push(v),
+                        Err(e) => {
+                            if listed.len() < BATCHED_ERROR_CAP {
+                                listed.push(e.at_index(i));
+                            }
+                            total += 1;
+                        }
+                    }
+                }
+                if total > 0 {
+                    return Err(StorageCoerceError::Batched {
+                        container: concat!("Vec<", $from_name, ">"),
+                        listed,
+                        total,
+                    });
                 }
                 Ok(result.into_sexp())
             }
@@ -604,10 +651,25 @@ macro_rules! impl_vec_into_r_as {
         impl IntoRAs<$target> for &[$from] {
             fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
                 let mut result = Vec::with_capacity(self.len());
+                let mut listed: Vec<StorageCoerceError> = Vec::new();
+                let mut total = 0usize;
                 for (i, &val) in self.iter().enumerate() {
-                    let v: $target = try_coerce_scalar(val, $from_name, $target_name)
-                        .map_err(|e| e.at_index(i))?;
-                    result.push(v);
+                    match try_coerce_scalar::<$from, $target>(val, $from_name, $target_name) {
+                        Ok(v) => result.push(v),
+                        Err(e) => {
+                            if listed.len() < BATCHED_ERROR_CAP {
+                                listed.push(e.at_index(i));
+                            }
+                            total += 1;
+                        }
+                    }
+                }
+                if total > 0 {
+                    return Err(StorageCoerceError::Batched {
+                        container: concat!("&[", $from_name, "]"),
+                        listed,
+                        total,
+                    });
                 }
                 Ok(result.into_sexp())
             }
@@ -663,13 +725,25 @@ impl IntoRAs<i32> for &[bool] {
 // Identity - but check for finite values
 impl IntoRAs<f64> for Vec<f64> {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, &val) in self.iter().enumerate() {
             if !val.is_finite() {
-                return Err(StorageCoerceError::NonFinite {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::NonFinite {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
             }
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "Vec<f64>",
+                listed,
+                total,
+            });
         }
         Ok(self.into_sexp())
     }
@@ -677,13 +751,25 @@ impl IntoRAs<f64> for Vec<f64> {
 
 impl IntoRAs<f64> for &[f64] {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, &val) in self.iter().enumerate() {
             if !val.is_finite() {
-                return Err(StorageCoerceError::NonFinite {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::NonFinite {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
             }
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "&[f64]",
+                listed,
+                total,
+            });
         }
         Ok(self.into_sexp())
     }
@@ -693,14 +779,27 @@ impl IntoRAs<f64> for &[f64] {
 impl IntoRAs<f64> for Vec<f32> {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
         let mut result = Vec::with_capacity(self.len());
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, val) in self.into_iter().enumerate() {
             if !val.is_finite() {
-                return Err(StorageCoerceError::NonFinite {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::NonFinite {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
+            } else {
+                result.push(val as f64);
             }
-            result.push(val as f64);
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "Vec<f32>",
+                listed,
+                total,
+            });
         }
         Ok(result.into_sexp())
     }
@@ -709,14 +808,27 @@ impl IntoRAs<f64> for Vec<f32> {
 impl IntoRAs<f64> for &[f32] {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
         let mut result = Vec::with_capacity(self.len());
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, &val) in self.iter().enumerate() {
             if !val.is_finite() {
-                return Err(StorageCoerceError::NonFinite {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::NonFinite {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
+            } else {
+                result.push(val as f64);
             }
-            result.push(val as f64);
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "&[f32]",
+                listed,
+                total,
+            });
         }
         Ok(result.into_sexp())
     }
@@ -753,14 +865,27 @@ impl_vec_into_r_as_f64_infallible!(u32);
 impl IntoRAs<f64> for Vec<i32> {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
         let mut result = Vec::with_capacity(self.len());
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, val) in self.into_iter().enumerate() {
             if val == crate::altrep_traits::NA_INTEGER {
-                return Err(StorageCoerceError::MissingValue {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::MissingValue {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
+            } else {
+                result.push(val as f64);
             }
-            result.push(val as f64);
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "Vec<i32>",
+                listed,
+                total,
+            });
         }
         Ok(result.into_sexp())
     }
@@ -769,14 +894,27 @@ impl IntoRAs<f64> for Vec<i32> {
 impl IntoRAs<f64> for &[i32] {
     fn into_r_as(self) -> Result<SEXP, StorageCoerceError> {
         let mut result = Vec::with_capacity(self.len());
+        let mut listed: Vec<StorageCoerceError> = Vec::new();
+        let mut total = 0usize;
         for (i, &val) in self.iter().enumerate() {
             if val == crate::altrep_traits::NA_INTEGER {
-                return Err(StorageCoerceError::MissingValue {
-                    to: "f64",
-                    index: Some(i),
-                });
+                if listed.len() < BATCHED_ERROR_CAP {
+                    listed.push(StorageCoerceError::MissingValue {
+                        to: "f64",
+                        index: Some(i),
+                    });
+                }
+                total += 1;
+            } else {
+                result.push(val as f64);
             }
-            result.push(val as f64);
+        }
+        if total > 0 {
+            return Err(StorageCoerceError::Batched {
+                container: "&[i32]",
+                listed,
+                total,
+            });
         }
         Ok(result.into_sexp())
     }
@@ -993,6 +1131,74 @@ mod tests {
         // Vecs -> String
         _assert_into_r_as::<Vec<String>, String>();
         _assert_into_r_as::<Vec<f64>, String>();
+    }
+
+    // Batched-error tests (#1097). These only exercise the failure path
+    // (`into_sexp()` is never reached), so they don't need `with_r_thread` —
+    // unlike the success-path integration tests in `conversion_coverage.rs`.
+
+    /// Failures at indices 3, 17, 42 must all be listed in one `Batched`
+    /// error's `Display` string, not just the first one.
+    #[test]
+    fn batched_vec_i64_to_i32_lists_all_failing_indices() {
+        let mut v = vec![0i64; 43];
+        for &i in &[3usize, 17, 42] {
+            v[i] = i64::MAX;
+        }
+        let result = IntoRAs::<i32>::into_r_as(v);
+        match result {
+            Err(StorageCoerceError::Batched {
+                container,
+                listed,
+                total,
+            }) => {
+                assert_eq!(container, "Vec<i64>");
+                assert_eq!(total, 3);
+                assert_eq!(listed.len(), 3);
+                let display = StorageCoerceError::Batched {
+                    container,
+                    listed,
+                    total,
+                }
+                .to_string();
+                assert!(display.contains("index 3"), "{display}");
+                assert!(display.contains("index 17"), "{display}");
+                assert!(display.contains("index 42"), "{display}");
+            }
+            other => panic!("expected Batched, got {other:?}"),
+        }
+    }
+
+    /// A 15-failure input lists only the first `BATCHED_ERROR_CAP` (10) and
+    /// summarizes the rest as `"and 5 more"`.
+    #[test]
+    fn batched_vec_i64_to_i32_caps_listed_and_summarizes_rest() {
+        let v = vec![i64::MAX; 15];
+        let result = IntoRAs::<i32>::into_r_as(v);
+        match result {
+            Err(e @ StorageCoerceError::Batched { .. }) => {
+                if let StorageCoerceError::Batched { listed, total, .. } = &e {
+                    assert_eq!(*total, 15);
+                    assert_eq!(listed.len(), BATCHED_ERROR_CAP);
+                }
+                let display = e.to_string();
+                assert!(display.contains("and 5 more"), "{display}");
+            }
+            other => panic!("expected Batched, got {other:?}"),
+        }
+    }
+
+    /// Scalar conversion failures must keep the plain (non-`Batched`) shape
+    /// and Display grammar — only vector conversions batch.
+    #[test]
+    fn scalar_failure_display_unchanged() {
+        let result = IntoRAs::<i32>::into_r_as(i64::MAX);
+        match result {
+            Err(e @ StorageCoerceError::OutOfRange { .. }) => {
+                assert_eq!(e.to_string(), "value out of range for i64 → i32");
+            }
+            other => panic!("expected scalar OutOfRange, got {other:?}"),
+        }
     }
 }
 // endregion

--- a/miniextendr-api/src/into_r_as.rs
+++ b/miniextendr-api/src/into_r_as.rs
@@ -1188,6 +1188,35 @@ mod tests {
         }
     }
 
+    /// The `&[T]` slice arms carry their own container label (`"&[i64]"`,
+    /// not `"Vec<i64>"`) and batch failures the same way as the `Vec` arms.
+    #[test]
+    fn batched_slice_i64_to_i32_lists_all_failing_indices() {
+        let mut v = vec![0i64; 6];
+        v[1] = i64::MAX;
+        v[4] = i64::MIN;
+        let result = IntoRAs::<i32>::into_r_as(v.as_slice());
+        match result {
+            Err(e @ StorageCoerceError::Batched { .. }) => {
+                if let StorageCoerceError::Batched {
+                    container,
+                    listed,
+                    total,
+                } = &e
+                {
+                    assert_eq!(*container, "&[i64]");
+                    assert_eq!(*total, 2);
+                    assert_eq!(listed.len(), 2);
+                }
+                let display = e.to_string();
+                assert!(display.contains("&[i64] conversion failed"), "{display}");
+                assert!(display.contains("index 1"), "{display}");
+                assert!(display.contains("index 4"), "{display}");
+            }
+            other => panic!("expected Batched, got {other:?}"),
+        }
+    }
+
     /// Scalar conversion failures must keep the plain (non-`Batched`) shape
     /// and Display grammar — only vector conversions batch.
     #[test]

--- a/miniextendr-api/tests/conversion_coverage.rs
+++ b/miniextendr-api/tests/conversion_coverage.rs
@@ -1747,6 +1747,10 @@ fn into_r_as_scalar_i64_to_i32_too_large_errors() {
 /// Vec<i32> IntoRAs<f64> — NA_integer_ (i32::MIN) sentinel must surface
 /// MissingValue rather than silently widening to the finite -2147483648.0.
 /// Parallels `into_r_as_vec_f64_nan_to_i32_errors` on the NonFinite path.
+///
+/// Vector conversions now batch element failures (#1097): a single failure
+/// still comes back wrapped in `StorageCoerceError::Batched` (one listed
+/// entry, `total == 1`) rather than the bare `MissingValue`.
 #[test]
 fn into_r_as_vec_i32_na_to_f64_missing_value_errors() {
     use miniextendr_api::into_r_as::StorageCoerceError;
@@ -1755,13 +1759,20 @@ fn into_r_as_vec_i32_na_to_f64_missing_value_errors() {
         let result = IntoRAs::<f64>::into_r_as(v);
         assert!(
             matches!(
-                result,
-                Err(StorageCoerceError::MissingValue {
-                    to: "f64",
-                    index: Some(1)
-                })
+                &result,
+                Err(StorageCoerceError::Batched {
+                    container: "Vec<i32>",
+                    listed,
+                    total: 1,
+                }) if matches!(
+                    listed.as_slice(),
+                    [StorageCoerceError::MissingValue {
+                        to: "f64",
+                        index: Some(1)
+                    }]
+                )
             ),
-            "NA_integer_ in Vec<i32> must error as MissingValue at index 1, got {result:?}"
+            "NA_integer_ in Vec<i32> must batch as MissingValue at index 1, got {result:?}"
         );
     });
 }

--- a/plans/2026-07-11-issue-1097-intoras-batched-errors.md
+++ b/plans/2026-07-11-issue-1097-intoras-batched-errors.md
@@ -1,0 +1,103 @@
+# Plan: #1097 — batch all element errors in `IntoRAs` vector conversions
+
+Date: 2026-07-11. Anchors verified against main @ 17f634d8.
+Branch: `fix/1097-intoras-batched-errors`.
+
+Decision baked in (ledger): **option 2** — change the error contract to an
+aggregate (pre-release, no backcompat), implemented directly on the vector
+`IntoRAs` impls (the blanket `TryCoerce` route is E0119-infeasible —
+`audit/coerce.md` issue #4). Reuse #1192's grammar. No file overlap with the
+#1217 PRs; land any order.
+
+## Design
+
+1. New variant on `StorageCoerceError` (`miniextendr-api/src/into_r_as.rs:59`;
+   derives `Debug, Clone, PartialEq, Eq` — the new variant must keep those):
+   ```rust
+   /// Aggregated per-element failures from a vector conversion (#1097).
+   /// `listed` holds at most the first BATCHED_ERROR_CAP element errors
+   /// (each with `index` set); `total` counts all failures.
+   Batched {
+       container: &'static str,   // e.g. "Vec<i64>"
+       listed: Vec<StorageCoerceError>,
+       total: usize,
+   },
+   ```
+2. Cap sharing: `BATCHED_ERROR_CAP` in `miniextendr-api/src/from_r.rs:1989`
+   is file-private — widen to `pub(crate)` and import it here so the cap
+   can't drift from the #1192 paths.
+3. `Display` for `Batched`:
+   `"{container} conversion failed: {e1}; {e2}; ...; and {total-listed} more"`
+   (elements' own Display already carries `index`; the `and N more` tail only
+   when `total > listed.len()` — mirror `BatchedErrors::into_error`,
+   `from_r.rs:2037-2046`). Update the `at_index` helper (`:180`) with a
+   `Batched` arm that is a no-op (indices live on the elements).
+4. Convert every SHORT-CIRCUITING vector impl in `into_r_as.rs` to
+   accumulate: the authoritative inventory is
+   `grep -n 'at_index' miniextendr-api/src/into_r_as.rs` — currently the
+   macro-generated impls (`:592-610`, two `.map_err(...)?` sites covering
+   many `Vec<$from>` impls) plus any direct `Vec<...>` impls that propagate
+   an element error (walk `:619-930`; impls that are infallible per element
+   stay untouched). Pattern per site: enumerate; push successes; on failure,
+   if `listed.len() < BATCHED_ERROR_CAP` push `e.at_index(i)`; count total;
+   after the walk return `Err(StorageCoerceError::Batched { ... })` when
+   `total > 0`. Container labels: use the same `from`/`to` naming the impl's
+   scalar errors already use, formatted as `Vec<{from}>` (a `&'static str`
+   per impl — hardcode per impl/macro-arm; do not invent a new naming
+   scheme).
+5. Scalar impls and the scalar error variants are UNCHANGED — a scalar
+   conversion still returns the plain variant (no single-element `Batched`).
+6. Callers: `grep -rn 'into_r_as' miniextendr-api miniextendr-macros rpkg/src/rust`
+   — any caller that pattern-matches `StorageCoerceError` variants must gain
+   a `Batched` arm (rustc will find them: the enum is exhaustively matched or
+   Display-routed; fix what the compiler flags, changing no behavior beyond
+   message text).
+
+## Tests
+
+7. Unit tests beside the existing into_r_as tests (find the test module via
+   `grep -n 'mod tests' miniextendr-api/src/into_r_as.rs` or the
+   `tests/` dir): `Vec<i64>` → i32 storage with failures at indices 3, 17, 42
+   lists all three in one Display string; a 15-failure input shows 10 + `and
+   5 more`; scalar failure Display unchanged.
+8. R-side: grep `rpkg/tests/testthat/` for pins on storage-coerce messages
+   (`conversion failed`/`out of range` shapes tied to `into_r_as` fixtures)
+   and update to the batched grammar where a vector path is pinned.
+
+## Exact commands (worktree)
+
+```bash
+rig default 4.6 && R --version | head -1        # must print 4.6.x
+just worktree-sync                               # FIRST
+cargo test -p miniextendr-api 2>&1 > /tmp/1097-api.log   # Read it
+just configure && just rcmdinstall && just force-document
+# (no new exports expected — single install)
+just test 2>&1 > /tmp/1097-rust.log
+just devtools-test 2>&1 > /tmp/1097-devtools.log
+grep -E '\[ FAIL [0-9]+' /tmp/1097-devtools.log  # devtools::test always exits 0
+cargo clippy --workspace --all-targets --locked -- -D warnings  # + all/all_s7 legs per ci.yml
+cargo fmt --all
+```
+
+No snapshot churn expected. If trybuild/insta move, stop and report (never
+`TRYBUILD=overwrite` locally — #1239).
+
+## Must NOT touch
+
+- Which elements pass/fail (semantics identical; only aggregation changes).
+- `BatchedErrors`/`SexpError` (#1192 machinery) beyond the `pub(crate)` cap.
+- NA handling (#1217 item 4 decision pending).
+- `coerce.rs` blankets (E0119 — documented infeasible).
+
+## Done criteria
+
+- All fallible `IntoRAs` vector impls report every failing index (cap 10 +
+  `and N more`) in one error; scalar contract untouched; unit tests pin the
+  shapes; suites + three clippy legs green; `Fixes #1097`.
+
+## Escalation rule
+
+If reality diverges from this plan — an impl's error flow doesn't match the
+`at_index` inventory, a caller relies on receiving the FIRST error only, the
+enum's `Eq` derive breaks — **stop, commit nothing further, and report back.
+Do not improvise.**


### PR DESCRIPTION
TODO (author): framing

<details>
<summary>AI-written implementation notes</summary>

**What**

`IntoRAs` vector conversions (`miniextendr-api/src/into_r_as.rs`) used to
short-circuit and return only the first failing element's `StorageCoerceError`.
This PR makes every fallible vector/slice `IntoRAs` impl walk the whole input
and batch all failing indices into one new `StorageCoerceError::Batched`
variant (`container`, `listed` (capped at `BATCHED_ERROR_CAP` = 10), `total`),
matching the project's "collect all errors in vectorized ops" principle and
option 2 from #1097 (aggregate error contract, pre-release/no-backcompat).

**Why**

A user converting e.g. `Vec<i64> -> INTSXP` with several out-of-range elements
previously saw only the first failing index, fixed it, re-ran, and hit the
next one. `Batched` surfaces every failing index (up to the cap) in one
Display string, with an `"and N more"` tail beyond the cap — mirroring the
`BatchedErrors` grammar already used on the inbound (`TryFromSexp`) path
(#1192).

**How**

- Added `StorageCoerceError::Batched { container, listed, total }` (keeps the
  enum's `Debug, Clone, PartialEq, Eq` derives).
- `Display` renders `"{container} conversion failed: {e1}; {e2}; ...; and N
  more"` (elements' own `Display` already carries `index`).
- `at_index` gained a no-op arm for `Batched` — indices already live on the
  listed elements.
- Widened `BATCHED_ERROR_CAP` in `from_r.rs` from file-private to
  `pub(crate)` so both the inbound and outbound batching paths share one cap
  instead of drifting.
- Converted every short-circuiting vector/slice impl to accumulate:
  - The `impl_vec_into_r_as!` macro (covers `Vec<$from>`/`&[$from]` for all
    `i32`, `u8`, and large-integer-`f64` target arms).
  - `Vec<f64>`/`&[f64] -> f64` (NonFinite check).
  - `Vec<f32>`/`&[f32] -> f64` (NonFinite check + widen).
  - `Vec<i32>`/`&[i32] -> f64` (NA_integer_ sentinel check).
  - Impls that are infallible per element (identity copies, `bool` widening,
    stringify paths) are unchanged, per the plan.
- Scalar impls/error variants are untouched — only vector paths batch.

**How verified**

- New unit tests in `into_r_as.rs`: failures at indices 3/17/42 all appear in
  one `Batched` Display string; a 15-failure input lists the first 10 and
  summarizes `"and 5 more"`; scalar failure Display is unchanged (still the
  bare `OutOfRange`, no `Batched` wrapper).
- Updated the one existing integration test in `conversion_coverage.rs`
  (`into_r_as_vec_i32_na_to_f64_missing_value_errors`) that pinned the bare
  first-error shape for a converted impl — it now expects
  `Batched { total: 1, listed: [MissingValue { index: Some(1) }] }`.
- `cargo test -p miniextendr-api` — all into_r_as / conversion_coverage tests
  pass.
- Full Rust workspace suite (`just test` equivalent, run piecewise since a
  pre-existing unrelated `miniextendr-macros` trybuild UI failure — confirmed
  present on unmodified `origin/main` via `git stash` — blocks the chained
  `just test` recipe) green: root workspace, rpkg's patched `src/rust`
  workspace.
- `just configure && just rcmdinstall && just force-document` — no new
  exports, no NAMESPACE/man drift.
- `just devtools-test` — 0 failures.
- All three CI clippy legs (`clippy_default`, `clippy_all`,
  `clippy_all_s7`, feature lists read from `.github/workflows/ci.yml`) clean
  with `-D warnings`.
- `cargo fmt --all` applied.

Fixes #1097

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
