### PR TITLE
ci(macros): run ui_vctrs trybuild suite and refresh its stale snapshot (#1336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,14 @@ jobs:
       - name: Tests (root workspace)
         run: cargo test --workspace --locked --no-fail-fast
 
+      # The ui_vctrs trybuild suite is `#[cfg(feature = "vctrs")]` and `vctrs`
+      # is not a default feature, so the feature-less --workspace run above
+      # compiles it to an empty test binary and its `.stderr` snapshots drift
+      # undetected (#1336). Run it explicitly; kept separate from the workspace
+      # step so the vctrs feature never leaks into other suites' rendering.
+      - name: Tests (ui_vctrs trybuild, vctrs feature)
+        run: cargo test -p miniextendr-macros --test ui_vctrs --features vctrs --locked --no-fail-fast
+
       # cargo-revendor is a standalone workspace excluded from the root
       # workspace, so the `--workspace` step above never reaches it (#778).
       - name: Tests (cargo-revendor)

--- a/justfile
+++ b/justfile
@@ -342,11 +342,12 @@ test *args:
 test-ui *cargo_flags:
     set -euo pipefail
     run_ui() {
-        # The `ui_vctrs` trybuild target is intentionally NOT run here: its
-        # committed snapshot is stale and no CI job runs it (issue #1336). Re-add
-        # `--test ui_vctrs --features vctrs` once that snapshot + a CI leg land.
         local tc="$1"
         env ${tc:+RUSTUP_TOOLCHAIN="$tc"} cargo test -p miniextendr-macros --test ui --locked {{cargo_flags}}
+        # `ui_vctrs` is behind the non-default `vctrs` feature, so it needs its
+        # own invocation (#1336). Kept separate from `--test ui` so the vctrs
+        # feature never leaks into the feature-less `ui` snapshot rendering.
+        env ${tc:+RUSTUP_TOOLCHAIN="$tc"} cargo test -p miniextendr-macros --test ui_vctrs --features vctrs --locked {{cargo_flags}}
     }
     if rustup component list --installed 2>/dev/null | grep -q '^rust-src'; then
         ver="$(rustc --version | awk '{print $2}')"

--- a/miniextendr-macros/tests/ui_vctrs.rs
+++ b/miniextendr-macros/tests/ui_vctrs.rs
@@ -6,6 +6,15 @@
 #[test]
 #[cfg(feature = "vctrs")]
 fn ui_vctrs() {
+    // Same skip contract as tests/ui.rs: `just test` sets MINIEXTENDR_SKIP_UI=1
+    // on its root-workspace leg so trybuild snapshots run only via `just test-ui`,
+    // which isolates them under a CI-matching minimal-profile (no rust-src)
+    // toolchain (issues #1239, #1336). Bare `cargo test` (CI included) leaves
+    // the var unset and runs normally.
+    if std::env::var_os("MINIEXTENDR_SKIP_UI").is_some() {
+        eprintln!("MINIEXTENDR_SKIP_UI set: skipping trybuild UI snapshots (run `just test-ui`).");
+        return;
+    }
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui_vctrs/*.rs");
 }

--- a/miniextendr-macros/tests/ui_vctrs/derive_vctrs_unknown_container_attr.stderr
+++ b/miniextendr-macros/tests/ui_vctrs/derive_vctrs_unknown_container_attr.stderr
@@ -1,4 +1,4 @@
-error: unknown vctrs attribute; expected one of: class, base, abbr, inherit_base, coerce, ptype, proxy_equal, proxy_compare, proxy_order, arith, math
+error: unknown vctrs attribute; expected one of: class, base, abbr, inherit_base, coerce, extends, ptype, proxy_equal, proxy_compare, proxy_order, arith, math
  --> tests/ui_vctrs/derive_vctrs_unknown_container_attr.rs:6:29
   |
 6 | #[vctrs(class = "my_class", bogus = true)]


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Regenerated `miniextendr-macros/tests/ui_vctrs/derive_vctrs_unknown_container_attr.stderr` under a version-named minimal-profile (no `rust-src`) toolchain, per CLAUDE.md "UI test snapshots". The diff is exactly the expected one-line change: the valid-attribute list now includes `extends`, matching `vctrs_derive.rs`. No stdlib spans were baked in.
- Added a `rust-tests` CI step: `cargo test -p miniextendr-macros --test ui_vctrs --features vctrs --locked --no-fail-fast`. The suite is `#[cfg(feature = "vctrs")]` and `vctrs` is not a default feature, so the existing feature-less `--workspace` step compiles it to an empty test binary and the snapshot drifted undetected. Kept as a separate invocation so the vctrs feature never leaks into other suites' feature unification or snapshot rendering.
- Re-wired `just test-ui`: `run_ui()` now also runs `--test ui_vctrs --features vctrs --locked`. Both callers of `run_ui()` (the plain branch and the rust-src-detecting minimal-toolchain rerun branch) go through it, so local runs under a rust-src toolchain get the same CI-parity isolation for ui_vctrs as for ui.
- Mirrored the `MINIEXTENDR_SKIP_UI` guard from `tests/ui.rs` into `tests/ui_vctrs.rs`, so `just test`'s root-workspace leg defers all trybuild snapshots to `just test-ui` even if feature flags are passed through.
- Closes #1336.

## Test plan
- [x] `RUSTUP_TOOLCHAIN=1.97.0 cargo test -p miniextendr-macros --test ui_vctrs --features vctrs --locked` green (all 8 cases) under the minimal-profile toolchain
- [x] `just test-ui` green through the rust-src isolation path (active toolchain carries rust-src; recipe isolated under `1.97.0`, ran both `ui` and `ui_vctrs`)
- [x] `just test` green (root-workspace leg skips/empties the trybuild suites as designed, `test-ui` leg covers them)
- [x] `just check`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo clippy -p miniextendr-macros --all-targets --features vctrs --locked -- -D warnings` all green
- [x] `ci.yml` parses (`yaml.safe_load`)
- [ ] The new "Tests (ui_vctrs trybuild, vctrs feature)" CI step passes on this PR

## Notes
- CI green on the new step is the real proof that the snapshot matches CI's rendering. The local minimal-profile toolchain run is the best local approximation (same no-rust-src component set as `dtolnay/rust-toolchain@stable`), but CI is authoritative.
- No scope cuts or deferrals.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)