### PR TITLE
fix(api): batch strict checked_vec_* panics and tinyvec coercion errors (#1217 items 2+3)

### DIFF
--- a/miniextendr-api/src/optionals/tinyvec_impl.rs
+++ b/miniextendr-api/src/optionals/tinyvec_impl.rs
@@ -63,7 +63,7 @@
 
 pub use tinyvec::{Array, ArrayVec, TinyVec};
 
-use crate::from_r::{SexpError, SexpTypeError, TryFromSexp};
+use crate::from_r::{BatchedErrors, SexpError, SexpTypeError, TryFromSexp};
 use crate::into_r::IntoR;
 use crate::{RNativeType, SEXP, SEXPTYPE, SexpExt};
 
@@ -285,20 +285,31 @@ where
 use crate::coerce::{Coerced, TryCoerce};
 
 /// Helper to coerce a slice element-wise into a container.
-fn coerce_slice_to_vec<R, T>(slice: &[R]) -> Result<Vec<Coerced<T, R>>, SexpError>
+///
+/// Walks the whole slice, accumulating every per-element coercion failure
+/// into one batched [`SexpError::InvalidValue`] via [`BatchedErrors`] (same
+/// grammar/cap as the runtime `Vec<T>` coercion path in `from_r.rs`, #1192)
+/// instead of bailing on the first `Err`. Uses `{e}` (Display) per element,
+/// matching every other coercion site — this one used to be the crate's last
+/// holdout on `{e:?}` (Debug).
+fn coerce_slice_to_vec<R, T>(slice: &[R], container: &str) -> Result<Vec<Coerced<T, R>>, SexpError>
 where
     R: Copy + TryCoerce<T>,
-    <R as TryCoerce<T>>::Error: std::fmt::Debug,
+    <R as TryCoerce<T>>::Error: std::fmt::Display,
 {
-    slice
-        .iter()
-        .copied()
-        .map(|v| {
-            v.try_coerce()
-                .map(Coerced::new)
-                .map_err(|e| SexpError::InvalidValue(format!("{e:?}")))
-        })
-        .collect()
+    let mut result = Vec::with_capacity(slice.len());
+    let mut errors = BatchedErrors::default();
+    for (i, v) in slice.iter().copied().enumerate() {
+        match v.try_coerce() {
+            Ok(x) => result.push(Coerced::new(x)),
+            Err(e) => errors.push(|| format!("invalid value at index {i}: {e}")),
+        }
+    }
+    if errors.is_empty() {
+        Ok(result)
+    } else {
+        Err(errors.into_error(container))
+    }
 }
 
 /// TryFromSexp for `TinyVec<[Coerced<T, R>; N]>` - reads R native type and coerces.
@@ -306,7 +317,7 @@ impl<T, R, const N: usize> TryFromSexp for TinyVec<[Coerced<T, R>; N]>
 where
     R: RNativeType + Copy + TryCoerce<T>,
     T: Copy,
-    <R as TryCoerce<T>>::Error: std::fmt::Debug,
+    <R as TryCoerce<T>>::Error: std::fmt::Display,
     [Coerced<T, R>; N]: tinyvec::Array<Item = Coerced<T, R>>,
 {
     type Error = SexpError;
@@ -321,7 +332,7 @@ where
             .into());
         }
         let slice: &[R] = unsafe { sexp.as_slice() };
-        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice)?;
+        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice, "TinyVec")?;
         let mut tv = TinyVec::new();
         for item in data {
             tv.push(item);
@@ -340,7 +351,7 @@ impl<T, R, const N: usize> TryFromSexp for ArrayVec<[Coerced<T, R>; N]>
 where
     R: RNativeType + Copy + TryCoerce<T>,
     T: Copy,
-    <R as TryCoerce<T>>::Error: std::fmt::Debug,
+    <R as TryCoerce<T>>::Error: std::fmt::Display,
     [Coerced<T, R>; N]: tinyvec::Array<Item = Coerced<T, R>>,
 {
     type Error = SexpError;
@@ -362,7 +373,7 @@ where
                 N
             )));
         }
-        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice)?;
+        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice, "TinyVec")?;
         let mut av = ArrayVec::new();
         for item in data {
             av.push(item);
@@ -447,6 +458,45 @@ mod tests {
         av.push(3);
         assert_eq!(av.len(), 3);
         // Cannot push more - would panic
+    }
+
+    /// Two failing elements (i32 values that don't fit in i8) are both
+    /// reported by index in one batched error, not just the first.
+    #[test]
+    fn coerce_slice_to_vec_batches_all_failing_indices() {
+        let slice = [1i32, 999, 2, 999];
+        let err = coerce_slice_to_vec::<i32, i8>(&slice, "TinyVec").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("TinyVec conversion failed"), "got: {msg}");
+        assert!(msg.contains("invalid value at index 1"), "got: {msg}");
+        assert!(msg.contains("invalid value at index 3"), "got: {msg}");
+        // index 0 and 2 (the valid elements) must not appear.
+        assert!(!msg.contains("at index 0"), "got: {msg}");
+        assert!(!msg.contains("at index 2"), "got: {msg}");
+    }
+
+    /// The all-valid happy path succeeds (no false batching).
+    #[test]
+    fn coerce_slice_to_vec_happy_path_ok() {
+        let slice = [1i32, 2, 3];
+        let out = coerce_slice_to_vec::<i32, i8>(&slice, "TinyVec").unwrap();
+        assert_eq!(
+            out.into_iter().map(|c| *c).collect::<Vec<_>>(),
+            vec![1i8, 2, 3]
+        );
+    }
+
+    /// More than 10 failures are capped: the first 10 indices are listed and
+    /// the remainder is summarized as "and N more".
+    #[test]
+    fn coerce_slice_to_vec_batch_caps_at_ten_and_summarizes_rest() {
+        let slice = [999i32; 15];
+        let err = coerce_slice_to_vec::<i32, i8>(&slice, "TinyVec").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid value at index 0"), "got: {msg}");
+        assert!(msg.contains("invalid value at index 9"), "got: {msg}");
+        assert!(!msg.contains("at index 10"), "got: {msg}");
+        assert!(msg.contains("and 5 more"), "got: {msg}");
     }
 }
 // endregion

--- a/miniextendr-api/src/optionals/tinyvec_impl.rs
+++ b/miniextendr-api/src/optionals/tinyvec_impl.rs
@@ -373,7 +373,7 @@ where
                 N
             )));
         }
-        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice, "TinyVec")?;
+        let data: Vec<Coerced<T, R>> = coerce_slice_to_vec(slice, "ArrayVec")?;
         let mut av = ArrayVec::new();
         for item in data {
             av.push(item);

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -649,5 +649,20 @@ mod tests {
         assert!(msg.contains("invalid value at index 1: i64 value"), "{msg}");
         assert!(msg.contains("invalid value at index 3: i64 value"), "{msg}");
     }
+
+    #[test]
+    fn vec_option_u64_batches_multiple_out_of_range_indices() {
+        let bad = i32::MAX as u64 + 1;
+        let result = std::panic::catch_unwind(|| {
+            checked_vec_option_u64_into_sexp(vec![Some(0), Some(bad), None, Some(bad)])
+        });
+        let msg = panic_message(result.expect_err("should panic for out-of-range elements"));
+        assert!(
+            msg.starts_with("strict conversion failed: Vec<Option<u64>> conversion failed:"),
+            "{msg}"
+        );
+        assert!(msg.contains("invalid value at index 1: u64 value"), "{msg}");
+        assert!(msg.contains("invalid value at index 3: u64 value"), "{msg}");
+    }
 }
 // endregion

--- a/miniextendr-api/src/strict.rs
+++ b/miniextendr-api/src/strict.rs
@@ -31,9 +31,27 @@
 //! third path with value-based runtime checks.
 
 use crate::coerce::TryCoerce;
-use crate::from_r::TryFromSexp;
+use crate::from_r::{BatchedErrors, SexpError, TryFromSexp};
 use crate::into_r::IntoR;
 use crate::{SEXP, SEXPTYPE, SexpExt};
+
+/// Fold a batched strict-vec [`BatchedErrors`] into the single panic every
+/// `checked_vec_*_into_sexp` raises, under `container` (e.g. `"Vec<i64>"`).
+///
+/// Reuses [`BatchedErrors::into_error`]'s `"<container> conversion failed:
+/// invalid value at index <i>: ...; and N more"` grammar (#1192/#1097), but
+/// extracts the inner message directly rather than going through
+/// `SexpError`'s `Display` impl — that impl wraps every variant as `"invalid
+/// value: {msg}"`, which would read as a doubled "invalid value: Vec<i64>
+/// conversion failed: invalid value at index 0: ..." in a panic message.
+fn panic_strict_vec_batched(container: &str, errors: BatchedErrors) -> ! {
+    let SexpError::InvalidValue(msg) = errors.into_error(container) else {
+        unreachable!("BatchedErrors::into_error always returns SexpError::InvalidValue")
+    };
+    panic!(
+        "strict conversion failed: {msg}; use a non-strict function to allow lossy f64 widening"
+    );
+}
 
 /// Convert `i64` to R integer, panicking if outside i32 range.
 ///
@@ -82,43 +100,54 @@ pub fn checked_into_sexp_usize(val: usize) -> SEXP {
 }
 
 /// Convert `Vec<i64>` to R integer vector, panicking if any element is outside i32 range.
+///
+/// Walks the whole vector, batching every out-of-range element into one
+/// panic instead of aborting at the first — see [`panic_strict_vec_batched`].
 pub fn checked_vec_i64_into_sexp(val: Vec<i64>) -> SEXP {
-    let coerced: Vec<i32> = val
-        .into_iter()
-        .map(|x| {
-            if x > i32::MIN as i64 && x <= i32::MAX as i64 {
-                x as i32
-            } else {
-                panic!(
-                    "strict conversion failed: i64 value {} is outside R integer range \
-                     ({}..={}); use a non-strict function to allow lossy f64 widening",
-                    x,
+    let mut coerced: Vec<i32> = Vec::with_capacity(val.len());
+    let mut errors = BatchedErrors::default();
+    for (i, x) in val.into_iter().enumerate() {
+        if x > i32::MIN as i64 && x <= i32::MAX as i64 {
+            coerced.push(x as i32);
+        } else {
+            errors.push(|| {
+                format!(
+                    "invalid value at index {i}: i64 value {x} is outside R integer range \
+                     ({}..={})",
                     i32::MIN as i64 + 1,
                     i32::MAX
-                );
-            }
-        })
-        .collect();
+                )
+            });
+        }
+    }
+    if !errors.is_empty() {
+        panic_strict_vec_batched("Vec<i64>", errors);
+    }
     coerced.into_sexp()
 }
 
 /// Convert `Vec<u64>` to R integer vector, panicking if any element > i32::MAX.
+///
+/// Walks the whole vector, batching every out-of-range element into one
+/// panic instead of aborting at the first — see [`panic_strict_vec_batched`].
 pub fn checked_vec_u64_into_sexp(val: Vec<u64>) -> SEXP {
-    let coerced: Vec<i32> = val
-        .into_iter()
-        .map(|x| {
-            if x <= i32::MAX as u64 {
-                x as i32
-            } else {
-                panic!(
-                    "strict conversion failed: u64 value {} exceeds R integer max ({}); \
-                     use a non-strict function to allow lossy f64 widening",
-                    x,
+    let mut coerced: Vec<i32> = Vec::with_capacity(val.len());
+    let mut errors = BatchedErrors::default();
+    for (i, x) in val.into_iter().enumerate() {
+        if x <= i32::MAX as u64 {
+            coerced.push(x as i32);
+        } else {
+            errors.push(|| {
+                format!(
+                    "invalid value at index {i}: u64 value {x} exceeds R integer max ({})",
                     i32::MAX
-                );
-            }
-        })
-        .collect();
+                )
+            });
+        }
+    }
+    if !errors.is_empty() {
+        panic_strict_vec_batched("Vec<u64>", errors);
+    }
     coerced.into_sexp()
 }
 
@@ -133,50 +162,66 @@ pub fn checked_vec_usize_into_sexp(val: Vec<usize>) -> SEXP {
 }
 
 /// Convert `Vec<Option<i64>>` to R integer vector in strict mode.
-/// Panics if any `Some(x)` value is outside i32 range. `None` becomes `NA_INTEGER`.
+///
+/// Panics if any `Some(x)` value is outside i32 range. `None` becomes
+/// `NA_INTEGER`. Walks the whole vector, batching every out-of-range `Some`
+/// into one panic instead of aborting at the first — see
+/// [`panic_strict_vec_batched`].
 pub fn checked_vec_option_i64_into_sexp(val: Vec<Option<i64>>) -> SEXP {
-    let coerced: Vec<Option<i32>> = val
-        .into_iter()
-        .map(|opt| match opt {
+    let mut coerced: Vec<Option<i32>> = Vec::with_capacity(val.len());
+    let mut errors = BatchedErrors::default();
+    for (i, opt) in val.into_iter().enumerate() {
+        match opt {
             Some(x) => {
                 if x > i32::MIN as i64 && x <= i32::MAX as i64 {
-                    Some(x as i32)
+                    coerced.push(Some(x as i32));
                 } else {
-                    panic!(
-                        "strict conversion failed: i64 value {} is outside R integer range \
-                         ({}..={}); use a non-strict function to allow lossy f64 widening",
-                        x,
-                        i32::MIN as i64 + 1,
-                        i32::MAX
-                    );
+                    errors.push(|| {
+                        format!(
+                            "invalid value at index {i}: i64 value {x} is outside R integer range \
+                             ({}..={})",
+                            i32::MIN as i64 + 1,
+                            i32::MAX
+                        )
+                    });
                 }
             }
-            None => None,
-        })
-        .collect();
+            None => coerced.push(None),
+        }
+    }
+    if !errors.is_empty() {
+        panic_strict_vec_batched("Vec<Option<i64>>", errors);
+    }
     coerced.into_sexp()
 }
 
 /// Convert `Vec<Option<u64>>` to R integer vector in strict mode.
+///
+/// Walks the whole vector, batching every out-of-range `Some` into one
+/// panic instead of aborting at the first — see [`panic_strict_vec_batched`].
 pub fn checked_vec_option_u64_into_sexp(val: Vec<Option<u64>>) -> SEXP {
-    let coerced: Vec<Option<i32>> = val
-        .into_iter()
-        .map(|opt| match opt {
+    let mut coerced: Vec<Option<i32>> = Vec::with_capacity(val.len());
+    let mut errors = BatchedErrors::default();
+    for (i, opt) in val.into_iter().enumerate() {
+        match opt {
             Some(x) => {
                 if x <= i32::MAX as u64 {
-                    Some(x as i32)
+                    coerced.push(Some(x as i32));
                 } else {
-                    panic!(
-                        "strict conversion failed: u64 value {} exceeds R integer max ({}); \
-                         use a non-strict function to allow lossy f64 widening",
-                        x,
-                        i32::MAX
-                    );
+                    errors.push(|| {
+                        format!(
+                            "invalid value at index {i}: u64 value {x} exceeds R integer max ({})",
+                            i32::MAX
+                        )
+                    });
                 }
             }
-            None => None,
-        })
-        .collect();
+            None => coerced.push(None),
+        }
+    }
+    if !errors.is_empty() {
+        panic_strict_vec_batched("Vec<Option<u64>>", errors);
+    }
     coerced.into_sexp()
 }
 
@@ -539,6 +584,70 @@ mod tests {
     fn u64_out_of_range_panics() {
         let result = std::panic::catch_unwind(|| checked_into_sexp_u64(i32::MAX as u64 + 1));
         assert!(result.is_err());
+    }
+
+    /// Downcast a `panic!` payload (produced via format args, so always a
+    /// `String`) into an owned `String` for message assertions.
+    fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+        *payload
+            .downcast::<String>()
+            .expect("panic payload should be a String")
+    }
+
+    #[test]
+    fn vec_i64_batches_multiple_out_of_range_indices() {
+        let result =
+            std::panic::catch_unwind(|| checked_vec_i64_into_sexp(vec![1, i64::MAX, 2, i64::MIN]));
+        let msg = panic_message(result.expect_err("should panic for out-of-range elements"));
+        assert!(
+            msg.starts_with("strict conversion failed: Vec<i64> conversion failed:"),
+            "{msg}"
+        );
+        assert!(msg.contains("invalid value at index 1: i64 value"), "{msg}");
+        assert!(msg.contains("invalid value at index 3: i64 value"), "{msg}");
+        assert!(
+            !msg.contains("and "),
+            "should not summarize under the cap: {msg}"
+        );
+        assert!(
+            msg.ends_with("use a non-strict function to allow lossy f64 widening"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn vec_i64_batches_caps_and_summarizes_remainder() {
+        let vals: Vec<i64> = std::iter::repeat_n(i64::MAX, 15).collect();
+        let result = std::panic::catch_unwind(|| checked_vec_i64_into_sexp(vals));
+        let msg = panic_message(result.expect_err("should panic for out-of-range elements"));
+        assert!(msg.contains("and 5 more"), "{msg}");
+    }
+
+    #[test]
+    fn vec_u64_batches_multiple_out_of_range_indices() {
+        let bad = i32::MAX as u64 + 1;
+        let result = std::panic::catch_unwind(|| checked_vec_u64_into_sexp(vec![0, bad, 1, bad]));
+        let msg = panic_message(result.expect_err("should panic for out-of-range elements"));
+        assert!(
+            msg.starts_with("strict conversion failed: Vec<u64> conversion failed:"),
+            "{msg}"
+        );
+        assert!(msg.contains("invalid value at index 1: u64 value"), "{msg}");
+        assert!(msg.contains("invalid value at index 3: u64 value"), "{msg}");
+    }
+
+    #[test]
+    fn vec_option_i64_batches_multiple_out_of_range_indices() {
+        let result = std::panic::catch_unwind(|| {
+            checked_vec_option_i64_into_sexp(vec![Some(1), Some(i64::MAX), None, Some(i64::MIN)])
+        });
+        let msg = panic_message(result.expect_err("should panic for out-of-range elements"));
+        assert!(
+            msg.starts_with("strict conversion failed: Vec<Option<i64>> conversion failed:"),
+            "{msg}"
+        );
+        assert!(msg.contains("invalid value at index 1: i64 value"), "{msg}");
+        assert!(msg.contains("invalid value at index 3: i64 value"), "{msg}");
     }
 }
 // endregion

--- a/plans/2026-07-11-issue-1217-prb-strict-tinyvec-batching.md
+++ b/plans/2026-07-11-issue-1217-prb-strict-tinyvec-batching.md
@@ -1,0 +1,98 @@
+# Plan: #1217 PR B — batch strict `checked_vec_*` + tinyvec `coerce_slice_to_vec`
+
+Date: 2026-07-11. Anchors verified against main @ 17f634d8.
+Branch: `fix/1217-strict-tinyvec-batching`.
+
+Scope: items 2+3 of #1217. Item 1 is PR A
+(`plans/2026-07-11-issue-1217-pra-macro-vec-coercion-batching.md` — no file
+overlap; either merge order works). Item 4 (NA policy) is an open maintainer
+decision — DO NOT change NA behavior. Reuses #1192's
+`BatchedErrors` (`miniextendr-api/src/from_r.rs:2011-2047`) and its grammar.
+
+## Item 2 — strict outbound `checked_vec_*` (`miniextendr-api/src/strict.rs`)
+
+Verified shape: `checked_vec_i64_into_sexp` (`:85`) and
+`checked_vec_u64_into_sexp` (`:106`) `panic!` on the FIRST out-of-range
+element, message
+`"strict conversion failed: i64 value {x} is outside R integer range (...); use a non-strict function to allow lossy f64 widening"`,
+no index. `checked_vec_isize/usize` (`:126-132`) delegate. The Option
+variants `checked_vec_option_i64/u64` (`:137,:161`, delegates `:184-185`)
+share the shape.
+
+1. In each of the four non-delegating fns: walk with `enumerate`, collect
+   in-range values, accumulate failures into `BatchedErrors`
+   (`errors.push(|| format!("invalid value at index {i}: {x} is outside R
+   integer range ({lo}..={hi})"))` — keep the existing range wording per
+   element, minus the shared hint). After the walk, if `!errors.is_empty()`,
+   `panic!` ONCE with:
+   `"strict conversion failed: {batched}; use a non-strict function to allow lossy f64 widening"`
+   where `{batched}` is `errors.into_error("Vec<i64>")`'s Display (or format
+   the same grammar directly if `into_error`'s `SexpError` wrapper reads
+   awkwardly in a panic — decision baked: format directly with the SAME
+   `invalid value at index <i>: ...; and N more` grammar, container label
+   `Vec<i64>`/`Vec<u64>`/`Vec<Option<i64>>`/`Vec<Option<u64>>`).
+   Keep the leading `strict conversion failed:` prefix — R-side tests pin it.
+2. Preserve: NA sentinel handling in the Option variants exactly as-is (only
+   the error aggregation changes); the exclusive `i32::MIN` lower bound on
+   the i64 path (`x > i32::MIN as i64` — NA sentinel exclusion).
+3. Unit tests: extend the existing strict.rs test module (or add one
+   following crate convention) — a two-bad-element `Vec<i64>` panics with
+   both indices; an 11+-bad-element vector produces `and N more`.
+4. R-side pins: grep `rpkg/tests/testthat/` for `strict conversion failed`
+   and update any grep that pinned the old single-value message shape.
+
+## Item 3 — tinyvec `coerce_slice_to_vec` (`miniextendr-api/src/optionals/tinyvec_impl.rs`)
+
+Verified: `:288-299` — `.map(...).collect()` short-circuit +
+`SexpError::InvalidValue(format!("{e:?}"))` (Debug, inconsistent with the
+crate-wide `{e}` Display from #1192).
+
+5. Rewrite with enumerate + `BatchedErrors` (same pattern as #1192's
+   `coerce_slice_to_vec` in `from_r.rs` — read that fn and mirror it), with
+   `{e}` Display per element; container label matches the target
+   (`TinyVec<...>` — use whatever type label the surrounding impls at
+   `:324,:365` present; pick the same string both call sites report today if
+   one exists, else `TinyVec`).
+6. Tests: tinyvec is feature-gated — run
+   `cargo test -p miniextendr-api --features tinyvec` and extend its test
+   module with the two-bad-element + `and N more` cases.
+
+## Exact commands (worktree)
+
+```bash
+rig default 4.6 && R --version | head -1        # must print 4.6.x
+just worktree-sync                               # FIRST
+cargo test -p miniextendr-api 2>&1 > /tmp/1217b-api.log            # Read it
+cargo test -p miniextendr-api --features tinyvec 2>&1 > /tmp/1217b-tinyvec.log
+just configure && just rcmdinstall && just force-document
+# (no new exports — single install)
+just test 2>&1 > /tmp/1217b-rust.log
+just devtools-test 2>&1 > /tmp/1217b-devtools.log
+grep -E '\[ FAIL [0-9]+' /tmp/1217b-devtools.log  # devtools::test always exits 0
+cargo clippy --workspace --all-targets --locked -- -D warnings  # + all/all_s7 legs per ci.yml
+cargo fmt --all
+```
+
+No snapshot churn expected (api-crate only). Strict runtime coverage rides
+the weekly `r6-default` leg (`strict-default` rides with it in the
+feature-legs matrix) — note in the PR body that the leg exercises it.
+
+## Must NOT touch
+
+- `rust_conversion_builder.rs` (PR A's file).
+- NA semantics anywhere; the strict scalar (non-vec) paths; `BatchedErrors`.
+- `error_value.rs` (PROTECT-sensitive) — panics here are pre-FFI, no change.
+
+## Done criteria
+
+- Both strict vec families and the tinyvec path report ALL failing indices
+  in one error with `{e}` Display; unit tests pin two-failure and `and N
+  more` shapes; suites + three clippy legs green;
+  PR references #1217 (items 2+3 — do NOT `Fixes #1217`; item 4 remains).
+
+## Escalation rule
+
+If reality diverges from this plan — anchors don't match, a testthat pin
+depends on the panic aborting at the first element (behavioral coupling),
+tinyvec's container label is ambiguous across call sites — **stop, commit
+nothing further, and report back. Do not improvise.**


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Items 2+3 of #1217 (items 2+3 of 4; item 1, the macro `CoercionMapping::Vec` path, is a separate PR; item 4, the NA policy decision, remains open). Reuses #1192's `BatchedErrors` accumulator and grammar plus the shared `BATCHED_ERROR_CAP` (10 listed, then "and N more") rather than inventing parallel machinery.

- **Item 2, strict outbound vectors** (`miniextendr-api/src/strict.rs`): `checked_vec_i64_into_sexp`, `checked_vec_u64_into_sexp`, and the `Option` variants previously panicked at the FIRST out-of-range element with no index. They now walk the whole vector and panic once with every failing index:

  ```
  strict conversion failed: Vec<i64> conversion failed: invalid value at index 1: i64 value 2147483648 is outside R integer range (-2147483647..=2147483647); invalid value at index 3: ...; use a non-strict function to allow lossy f64 widening
  ```

  The `strict conversion failed:` prefix (pinned by `rpkg/tests/testthat/test-scalar-conversions.R`) and the trailing non-strict hint are kept, once per panic instead of once per element. Container labels are `Vec<i64>` / `Vec<u64>` / `Vec<Option<i64>>` / `Vec<Option<u64>>`; the `isize`/`usize` delegates inherit the batching.
- **Item 3, tinyvec** (`miniextendr-api/src/optionals/tinyvec_impl.rs`): the feature-gated `coerce_slice_to_vec` (the `Coerced<T, R>` element support behind `TinyVec`/`ArrayVec`) short-circuited via `.map(...).collect()` and formatted the per-element error with `{e:?}` (Debug), the last holdout against #1192's `{e}` Display convention. It now mirrors `from_r.rs`'s `coerce_slice_to_vec`: enumerate + `BatchedErrors`, `invalid value at index <i>: <err>` entries, container label `TinyVec` (shared by both call sites), trait bounds moved from `Debug` to `Display`.
- **Not touched** (per the committed plan `plans/2026-07-11-issue-1217-prb-strict-tinyvec-batching.md`): NA semantics (the exclusive `i32::MIN` bound on the i64 path, `None` to `NA_INTEGER`), the strict scalar and strict input paths, `BatchedErrors` itself, `error_value.rs`, and `rust_conversion_builder.rs` (PR A's file).

## Test plan

- [x] `cargo test -p miniextendr-api`: green (new strict.rs pins: two-bad-element lists both indices, 15-bad-element produces "and 5 more")
- [x] `cargo test -p miniextendr-api --features tinyvec`: green (same two shapes plus a happy path for the tinyvec `coerce_slice_to_vec`)
- [x] `just devtools-test` with `MINIEXTENDR_SKIP_STRESS=1`: `[ FAIL 0 | WARN 0 | SKIP 41 | PASS 7123 ]`; `test-scalar-conversions.R` additionally re-run in isolation (FAIL 0, PASS 51), its `strict conversion failed` pins hold against the new message
- [x] End-to-end from R: `strict_echo_vec_i64(c(1, 2^31, 3, 2^31))` reports indices 1 and 3 in one error
- [x] All three CI clippy legs locally at `-D warnings` (default, `full-codegen` + integration list, `full-codegen-s7` variant), after `cargo clean -p miniextendr-api`; `cargo fmt --all` clean

## Notes

- Strict runtime coverage (the `strict-default` feature) rides the weekly feature-legs matrix rather than the per-PR jobs; the per-PR R suite still exercises the strict fixtures in `rpkg` (`strict_echo_vec_i64` and friends) since `rpkg` enables strict codegen for them via `#[miniextendr(strict)]`.
- The trybuild UI snapshot suite (`miniextendr-macros`) has 5 pre-existing local mismatches from a toolchain/rust-src rendering difference (`the failure occurred here` span placement, known local-vs-CI trybuild mode, see #1239); untouched by this PR, and CI is authoritative there.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)