### PR TITLE
fix(warnings): make the standard green path warning-clean (2026-07-12 audit)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1208,10 +1208,28 @@ wrappers-sync-check: _assert-no-vendor-leak configure
     set -euo pipefail
     # The source-mode `R CMD INSTALL` below drifts rpkg/src/rust/Cargo.lock; restore
     # it on every exit path, incl. the exit-1 diff-failure branches. (#1052)
-    trap 'just cargo-lock-restore' EXIT
+    install_log="$(mktemp)"
+    trap 'just cargo-lock-restore; rm -f "$install_log"' EXIT
 
     # Install regenerates R/miniextendr-wrappers.R + src/rust/wasm_registry.rs on disk.
-    R CMD INSTALL rpkg >/dev/null
+    # Capture output (instead of >/dev/null) so the audit grep-gate below can scan
+    # it; print the log only if the install itself fails, to preserve diagnostics.
+    if ! R CMD INSTALL rpkg >"$install_log" 2>&1; then
+      cat "$install_log" >&2
+      exit 1
+    fi
+
+    # Regression guard (2026-07-12 audit): the impl-method roxygen-tag deprecation
+    # nudge (`miniextendr: @<tag> on impl block ...`, emitted by
+    # miniextendr-macros/src/roxygen.rs) must not reappear from an rpkg fixture.
+    # Scoped to our macro's unique prefix so upstream cargo/rustc future-incompat
+    # noise (e.g. proc-macro-error2) can't flake this gate.
+    if grep -n 'miniextendr: @' "$install_log" >&2; then
+      echo "" >&2
+      echo "ERROR: impl-method roxygen-tag deprecation nudge fired during R CMD INSTALL (above)." >&2
+      echo "Move each flagged @tag off the impl block onto its method (see rpkg/src/rust/impl_dots_tests.rs)." >&2
+      exit 1
+    fi
 
     # The generated (untracked) files must exist and be real, not stubs.
     if [ ! -s rpkg/R/miniextendr-wrappers.R ]; then

--- a/justfile
+++ b/justfile
@@ -1224,6 +1224,9 @@ wrappers-sync-check: _assert-no-vendor-leak configure
     # miniextendr-macros/src/roxygen.rs) must not reappear from an rpkg fixture.
     # Scoped to our macro's unique prefix so upstream cargo/rustc future-incompat
     # noise (e.g. proc-macro-error2) can't flake this gate.
+    # Cold-build gate: the nudge is a rustc deprecation warning emitted only when
+    # the rpkg crate recompiles — a warm cargo cache skips rustc, but introducing a
+    # tag IS a source change forcing recompile, and CI Sync Checks always starts cold.
     if grep -n 'miniextendr: @' "$install_log" >&2; then
       echo "" >&2
       echo "ERROR: impl-method roxygen-tag deprecation nudge fired during R CMD INSTALL (above)." >&2

--- a/plans/2026-07-13-audit-standard-path-warnings.md
+++ b/plans/2026-07-13-audit-standard-path-warnings.md
@@ -1,0 +1,115 @@
+# Plan: audit 2026-07-12 P2 — make the standard green path warning-clean
+
+Date: 2026-07-13. Anchors verified against main @ 656e5cdd.
+Branch: `fix/audit-standard-path-warnings`.
+
+Covers 2026-07-12 audit worklist item 14. Verified DISTINCT from existing
+issues: #1292 tracks two *clippy* warnings in rpkg
+(`serde_json_adapter_tests.rs:101` etc. — cross-reference, do not fold);
+#1261 (R CMD check WARNINGs) was closed by `d10462ce`. No open issue
+covers the two findings below.
+
+## Verified defects (on 656e5cdd)
+
+**A. Two impl-level roxygen-tag deprecation warnings on every
+`just check` / `just clippy` / `just rcmdinstall`.**
+- Emission sites: `miniextendr-macros/src/roxygen.rs:719` and `:896`
+  ("miniextendr: @{} on impl block `{}` has no effect — move it to the
+  method. Tag: {}"). The nudge was deliberately activated by #1296
+  (`e504646c`, 2026-07-11) — and rpkg's own fixture still trips it.
+- Tripping site: `rpkg/src/rust/impl_dots_tests.rs:52-53` — impl-level
+  `/// @param seed` + `/// @param ...` on the doc block above
+  `#[miniextendr(s3)] impl ImplDotsS3` (:55-56). The methods already carry
+  their own `@param` tags (:57-58, :72-73), so the impl-level pair is
+  redundant, not load-bearing.
+- The warning path has dedicated UI coverage
+  (`miniextendr-macros/tests/ui/impl_method_tag_deprecated_deny.stderr`),
+  so the rpkg fixture is NOT needed as warning-coverage.
+- `rpkg/tests/testthat/test-impl-dots.R:8-10` pins only `formals(...)`
+  shapes — unaffected by moving doc tags.
+- Note the struct-level tags at `impl_dots_tests.rs:7-8` (on the
+  `ImplDotsR6` struct) feed constructor docs legitimately — leave them;
+  only the *impl-block* tags at :52-53 warn.
+
+**B. `proc-macro-error2 v2.0.1` future-incompatibility notice** on release
+installs (also visible in webR CI build logs). Dependency chain, verified
+in both lockfiles: `miniextendr-api` optional feature `tabled`
+(`miniextendr-api/Cargo.toml:97-98,230` — `tabled = "0.20.0"`) →
+`tabled_derive 0.11.0` → `proc-macro-error2 2.0.1`
+(root `Cargo.lock:2663,3315`; `rpkg/src/rust/Cargo.lock:2463,3040`;
+rpkg re-exports the feature at `rpkg/src/rust/Cargo.toml:53`).
+
+## Work items (flat order)
+
+1. **Fix A**: delete the two impl-level `@param` lines
+   (`impl_dots_tests.rs:52-53`), keeping the class description sentence.
+   Then the doc-regeneration loop:
+   `just configure && just rcmdinstall && just force-document` — expect
+   little/no `man/*.Rd` churn (params were "no effect") and NO `NAMESPACE`
+   change; if force-document flips `S3method`↔`export` lines, apply the
+   known revert-NAMESPACE lesson and keep only intended diffs. Commit any
+   legitimate man/ diffs with the Rust change.
+2. **Fix B — bump the chain**: check crates.io for a `tabled` release
+   whose derive no longer depends on `proc-macro-error2` (check
+   `tabled_derive` changelogs; the future-incompat is in the ecosystem's
+   sights). If one exists: bump `miniextendr-api/Cargo.toml:230`, refresh
+   the root `Cargo.lock` AND `rpkg/src/rust/Cargo.lock`, run
+   `just vendor-sync-check`, and confirm the notice is gone from a release
+   install log. Spot-check the `tabled` API surface we use
+   (`grep -rn "tabled" miniextendr-api/src | head`) against the new
+   version's breaking changes.
+3. **Fix B — if no upstream fix exists**: run
+   `cargo report future-incompatibilities --id <id>` for the exact
+   offense, file a tracked repo issue (implementer files it — repo
+   policy: no untracked known-issues) with the upstream link, and state in
+   the PR body that the notice is upstream-blocked. Do NOT silence it via
+   `[future-incompat-report]` config — visibility is the point.
+4. **Keep it clean — cheap regression guard**: add a grep gate to an
+   existing CI step that already captures an rpkg build log (candidates:
+   the wrappers-sync-check or install step): fail if the log contains
+   `miniextendr: @` warning lines. Scope it narrowly (our own macro's
+   nudge prefix) so upstream noise can't flake it. If no existing step's
+   log is convenient, note the gap in the PR body instead of adding a new
+   build job — the audit's broader "warning-free default gate for every
+   manifest" is a maintainer-scoped follow-up.
+
+## Exact commands (worktree)
+
+```bash
+rig default 4.6 && R --version | head -1        # must print 4.6.x
+just worktree-sync                               # FIRST
+just check 2>&1 > /tmp/audit-warn-check.log      # Read it — zero miniextendr warnings
+just clippy 2>&1 > /tmp/audit-warn-clippy.log    # Read it — zero warnings
+just configure && just rcmdinstall 2>&1 > /tmp/audit-warn-install.log && just force-document
+grep -n "miniextendr: @\|future" /tmp/audit-warn-install.log   # expect empty (or upstream-blocked note)
+just devtools-test 2>&1 > /tmp/audit-warn-devtools.log
+grep -E '\[ FAIL [0-9]+' /tmp/audit-warn-devtools.log
+cargo clippy --workspace --all-targets --locked -- -D warnings   # + all/all_s7 legs per ci.yml
+cargo fmt --all
+```
+
+## Must NOT touch
+
+- The nudge itself (`roxygen.rs:719,:896`) and its UI test — the warning
+  is correct; the fixture is what's wrong.
+- #1292's two clippy warnings (separate issue, separate fix — cross-ref
+  only).
+- `impl_dots_tests.rs` behavior/fixtures beyond the two doc lines (the
+  dots formals are pinned by test-impl-dots.R).
+- `rpkg/R/miniextendr-wrappers.R` / `wasm_registry.rs` (generated,
+  gitignored).
+
+## Done criteria
+
+- `just check`, `just clippy`, `just rcmdinstall` produce zero
+  miniextendr-emitted warnings on a clean tree.
+- `proc-macro-error2` notice gone (bump) or tracked in a referenced issue
+  (upstream-blocked), stated in the PR body.
+- Suites + three clippy legs green; NAMESPACE unchanged.
+
+## Escalation rule
+
+If reality diverges from this plan — removing the impl-level tags changes
+rendered Rd in a way tests pin, the tabled bump breaks our formatting
+API, or the warnings turn out to come from a second site — **stop, commit
+nothing further, and report back. Do not improvise.**

--- a/rpkg/src/rust/convert_pref_tests.rs
+++ b/rpkg/src/rust/convert_pref_tests.rs
@@ -146,6 +146,9 @@ pub struct StructPreferNative(pub i32);
 /// struct_prefer_native(3L)
 pub fn struct_prefer_native(x: i32) -> StructPreferNative {
     let value = StructPreferNative(x);
+    // Read the inner field: unlike the IntoList-deriving siblings above, the
+    // RNativeType derive only emits consts and pointer casts, so without this
+    // read rustc's dead_code lint flags field `0` as never read (lib test).
     debug_assert_eq!(value.0, x);
     value
 }


### PR DESCRIPTION
**TODO (author): replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Makes the standard green path (`just check` / `just clippy` / `just rcmdinstall`) free of the two miniextendr-emitted warnings surfaced by the 2026-07-12 standard-path warnings audit (worklist item 14). Verified distinct from #1292 (two rpkg *clippy* warnings) and #1261 (R CMD check WARNINGs, already closed).

**Fix A — impl-method roxygen-tag deprecation nudge (x2) — #1322 beat this branch to it; the guard below is the durable part.** `rpkg/src/rust/impl_dots_tests.rs` carried impl-block `/// @param seed` + `/// @param ...` tags above `#[miniextendr(s3)] impl ImplDotsS3`. Since #1206 / PR #1296 (`e504646c`) deliberately activated the "@tag on impl block has no effect, move it to the method" nudge, that redundant pair tripped it on every build. This branch removed the two lines (the `new` method already carries its own `@param` copies) — but #1322's final sub-commit (`541e833a`) made the identical deletion on main first, so after merging `origin/main` back in **the net diff no longer touches `impl_dots_tests.rs` at all**. What this PR durably contributes for Fix A is the regression guard below, which keeps the nudge from reappearing. The nudge itself (`miniextendr-macros/src/roxygen.rs`) and its UI coverage are untouched, the fixture was what was wrong, not the warning.

- `just check` before (pre-#1322): `impl_dots_tests.rs:54 ... use of deprecated constant _MINIEXTENDR_IMPL_METHOD_TAG_WARN_ImplDotsS3_67_0 / _67_1` (2 warnings).
- `just check` after: zero miniextendr warnings across the whole multi-manifest workspace (main, consumer.pkg, producer.pkg, rpkg, cargo-revendor).
- `just force-document` produced NO `NAMESPACE` / `man/*.Rd` churn (the tags had no rendered-doc effect, exactly as the audit predicted), so nothing regenerated to commit.

**Fix B — `proc-macro-error2 2.0.1` future-incompat notice (upstream-blocked).** Tracked in #1329. Chain: `tabled = "0.20.0"` -> `tabled_derive 0.11.0` -> `proc-macro-error2 2.0.1`, whose `pub use proc_macro;` trips `E0365` (rust-lang/rust#127909). Confirmed on crates.io (2026-07-12) that there is no fix to pull: `proc-macro-error2` max is 2.0.1, and `tabled 0.21.0` still depends on `tabled_derive ^0.11 -> proc-macro-error2 ^2.0.1`. Per repo policy the deferred item is a tracked issue (#1329) rather than a `[future-incompat-report]` silencer, visibility is the point, and a routine dep bump will make it vanish once upstream ships.

**Regression guard.** Added a scoped grep-gate to the existing `wrappers-sync-check` recipe (already a full source-mode `R CMD INSTALL` of rpkg, run in CI's Sync Checks job): it now captures the install log and fails if any `miniextendr: @` nudge line appears. Scoped to our macro's unique prefix so upstream cargo/rustc future-incompat noise (e.g. proc-macro-error2) cannot flake it.

**Drive-by (post-merge): `dead_code` on `StructPreferNative` (from #1325).** Merging `origin/main` mid-branch brought in the #1283 regression fixture, which tripped `field 0 is never read` in rpkg's lib-test target on every `just check`. Root cause: its only derive (`RNativeType`) emits consts and pointer casts, never a field read, unlike the `IntoList`-deriving sibling fixtures. Fixed by reading the field via `debug_assert_eq!` inside the fixture fn (R-visible behavior and the #1283 coverage unchanged). Per CLAUDE.md "fix warnings you see".

## Test plan

- [x] `just check` — zero miniextendr warnings (before: 2 impl-tag deprecations).
- [x] `just configure && just rcmdinstall && just force-document` — clean; no `NAMESPACE`/`man` change.
- [x] `just devtools-test` — `[ FAIL 0 | WARN 0 | SKIP 27 | PASS 7168 ]`.
- [x] `just wrappers-sync-check` — passes with the new grep-gate; still asserts NAMESPACE/man sync. Negative-tested: temporarily re-adding one impl-level `@param` makes the recipe exit 1 with the offending line + an actionable message (then reverted).
- [x] Three clippy legs (`clippy_default`, `clippy_all`, `clippy_all_s7` per `.github/workflows/ci.yml`) — all green with `-D warnings`, re-run after the `origin/main` merge. `cargo fmt --all` — no changes.
- [x] Post-merge re-verification: `just check` fully warning-free; `just rcmdinstall` — 0 nudge lines; `just wrappers-sync-check` green; targeted `test-convert-pref.R` (25 PASS) and `test-impl-dots.R` (20 PASS), both FAIL 0.

## Notes

- The Fix B notice remains visible on release installs until upstream publishes a fix; #1329 tracks it with the exact offense, the crates.io verification, and the bump-and-close plan.
- Net diff vs main: `justfile` (the guard — including a note that it is a cold-build gate: the nudge is a rustc deprecation warning emitted only on recompile, but introducing a tag is itself a source change forcing recompile, and CI Sync Checks always starts cold), `rpkg/src/rust/convert_pref_tests.rs` (post-merge dead_code drive-by), and the branch's plan file. `impl_dots_tests.rs` is NOT in the net diff (see Fix A: #1322 landed the identical deletion on main first). The root workspace crates that clippy runs against are untouched.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

