### PR TITLE
ci(feature-legs): run the full suite on the r6-default / s7-default legs (#1113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1173,16 +1173,20 @@ jobs:
   # (audit A5/A10). Each leg rebuilds rpkg with one bundle of denylisted
   # features on top of the auto-detected base set and runs testthat against it.
   #
-  # The extras and worker-default legs run the full suite (their features are
-  # additive/transparent). The r6-default, s7-default, and fast-default legs
-  # flip codegen semantics for every bare #[miniextendr] impl block / coerced
-  # parameter / precondition in the package, so the pre-existing suite fails
-  # by design under them — they run only the feature-default fixture tests
-  # (tests/testthat/test-feature-defaults.R). #1113 tracks broadening them.
+  # The extras, worker-default, r6-default, and s7-default legs run the full
+  # suite. extras/worker-default features are additive/transparent; the class
+  # legs became full-suite-safe in #1113, which made every #[miniextendr] impl
+  # block in rpkg explicitly `env` — the class flip now only reaches the one
+  # deliberately bare probe (FdefaultProbe in feature_default_fixtures.rs) plus
+  # the divergence assertions in tests/testthat/test-feature-defaults.R.
+  # The strict-default, coerce-default, and fast-default legs stay filtered to
+  # the feature-default fixture tests: they flip conversion semantics /
+  # preconditions for every parameter suite-wide, so the pre-existing suite
+  # fails by design under them.
   # The fast-default leg additionally runs the two fast_default unit tests in
   # miniextendr-macros/src/tests.rs, which no other job compiles+runs.
   #
-  # Weekly-only + workflow_dispatch: five extra full rpkg builds are too heavy
+  # Weekly-only + workflow_dispatch: seven extra full rpkg builds are too heavy
   # for a per-PR gate. Intentionally NOT in ci-success.needs; failures surface
   # via the job summary (same pattern as gctorture-nightly.yml).
   feature-legs:
@@ -1200,15 +1204,25 @@ jobs:
           - leg: worker-default
             features: worker-default
             filter: ""
-          # strict-default rides with r6, coerce-default with s7: under
+          # The class legs run the full suite (#1113): rpkg's impl blocks are
+          # explicitly `env`, so the class flip only reaches the deliberate
+          # probe. strict/coerce cannot ride on them — they flip conversion
+          # semantics suite-wide — so they get their own fixture-filtered
+          # rows. They must also stay separate from EACH OTHER: under
           # coerce-default, lossy-int params convert via R's integer native
           # type, which masks the strict/no_strict divergence the fixtures
-          # assert (#1112) — the two must stay on separate rows.
+          # assert (#1112).
           - leg: r6-default
-            features: r6-default,strict-default
-            filter: feature-defaults
+            features: r6-default
+            filter: ""
           - leg: s7-default
-            features: s7-default,coerce-default
+            features: s7-default
+            filter: ""
+          - leg: strict-default
+            features: strict-default
+            filter: feature-defaults
+          - leg: coerce-default
+            features: coerce-default
             filter: feature-defaults
           - leg: fast-default
             features: fast-default
@@ -1218,6 +1232,8 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      # gctorture coverage lives in the sharded r-stress-tests job + nightly.
+      MINIEXTENDR_SKIP_STRESS: "1"
 
     steps:
       - uses: actions/checkout@v7

--- a/plans/2026-07-11-issue-1113-feature-legs-full-suite.md
+++ b/plans/2026-07-11-issue-1113-feature-legs-full-suite.md
@@ -1,0 +1,115 @@
+# Plan: #1113 — default-agnostic fixtures + full-suite r6/s7 feature legs
+
+Date: 2026-07-11. Anchors verified against main @ 17f634d8.
+Branch: `ci/1113-feature-legs-full-suite`.
+
+Decision baked in (the issue's own "cleaner path" + one matrix restructure):
+
+- Make every bare `#[miniextendr]` **impl block** in `rpkg/src/rust/` explicit
+  (`#[miniextendr(env)]` — env IS the compiled default, so this is
+  behavior-preserving), EXCEPT the deliberate class-system probe.
+- Split the strict/coerce riders onto their own filtered rows so the class
+  legs can run the full suite: the blocker for full-suite was never only the
+  class flip — `strict-default`/`coerce-default` change conversion semantics
+  suite-wide and CANNOT go full-suite without a second sweep that is out of
+  scope here.
+
+Sequencing note: `ci/1244-fast-default-leg`
+(`plans/2026-07-11-issue-1244-fast-default-ci-leg.md`) edits the same matrix
+block — whichever lands second rebases (trivial adjacent-row conflict).
+
+## Work items (flat order)
+
+1. **Sweep** (own commit, mechanical): inventory bare impl-block attributes:
+   `rg -U -n '#\[miniextendr\]\s*\nimpl ' rpkg/src/rust/` (expect ≈52 per the
+   issue; the count validates the pattern — if you find <40 or >70, stop and
+   report). For each hit, rewrite `#[miniextendr]` → `#[miniextendr(env)]`,
+   EXCEPT the class-system probe region in
+   `rpkg/src/rust/feature_default_fixtures.rs:69-94` (its bareness is the
+   probe — leave it, add a comment `// deliberately bare: flips under
+   r6-default/s7-default (#1113)` if not already stated). Bare `#[miniextendr]`
+   on FNS is untouched (class flips don't affect functions).
+   Behavior-preservation proof: full regen loop, then `git status` — NAMESPACE
+   and `man/*.Rd` must show ZERO diff. If any diff appears, stop and report.
+2. **Matrix restructure** in `.github/workflows/ci.yml` feature-legs
+   (`:1188-1207`): replace the two bundled rows with four:
+   ```yaml
+   - leg: r6-default
+     features: r6-default
+     filter: ""
+   - leg: s7-default
+     features: s7-default
+     filter: ""
+   - leg: strict-default
+     features: strict-default
+     filter: feature-defaults
+   - leg: coerce-default
+     features: coerce-default
+     filter: feature-defaults
+   ```
+   Keep the existing comment about strict/coerce needing separate rows
+   (`:1198-1201`), rewritten to explain the new split (class legs full-suite
+   per #1113; strict/coerce stay fixture-filtered because they flip
+   conversion semantics suite-wide). Update the job header comment
+   (`:1173-1178`) which currently documents the filtered r6/s7 behavior.
+3. **Stress-file exclusion**: the job currently leaves
+   `MINIEXTENDR_SKIP_STRESS` unset, so full-suite legs run the gctorture
+   files (slow interpreter-heavy tests whose coverage lives in the sharded
+   `r-stress-tests` job + nightly). Add `MINIEXTENDR_SKIP_STRESS: "1"` to the
+   feature-legs job `env:` block (`:1209-1212`) with a one-line comment. This
+   also applies to the existing extras/worker rows — deliberate; note it in
+   the PR body.
+4. **Full-suite proof for the class legs** (local, one leg is enough —
+   r6-default; s7 is symmetric and CI-verified weekly):
+   ```bash
+   export CARGO_FEATURES="$(Rscript rpkg/tools/detect-features.R 2>/dev/null | tail -1),r6-default"
+   ```
+   — NO: compose it exactly the way the CI step does (`:1248-1256` — read
+   the "Compose CARGO_FEATURES" step and replicate its base-detection
+   command verbatim; do not invent a different composition). Then in the SAME
+   shell: `just configure && just rcmdinstall`, then
+   `MINIEXTENDR_SKIP_STRESS=1 Rscript -e 'testthat::test_local()'` from
+   `rpkg/` — must be FAIL 0. Triage any failure: it is either a fixture the
+   sweep missed (fix: make it explicit) or a genuinely flip-sensitive test
+   (fix: branch it on `miniextendr_has_feature()` like
+   `test-feature-defaults.R` does) — those two remedies are in scope; any
+   third kind of failure → escalate. Restore the default build afterwards
+   (`unset CARGO_FEATURES && just configure && just rcmdinstall`).
+
+## Exact commands (worktree)
+
+```bash
+rig default 4.6 && R --version | head -1        # must print 4.6.x
+just worktree-sync                               # FIRST
+just configure && just rcmdinstall && just force-document
+# sweep is attr-only, no new exports — single install; expect zero NAMESPACE/man diff
+just devtools-test 2>&1 > /tmp/1113-devtools.log      # default build stays green
+grep -E '\[ FAIL [0-9]+' /tmp/1113-devtools.log       # devtools::test always exits 0
+# r6-default full-suite proof per item 4 (redirect to /tmp/1113-r6leg.log, Read it)
+just test 2>&1 > /tmp/1113-rust.log
+cargo clippy --workspace --all-targets --locked -- -D warnings  # + all/all_s7 legs per ci.yml
+cargo fmt --all
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'
+```
+
+## Must NOT touch
+
+- `test-feature-defaults.R`'s divergence probes (they remain the deliberate
+  flip-sensitive coverage).
+- Bare `#[miniextendr]` on functions; conversion fixtures' strict/coerce
+  knobs (out of scope — strict/coerce rows stay filtered).
+- The extras/worker rows beyond the shared env addition.
+- cross-package crates.
+
+## Done criteria
+
+- r6-default and s7-default rows run `testthat::test_local()` unfiltered;
+  local r6 full-suite run FAIL 0; sweep commit shows zero tracked-artifact
+  diff; strict/coerce rows still cover their fixtures; three clippy legs +
+  default suite green; `Fixes #1113`.
+
+## Escalation rule
+
+If reality diverges from this plan — the sweep count is far off, explicit
+`env` changes generated output, a full-suite failure fits neither remedy in
+item 4 — **stop, commit nothing further, and report back. Do not improvise.**

--- a/plans/2026-07-11-issue-1113-feature-legs-full-suite.md
+++ b/plans/2026-07-11-issue-1113-feature-legs-full-suite.md
@@ -21,9 +21,13 @@ block — whichever lands second rebases (trivial adjacent-row conflict).
 ## Work items (flat order)
 
 1. **Sweep** (own commit, mechanical): inventory bare impl-block attributes:
-   `rg -U -n '#\[miniextendr\]\s*\nimpl ' rpkg/src/rust/` (expect ≈52 per the
-   issue; the count validates the pattern — if you find <40 or >70, stop and
-   report). For each hit, rewrite `#[miniextendr]` → `#[miniextendr(env)]`,
+   `rg -U -n '#\[miniextendr\]\s*\nimpl ' rpkg/src/rust/` (expect exactly 32
+   — verified stable at plan-anchor 17f634d8 and main a88db764 on 2026-07-12;
+   the issue's ≈52 was a miscount, and cross-package's 13 out-of-scope bare
+   blocks don't close the gap either. Historical note: the plan originally
+   said ≈52 with a <40/>70 escalation band; the first implementation pass
+   correctly stopped on finding 32 and the count was re-verified from the
+   main session). For each hit, rewrite `#[miniextendr]` → `#[miniextendr(env)]`,
    EXCEPT the class-system probe region in
    `rpkg/src/rust/feature_default_fixtures.rs:69-94` (its bareness is the
    probe — leave it, add a comment `// deliberately bare: flips under

--- a/rpkg/src/rust/adapter_traits_tests.rs
+++ b/rpkg/src/rust/adapter_traits_tests.rs
@@ -424,7 +424,7 @@ impl IterableVec {
 }
 
 /// RIterator blanket trait ABI registration for IterableVecIter.
-#[miniextendr(blanket)]
+#[miniextendr(env, blanket)]
 impl miniextendr_api::adapter_traits::RIterator for IterableVecIter {
     type Item = i32;
 
@@ -456,7 +456,7 @@ impl miniextendr_api::adapter_traits::RIterator for IterableVecIter {
 }
 
 /// IterableVecIter blanket impl: collect all remaining items.
-#[miniextendr(blanket)]
+#[miniextendr(env, blanket)]
 impl IterableVecIter {
     fn collect_all(&self) -> Vec<i32> {
         let mut result = Vec::new();
@@ -482,7 +482,7 @@ impl fmt::Display for ExportControlTraitPoint {
 }
 
 /// @keywords internal
-#[miniextendr(internal)]
+#[miniextendr(env, internal)]
 impl ExportControlTraitPoint {
     fn new(x: i32) -> Self {
         ExportControlTraitPoint { x }
@@ -490,13 +490,13 @@ impl ExportControlTraitPoint {
 }
 
 /// Internal trait impl: should have @keywords internal, no @export
-#[miniextendr(internal)]
+#[miniextendr(env, internal)]
 impl miniextendr_api::adapter_traits::RDebug for ExportControlTraitPoint {}
 
 /// Noexport trait impl: no Rd contribution at all (no alias, no usage, no
 /// @export) — distinct from `internal` above, which stays documented under
 /// `@keywords internal`. See audit A10.
-#[miniextendr(noexport)]
+#[miniextendr(env, noexport)]
 impl miniextendr_api::adapter_traits::RDisplay for ExportControlTraitPoint {}
 // endregion
 

--- a/rpkg/src/rust/error_in_r_tests.rs
+++ b/rpkg/src/rust/error_in_r_tests.rs
@@ -94,7 +94,7 @@ pub struct ErrorInRCounter {
     value: i32,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl ErrorInRCounter {
     /// Create a new counter.
     fn new() -> Self {
@@ -213,7 +213,7 @@ pub struct FallibleImpl {
     value: i32,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl FallibleImpl {
     /// Create a new FallibleImpl.
     fn new(value: i32) -> Self {
@@ -227,7 +227,7 @@ impl FallibleImpl {
 }
 
 /// Fallible trait implementation for FallibleImpl with error_in_r on each method.
-#[miniextendr]
+#[miniextendr(env)]
 impl Fallible for FallibleImpl {
     fn get_value(&self) -> i32 {
         self.value

--- a/rpkg/src/rust/externalptr_any_tests.rs
+++ b/rpkg/src/rust/externalptr_any_tests.rs
@@ -17,7 +17,7 @@ pub struct TypeB {
     pub val: String,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl TypeA {
     pub fn new(val: i32) -> Self {
         TypeA { val }
@@ -27,7 +27,7 @@ impl TypeA {
     }
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl TypeB {
     pub fn new(val: String) -> Self {
         TypeB { val }

--- a/rpkg/src/rust/feature_default_fixtures.rs
+++ b/rpkg/src/rust/feature_default_fixtures.rs
@@ -94,6 +94,7 @@ pub struct FdefaultProbe {
 }
 
 /// Class-system probe generated under the build's default class system.
+// deliberately bare: flips under r6-default/s7-default (#1113)
 #[miniextendr]
 impl FdefaultProbe {
     /// Creates a new probe holding `value`.

--- a/rpkg/src/rust/impl_dots_tests.rs
+++ b/rpkg/src/rust/impl_dots_tests.rs
@@ -49,8 +49,6 @@ pub struct ImplDotsS3 {
 }
 
 /// S3 class exercising dots in both the constructor and an instance method.
-/// @param seed Integer base value.
-/// @param ... Additional constructor arguments counted by Rust.
 #[miniextendr(s3)]
 impl ImplDotsS3 {
     /// Create an S3 dots fixture.

--- a/rpkg/src/rust/ndarray_tests.rs
+++ b/rpkg/src/rust/ndarray_tests.rs
@@ -22,7 +22,7 @@ pub struct NdVec(Array1<f64>);
 ///   out-of-bounds element instead (vectorized contract). `slice_1d` takes
 ///   1-based inclusive bounds (R's `x[start:end]` convention) and errors
 ///   unless `1 <= start <= end <= length`.
-#[miniextendr]
+#[miniextendr(env)]
 impl NdVec {
     fn new(data: Vec<f64>) -> Self {
         NdVec(Array1::from_vec(data))
@@ -154,7 +154,7 @@ pub struct NdMatrix(Array2<f64>);
 /// @details `get_2d`, `row`, and `col` take 1-based indices (R-idiomatic,
 ///   matching the rest of the package) and error on an out-of-bounds or
 ///   non-positive index.
-#[miniextendr]
+#[miniextendr(env)]
 impl NdMatrix {
     fn new(data: Array2<f64>) -> Self {
         NdMatrix(data)
@@ -298,7 +298,7 @@ pub struct NdArrayDyn(ArrayD<f64>);
 ///   `MARGIN` convention (1 = first dimension). `get_nd`, `reshape`,
 ///   `slice_nd`, and `axis_slice` error on an out-of-bounds/invalid argument
 ///   instead of silently yielding no value.
-#[miniextendr]
+#[miniextendr(env)]
 impl NdArrayDyn {
     fn new(shape: Vec<i32>, data: Vec<f64>) -> Self {
         let shape_usize: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
@@ -468,7 +468,7 @@ pub struct NdIntVec(Array1<i32>);
 ///   the rest of the package) and error on out-of-bounds or non-positive
 ///   indices. `slice_1d` takes 1-based inclusive bounds (R's `x[start:end]`
 ///   convention) and errors unless `1 <= start <= end <= length`.
-#[miniextendr]
+#[miniextendr(env)]
 impl NdIntVec {
     fn new(data: Vec<i32>) -> Self {
         NdIntVec(Array1::from_vec(data))

--- a/rpkg/src/rust/option_self_tests.rs
+++ b/rpkg/src/rust/option_self_tests.rs
@@ -16,7 +16,7 @@ pub struct OptionSelfLookup {
 
 /// @name rpkg_option_self_lookup
 /// @aliases OptionSelfLookup
-#[miniextendr]
+#[miniextendr(env)]
 impl OptionSelfLookup {
     /// Create a new entry directly.
     /// @param id Integer id.

--- a/rpkg/src/rust/rand_adapter_tests.rs
+++ b/rpkg/src/rust/rand_adapter_tests.rs
@@ -64,7 +64,7 @@ pub fn rand_rdistributions_sample() -> Vec<f64> {
 pub struct SeededRng(RefCell<StdRng>);
 
 /// SeededRng inherent methods: constructor.
-#[miniextendr]
+#[miniextendr(env)]
 impl SeededRng {
     /// @param seed Integer seed (absolute value is used).
     fn new(seed: i32) -> Self {
@@ -75,7 +75,7 @@ impl SeededRng {
 }
 
 /// RRngOps trait implementation for SeededRng (interior-mutable StdRng).
-#[miniextendr]
+#[miniextendr(env)]
 impl miniextendr_api::rand_impl::RRngOps for SeededRng {
     fn random_f64(&self) -> f64 {
         self.0.borrow_mut().random()
@@ -166,7 +166,7 @@ pub struct SeededNormal {
 
 /// SeededNormal inherent methods: constructor.
 #[cfg(feature = "rand_distr")]
-#[miniextendr]
+#[miniextendr(env)]
 impl SeededNormal {
     /// @param mean Mean of the normal distribution.
     /// @param sd Standard deviation (must be finite).
@@ -182,7 +182,7 @@ impl SeededNormal {
 
 /// RDistributionOps trait implementation for SeededNormal.
 #[cfg(feature = "rand_distr")]
-#[miniextendr]
+#[miniextendr(env)]
 impl miniextendr_api::rand_impl::RDistributionOps<f64> for SeededNormal {
     fn sample(&self) -> f64 {
         use miniextendr_api::rand_distr::Distribution;

--- a/rpkg/src/rust/rng_tests.rs
+++ b/rpkg/src/rust/rng_tests.rs
@@ -87,7 +87,7 @@ pub struct RngSampler {
     seed_hint: i32,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl RngSampler {
     /// Create a new RngSampler.
     fn new(seed_hint: i32) -> Self {

--- a/rpkg/src/rust/serde_r_tests.rs
+++ b/rpkg/src/rust/serde_r_tests.rs
@@ -26,7 +26,7 @@ pub struct SerdeRPoint {
     pub y: f64,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl SerdeRPoint {
     pub fn new(x: f64, y: f64) -> Self {
         SerdeRPoint { x, y }
@@ -53,7 +53,7 @@ pub struct SerdeRPoint3D {
     pub label: Option<String>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl SerdeRPoint3D {
     pub fn new(x: f64, y: f64, z: f64, label: Option<String>) -> Self {
         SerdeRPoint3D { x, y, z, label }
@@ -80,7 +80,7 @@ pub struct Rectangle {
     pub fill_color: Option<String>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl Rectangle {
     pub fn new(x1: f64, y1: f64, x2: f64, y2: f64) -> Self {
         Rectangle {
@@ -135,7 +135,7 @@ pub struct Level3 {
     pub flag: bool,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl DeepNest {
     pub fn new() -> Self {
         DeepNest {
@@ -175,7 +175,7 @@ pub struct Collections {
     pub points: Vec<SerdeRPoint>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl Collections {
     pub fn new() -> Self {
         Collections {
@@ -221,7 +221,7 @@ pub struct Maps {
     pub metadata: HashMap<String, String>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl Maps {
     pub fn new() -> Self {
         let mut string_to_int = HashMap::new();
@@ -283,7 +283,7 @@ pub struct WithEnums {
     pub optional_status: Option<Status>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl WithEnums {
     pub fn new_circle(radius: f64) -> Self {
         WithEnums {
@@ -324,7 +324,7 @@ pub struct WithOptionals {
     pub optional_bool: Option<bool>,
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl WithOptionals {
     pub fn all_present() -> Self {
         WithOptionals {

--- a/rpkg/src/rust/shared_trait_test.rs
+++ b/rpkg/src/rust/shared_trait_test.rs
@@ -66,7 +66,7 @@ pub struct SharedSimpleCounter {
 
 // Bare (default class system): the inherent + trait impls flip together, so a
 // feature-default leg gets a consistent class system for both.
-#[miniextendr]
+#[miniextendr(env)]
 impl SharedSimpleCounter {
     fn new(initial: i32) -> Self {
         Self { value: initial }
@@ -82,7 +82,7 @@ impl SharedSimpleCounter {
 // flip to r6 under r6-default. (The `Type$Trait$method(x)` call form these
 // tests use works under env and r6; test-shared-trait.R runs in the default
 // env build only.)
-#[miniextendr]
+#[miniextendr(env)]
 impl SharedCounter for SharedSimpleCounter {
     fn value(&self) -> i32 {
         self.value
@@ -110,7 +110,7 @@ pub struct AtomicCounter {
 }
 
 // Bare (default class system): flips together with its trait impl below.
-#[miniextendr]
+#[miniextendr(env)]
 impl AtomicCounter {
     fn new_atomic(initial: i32) -> Self {
         Self {
@@ -121,7 +121,7 @@ impl AtomicCounter {
 
 // Bare: see SharedSimpleCounter above — class-scoped r6 wrappers (#1115 fix)
 // mean this and SharedSimpleCounter no longer collide under r6-default.
-#[miniextendr]
+#[miniextendr(env)]
 impl SharedCounter for AtomicCounter {
     fn value(&self) -> i32 {
         self.value.load(Ordering::SeqCst)

--- a/rpkg/src/rust/trait_abi_tests.rs
+++ b/rpkg/src/rust/trait_abi_tests.rs
@@ -45,7 +45,7 @@ impl SimpleCounter {
 // Bare (default class system): #1115 is fixed — r6 trait wrappers are now
 // class-scoped (`Type$Trait$method`), so this flipping to r6 under r6-default
 // no longer collides with R6TraitCounter's explicit r6 Counter impl.
-#[miniextendr]
+#[miniextendr(env)]
 impl Counter for SimpleCounter {
     const MAX_VALUE: i32 = i32::MAX;
 
@@ -69,7 +69,7 @@ impl Counter for SimpleCounter {
 
 // region: R-exposed functions for testing (using impl block pattern)
 
-#[miniextendr]
+#[miniextendr(env)]
 impl SimpleCounter {
     /// Create a new counter with given initial value.
     fn new_counter(initial: i32) -> Self {
@@ -106,7 +106,7 @@ impl PanickyCounter {
 // Bare (default class system): #1115 is fixed — r6 trait wrappers are now
 // class-scoped (`Type$Trait$method`), so this flipping to r6 under r6-default
 // no longer collides with R6TraitCounter's explicit r6 Counter impl.
-#[miniextendr]
+#[miniextendr(env)]
 impl Counter for PanickyCounter {
     const MAX_VALUE: i32 = 1000; // PanickyCounter has a lower max
 
@@ -133,7 +133,7 @@ impl Counter for PanickyCounter {
     }
 }
 
-#[miniextendr]
+#[miniextendr(env)]
 impl PanickyCounter {
     /// Create a new panicky counter.
     fn new_panicky(initial: i32) -> Self {


### PR DESCRIPTION
TODO (author): replace this line with your own framing, in your own voice.

<details>
<summary>AI-written implementation notes</summary>

Implements `plans/2026-07-11-issue-1113-feature-legs-full-suite.md` (committed on this branch, with one correction noted below).

## Sweep: default-agnostic fixtures (36 impl blocks)

Every impl-block attribute in `rpkg/src/rust/` that lacked a class-system keyword is now explicitly `env` — env is the compiled default, so the rewrite is behavior-preserving:

- 31 literally-bare `#[miniextendr]` attrs → `#[miniextendr(env)]`.
- 5 option-only attrs in `adapter_traits_tests.rs` (`blanket` ×2, `internal` ×2, `noexport` ×1) gain a leading `env`. These were caught by the local r6-default full-suite proof, not the plan's rg pattern: the class system falls through to the compiled default for option-only attrs too, so `$.IterableVecIter` / `$.ExportControlTraitPoint` S3 methods vanished under the flip ("declared in NAMESPACE but not found" + `object of type 'externalptr' is not subsettable`).

The one deliberate exception: `FdefaultProbe` in `feature_default_fixtures.rs` stays bare — its bareness IS the class-system probe — and now carries a `// deliberately bare: flips under r6-default/s7-default (#1113)` comment. Bare `#[miniextendr]` on functions is untouched (class flips don't affect functions).

**Count correction**: the issue said ~52 bare impl blocks; the actual count is exactly **32**, verified stable at both the plan anchor (17f634d8) and main (a88db764) with the plan's own rg pattern — the ~52 was a miscount (cross-package's 13 out-of-scope bare blocks don't close the gap either). The committed plan file was amended accordingly.

**Behavior-preservation proof**: full regen loop (`just configure && just rcmdinstall && just force-document`) after the sweep → zero `NAMESPACE` / `man/*.Rd` diff.

## CI matrix restructure (`feature-legs` job)

The two bundled class rows become four:

| leg | features | filter |
|---|---|---|
| r6-default | `r6-default` | *(full suite)* |
| s7-default | `s7-default` | *(full suite)* |
| strict-default | `strict-default` | `feature-defaults` |
| coerce-default | `coerce-default` | `feature-defaults` |

- The class legs can now run the full suite because the sweep made it default-agnostic — the flip reaches only the deliberate probe plus the divergence assertions in `test-feature-defaults.R`.
- `strict-default` / `coerce-default` stay fixture-filtered: they flip conversion semantics suite-wide and cannot go full-suite without a second (out-of-scope) sweep. They also stay on separate rows from each other per the #1112 masking.
- The `fast-default` row (#1282) is untouched. Job header comment updated ("five" → "seven" builds; documents the new split).

## MINIEXTENDR_SKIP_STRESS (deliberate scope note)

`MINIEXTENDR_SKIP_STRESS: "1"` is added to the feature-legs job `env:` block. Previously unset, so full-suite legs would run the slow gctorture files whose coverage already lives in the sharded `r-stress-tests` job + nightly. **This deliberately also applies to the existing `extras` / `worker-default` full-suite rows** — same rationale, flagged here per the plan.

## Drive-by warning fix

`ImplDotsS3` in `impl_dots_tests.rs` carried two `@param` tags on the impl block, tripping the macro's "no effect — move it to the method" deprecation warning on every rpkg build. Removed (the tags already live on the method); generated wrappers are byte-identical modulo source-line comments, NAMESPACE/man unchanged. The warn mechanism stays covered by miniextendr-macros' `impl_method_tag_deprecated_deny` ui test.

## Local proofs

- Default build: `just devtools-test` full suite (stress files included) — `[ FAIL 0 | WARN 0 | SKIP 28 | PASS 7141 ]`.
- r6-default full-suite proof: `CARGO_FEATURES` composed exactly as the CI "Compose CARGO_FEATURES" step (`Rscript rpkg/tools/detect-features.R` base + `,r6-default`), exported in the same shell as `just configure && just rcmdinstall`, then `MINIEXTENDR_SKIP_STRESS=1 Rscript -e 'testthat::test_local()'` from `rpkg/` — `[ FAIL 0 | WARN 0 | SKIP 42 | PASS 7096 ]`, and the install-time NAMESPACE warning names only the deliberate probe's methods. (Local harness note: `R_LIBS` must point at the rv library for this invocation so `run_isolated()` callr children resolve the installed flipped package — in CI the site library serves that role. s7 is symmetric; CI-verified weekly.)
- Default build restored afterwards; regen loop re-verified zero diff.
- Rust: workspace `cargo test` green except the pre-existing local-only trybuild ui mismatch on `derive_dataframe_enum_struct_field_no_derive` (rust-src component false mismatch, #1239 pattern — expected/actual differ only by stdlib-span expansion; this branch does not touch miniextendr-macros; CI authoritative). rpkg/src/rust + both cross-package manifests `cargo test` green.
- Three CI clippy legs (default / all / all_s7, feature lists read from ci.yml) at `-D warnings` — green; plus rpkg/src/rust clippy at `-D warnings` after `cargo clean -p miniextendr` — green. `cargo fmt --all` clean. ci.yml YAML-parse check OK.

Note: the `feature-legs` job is weekly-scheduled + `workflow_dispatch` — per-PR CI does not exercise the new rows.

</details>

Fixes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
