### PR TITLE
fix(cli): init scaffolds the canonical minirextendr templates (#1351)

### DIFF
--- a/miniextendr-cli/README.md
+++ b/miniextendr-cli/README.md
@@ -35,17 +35,31 @@ End-user commands for building R packages with Rust. No knowledge of miniextendr
 ### `init` — Create or add miniextendr to a project
 
 ```bash
-miniextendr init package mypackage          # New R package with Rust
-miniextendr init monorepo myproject         # Rust workspace + embedded R package
+miniextendr init package my.package         # New R package with Rust
+miniextendr init monorepo my.project        # Rust workspace + embedded R package
 miniextendr init use                        # Add miniextendr to existing package
 ```
+
+`init` renders the canonical `minirextendr` templates (embedded at compile
+time from `minirextendr/inst/templates/`), so a CLI-generated package is
+identical to one scaffolded by `minirextendr::create_miniextendr_package()` /
+`create_miniextendr_monorepo()` / `use_miniextendr()`: same two install modes
+(source vs. offline tarball, keyed on `inst/vendor.tar.xz` presence), same
+configure-written `.cargo/config.toml`, same wrapper and wasm-registry
+generation — and no `just` required to build the result.
+
+`init use` auto-detects the layout: run it inside an R package (has
+`DESCRIPTION`) to add Rust scaffolding in place, or inside a Rust workspace
+(has `Cargo.toml`) to embed an R package subdirectory
+(`--template-type rpkg|monorepo` overrides detection).
 
 ### `workflow` — Build, document, check, and manage R package
 
 ```bash
 miniextendr workflow build                  # Full two-pass build
 miniextendr workflow configure              # Generate Makevars and build config
-miniextendr workflow configure --cran       # Configure for CRAN release
+                                            # (install mode auto-detected from
+                                            #  inst/vendor.tar.xz presence)
 miniextendr workflow document               # Derive NAMESPACE/man from generated wrappers
 miniextendr workflow test                   # Run R tests (devtools::test)
 miniextendr workflow test --filter vec      # Run filtered tests

--- a/miniextendr-cli/src/cli.rs
+++ b/miniextendr-cli/src/cli.rs
@@ -119,12 +119,17 @@ pub enum InitCmd {
     /// Create a new R package with miniextendr.
     Package {
         /// Destination path for the new package.
-        path: String,
+        //
+        // Named `dest`, not `path`: the global `--path` arg propagates into
+        // subcommands under the clap id "path", and a positional with the
+        // same id captures into BOTH — `ProjectContext::discover` then ran on
+        // the not-yet-created destination and errored before dispatch.
+        dest: String,
     },
     /// Create a Rust workspace with embedded R package.
     Monorepo {
         /// Destination path for the monorepo.
-        path: String,
+        dest: String,
         /// Package name.
         #[arg(long)]
         package: Option<String>,

--- a/miniextendr-cli/src/commands/init.rs
+++ b/miniextendr-cli/src/commands/init.rs
@@ -1,126 +1,91 @@
+//! `miniextendr init` — scaffold packages from the canonical minirextendr
+//! templates.
+//!
+//! Every file comes from the embedded copy of `minirextendr/inst/templates/`
+//! (see [`crate::scaffold`]), so a CLI-generated package uses exactly the
+//! same build system as `minirextendr::create_miniextendr_package()` /
+//! `create_miniextendr_monorepo()` / `use_miniextendr()`: the two-mode
+//! install latch keyed on `inst/vendor.tar.xz` presence, configure-written
+//! `.cargo/config.toml`, wrapper + wasm-registry generation, and no `just`
+//! requirement (#1351).
+
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 
 use crate::bridge::{has_program, run_command};
 use crate::cli::InitCmd;
-use crate::project::ProjectContext;
+use crate::project::{ProjectContext, parse_description_field};
+use crate::scaffold::{self, MONOREPO_ROOT_PLAN, RPKG_PLAN, RUST_SYSTEM_REQUIREMENT, TemplateData};
 
 pub fn dispatch(cmd: &InitCmd, ctx: &ProjectContext, quiet: bool) -> Result<()> {
     match cmd {
-        InitCmd::Package { path } => init_package(path, quiet),
+        InitCmd::Package { dest } => init_package(dest, quiet),
         InitCmd::Monorepo {
-            path,
+            dest,
             package,
             crate_name,
             rpkg_name,
             local_path: _,
             miniextendr_version: _,
         } => init_monorepo(
-            path,
+            dest,
             package.as_deref(),
             crate_name.as_deref(),
             rpkg_name.as_deref(),
             quiet,
         ),
         InitCmd::Use {
-            template_type: _,
-            rpkg_name: _,
+            template_type,
+            rpkg_name,
             miniextendr_version: _,
             local_path: _,
-        } => init_use(ctx, quiet),
+        } => init_use(ctx, template_type, rpkg_name.as_deref(), quiet),
     }
 }
 
-/// Create a new R package with miniextendr scaffolding.
+// region: init package
+
+/// Create a new standalone R package
+/// (~ `minirextendr::create_miniextendr_package()`).
 fn init_package(path: &str, quiet: bool) -> Result<()> {
     let root = Path::new(path);
     if root.exists() {
         bail!("Directory already exists: {path}");
     }
 
-    let pkg_name = root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("mypackage");
-    let crate_name = pkg_name.replace(['.', '-'], "_");
+    let pkg_name = package_name_from_path(root)?;
+    validate_package_name(&pkg_name)?;
 
     if !quiet {
         eprintln!("Creating R package: {pkg_name}");
     }
 
-    // Create directory structure
-    std::fs::create_dir_all(root.join("R"))?;
-    std::fs::create_dir_all(root.join("man"))?;
-    std::fs::create_dir_all(root.join("src/rust"))?;
-    std::fs::create_dir_all(root.join("tools"))?;
-    std::fs::create_dir_all(root.join("inst/include"))?;
-
-    // DESCRIPTION
-    write_description(root, pkg_name)?;
-
-    // NAMESPACE
-    std::fs::write(root.join("NAMESPACE"), "")?;
-
-    // .Rbuildignore
-    write_rbuildignore(root)?;
-
-    // .gitignore
-    write_gitignore(root)?;
-
-    // configure.ac
-    write_configure_ac(root, pkg_name)?;
-
-    // src/Makevars.in
-    write_makevars_in(root)?;
-
-    // src/stub.c
-    write_stub_c(root)?;
-
-    // src/rust/Cargo.toml
-    write_cargo_toml(root, &crate_name)?;
-
-    // src/rust/lib.rs
-    write_lib_rs(root, &crate_name)?;
-
-    // src/rust/build.rs
-    write_build_rs(root)?;
-
-    // src/rust/cargo-config.toml.in
-    write_cargo_config_in(root)?;
-
-    // bootstrap.R
-    write_bootstrap_r(root)?;
-
-    // cleanup
-    write_cleanup(root)?;
-
-    // miniextendr.yml
-    write_config_yml(root)?;
-
-    // R/{pkg}-package.R
-    write_package_r(root, pkg_name)?;
-
-    // Run autoconf if available
-    if has_program("autoconf") {
-        let _ = run_command("autoconf", &["-vif"], root, quiet);
-    }
+    let data = TemplateData::new(&pkg_name);
+    scaffold_rpkg_fresh(root, &data)?;
+    write_miniextendr_yml(root, quiet)?;
+    run_autoconf(root, quiet);
 
     if !quiet {
         eprintln!("\nPackage created at: {path}");
         eprintln!("Next steps:");
         eprintln!("  cd {path}");
+        eprintln!("  # edit src/rust/lib.rs, then:");
         eprintln!("  miniextendr workflow build");
     }
-
     Ok(())
 }
 
-/// Create a Rust workspace with an embedded R package.
+// endregion
+
+// region: init monorepo
+
+/// Create a Rust workspace with an embedded R package
+/// (~ `minirextendr::create_miniextendr_monorepo()`).
 fn init_monorepo(
     path: &str,
     package: Option<&str>,
-    _crate_name: Option<&str>,
+    crate_name: Option<&str>,
     rpkg_name: Option<&str>,
     quiet: bool,
 ) -> Result<()> {
@@ -129,397 +94,768 @@ fn init_monorepo(
         bail!("Directory already exists: {path}");
     }
 
-    let dir_name = root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("myproject");
-    let pkg_name = package.unwrap_or(dir_name);
-    let rpkg_dir = rpkg_name.unwrap_or("rpkg");
+    // Defaults mirror create_miniextendr_monorepo(): package from the
+    // directory name, crate name = package with dots as dashes, R package
+    // subdirectory named after the package.
+    let pkg_name = match package {
+        Some(p) => p.to_string(),
+        None => package_name_from_path(root)?,
+    };
+    validate_package_name(&pkg_name)?;
+    let crate_name = crate_name
+        .map(str::to_string)
+        .unwrap_or_else(|| pkg_name.replace('.', "-"));
+    let rpkg_name = rpkg_name.map(str::to_string).unwrap_or_else(|| {
+        // rpkg_name defaults to the package name; when that collides with the
+        // crate directory (dot-less package names), fall back to "rpkg"
+        // instead of erroring like R does — same layout the templates
+        // document, one less required flag.
+        if pkg_name == crate_name {
+            "rpkg".to_string()
+        } else {
+            pkg_name.clone()
+        }
+    });
+    if rpkg_name == crate_name {
+        bail!(
+            "--rpkg-name and --crate-name must be different (both are \"{crate_name}\" — \
+             they are sibling directories under the project root).\n\
+             Pass e.g. --rpkg-name {crate_name}-rpkg"
+        );
+    }
 
     if !quiet {
-        eprintln!("Creating monorepo: {dir_name}");
+        eprintln!("Creating monorepo: {}", root.display());
+        eprintln!("  package:   {pkg_name}");
+        eprintln!("  crate:     {crate_name}/");
+        eprintln!("  R package: {rpkg_name}/");
     }
 
-    // Create workspace root
-    std::fs::create_dir_all(root)?;
+    let data = TemplateData::new(&pkg_name)
+        .with_crate(&crate_name)
+        .with_rpkg(&rpkg_name);
 
-    // Workspace Cargo.toml
-    std::fs::write(
-        root.join("Cargo.toml"),
-        format!(
-            "[workspace]\nresolver = \"3\"\nmembers = []\nexclude = [\"{rpkg_dir}\", \"{rpkg_dir}/src/rust\"]\n"
-        ),
-    )?;
+    // Workspace root: Cargo.toml, .gitignore, tools/bump-version.R, core crate.
+    scaffold::apply_plan(root, "templates/monorepo", MONOREPO_ROOT_PLAN, &data, true)?;
 
-    // Create the R package inside
-    let rpkg_path = root.join(rpkg_dir);
-    init_package(&rpkg_path.to_string_lossy(), quiet)?;
-
-    // Override DESCRIPTION package name if specified
-    if package.is_some() {
-        write_description(&rpkg_path, pkg_name)?;
-    }
+    // Embedded R package (~ create_rpkg_subdirectory()).
+    let rpkg_root = root.join(&rpkg_name);
+    scaffold_rpkg_at(&rpkg_root, "templates/monorepo/rpkg", &data)?;
+    run_autoconf(&rpkg_root, quiet);
 
     if !quiet {
         eprintln!("\nMonorepo created at: {path}");
-        eprintln!("  R package: {rpkg_dir}/");
         eprintln!("Next steps:");
-        eprintln!("  cd {path}/{rpkg_dir}");
-        eprintln!("  miniextendr workflow build");
+        eprintln!("  1. Edit {crate_name}/src/lib.rs for your core Rust library");
+        eprintln!("  2. Edit {rpkg_name}/src/rust/lib.rs for R-exposed functions");
+        eprintln!("  3. cd {path}/{rpkg_name} && miniextendr workflow build");
     }
-
     Ok(())
 }
 
-/// Add miniextendr scaffolding to an existing project.
-fn init_use(ctx: &ProjectContext, quiet: bool) -> Result<()> {
+// endregion
+
+// region: init use
+
+/// Add miniextendr scaffolding to an existing project
+/// (~ `minirextendr::use_miniextendr()`), auto-detecting standalone-package
+/// vs monorepo layout.
+fn init_use(
+    ctx: &ProjectContext,
+    template_type: &str,
+    rpkg_name: Option<&str>,
+    quiet: bool,
+) -> Result<()> {
     let root = &ctx.root;
-    let desc_path = root.join("DESCRIPTION");
-    if !desc_path.exists() {
-        bail!("No DESCRIPTION found. Is this an R package directory?");
+
+    let template_type = match template_type {
+        "auto" => {
+            // Mirror detect_project_type(): a Cargo.toml at the project root
+            // means "Rust project, embed an R package"; a DESCRIPTION means
+            // "standalone R package".
+            if root.join("Cargo.toml").is_file() {
+                "monorepo"
+            } else if root.join("DESCRIPTION").is_file() {
+                "rpkg"
+            } else {
+                bail!(
+                    "Could not detect project type: no Cargo.toml or DESCRIPTION in {}.\n\
+                     Use `miniextendr init package <path>` to create a new package, or pass\n\
+                     --template-type rpkg|monorepo explicitly.",
+                    root.display()
+                );
+            }
+        }
+        t @ ("rpkg" | "monorepo") => t,
+        other => bail!("Unknown template type: {other} (expected auto, rpkg, or monorepo)"),
+    };
+
+    match template_type {
+        "monorepo" => init_use_monorepo(root, rpkg_name, quiet),
+        _ => init_use_rpkg(root, quiet),
+    }
+}
+
+/// `init use` in a Rust workspace: create the R package subdirectory.
+fn init_use_monorepo(root: &Path, rpkg_name: Option<&str>, quiet: bool) -> Result<()> {
+    // Mirror get_package_name_from_cargo(): crate name from the root
+    // Cargo.toml, hyphens become dots for the R package name.
+    let cargo_toml = root.join("Cargo.toml");
+    let content = std::fs::read_to_string(&cargo_toml)
+        .with_context(|| format!("failed to read {}", cargo_toml.display()))?;
+    let crate_name = content
+        .lines()
+        .find_map(|line| {
+            let rest = line.strip_prefix("name")?.trim_start().strip_prefix('=')?;
+            rest.trim().strip_prefix('"')?.split('"').next()
+        })
+        .with_context(|| {
+            format!(
+                "could not find a package name in {} — the monorepo template reads the crate \
+                 name from the workspace Cargo.toml",
+                cargo_toml.display()
+            )
+        })?
+        .to_string();
+    let pkg_name = crate_name.replace('-', ".");
+    let rpkg_name = rpkg_name.map(str::to_string).unwrap_or_else(|| {
+        if pkg_name == crate_name {
+            "rpkg".to_string()
+        } else {
+            pkg_name.clone()
+        }
+    });
+
+    if !quiet {
+        eprintln!("Detected Rust project — creating R package in {rpkg_name}/");
+        eprintln!("Using package name: {pkg_name}");
     }
 
-    // Read package name
-    let pkg_name = ctx
-        .package_name()
-        .context("Could not read Package field from DESCRIPTION")?;
-    let crate_name = pkg_name.replace(['.', '-'], "_");
+    let data = TemplateData::new(&pkg_name)
+        .with_crate(&crate_name)
+        .with_rpkg(&rpkg_name);
+    let rpkg_root = root.join(&rpkg_name);
+    scaffold_rpkg_at(&rpkg_root, "templates/monorepo/rpkg", &data)?;
+    run_autoconf(&rpkg_root, quiet);
+    write_miniextendr_yml(root, quiet)?;
+
+    if !quiet {
+        eprintln!("\nminiextendr scaffolding added.");
+        eprintln!("Next: cd {rpkg_name} && miniextendr workflow build");
+    }
+    Ok(())
+}
+
+/// `init use` in an R package directory: add scaffolding in place.
+fn init_use_rpkg(root: &Path, quiet: bool) -> Result<()> {
+    let desc_path = root.join("DESCRIPTION");
+    let pkg_name = if desc_path.is_file() {
+        let content = std::fs::read_to_string(&desc_path)?;
+        parse_description_field(&content, "Package")
+            .context("Could not read Package field from DESCRIPTION")?
+    } else {
+        // ~ use_miniextendr_description(): seed a minimal DESCRIPTION when
+        // none exists, deriving the package name from the directory.
+        let pkg_name = package_name_from_path(root)?;
+        validate_package_name(&pkg_name)?;
+        std::fs::write(&desc_path, scaffold::description_content(&pkg_name))?;
+        if !quiet {
+            eprintln!("No DESCRIPTION found; created a minimal one");
+        }
+        pkg_name
+    };
 
     if !quiet {
         eprintln!("Adding miniextendr to: {pkg_name}");
     }
 
-    // Create directories
-    std::fs::create_dir_all(root.join("src/rust"))?;
-    std::fs::create_dir_all(root.join("tools"))?;
-    std::fs::create_dir_all(root.join("inst/include"))?;
+    update_description(root)?;
 
-    write_configure_ac(root, &pkg_name)?;
-    write_makevars_in(root)?;
-    write_stub_c(root)?;
-    write_cargo_toml(root, &crate_name)?;
-    write_lib_rs(root, &crate_name)?;
-    write_build_rs(root)?;
-    write_cargo_config_in(root)?;
-    write_bootstrap_r(root)?;
-    write_cleanup(root)?;
-    write_config_yml(root)?;
-
-    // Update DESCRIPTION
-    update_description_for_miniextendr(root)?;
-
-    // Run autoconf if available
-    if has_program("autoconf") {
-        let _ = run_command("autoconf", &["-vif"], root, quiet);
+    // LICENSE if missing (required by License: MIT + file LICENSE).
+    let license_path = root.join("LICENSE");
+    if !license_path.is_file() {
+        std::fs::write(&license_path, scaffold::license_content(&pkg_name))?;
     }
+
+    // Minimal NAMESPACE if missing (~ use_miniextendr_namespace()): without
+    // it the first build fails on the configure-time guard.
+    let namespace_path = root.join("NAMESPACE");
+    if !namespace_path.is_file() {
+        std::fs::write(&namespace_path, scaffold::minimal_namespace(&pkg_name))?;
+        if !quiet {
+            eprintln!(
+                "No NAMESPACE found; created a minimal one with useDynLib({pkg_name}, .registration = TRUE)"
+            );
+        }
+    }
+
+    let data = TemplateData::new(&pkg_name);
+    scaffold::apply_plan(root, "templates/rpkg", RPKG_PLAN, &data, false)?;
+    scaffold::write_config_scripts(root)?;
+    std::fs::create_dir_all(root.join("vendor"))?;
+
+    run_autoconf(root, quiet);
+    write_miniextendr_yml(root, quiet)?;
 
     if !quiet {
         eprintln!("\nminiextendr scaffolding added.");
-        eprintln!("Next: miniextendr workflow build");
-    }
-
-    Ok(())
-}
-
-// --- File generation helpers ---
-
-fn write_description(root: &Path, pkg_name: &str) -> Result<()> {
-    let content = format!(
-        "Package: {pkg_name}\n\
-         Title: What the Package Does (One Line, Title Case)\n\
-         Version: 0.0.0.9000\n\
-         Authors@R: person(\"First\", \"Last\", email = \"first.last@example.com\", role = c(\"aut\", \"cre\"))\n\
-         Description: What the package does (one paragraph).\n\
-         License: MIT + file LICENSE\n\
-         Encoding: UTF-8\n\
-         SystemRequirements: Rust (>= 1.83), Cargo\n\
-         Config/build/bootstrap: TRUE\n\
-         Config/roxygen2/markdown: TRUE\n\
-         Config/roxygen2/version: 8.0.0\n\
-         NeedsCompilation: yes\n"
-    );
-    std::fs::write(root.join("DESCRIPTION"), content)?;
-    Ok(())
-}
-
-fn write_rbuildignore(root: &Path) -> Result<()> {
-    let content = "^.*\\.Rproj$\n\
-                   ^\\.Rproj\\.user$\n\
-                   ^src/rust/target$\n\
-                   ^vendor$\n\
-                   ^src/rust/\\.cargo$\n";
-    std::fs::write(root.join(".Rbuildignore"), content)?;
-    Ok(())
-}
-
-fn write_gitignore(root: &Path) -> Result<()> {
-    let content = "src/rust/target/\n\
-                   src/rust/.cargo/\n\
-                   src/Makevars\n\
-                   src/*.o\n\
-                   src/*.so\n\
-                   src/*.dll\n\
-                   src/*.a\n\
-                   src/*.lib\n\
-                   src/*.def\n";
-    std::fs::write(root.join(".gitignore"), content)?;
-    Ok(())
-}
-
-fn write_configure_ac(root: &Path, pkg_name: &str) -> Result<()> {
-    let content = format!(
-        r#"AC_INIT([{pkg_name}], [0.0.0.9000])
-
-# Detect build context: dev-monorepo, dev-detached, vendored-install, or prepare-cran
-AC_MSG_CHECKING([build context])
-if test "${{PREPARE_CRAN}}" = "true"; then
-  BUILD_CONTEXT=prepare-cran
-elif test "${{NOT_CRAN}}" = "true" -o -d "${{srcdir}}/../../miniextendr-api"; then
-  BUILD_CONTEXT=dev-monorepo
-elif test -f "${{srcdir}}/inst/vendor.tar.xz" -o -d "${{srcdir}}/vendor"; then
-  BUILD_CONTEXT=vendored-install
-else
-  BUILD_CONTEXT=dev-detached
-fi
-AC_MSG_RESULT([$BUILD_CONTEXT])
-
-AC_SUBST(BUILD_CONTEXT)
-AC_SUBST(PACKAGE_NAME)
-
-AC_CONFIG_FILES([src/Makevars])
-AC_CONFIG_FILES([src/rust/.cargo/config.toml:src/rust/cargo-config.toml.in])
-AC_OUTPUT
-"#
-    );
-    let p = root.join("configure.ac");
-    if !p.exists() {
-        std::fs::write(p, content)?;
+        eprintln!("Next: edit src/rust/lib.rs, then run: miniextendr workflow build");
     }
     Ok(())
 }
 
-fn write_makevars_in(root: &Path) -> Result<()> {
-    let content = r#"RUST_SRC = rust
-CARGO_MANIFEST = $(RUST_SRC)/Cargo.toml
-STATLIB = $(RUST_SRC)/target/release/lib@PACKAGE_NAME@.a
+// endregion
 
-PKG_LIBS = -L$(RUST_SRC)/target/release -l@PACKAGE_NAME@ -lpthread
+// region: shared scaffold steps
 
-all: $(SHLIB)
+/// Write the full fresh standalone-package surface into `root`.
+fn scaffold_rpkg_fresh(root: &Path, data: &TemplateData) -> Result<()> {
+    scaffold_rpkg_at(root, "templates/rpkg", data)
+}
 
-$(SHLIB): $(STATLIB)
-
-$(STATLIB):
-	@cd $(RUST_SRC) && cargo build --lib --release --manifest-path=Cargo.toml
-
-clean:
-	rm -Rf $(RUST_SRC)/target $(SHLIB) $(OBJECTS)
-"#;
-    let p = root.join("src/Makevars.in");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
+/// Write the fresh R-package scaffold surface: the canonical DESCRIPTION
+/// literal, LICENSE, NAMESPACE, the template plan, autoconf helper scripts,
+/// and the `vendor/` directory (~ `create_rpkg_subdirectory()`).
+fn scaffold_rpkg_at(root: &Path, prefix: &str, data: &TemplateData) -> Result<()> {
+    scaffold::write_file(
+        &root.join("DESCRIPTION"),
+        &scaffold::description_content(&data.package),
+        false,
+    )?;
+    scaffold::write_file(
+        &root.join("LICENSE"),
+        &scaffold::license_content(&data.package),
+        false,
+    )?;
+    scaffold::write_file(
+        &root.join("NAMESPACE"),
+        &scaffold::minimal_namespace(&data.package),
+        false,
+    )?;
+    scaffold::apply_plan(root, prefix, RPKG_PLAN, data, true)?;
+    scaffold::write_config_scripts(root)?;
+    std::fs::create_dir_all(root.join("vendor"))?;
     Ok(())
 }
 
-fn write_stub_c(root: &Path) -> Result<()> {
-    let content = "// Minimal stub so R's build system produces a shared library.\n\
-                   // All entry points (R_init_*) are defined in Rust via miniextendr_init!().\n";
-    let p = root.join("src/stub.c");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_cargo_toml(root: &Path, crate_name: &str) -> Result<()> {
-    let content = format!(
-        r#"[package]
-name = "{crate_name}"
-version = "0.1.0"
-edition = "2024"
-publish = false
-
-[workspace]
-
-[lib]
-path = "lib.rs"
-crate-type = ["staticlib"]
-
-[features]
-default = []
-
-[dependencies]
-miniextendr-api = {{ path = "../../vendor/miniextendr-api" }}
-
-[build-dependencies]
-miniextendr-lint = {{ path = "../../vendor/miniextendr-lint" }}
-"#
-    );
-    let p = root.join("src/rust/Cargo.toml");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_lib_rs(root: &Path, crate_name: &str) -> Result<()> {
-    let content = format!(
-        r#"use miniextendr_api::miniextendr;
-
-/// Add two numbers
-///
-/// @param a First number
-/// @param b Second number
-/// @return Sum of a and b
-#[miniextendr]
-pub fn add(a: f64, b: f64) -> f64 {{
-    a + b
-}}
-
-/// Say hello
-///
-/// @param name Name to greet
-/// @return Greeting string
-#[miniextendr]
-pub fn hello(name: &str) -> String {{
-    format!("Hello, {{}}!", name)
-}}
-
-miniextendr_api::miniextendr_init!({crate_name});
-"#
-    );
-    let p = root.join("src/rust/lib.rs");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_build_rs(root: &Path) -> Result<()> {
-    let content = r#"fn main() {
-    println!("cargo::rerun-if-changed=lib.rs");
-}
-"#;
-    let p = root.join("src/rust/build.rs");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_cargo_config_in(root: &Path) -> Result<()> {
-    let content = r#"# Generated by configure from cargo-config.toml.in
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "../../vendor"
-"#;
-    let dir = root.join("src/rust");
-    std::fs::create_dir_all(&dir)?;
-    let p = dir.join("cargo-config.toml.in");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_bootstrap_r(root: &Path) -> Result<()> {
-    let content = r#"# Bootstrap script — called by devtools/pkgbuild before compilation.
-# Runs autoconf + configure to generate Makevars, etc.
-
-local({
-  # Only bootstrap if configure.ac exists and configure doesn't
-  if (file.exists("configure.ac") && !file.exists("configure")) {
-    if (Sys.which("autoconf") != "") {
-      system("autoconf -vif")
-    }
-  }
-
-  if (file.exists("configure") && !file.exists("src/Makevars")) {
-    system("NOT_CRAN=true bash ./configure")
-  }
-})
-"#;
-    let p = root.join("bootstrap.R");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_cleanup(root: &Path) -> Result<()> {
-    let content = "#!/bin/sh\nrm -rf src/rust/target src/Makevars src/rust/.cargo\n";
-    let p = root.join("cleanup");
-    if !p.exists() {
-        std::fs::write(&p, content)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755))?;
-        }
-    }
-    Ok(())
-}
-
-fn write_config_yml(root: &Path) -> Result<()> {
-    let content = "class_system: env\nstrict: false\ncoerce: false\nfeatures: []\nrust_version: stable\nvendor: true\n";
-    let p = root.join("miniextendr.yml");
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn write_package_r(root: &Path, pkg_name: &str) -> Result<()> {
-    let content = format!(
-        "#' @keywords internal\n\"_PACKAGE\"\n\n#' @useDynLib {pkg_name}, .registration = TRUE\nNULL\n"
-    );
-    let r_dir = root.join("R");
-    std::fs::create_dir_all(&r_dir)?;
-    let p = r_dir.join(format!("{pkg_name}-package.R"));
-    if !p.exists() {
-        std::fs::write(p, content)?;
-    }
-    Ok(())
-}
-
-fn update_description_for_miniextendr(root: &Path) -> Result<()> {
+/// Merge the miniextendr DESCRIPTION fields into an existing file
+/// (~ `use_miniextendr_description()`).
+fn update_description(root: &Path) -> Result<()> {
     let desc_path = root.join("DESCRIPTION");
-    let content = std::fs::read_to_string(&desc_path)?;
+    let mut content = std::fs::read_to_string(&desc_path)?;
 
-    let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
-    let mut modified = false;
-
-    // Add SystemRequirements if missing
-    if !lines.iter().any(|l| l.starts_with("SystemRequirements:")) {
-        lines.push("SystemRequirements: Rust (>= 1.83), Cargo".into());
-        modified = true;
+    for (field, value) in scaffold::CONFIG_BUILD_FIELDS {
+        content = scaffold::desc_set_field(&content, field, value);
     }
 
-    // Add Config/build/bootstrap if missing
-    if !lines
-        .iter()
-        .any(|l| l.starts_with("Config/build/bootstrap:"))
-    {
-        lines.push("Config/build/bootstrap: TRUE".into());
-        modified = true;
+    // License: fill in when unset or still a usethis placeholder
+    // ("`use_mit_license()`, `use_gpl3_license()` or friends ...").
+    let license = parse_description_field(&content, "License").unwrap_or_default();
+    if license.is_empty() || license.contains("_license()") {
+        content = scaffold::desc_set_field(&content, "License", "MIT + file LICENSE");
     }
 
-    // Add NeedsCompilation if missing
-    if !lines.iter().any(|l| l.starts_with("NeedsCompilation:")) {
-        lines.push("NeedsCompilation: yes".into());
-        modified = true;
+    // SystemRequirements: append the Rust toolchain requirement if absent.
+    let sys_req = parse_description_field(&content, "SystemRequirements").unwrap_or_default();
+    if !sys_req.to_lowercase().contains("rust") {
+        let merged = if sys_req.is_empty() {
+            RUST_SYSTEM_REQUIREMENT.to_string()
+        } else {
+            format!("{sys_req}, {RUST_SYSTEM_REQUIREMENT}")
+        };
+        content = scaffold::desc_set_field(&content, "SystemRequirements", &merged);
     }
 
-    if modified {
-        let mut out = lines.join("\n");
-        if !out.ends_with('\n') {
-            out.push('\n');
-        }
-        std::fs::write(&desc_path, out)?;
-    }
-
+    std::fs::write(&desc_path, content)?;
     Ok(())
+}
+
+/// Copy the default `miniextendr.yml` unless one exists
+/// (~ `use_miniextendr_config()`).
+fn write_miniextendr_yml(root: &Path, quiet: bool) -> Result<()> {
+    let target = root.join("miniextendr.yml");
+    if target.is_file() {
+        if !quiet {
+            eprintln!("miniextendr.yml already exists, skipping");
+        }
+        return Ok(());
+    }
+    scaffold::write_file(
+        &target,
+        scaffold::embedded("templates/miniextendr.yml"),
+        false,
+    )
+}
+
+/// Run autoconf when available and make `configure` executable
+/// (~ `miniextendr_autoconf()`). Failure is a warning, not an error — the
+/// user can install autoconf and rerun `miniextendr workflow autoconf`.
+fn run_autoconf(dir: &Path, quiet: bool) {
+    if !has_program("autoconf") {
+        if !quiet {
+            eprintln!(
+                "autoconf not found; run `miniextendr workflow autoconf` after installing it"
+            );
+        }
+        return;
+    }
+    match run_command("autoconf", &["-v", "-i", "-f"], dir, quiet) {
+        Ok(_) => {
+            let configure = dir.join("configure");
+            #[cfg(unix)]
+            if configure.is_file() {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    std::fs::set_permissions(&configure, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+        Err(e) => {
+            if !quiet {
+                eprintln!("autoconf failed: {e:#}");
+                eprintln!("Run `miniextendr workflow autoconf` manually later");
+            }
+        }
+    }
+}
+
+// endregion
+
+// region: validation helpers
+
+fn package_name_from_path(root: &Path) -> Result<String> {
+    root.file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+        .with_context(|| format!("could not derive a package name from {}", root.display()))
+}
+
+/// Validate an R package name (~ `create_miniextendr_package()`): ASCII
+/// letters, digits, and dots; starts with a letter; does not end with a dot;
+/// at least 2 characters.
+fn validate_package_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let valid = name.len() >= 2
+        && chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '.')
+        && !name.ends_with('.');
+    if !valid {
+        let suggestion: String = name
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '.')
+            .collect();
+        bail!(
+            "\"{name}\" is not a valid R package name.\n\
+             R package names must start with a letter, contain only ASCII letters, digits,\n\
+             and dots, and not end with a dot. Try: \"{suggestion}\" \
+             (or pass --package for monorepos)"
+        );
+    }
+    Ok(())
+}
+
+// endregion
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+    use crate::scaffold::{Dest, EMBEDDED, Render, dest_rel};
+
+    // region: test harness
+
+    /// Fresh scratch directory per test (removed by `Scratch::drop`).
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "miniextendr-cli-init-{}-{}-{tag}",
+                std::process::id(),
+                COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create scratch dir");
+            Scratch(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Independent re-implementation of the substitution used to compute the
+    /// EXPECTED file content from the on-disk template. Deliberately naive so
+    /// a bug in `scaffold::render` cannot cancel itself out in the test.
+    fn naive_substitute(template: &str, data: &[(&str, &str)], triple_only: bool) -> String {
+        let mut out = template.to_string();
+        for (key, value) in data {
+            out = out.replace(&format!("{{{{{{{key}}}}}}}"), value);
+            if !triple_only {
+                out = out.replace(&format!("{{{{{key}}}}}"), value);
+            }
+        }
+        out
+    }
+
+    /// Read a template from the repo checkout (NOT the embedded copy).
+    fn disk_template(rel: &str) -> String {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../minirextendr/inst")
+            .join(rel);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
+
+    fn read(root: &Path, rel: &str) -> String {
+        std::fs::read_to_string(root.join(rel))
+            .unwrap_or_else(|e| panic!("read {rel} from scaffold: {e}"))
+    }
+
+    fn walk_scaffold(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("readable scaffold dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk_scaffold(&path, out);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+
+    // endregion
+
+    /// The #1351 regression test: the standalone scaffold's build-system
+    /// surface must equal the canonical minirextendr templates modulo the
+    /// documented substitutions, for every file in the plan — expected
+    /// content is computed from the templates ON DISK, so both the embedded
+    /// copies and the renderer are checked against the source of truth.
+    #[test]
+    fn package_scaffold_matches_canonical_templates() {
+        let scratch = Scratch::new("pkg-surface");
+        let root = scratch.path().join("my.pkg");
+        let data = TemplateData::new("my.pkg");
+        scaffold_rpkg_fresh(&root, &data).unwrap();
+
+        let subs: Vec<(&str, &str)> = data.pairs().iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        let mut problems = Vec::new();
+        for entry in RPKG_PLAN {
+            let dest = dest_rel(entry, &data).unwrap();
+            let got = read(&root, &dest.to_string_lossy());
+            let template = disk_template(&format!("templates/rpkg/{}", entry.template));
+            let expected = match entry.render {
+                Render::Mustache => naive_substitute(&template, &subs, false),
+                Render::TripleOnly => naive_substitute(&template, &subs, true),
+                Render::Verbatim => template,
+                Render::IgnoreFilter => {
+                    let patterns: Vec<&str> = template
+                        .lines()
+                        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+                        .collect();
+                    patterns.join("\n") + "\n"
+                }
+            };
+            if got != expected {
+                problems.push(format!(
+                    "{}: scaffolded content differs from canonical template {}",
+                    dest.display(),
+                    entry.template
+                ));
+            }
+        }
+        assert!(problems.is_empty(), "{}", problems.join("\n"));
+
+        // config.guess / config.sub come from the bundled scripts.
+        for (src, dest) in scaffold::CONFIG_SCRIPTS {
+            assert_eq!(read(&root, dest), disk_template(src), "{dest}");
+        }
+    }
+
+    /// The obsolete four-mode build model must be gone from every scaffolded
+    /// file: no PREPARE_CRAN / NOT_CRAN / BUILD_CONTEXT, no
+    /// cargo-config.toml.in indirection, and no unresolved placeholders.
+    #[test]
+    fn no_obsolete_build_system_markers() {
+        let scratch = Scratch::new("pkg-markers");
+        let root = scratch.path().join("my.pkg");
+        let data = TemplateData::new("my.pkg");
+        scaffold_rpkg_fresh(&root, &data).unwrap();
+        scaffold::write_file(
+            &root.join("miniextendr.yml"),
+            scaffold::embedded("templates/miniextendr.yml"),
+            false,
+        )
+        .unwrap();
+
+        let mut files = Vec::new();
+        walk_scaffold(&root, &mut files);
+        assert!(files.len() > 20, "scaffold unexpectedly small: {files:?}");
+
+        let mut problems = Vec::new();
+        for file in &files {
+            let name = file.file_name().unwrap().to_string_lossy();
+            if name == "cargo-config.toml.in" {
+                problems.push(format!("{}: retired file scaffolded", file.display()));
+            }
+            let content = std::fs::read_to_string(file).expect("scaffolded files are UTF-8");
+            for marker in ["PREPARE_CRAN", "NOT_CRAN", "BUILD_CONTEXT"] {
+                if content.contains(marker) {
+                    problems.push(format!("{}: contains retired {marker}", file.display()));
+                }
+            }
+            for placeholder in ["{{package", "{{crate_name", "{{rpkg_name", "{{year"] {
+                if content.contains(placeholder) {
+                    problems.push(format!(
+                        "{}: unresolved placeholder {placeholder}",
+                        file.display()
+                    ));
+                }
+            }
+        }
+        assert!(problems.is_empty(), "{}", problems.join("\n"));
+
+        // The canonical two-mode latch and its consumers must be present.
+        let configure_ac = read(&root, "configure.ac");
+        assert!(
+            configure_ac.contains("inst/vendor.tar.xz"),
+            "install-mode latch missing"
+        );
+        assert!(
+            configure_ac.starts_with("AC_INIT([my.pkg]"),
+            "package name not substituted"
+        );
+        let cargo_toml = read(&root, "src/rust/Cargo.toml");
+        assert!(cargo_toml.contains("name = \"my_pkg\""));
+        assert!(
+            cargo_toml.contains("miniextendr-api = { git ="),
+            "source mode must declare the git dependency"
+        );
+        assert!(
+            !cargo_toml.contains("../../vendor/miniextendr-api"),
+            "retired hardcoded vendor path dependency"
+        );
+        let desc = read(&root, "DESCRIPTION");
+        for (field, value) in scaffold::CONFIG_BUILD_FIELDS {
+            assert!(
+                desc.contains(&format!("{field}: {value}")),
+                "{field} missing"
+            );
+        }
+        assert!(desc.contains(&format!("SystemRequirements: {RUST_SYSTEM_REQUIREMENT}")));
+        assert!(read(&root, "NAMESPACE").contains("useDynLib(my.pkg, .registration = TRUE)"));
+        assert!(root.join("vendor").is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_hooks_are_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let scratch = Scratch::new("pkg-exec");
+        let root = scratch.path().join("my.pkg");
+        scaffold_rpkg_fresh(&root, &TemplateData::new("my.pkg")).unwrap();
+        for rel in [
+            "cleanup",
+            "cleanup.win",
+            "cleanup.ucrt",
+            "configure.win",
+            "configure.ucrt",
+            "tools/config.guess",
+            "tools/config.sub",
+        ] {
+            let mode = std::fs::metadata(root.join(rel))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o111,
+                0o111,
+                "{rel} must be executable (mode {mode:o})"
+            );
+        }
+    }
+
+    #[test]
+    fn monorepo_scaffold_matches_canonical_templates() {
+        let scratch = Scratch::new("monorepo");
+        let root = scratch.path().join("proj");
+        init_monorepo(
+            &root.to_string_lossy(),
+            Some("my.proj"),
+            None, // crate_name defaults to my-proj
+            None, // rpkg_name defaults to my.proj
+            true,
+        )
+        .unwrap();
+
+        let data = TemplateData::new("my.proj")
+            .with_crate("my-proj")
+            .with_rpkg("my.proj");
+        let subs: Vec<(&str, &str)> = data.pairs().iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        // Workspace root surface vs disk templates.
+        for entry in MONOREPO_ROOT_PLAN {
+            let dest = dest_rel(entry, &data).unwrap();
+            let got = read(&root, &dest.to_string_lossy());
+            let template = disk_template(&format!("templates/monorepo/{}", entry.template));
+            let expected = match entry.render {
+                Render::TripleOnly => naive_substitute(&template, &subs, true),
+                _ => naive_substitute(&template, &subs, false),
+            };
+            assert_eq!(got, expected, "{} differs from canonical", dest.display());
+        }
+
+        // Embedded R package uses the monorepo/rpkg templates (sibling path
+        // dependency present, monorepo-flavored configure.ac).
+        let rpkg_cargo = read(&root, "my.proj/src/rust/Cargo.toml");
+        assert!(rpkg_cargo.contains("my-proj = { path = \"../../../my-proj\" }"));
+        let configure_ac = read(&root, "my.proj/configure.ac");
+        assert_eq!(
+            configure_ac,
+            naive_substitute(
+                &disk_template("templates/monorepo/rpkg/configure.ac"),
+                &subs,
+                false
+            )
+        );
+        // bump-version.R keeps copy_template() semantics: {{{rpkg_name}}}
+        // substituted, nothing else touched, no placeholder residue.
+        let bump = read(&root, "tools/bump-version.R");
+        assert!(bump.contains("tools/bump-version.R my.proj"));
+        assert!(!bump.contains("{{{"));
+        // create_miniextendr_monorepo() does not write miniextendr.yml.
+        assert!(!root.join("miniextendr.yml").exists());
+    }
+
+    #[test]
+    fn monorepo_rejects_colliding_names() {
+        let scratch = Scratch::new("monorepo-collide");
+        let root = scratch.path().join("proj");
+        let err = init_monorepo(
+            &root.to_string_lossy(),
+            Some("mypkg"),
+            Some("mypkg"),
+            Some("mypkg"),
+            true,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("must be different"), "{err}");
+    }
+
+    #[test]
+    fn init_use_merges_into_existing_package() {
+        let scratch = Scratch::new("use-existing");
+        let root = scratch.path().to_path_buf();
+        std::fs::write(
+            root.join("DESCRIPTION"),
+            "Package: existing.pkg\n\
+             Title: Existing\n\
+             Version: 1.0.0\n\
+             License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a license\n\
+             SystemRequirements: GNU make\n\
+             Encoding: UTF-8\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("NAMESPACE"), "export(existing_fn)\n").unwrap();
+        std::fs::write(root.join(".Rbuildignore"), "^custom$\n").unwrap();
+
+        init_use_rpkg(&root, true).unwrap();
+
+        let desc = read(&root, "DESCRIPTION");
+        assert!(desc.contains("Package: existing.pkg"));
+        assert!(desc.contains("Version: 1.0.0"), "existing fields preserved");
+        for (field, value) in scaffold::CONFIG_BUILD_FIELDS {
+            assert!(desc.contains(&format!("{field}: {value}")), "{field}");
+        }
+        assert!(
+            desc.contains("License: MIT + file LICENSE"),
+            "placeholder replaced"
+        );
+        assert!(
+            desc.contains(&format!(
+                "SystemRequirements: GNU make, {RUST_SYSTEM_REQUIREMENT}"
+            )),
+            "Rust appended to existing SystemRequirements: {desc}"
+        );
+
+        // Existing NAMESPACE untouched; ignore file merged with dedupe.
+        assert_eq!(read(&root, "NAMESPACE"), "export(existing_fn)\n");
+        let rbuildignore = read(&root, ".Rbuildignore");
+        assert!(
+            rbuildignore.starts_with("^custom$\n"),
+            "existing patterns kept"
+        );
+        assert!(rbuildignore.contains("^src/rust/target$"));
+        // Idempotence: rerunning must not duplicate patterns.
+        init_use_rpkg(&root, true).unwrap();
+        let again = read(&root, ".Rbuildignore");
+        assert_eq!(again.matches("^src/rust/target$").count(), 1);
+
+        // Build-system files landed and are canonical.
+        assert!(read(&root, "configure.ac").starts_with("AC_INIT([existing.pkg]"));
+        assert!(root.join("src/rust/lib.rs").is_file());
+        assert!(root.join("tools/lock-shape-check.R").is_file());
+        assert!(root.join("miniextendr.yml").is_file());
+    }
+
+    #[test]
+    fn init_use_detects_monorepo_from_cargo_toml() {
+        let scratch = Scratch::new("use-monorepo");
+        let root = scratch.path().to_path_buf();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"my-core\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+
+        init_use_monorepo(&root, None, true).unwrap();
+
+        // Package name derived from the crate name (dashes -> dots), R
+        // package scaffolded into a sibling subdirectory.
+        let desc = read(&root, "my.core/DESCRIPTION");
+        assert!(desc.contains("Package: my.core"));
+        let cargo = read(&root, "my.core/src/rust/Cargo.toml");
+        assert!(cargo.contains("my-core = { path = \"../../../my-core\" }"));
+        assert!(root.join("miniextendr.yml").is_file());
+    }
+
+    #[test]
+    fn validate_package_name_mirrors_r() {
+        for good in ["my.pkg", "abc", "a2", "A.b.c"] {
+            assert!(validate_package_name(good).is_ok(), "{good}");
+        }
+        for bad in ["a", "1pkg", "my-pkg", "pkg.", "my_pkg", ".pkg"] {
+            assert!(validate_package_name(bad).is_err(), "{bad}");
+        }
+    }
+
+    /// Guard: every plan template resolves inside the embedded manifest for
+    /// both template-type prefixes, and destinations are well-formed.
+    #[test]
+    fn plans_are_consistent_with_manifest() {
+        for (prefix, plan) in [
+            ("templates/rpkg", RPKG_PLAN),
+            ("templates/monorepo/rpkg", RPKG_PLAN),
+            ("templates/monorepo", MONOREPO_ROOT_PLAN),
+        ] {
+            for entry in plan {
+                let rel = format!("{prefix}/{}", entry.template);
+                assert!(
+                    EMBEDDED.iter().any(|(p, _)| *p == rel),
+                    "plan references unembedded template {rel}"
+                );
+                if let Dest::Path(p) = entry.dest {
+                    assert!(!p.starts_with('/'), "absolute dest {p}");
+                }
+            }
+        }
+    }
 }

--- a/miniextendr-cli/src/main.rs
+++ b/miniextendr-cli/src/main.rs
@@ -10,6 +10,7 @@ mod cli;
 mod commands;
 mod output;
 mod project;
+mod scaffold;
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/miniextendr-cli/src/project.rs
+++ b/miniextendr-cli/src/project.rs
@@ -150,7 +150,7 @@ impl ProjectContext {
 /// Parse a single field's value out of DCF-formatted `content` (the format
 /// used by `DESCRIPTION` files), joining continuation lines onto the field
 /// they extend.
-fn parse_description_field(content: &str, field: &str) -> Option<String> {
+pub fn parse_description_field(content: &str, field: &str) -> Option<String> {
     let prefix = format!("{field}:");
     let mut lines = content.lines().peekable();
     while let Some(line) = lines.next() {

--- a/miniextendr-cli/src/scaffold.rs
+++ b/miniextendr-cli/src/scaffold.rs
@@ -1,0 +1,866 @@
+//! Scaffolding engine over the canonical `minirextendr` templates.
+//!
+//! The single scaffold source of truth is `minirextendr/inst/templates/`
+//! (itself derived from `rpkg/` via the template sync pipeline — see the root
+//! `CLAUDE.md`). This module embeds those templates at compile time with
+//! `include_str!`, so `miniextendr init` renders exactly the same build
+//! system as `minirextendr::use_miniextendr()` and can never drift into a
+//! parallel handwritten implementation again (#1351). A template file added
+//! on disk without a matching entry in [`EMBEDDED`] fails the
+//! `embedded_covers_disk` test.
+//!
+//! The substitution contract mirrors the R scaffolder
+//! (`minirextendr/R/utils.R`):
+//!
+//! - [`Render::Mustache`] ~ `use_template()` (whisker): `{{{key}}}` then
+//!   `{{key}}` replacement. Divergence, deliberately stricter: an unresolved
+//!   `{{identifier}}` placeholder is a batched error instead of silently
+//!   rendering as the empty string, so a template that grows a new variable
+//!   fails loudly here. HTML escaping never applies — substituted values are
+//!   package/crate names, which cannot contain `&<>"`.
+//! - [`Render::TripleOnly`] ~ `copy_template()`: literal `{{{key}}}`
+//!   replacement only, double-brace text preserved, no leftover check.
+//! - [`Render::Verbatim`] ~ `fs::file_copy()`.
+//! - [`Render::IgnoreFilter`] ~ `mx_ignore_patterns()`: blank and `#` comment
+//!   lines dropped, patterns written as-is.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+// region: embedded template manifest
+
+/// Embed a file from `minirextendr/inst/` keyed by its path relative to that
+/// directory.
+macro_rules! tpl {
+    ($rel:literal) => {
+        (
+            $rel,
+            include_str!(concat!("../../minirextendr/inst/", $rel)),
+        )
+    };
+}
+
+/// Every file under `minirextendr/inst/templates/` plus the bundled autoconf
+/// helper scripts under `minirextendr/inst/scripts/`, embedded verbatim at
+/// compile time. Keys are paths relative to `minirextendr/inst/`.
+pub const EMBEDDED: &[(&str, &str)] = &[
+    tpl!("scripts/config.guess"),
+    tpl!("scripts/config.sub"),
+    tpl!("templates/README.md"),
+    tpl!("templates/miniextendr.yml"),
+    tpl!("templates/r-release.yml"),
+    // Standalone R package template.
+    tpl!("templates/rpkg/Cargo.toml.tmpl"),
+    tpl!("templates/rpkg/Makevars.in"),
+    tpl!("templates/rpkg/Makevars.win"),
+    tpl!("templates/rpkg/Rbuildignore"),
+    tpl!("templates/rpkg/bootstrap.R"),
+    tpl!("templates/rpkg/build.rs"),
+    tpl!("templates/rpkg/cleanup"),
+    tpl!("templates/rpkg/cleanup.ucrt"),
+    tpl!("templates/rpkg/cleanup.win"),
+    tpl!("templates/rpkg/configure.ac"),
+    tpl!("templates/rpkg/configure.ucrt"),
+    tpl!("templates/rpkg/configure.win"),
+    tpl!("templates/rpkg/gitignore"),
+    tpl!("templates/rpkg/inst_include/mx_abi.h"),
+    tpl!("templates/rpkg/lib.rs"),
+    tpl!("templates/rpkg/package.R"),
+    tpl!("templates/rpkg/r_shim.h"),
+    tpl!("templates/rpkg/stub.c"),
+    tpl!("templates/rpkg/tools/bump-version.R"),
+    tpl!("templates/rpkg/tools/detect-features.R"),
+    tpl!("templates/rpkg/tools/lock-shape-check.R"),
+    tpl!("templates/rpkg/win.def.in"),
+    // Monorepo template: workspace root + core crate.
+    tpl!("templates/monorepo/Cargo.toml.tmpl"),
+    tpl!("templates/monorepo/gitignore"),
+    tpl!("templates/monorepo/my-crate/Cargo.toml.tmpl"),
+    tpl!("templates/monorepo/my-crate/src/lib.rs"),
+    tpl!("templates/monorepo/tools/bump-version.R"),
+    // Monorepo template: embedded R package.
+    tpl!("templates/monorepo/rpkg/Cargo.toml.tmpl"),
+    tpl!("templates/monorepo/rpkg/Makevars.in"),
+    tpl!("templates/monorepo/rpkg/Makevars.win"),
+    tpl!("templates/monorepo/rpkg/Rbuildignore"),
+    tpl!("templates/monorepo/rpkg/bootstrap.R"),
+    tpl!("templates/monorepo/rpkg/build.rs"),
+    tpl!("templates/monorepo/rpkg/cleanup"),
+    tpl!("templates/monorepo/rpkg/cleanup.ucrt"),
+    tpl!("templates/monorepo/rpkg/cleanup.win"),
+    tpl!("templates/monorepo/rpkg/configure.ac"),
+    tpl!("templates/monorepo/rpkg/configure.ucrt"),
+    tpl!("templates/monorepo/rpkg/configure.win"),
+    tpl!("templates/monorepo/rpkg/gitignore"),
+    tpl!("templates/monorepo/rpkg/inst_include/mx_abi.h"),
+    tpl!("templates/monorepo/rpkg/lib.rs"),
+    tpl!("templates/monorepo/rpkg/package.R"),
+    tpl!("templates/monorepo/rpkg/r_shim.h"),
+    tpl!("templates/monorepo/rpkg/stub.c"),
+    tpl!("templates/monorepo/rpkg/tools/detect-features.R"),
+    tpl!("templates/monorepo/rpkg/tools/lock-shape-check.R"),
+    tpl!("templates/monorepo/rpkg/win.def.in"),
+];
+
+/// Look up an embedded file by its path relative to `minirextendr/inst/`.
+///
+/// Panics on a miss: the manifest is a compile-time constant, so a missing
+/// key is a programming error, not a runtime condition.
+pub fn embedded(rel: &str) -> &'static str {
+    EMBEDDED
+        .iter()
+        .find(|(path, _)| *path == rel)
+        .map(|(_, content)| *content)
+        .unwrap_or_else(|| panic!("template not embedded: {rel}"))
+}
+
+// endregion
+
+// region: template data (substitution contract)
+
+/// Convert an R package name to a Rust-safe identifier (dots and hyphens
+/// become underscores). Mirrors `to_rust_name()` in `minirextendr/R/utils.R`.
+pub fn to_rust_name(name: &str) -> String {
+    name.replace(['.', '-'], "_")
+}
+
+/// Substitution variables for template rendering. Mirrors `template_data()`
+/// in `minirextendr/R/utils.R`: `package`, `package_rs`, `Package`,
+/// `features_var`, `year`, plus optional `crate_name`/`crate_name_rs` and
+/// `rpkg_name` for the monorepo template.
+pub struct TemplateData {
+    pub package: String,
+    pub crate_name: Option<String>,
+    pairs: Vec<(&'static str, String)>,
+}
+
+impl TemplateData {
+    pub fn new(package: &str) -> Self {
+        let pairs = vec![
+            ("package", package.to_string()),
+            ("package_rs", to_rust_name(package)),
+            ("Package", title_case(package)),
+            ("features_var", "CARGO_FEATURES".to_string()),
+            ("year", current_year()),
+        ];
+        Self {
+            package: package.to_string(),
+            crate_name: None,
+            pairs,
+        }
+    }
+
+    pub fn with_crate(mut self, crate_name: &str) -> Self {
+        self.pairs.push(("crate_name", crate_name.to_string()));
+        self.pairs.push(("crate_name_rs", to_rust_name(crate_name)));
+        self.crate_name = Some(crate_name.to_string());
+        self
+    }
+
+    pub fn with_rpkg(mut self, rpkg_name: &str) -> Self {
+        self.pairs.push(("rpkg_name", rpkg_name.to_string()));
+        self
+    }
+
+    pub fn pairs(&self) -> &[(&'static str, String)] {
+        &self.pairs
+    }
+}
+
+/// Title-case a package name for the `{{Package}}` variable
+/// (~ `tools::toTitleCase()`): uppercase the first alphabetic character of
+/// each whitespace-separated word. Package names contain no whitespace, so in
+/// practice only the leading character changes. No scaffolded template
+/// consumes `{{Package}}` today (it appears only in the templates README).
+fn title_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut at_word_start = true;
+    for c in name.chars() {
+        if c.is_whitespace() {
+            at_word_start = true;
+            out.push(c);
+        } else if at_word_start && c.is_ascii_alphabetic() {
+            out.push(c.to_ascii_uppercase());
+            at_word_start = false;
+        } else {
+            at_word_start = false;
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Current UTC year, without a date-crate dependency (civil-from-days,
+/// Howard Hinnant's algorithm).
+fn current_year() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    civil_year_from_days(i64::try_from(secs / 86_400).unwrap_or(0)).to_string()
+}
+
+fn civil_year_from_days(days: i64) -> i64 {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    if m <= 2 { y + 1 } else { y }
+}
+
+// endregion
+
+// region: rendering
+
+/// How a template file's content is transformed before writing.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Render {
+    /// `{{{key}}}` then `{{key}}` substitution; unresolved `{{identifier}}`
+    /// placeholders are a (batched) error.
+    Mustache,
+    /// Literal `{{{key}}}` substitution only; `{{...}}` preserved.
+    TripleOnly,
+    /// Byte-for-byte copy.
+    Verbatim,
+    /// Ignore-file prep: drop blank lines and `#` comments.
+    IgnoreFilter,
+}
+
+/// Render `content` according to `render`, substituting from `data`.
+pub fn render(
+    template_rel: &str,
+    content: &str,
+    render: Render,
+    data: &TemplateData,
+) -> Result<String> {
+    match render {
+        Render::Verbatim => Ok(content.to_string()),
+        Render::IgnoreFilter => Ok(ignore_patterns(content).join("\n") + "\n"),
+        Render::TripleOnly => {
+            let mut out = content.to_string();
+            for (key, value) in data.pairs() {
+                out = out.replace(&format!("{{{{{{{key}}}}}}}"), value);
+            }
+            Ok(out)
+        }
+        Render::Mustache => {
+            let mut out = content.to_string();
+            for (key, value) in data.pairs() {
+                out = out.replace(&format!("{{{{{{{key}}}}}}}"), value);
+                out = out.replace(&format!("{{{{{key}}}}}"), value);
+            }
+            let leftovers = find_placeholders(&out);
+            if !leftovers.is_empty() {
+                bail!(
+                    "template {template_rel} has unresolved placeholders: {} \
+                     (the template grew a variable the CLI does not supply — \
+                     update TemplateData in miniextendr-cli/src/scaffold.rs)",
+                    leftovers.join(", ")
+                );
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Ignore-file patterns: non-blank, non-comment lines
+/// (~ `mx_ignore_patterns()` in `minirextendr/R/utils.R`).
+pub fn ignore_patterns(content: &str) -> Vec<&str> {
+    content
+        .lines()
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect()
+}
+
+/// Find `{{identifier}}` / `{{{identifier}}}`-shaped placeholders left in
+/// rendered output. Returns each distinct placeholder once, in order.
+fn find_placeholders(content: &str) -> Vec<String> {
+    let bytes = content.as_bytes();
+    let mut found: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if &bytes[i..i + 2] != b"{{" {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 2;
+        if j < bytes.len() && bytes[j] == b'{' {
+            j += 1;
+        }
+        let ident_start = j;
+        if j < bytes.len() && (bytes[j].is_ascii_alphabetic() || bytes[j] == b'_') {
+            j += 1;
+            while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+                j += 1;
+            }
+            if content[j..].starts_with("}}") {
+                let end = if content[j..].starts_with("}}}") {
+                    j + 3
+                } else {
+                    j + 2
+                };
+                let placeholder = format!("{{{{{}}}}}", &content[ident_start..j]);
+                if !found.contains(&placeholder) {
+                    found.push(placeholder);
+                }
+                i = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    found
+}
+
+// endregion
+
+// region: scaffold plans
+
+/// Destination of a scaffolded file, relative to the scaffold root.
+#[derive(Clone, Copy, Debug)]
+pub enum Dest {
+    /// Fixed relative path.
+    Path(&'static str),
+    /// `R/<package>-package.R`.
+    PackageDoc,
+    /// `<crate_name>/<path>` (monorepo core crate).
+    CratePath(&'static str),
+}
+
+/// One template → destination mapping.
+#[derive(Clone, Copy, Debug)]
+pub struct PlanEntry {
+    /// Template path relative to the template-type directory (the `prefix`
+    /// argument of [`apply_plan`]).
+    pub template: &'static str,
+    pub dest: Dest,
+    pub render: Render,
+    /// Whether the destination gets mode 755 (R build hooks must be
+    /// executable — `R CMD build` warns otherwise).
+    pub exec: bool,
+}
+
+/// The R-package scaffold surface, mirroring `use_miniextendr()`'s standalone
+/// path and `create_rpkg_subdirectory()`'s monorepo path (which write the
+/// same files from `templates/rpkg/` and `templates/monorepo/rpkg/`
+/// respectively). Render modes match the R helpers: `use_template()` entries
+/// are [`Render::Mustache`], `fs::file_copy()` entries are
+/// [`Render::Verbatim`], ignore files are [`Render::IgnoreFilter`].
+pub const RPKG_PLAN: &[PlanEntry] = &[
+    PlanEntry {
+        template: "configure.ac",
+        dest: Dest::Path("configure.ac"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "bootstrap.R",
+        dest: Dest::Path("bootstrap.R"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "cleanup",
+        dest: Dest::Path("cleanup"),
+        render: Render::Mustache,
+        exec: true,
+    },
+    PlanEntry {
+        template: "cleanup.win",
+        dest: Dest::Path("cleanup.win"),
+        render: Render::Mustache,
+        exec: true,
+    },
+    PlanEntry {
+        template: "cleanup.ucrt",
+        dest: Dest::Path("cleanup.ucrt"),
+        render: Render::Mustache,
+        exec: true,
+    },
+    PlanEntry {
+        template: "configure.win",
+        dest: Dest::Path("configure.win"),
+        render: Render::Mustache,
+        exec: true,
+    },
+    PlanEntry {
+        template: "configure.ucrt",
+        dest: Dest::Path("configure.ucrt"),
+        render: Render::Mustache,
+        exec: true,
+    },
+    PlanEntry {
+        template: "Makevars.in",
+        dest: Dest::Path("src/Makevars.in"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "win.def.in",
+        dest: Dest::Path("src/win.def.in"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "stub.c",
+        dest: Dest::Path("src/stub.c"),
+        render: Render::Verbatim,
+        exec: false,
+    },
+    PlanEntry {
+        template: "r_shim.h",
+        dest: Dest::Path("src/r_shim.h"),
+        render: Render::Verbatim,
+        exec: false,
+    },
+    PlanEntry {
+        template: "Cargo.toml.tmpl",
+        dest: Dest::Path("src/rust/Cargo.toml"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "build.rs",
+        dest: Dest::Path("src/rust/build.rs"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "lib.rs",
+        dest: Dest::Path("src/rust/lib.rs"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "inst_include/mx_abi.h",
+        dest: Dest::Path("inst/include/mx_abi.h"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "package.R",
+        dest: Dest::PackageDoc,
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "tools/lock-shape-check.R",
+        dest: Dest::Path("tools/lock-shape-check.R"),
+        render: Render::Verbatim,
+        exec: false,
+    },
+    PlanEntry {
+        template: "Rbuildignore",
+        dest: Dest::Path(".Rbuildignore"),
+        render: Render::IgnoreFilter,
+        exec: false,
+    },
+    PlanEntry {
+        template: "gitignore",
+        dest: Dest::Path(".gitignore"),
+        render: Render::IgnoreFilter,
+        exec: false,
+    },
+];
+
+/// The monorepo workspace-root surface, mirroring
+/// `create_miniextendr_monorepo()`. Note the root `.gitignore` is a full
+/// mustache render (it substitutes `{{rpkg_name}}`), unlike the rpkg ignore
+/// files, and `tools/bump-version.R` uses `copy_template()` semantics.
+pub const MONOREPO_ROOT_PLAN: &[PlanEntry] = &[
+    PlanEntry {
+        template: "Cargo.toml.tmpl",
+        dest: Dest::Path("Cargo.toml"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "gitignore",
+        dest: Dest::Path(".gitignore"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "tools/bump-version.R",
+        dest: Dest::Path("tools/bump-version.R"),
+        render: Render::TripleOnly,
+        exec: false,
+    },
+    PlanEntry {
+        template: "my-crate/Cargo.toml.tmpl",
+        dest: Dest::CratePath("Cargo.toml"),
+        render: Render::Mustache,
+        exec: false,
+    },
+    PlanEntry {
+        template: "my-crate/src/lib.rs",
+        dest: Dest::CratePath("src/lib.rs"),
+        render: Render::Mustache,
+        exec: false,
+    },
+];
+
+/// Bundled autoconf helper scripts (`AC_CONFIG_AUX_DIR([tools])`), copied
+/// 755 into `tools/` (~ `copy_config_scripts()`).
+pub const CONFIG_SCRIPTS: &[(&str, &str)] = &[
+    ("scripts/config.guess", "tools/config.guess"),
+    ("scripts/config.sub", "tools/config.sub"),
+];
+
+// endregion
+
+// region: writing
+
+/// Resolve a plan entry's destination relative to the scaffold root.
+pub fn dest_rel(entry: &PlanEntry, data: &TemplateData) -> Result<PathBuf> {
+    Ok(match entry.dest {
+        Dest::Path(p) => PathBuf::from(p),
+        Dest::PackageDoc => PathBuf::from(format!("R/{}-package.R", data.package)),
+        Dest::CratePath(p) => {
+            let crate_name = data
+                .crate_name
+                .as_deref()
+                .context("plan entry needs a crate_name but none was set")?;
+            Path::new(crate_name).join(p)
+        }
+    })
+}
+
+/// Apply a scaffold plan rooted at `root`, reading templates from
+/// `prefix` (e.g. `"templates/rpkg"` or `"templates/monorepo/rpkg"`).
+///
+/// `fresh` selects ignore-file semantics: a fresh scaffold writes the
+/// filtered patterns outright (byte-identical to the R fresh-file path, see
+/// minirextendr #1151); over an existing package (`init use`) the patterns
+/// are appended with dedupe, mirroring `usethis::use_build_ignore()` /
+/// `use_git_ignore()`. Every other file is overwritten — the template is the
+/// source of truth, matching `use_template()`'s delete-first behavior.
+pub fn apply_plan(
+    root: &Path,
+    prefix: &str,
+    plan: &[PlanEntry],
+    data: &TemplateData,
+    fresh: bool,
+) -> Result<()> {
+    for entry in plan {
+        let template_rel = format!("{prefix}/{}", entry.template);
+        let content = embedded(&template_rel);
+        let dest = root.join(dest_rel(entry, data)?);
+
+        if entry.render == Render::IgnoreFilter && !fresh && dest.is_file() {
+            let existing = std::fs::read_to_string(&dest)
+                .with_context(|| format!("failed to read {}", dest.display()))?;
+            let merged = merge_ignore_lines(&existing, &ignore_patterns(content));
+            write_file(&dest, &merged, entry.exec)?;
+            continue;
+        }
+
+        let rendered = render(&template_rel, content, entry.render, data)?;
+        write_file(&dest, &rendered, entry.exec)?;
+    }
+    Ok(())
+}
+
+/// Copy the bundled `config.guess` / `config.sub` scripts into `tools/`.
+pub fn write_config_scripts(root: &Path) -> Result<()> {
+    for (src, dest) in CONFIG_SCRIPTS {
+        write_file(&root.join(dest), embedded(src), true)?;
+    }
+    Ok(())
+}
+
+/// Append `patterns` not already present in `existing` (exact line match),
+/// preserving existing content.
+fn merge_ignore_lines(existing: &str, patterns: &[&str]) -> String {
+    let existing_lines: Vec<&str> = existing.lines().collect();
+    let mut out = existing.trim_end_matches('\n').to_string();
+    for pattern in patterns {
+        if !existing_lines.contains(pattern) {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(pattern);
+        }
+    }
+    out.push('\n');
+    out
+}
+
+/// Write `content` to `path`, creating parent directories; set mode 755 when
+/// `exec` (unix).
+pub fn write_file(path: &Path, content: &str, exec: bool) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
+    #[cfg(unix)]
+    if exec {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed to chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+// endregion
+
+// region: shared scaffold content (mirrors of minirextendr R literals)
+
+/// `Config/build/*` DESCRIPTION fields required by miniextendr packages
+/// (~ `MX_CONFIG_BUILD_FIELDS` in `minirextendr/R/utils.R`).
+pub const CONFIG_BUILD_FIELDS: &[(&str, &str)] = &[
+    ("Config/build/bootstrap", "TRUE"),
+    ("Config/build/never-clean", "true"),
+    ("Config/build/extra-sources", "src/rust/Cargo.lock"),
+];
+
+/// `SystemRequirements` entry for the Rust toolchain (shared between the
+/// fresh DESCRIPTION and the `init use` merge path).
+pub const RUST_SYSTEM_REQUIREMENT: &str = "Rust (>= 1.85)";
+
+/// Canonical fresh DESCRIPTION (~ the hand-written literal in
+/// `create_rpkg_subdirectory()`, `minirextendr/R/create.R`).
+pub fn description_content(package: &str) -> String {
+    let config_build = CONFIG_BUILD_FIELDS
+        .iter()
+        .map(|(name, value)| format!("{name}: {value}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Package: {package}\n\
+         Title: What the Package Does (One Line, Title Case)\n\
+         Version: 0.0.0.9000\n\
+         Authors@R:\n    \
+         person(\"First\", \"Last\", , \"first.last@example.com\", role = c(\"aut\", \"cre\"))\n\
+         Description: What the package does (one paragraph).\n\
+         License: MIT + file LICENSE\n\
+         Encoding: UTF-8\n\
+         SystemRequirements: {RUST_SYSTEM_REQUIREMENT}\n\
+         {config_build}\n\
+         Config/roxygen2/markdown: TRUE\n\
+         Config/roxygen2/version: 8.0.0\n"
+    )
+}
+
+/// Minimal LICENSE body for `License: MIT + file LICENSE`
+/// (~ `mx_license_content()`).
+pub fn license_content(package: &str) -> String {
+    format!(
+        "YEAR: {}\nCOPYRIGHT HOLDER: {package} authors\n",
+        current_year()
+    )
+}
+
+/// Minimal roxygen2-managed NAMESPACE (~ `mx_minimal_namespace()`): carries
+/// the roxygen2 header so a later `devtools::document()` overwrites it
+/// cleanly, plus `useDynLib()` so the fresh shared library loads.
+pub fn minimal_namespace(package: &str) -> String {
+    format!(
+        "# Generated by roxygen2: do not edit by hand\n\nuseDynLib({package}, .registration = TRUE)\n"
+    )
+}
+
+// endregion
+
+// region: DESCRIPTION editing (init use)
+
+/// Set a single-line field in DCF `content`, replacing an existing field (and
+/// its continuation lines) or appending (~ `mx_desc_set()`).
+pub fn desc_set_field(content: &str, field: &str, value: &str) -> String {
+    let prefix = format!("{field}:");
+    let lines: Vec<&str> = content.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 1);
+    let new_line = format!("{field}: {value}");
+    let mut replaced = false;
+    let mut i = 0;
+    while i < lines.len() {
+        if !replaced && lines[i].starts_with(&prefix) {
+            out.push(new_line.clone());
+            i += 1;
+            // Skip continuation lines of the replaced field.
+            while i < lines.len() && lines[i].starts_with(|c: char| c.is_whitespace()) {
+                i += 1;
+            }
+            replaced = true;
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+    if !replaced {
+        out.push(new_line);
+    }
+    out.join("\n") + "\n"
+}
+
+// endregion
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `minirextendr/inst/` in the repo checkout — the disk source the
+    /// embedded manifest must mirror.
+    fn inst_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../minirextendr/inst")
+    }
+
+    fn walk_files(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("readable template dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk_files(&path, out);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Drift guard: every file under `minirextendr/inst/templates/` and
+    /// `minirextendr/inst/scripts/` must be embedded with identical content,
+    /// and every embedded key must still exist on disk. A template added,
+    /// renamed, or removed without updating [`EMBEDDED`] fails here.
+    #[test]
+    fn embedded_covers_disk() {
+        let inst = inst_root();
+        let mut disk_files = Vec::new();
+        walk_files(&inst.join("templates"), &mut disk_files);
+        walk_files(&inst.join("scripts"), &mut disk_files);
+
+        let mut problems = Vec::new();
+        let mut seen = Vec::new();
+        for path in &disk_files {
+            let rel = path
+                .strip_prefix(&inst)
+                .expect("under inst root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            seen.push(rel.clone());
+            match EMBEDDED.iter().find(|(p, _)| *p == rel) {
+                None => problems.push(format!(
+                    "{rel}: on disk but not embedded — add tpl!(\"{rel}\") to EMBEDDED"
+                )),
+                Some((_, embedded_content)) => {
+                    let disk_content = std::fs::read_to_string(path).expect("readable template");
+                    if disk_content != *embedded_content {
+                        problems.push(format!(
+                            "{rel}: embedded copy differs from disk (stale build?)"
+                        ));
+                    }
+                }
+            }
+        }
+        for (rel, _) in EMBEDDED {
+            if !seen.contains(&(*rel).to_string()) {
+                problems.push(format!(
+                    "{rel}: embedded but missing on disk — template removed or renamed?"
+                ));
+            }
+        }
+        assert!(problems.is_empty(), "{}", problems.join("\n"));
+    }
+
+    #[test]
+    fn mustache_substitutes_triple_then_double() {
+        let data = TemplateData::new("my.pkg").with_rpkg("rp");
+        let out = render(
+            "t",
+            "x {{{rpkg_name}}} y {{package}} z {{package_rs}}",
+            Render::Mustache,
+            &data,
+        )
+        .unwrap();
+        assert_eq!(out, "x rp y my.pkg z my_pkg");
+    }
+
+    #[test]
+    fn mustache_rejects_unknown_placeholders_batched() {
+        let data = TemplateData::new("p");
+        let err = render(
+            "t",
+            "{{unknown_a}} and {{unknown_b}} and {{unknown_a}}",
+            Render::Mustache,
+            &data,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("{{unknown_a}}"), "{err}");
+        assert!(err.contains("{{unknown_b}}"), "{err}");
+    }
+
+    #[test]
+    fn mustache_ignores_non_placeholder_braces() {
+        let data = TemplateData::new("p");
+        // Rust format strings, shell ${...}, R code — none are placeholders.
+        let content = "format!(\"Hello, {}!\", name); ${srcdir}; if (x) {{ }}";
+        assert_eq!(
+            render("t", content, Render::Mustache, &data).unwrap(),
+            content
+        );
+    }
+
+    #[test]
+    fn triple_only_preserves_double_braces() {
+        let data = TemplateData::new("p").with_rpkg("rp");
+        let out = render(
+            "t",
+            "{{{rpkg_name}}} keeps {{rpkg_name}}",
+            Render::TripleOnly,
+            &data,
+        )
+        .unwrap();
+        assert_eq!(out, "rp keeps {{rpkg_name}}");
+    }
+
+    #[test]
+    fn ignore_filter_drops_blanks_and_comments() {
+        let data = TemplateData::new("p");
+        let out = render(
+            "t",
+            "# comment\n\npattern1\npattern2\n",
+            Render::IgnoreFilter,
+            &data,
+        )
+        .unwrap();
+        assert_eq!(out, "pattern1\npattern2\n");
+    }
+
+    #[test]
+    fn merge_ignore_appends_missing_only() {
+        let merged = merge_ignore_lines("existing\npattern1\n", &["pattern1", "pattern2"]);
+        assert_eq!(merged, "existing\npattern1\npattern2\n");
+    }
+
+    #[test]
+    fn desc_set_field_replaces_with_continuations() {
+        let content = "Package: p\nAuthors@R:\n    person(\"A\")\nLicense: old\n";
+        let out = desc_set_field(content, "License", "MIT + file LICENSE");
+        assert_eq!(
+            out,
+            "Package: p\nAuthors@R:\n    person(\"A\")\nLicense: MIT + file LICENSE\n"
+        );
+        let out = desc_set_field(&out, "NeedsCompilation", "yes");
+        assert!(out.ends_with("NeedsCompilation: yes\n"));
+        // Replacing a field with continuation lines drops the continuation.
+        let out = desc_set_field(content, "Authors@R", "person(\"B\")");
+        assert!(out.contains("Authors@R: person(\"B\")\n"));
+        assert!(!out.contains("person(\"A\")"));
+    }
+
+    #[test]
+    fn year_is_plausible() {
+        let year: i64 = current_year().parse().unwrap();
+        assert!((2026..2200).contains(&year), "year = {year}");
+    }
+
+    #[test]
+    fn to_rust_name_replaces_dots_and_hyphens() {
+        assert_eq!(to_rust_name("my.pkg-x"), "my_pkg_x");
+    }
+}

--- a/miniextendr-cli/tests/smoke.rs
+++ b/miniextendr-cli/tests/smoke.rs
@@ -1,0 +1,139 @@
+//! Smoke floor for the `miniextendr` binary: every subcommand's `--help`
+//! exits 0, error paths produce a diagnostic (not a panic), and `init
+//! package` scaffolds the canonical build system end to end.
+//!
+//! Runs the default-features binary via `CARGO_BIN_EXE_miniextendr`, so the
+//! assertions here match what `cargo test --workspace --locked` builds in CI
+//! (the `dev` feature and its subcommands are intentionally not exercised).
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_miniextendr"))
+}
+
+fn run(args: &[&str]) -> Output {
+    bin().args(args).output().expect("binary runs")
+}
+
+/// Default-features subcommands, mirroring `Command` in `src/cli.rs`.
+const SUBCOMMANDS: &[&str] = &[
+    "init",
+    "workflow",
+    "status",
+    "cargo",
+    "vendor",
+    "feature",
+    "render",
+    "rust",
+    "config",
+    "lint",
+    "clean",
+    "completions",
+];
+
+#[test]
+fn help_exits_zero_and_lists_subcommands() {
+    let out = run(&["--help"]);
+    assert!(out.status.success(), "--help failed: {out:?}");
+    let text = String::from_utf8_lossy(&out.stdout);
+    for sub in SUBCOMMANDS {
+        assert!(text.contains(sub), "--help does not list `{sub}`");
+    }
+}
+
+#[test]
+fn every_subcommand_help_exits_zero() {
+    for sub in SUBCOMMANDS {
+        let out = run(&[sub, "--help"]);
+        assert!(out.status.success(), "`{sub} --help` failed: {out:?}");
+    }
+}
+
+#[test]
+fn missing_path_is_a_clean_diagnostic() {
+    let out = run(&["--path", "/nonexistent-miniextendr-test", "status", "has"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Error") && !stderr.contains("panicked"),
+        "expected clean diagnostic, got: {stderr}"
+    );
+}
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new() -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("miniextendr-cli-smoke-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        Scratch(dir)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// End-to-end (minus configure/compile): `init package` through the real
+/// binary produces the canonical two-mode build system.
+#[test]
+fn init_package_scaffolds_canonical_build_system() {
+    let scratch = Scratch::new();
+    let pkg_dir = scratch.0.join("smoke.pkg");
+    let out = run(&["init", "package", &pkg_dir.to_string_lossy()]);
+    assert!(out.status.success(), "init package failed: {out:?}");
+
+    let read = |rel: &str| -> String {
+        std::fs::read_to_string(pkg_dir.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+    };
+
+    // The canonical install-mode latch, not the retired four-mode model.
+    let configure_ac = read("configure.ac");
+    assert!(configure_ac.contains("inst/vendor.tar.xz"));
+    for retired in ["PREPARE_CRAN", "NOT_CRAN", "BUILD_CONTEXT"] {
+        assert!(
+            !configure_ac.contains(retired),
+            "configure.ac contains {retired}"
+        );
+    }
+    assert!(
+        !pkg_dir.join("src/rust/cargo-config.toml.in").exists(),
+        "retired cargo-config.toml.in scaffolded"
+    );
+
+    // Build-system surface present.
+    for rel in [
+        "DESCRIPTION",
+        "NAMESPACE",
+        "LICENSE",
+        "bootstrap.R",
+        "cleanup",
+        "configure.win",
+        "src/Makevars.in",
+        "src/win.def.in",
+        "src/stub.c",
+        "src/r_shim.h",
+        "src/rust/Cargo.toml",
+        "src/rust/lib.rs",
+        "src/rust/build.rs",
+        "inst/include/mx_abi.h",
+        "tools/config.guess",
+        "tools/lock-shape-check.R",
+        ".Rbuildignore",
+        ".gitignore",
+        "miniextendr.yml",
+        "R/smoke.pkg-package.R",
+    ] {
+        assert!(pkg_dir.join(rel).is_file(), "missing {rel}");
+    }
+
+    // Re-running against the same directory refuses politely.
+    let again = run(&["init", "package", &pkg_dir.to_string_lossy()]);
+    assert!(!again.status.success());
+}

--- a/rust-llm-docs/generated/miniextendr-cli-impl-inventory.md
+++ b/rust-llm-docs/generated/miniextendr-cli-impl-inventory.md
@@ -2,37 +2,42 @@
 
 Source: `target/doc/miniextendr.json`
 
-Traits with impls: 26
+Traits with impls: 31
 
 ## Summary (impl count per trait)
 
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
-| `UnwindSafe` | 17 | 0 |
-| `Sync` | 17 | 0 |
-| `UnsafeUnpin` | 17 | 0 |
-| `Any` | 17 | 0 |
-| `BorrowMut` | 17 | 0 |
-| `RefUnwindSafe` | 17 | 0 |
-| `Send` | 17 | 0 |
-| `From` | 17 | 0 |
-| `Freeze` | 17 | 0 |
-| `TryInto` | 17 | 0 |
-| `Unpin` | 17 | 0 |
-| `Into` | 17 | 0 |
-| `Borrow` | 17 | 0 |
-| `TryFrom` | 17 | 0 |
+| `UnwindSafe` | 21 | 0 |
+| `Sync` | 21 | 0 |
+| `UnsafeUnpin` | 21 | 0 |
+| `Any` | 21 | 0 |
+| `BorrowMut` | 21 | 0 |
+| `RefUnwindSafe` | 21 | 0 |
+| `Send` | 21 | 0 |
+| `Freeze` | 21 | 0 |
+| `Borrow` | 21 | 0 |
+| `Into` | 21 | 0 |
+| `TryInto` | 21 | 0 |
+| `Unpin` | 21 | 0 |
+| `TryFrom` | 21 | 0 |
+| `From` | 21 | 0 |
 | `FromArgMatches` | 14 | 14 |
 | `Subcommand` | 12 | 12 |
-| `ToOwned` | 3 | 0 |
-| `CloneToUninit` | 3 | 0 |
-| `Clone` | 3 | 3 |
+| `ToOwned` | 6 | 0 |
+| `CloneToUninit` | 6 | 0 |
+| `Clone` | 6 | 6 |
+| `Debug` | 5 | 5 |
+| `Copy` | 3 | 3 |
 | `Serialize` | 2 | 2 |
+| `Equivalent` | 2 | 0 |
 | `Display` | 2 | 2 |
 | `ToString` | 2 | 0 |
-| `Debug` | 2 | 2 |
 | `Args` | 2 | 2 |
 | `CommandFactory` | 1 | 1 |
+| `StructuralPartialEq` | 1 | 1 |
+| `Eq` | 1 | 1 |
+| `PartialEq` | 1 | 1 |
 | `Parser` | 1 | 1 |
 
 ## `FromArgMatches` — 14 impls
@@ -40,44 +45,65 @@ Traits with impls: 26
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `InitCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:117 |
-| `WorkflowCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:164 |
-| `StatusCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:222 |
-| `CargoBuildOpts` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:236 |
-| `CargoCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:258 |
+| `WorkflowCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:169 |
+| `StatusCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:227 |
+| `CargoBuildOpts` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:241 |
+| `CargoCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:263 |
 | `Command` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:28 |
 | `Cli` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:4 |
-| `VendorCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:422 |
-| `FeatureCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:472 |
-| `FeatureDetectCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:493 |
-| `FeatureRuleCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:501 |
-| `RenderCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:528 |
-| `RustCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:549 |
-| `ConfigCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:568 |
+| `VendorCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:427 |
+| `FeatureCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:477 |
+| `FeatureDetectCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:498 |
+| `FeatureRuleCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:506 |
+| `RenderCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:533 |
+| `RustCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:554 |
+| `ConfigCmd` | `` | concrete | 4 | miniextendr-cli/src/cli.rs:573 |
 
 ## `Subcommand` — 12 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `InitCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:117 |
-| `WorkflowCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:164 |
-| `StatusCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:222 |
-| `CargoCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:258 |
+| `WorkflowCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:169 |
+| `StatusCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:227 |
+| `CargoCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:263 |
 | `Command` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:28 |
-| `VendorCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:422 |
-| `FeatureCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:472 |
-| `FeatureDetectCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:493 |
-| `FeatureRuleCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:501 |
-| `RenderCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:528 |
-| `RustCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:549 |
-| `ConfigCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:568 |
+| `VendorCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:427 |
+| `FeatureCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:477 |
+| `FeatureDetectCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:498 |
+| `FeatureRuleCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:506 |
+| `RenderCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:533 |
+| `RustCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:554 |
+| `ConfigCmd` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:573 |
 
-## `Clone` — 3 impls
+## `Clone` — 6 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `CargoBuildOpts` | `` | concrete | 1 | miniextendr-cli/src/cli.rs:236 |
+| `CargoBuildOpts` | `` | concrete | 1 | miniextendr-cli/src/cli.rs:241 |
 | `Config` | `` | concrete | 1 | miniextendr-cli/src/commands/config.rs:11 |
 | `ProjectContext` | `` | concrete | 1 | miniextendr-cli/src/project.rs:62 |
+| `Render` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:221 |
+| `Dest` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:325 |
+| `PlanEntry` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:336 |
+
+## `Debug` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `CargoBuildOpts` | `` | concrete | 1 | miniextendr-cli/src/cli.rs:241 |
+| `ProjectContext` | `` | concrete | 1 | miniextendr-cli/src/project.rs:62 |
+| `Render` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:221 |
+| `Dest` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:325 |
+| `PlanEntry` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:336 |
+
+## `Copy` — 3 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Render` | `` | concrete | 0 | miniextendr-cli/src/scaffold.rs:221 |
+| `Dest` | `` | concrete | 0 | miniextendr-cli/src/scaffold.rs:325 |
+| `PlanEntry` | `` | concrete | 0 | miniextendr-cli/src/scaffold.rs:336 |
 
 ## `Serialize` — 2 impls
 
@@ -93,18 +119,11 @@ Traits with impls: 26
 | `Config` | `` | concrete | 1 | miniextendr-cli/src/commands/config.rs:21 |
 | `HasResult` | `` | concrete | 1 | miniextendr-cli/src/commands/status.rs:18 |
 
-## `Debug` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `CargoBuildOpts` | `` | concrete | 1 | miniextendr-cli/src/cli.rs:236 |
-| `ProjectContext` | `` | concrete | 1 | miniextendr-cli/src/project.rs:62 |
-
 ## `Args` — 2 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `CargoBuildOpts` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:236 |
+| `CargoBuildOpts` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:241 |
 | `Cli` | `` | concrete | 3 | miniextendr-cli/src/cli.rs:4 |
 
 ## `CommandFactory` — 1 impls
@@ -112,6 +131,24 @@ Traits with impls: 26
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `Cli` | `` | concrete | 2 | miniextendr-cli/src/cli.rs:4 |
+
+## `StructuralPartialEq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Render` | `` | concrete | 0 | miniextendr-cli/src/scaffold.rs:221 |
+
+## `Eq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Render` | `` | concrete | 0 | miniextendr-cli/src/scaffold.rs:221 |
+
+## `PartialEq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Render` | `` | concrete | 1 | miniextendr-cli/src/scaffold.rs:221 |
 
 ## `Parser` — 1 impls
 

--- a/rust-llm-docs/generated/miniextendr-cli.md
+++ b/rust-llm-docs/generated/miniextendr-cli.md
@@ -27,6 +27,17 @@ end-user packages in the `minirextendr` R package.
 
 `pub mod init;`
 
+`miniextendr init` — scaffold packages from the canonical minirextendr
+templates.
+
+Every file comes from the embedded copy of `minirextendr/inst/templates/`
+(see [`crate::scaffold`]), so a CLI-generated package uses exactly the
+same build system as `minirextendr::create_miniextendr_package()` /
+`create_miniextendr_monorepo()` / `use_miniextendr()`: the two-mode
+install latch keyed on `inst/vendor.tar.xz` presence, configure-written
+`.cargo/config.toml`, wrapper + wasm-registry generation, and no `just`
+requirement (#1351).
+
 ### `commands::lint`
 
 `pub mod lint;`
@@ -170,6 +181,65 @@ fn require_configure_ac(self: &Self) -> Result<&Path>
 
 Returns the configure.ac path, or an error with guidance.
 
+### `scaffold::PlanEntry`
+
+```rust
+pub struct PlanEntry
+```
+
+One template → destination mapping.
+
+**Fields:**
+
+- `template`: `&'static str`
+  - Template path relative to the template-type directory (the `prefix`
+- `dest`: `Dest`
+- `render`: `Render`
+- `exec`: `bool`
+  - Whether the destination gets mode 755 (R build hooks must be
+
+### `scaffold::TemplateData`
+
+```rust
+pub struct TemplateData
+```
+
+Substitution variables for template rendering. Mirrors `template_data()`
+in `minirextendr/R/utils.R`: `package`, `package_rs`, `Package`,
+`features_var`, `year`, plus optional `crate_name`/`crate_name_rs` and
+`rpkg_name` for the monorepo template.
+
+**Fields:**
+
+- `package`: `String`
+- `crate_name`: `Option<String>`
+
+**Inherent associated items:**
+
+#### `new`
+
+```rust
+fn new(package: &str) -> Self
+```
+
+#### `pairs`
+
+```rust
+fn pairs(self: &Self) -> &[(&'static str, String)]
+```
+
+#### `with_crate`
+
+```rust
+fn with_crate(self: Self, crate_name: &str) -> Self
+```
+
+#### `with_rpkg`
+
+```rust
+fn with_rpkg(self: Self, rpkg_name: &str) -> Self
+```
+
 ---
 
 ## Enums
@@ -310,9 +380,9 @@ pub enum InitCmd
 
 **Variants:**
 
-- `Package { path: String }`
+- `Package { dest: String }`
   - Create a new R package with miniextendr.
-- `Monorepo { path: String, package: Option<String>, crate_name: Option<String>, rpkg_name: Option<String>, local_path: Option<String>, miniextendr_version: String }`
+- `Monorepo { dest: String, package: Option<String>, crate_name: Option<String>, rpkg_name: Option<String>, local_path: Option<String>, miniextendr_version: String }`
   - Create a Rust workspace with embedded R package.
 - `Use { template_type: String, rpkg_name: Option<String>, miniextendr_version: String, local_path: Option<String> }`
   - Add miniextendr scaffolding to an existing project.
@@ -431,6 +501,42 @@ pub enum WorkflowCmd
   - Sync project: autoconf + configure + document.
 - `DevLink`
   - Link package for development (devtools::load_all).
+
+### `scaffold::Dest`
+
+```rust
+pub enum Dest
+```
+
+Destination of a scaffolded file, relative to the scaffold root.
+
+**Variants:**
+
+- `Path(&'static str)`
+  - Fixed relative path.
+- `PackageDoc`
+  - `R/<package>-package.R`.
+- `CratePath(&'static str)`
+  - `<crate_name>/<path>` (monorepo core crate).
+
+### `scaffold::Render`
+
+```rust
+pub enum Render
+```
+
+How a template file's content is transformed before writing.
+
+**Variants:**
+
+- `Mustache`
+  - `{{{key}}}` then `{{key}}` substitution; unresolved `{{identifier}}`
+- `TripleOnly`
+  - Literal `{{{key}}}` substitution only; `{{...}}` preserved.
+- `Verbatim`
+  - Byte-for-byte copy.
+- `IgnoreFilter`
+  - Ignore-file prep: drop blank lines and `#` comments.
 
 ---
 
@@ -598,6 +704,131 @@ Tries `git rev-parse --show-toplevel` first (fast, accurate when in a git repo),
 then falls back to walking up to 3 parent directories looking for a `Cargo.toml`
 with `[workspace]`.
 
+### `project::parse_description_field`
+
+```rust
+fn parse_description_field(content: &str, field: &str) -> Option<String>
+```
+
+Parse a single field's value out of DCF-formatted `content` (the format
+used by `DESCRIPTION` files), joining continuation lines onto the field
+they extend.
+
+### `scaffold::apply_plan`
+
+```rust
+fn apply_plan(root: &std::path::Path, prefix: &str, plan: &[PlanEntry], data: &TemplateData, fresh: bool) -> anyhow::Result<()>
+```
+
+Apply a scaffold plan rooted at `root`, reading templates from
+`prefix` (e.g. `"templates/rpkg"` or `"templates/monorepo/rpkg"`).
+
+`fresh` selects ignore-file semantics: a fresh scaffold writes the
+filtered patterns outright (byte-identical to the R fresh-file path, see
+minirextendr #1151); over an existing package (`init use`) the patterns
+are appended with dedupe, mirroring `usethis::use_build_ignore()` /
+`use_git_ignore()`. Every other file is overwritten — the template is the
+source of truth, matching `use_template()`'s delete-first behavior.
+
+### `scaffold::desc_set_field`
+
+```rust
+fn desc_set_field(content: &str, field: &str, value: &str) -> String
+```
+
+Set a single-line field in DCF `content`, replacing an existing field (and
+its continuation lines) or appending (~ `mx_desc_set()`).
+
+### `scaffold::description_content`
+
+```rust
+fn description_content(package: &str) -> String
+```
+
+Canonical fresh DESCRIPTION (~ the hand-written literal in
+`create_rpkg_subdirectory()`, `minirextendr/R/create.R`).
+
+### `scaffold::dest_rel`
+
+```rust
+fn dest_rel(entry: &PlanEntry, data: &TemplateData) -> anyhow::Result<std::path::PathBuf>
+```
+
+Resolve a plan entry's destination relative to the scaffold root.
+
+### `scaffold::embedded`
+
+```rust
+fn embedded(rel: &str) -> &'static str
+```
+
+Look up an embedded file by its path relative to `minirextendr/inst/`.
+
+Panics on a miss: the manifest is a compile-time constant, so a missing
+key is a programming error, not a runtime condition.
+
+### `scaffold::ignore_patterns`
+
+```rust
+fn ignore_patterns(content: &str) -> Vec<&str>
+```
+
+Ignore-file patterns: non-blank, non-comment lines
+(~ `mx_ignore_patterns()` in `minirextendr/R/utils.R`).
+
+### `scaffold::license_content`
+
+```rust
+fn license_content(package: &str) -> String
+```
+
+Minimal LICENSE body for `License: MIT + file LICENSE`
+(~ `mx_license_content()`).
+
+### `scaffold::minimal_namespace`
+
+```rust
+fn minimal_namespace(package: &str) -> String
+```
+
+Minimal roxygen2-managed NAMESPACE (~ `mx_minimal_namespace()`): carries
+the roxygen2 header so a later `devtools::document()` overwrites it
+cleanly, plus `useDynLib()` so the fresh shared library loads.
+
+### `scaffold::render`
+
+```rust
+fn render(template_rel: &str, content: &str, render: Render, data: &TemplateData) -> anyhow::Result<String>
+```
+
+Render `content` according to `render`, substituting from `data`.
+
+### `scaffold::to_rust_name`
+
+```rust
+fn to_rust_name(name: &str) -> String
+```
+
+Convert an R package name to a Rust-safe identifier (dots and hyphens
+become underscores). Mirrors `to_rust_name()` in `minirextendr/R/utils.R`.
+
+### `scaffold::write_config_scripts`
+
+```rust
+fn write_config_scripts(root: &std::path::Path) -> anyhow::Result<()>
+```
+
+Copy the bundled `config.guess` / `config.sub` scripts into `tools/`.
+
+### `scaffold::write_file`
+
+```rust
+fn write_file(path: &std::path::Path, content: &str, exec: bool) -> anyhow::Result<()>
+```
+
+Write `content` to `path`, creating parent directories; set mode 755 when
+`exec` (unix).
+
 ---
 
 ## Constants
@@ -609,3 +840,64 @@ pub const MINIEXTENDR_CRATES: &[&str] = _;
 ```
 
 Miniextendr workspace crate names — the crates that get vendored/synced.
+
+### `scaffold::CONFIG_BUILD_FIELDS`
+
+```rust
+pub const CONFIG_BUILD_FIELDS: &[(&str, &str)] = _;
+```
+
+`Config/build/*` DESCRIPTION fields required by miniextendr packages
+(~ `MX_CONFIG_BUILD_FIELDS` in `minirextendr/R/utils.R`).
+
+### `scaffold::CONFIG_SCRIPTS`
+
+```rust
+pub const CONFIG_SCRIPTS: &[(&str, &str)] = _;
+```
+
+Bundled autoconf helper scripts (`AC_CONFIG_AUX_DIR([tools])`), copied
+755 into `tools/` (~ `copy_config_scripts()`).
+
+### `scaffold::EMBEDDED`
+
+```rust
+pub const EMBEDDED: &[(&str, &str)] = _;
+```
+
+Every file under `minirextendr/inst/templates/` plus the bundled autoconf
+helper scripts under `minirextendr/inst/scripts/`, embedded verbatim at
+compile time. Keys are paths relative to `minirextendr/inst/`.
+
+### `scaffold::MONOREPO_ROOT_PLAN`
+
+```rust
+pub const MONOREPO_ROOT_PLAN: &[PlanEntry] = _;
+```
+
+The monorepo workspace-root surface, mirroring
+`create_miniextendr_monorepo()`. Note the root `.gitignore` is a full
+mustache render (it substitutes `{{rpkg_name}}`), unlike the rpkg ignore
+files, and `tools/bump-version.R` uses `copy_template()` semantics.
+
+### `scaffold::RPKG_PLAN`
+
+```rust
+pub const RPKG_PLAN: &[PlanEntry] = _;
+```
+
+The R-package scaffold surface, mirroring `use_miniextendr()`'s standalone
+path and `create_rpkg_subdirectory()`'s monorepo path (which write the
+same files from `templates/rpkg/` and `templates/monorepo/rpkg/`
+respectively). Render modes match the R helpers: `use_template()` entries
+are [`Render::Mustache`], `fs::file_copy()` entries are
+[`Render::Verbatim`], ignore files are [`Render::IgnoreFilter`].
+
+### `scaffold::RUST_SYSTEM_REQUIREMENT`
+
+```rust
+pub const RUST_SYSTEM_REQUIREMENT: &str = "Rust (>= 1.85)";
+```
+
+`SystemRequirements` entry for the Rust toolchain (shared between the
+fresh DESCRIPTION and the `init use` merge path).


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Closes #1351 via the issue's preferred direction: `miniextendr init` now **consumes the canonical `minirextendr/inst/templates/`** instead of maintaining a parallel handwritten scaffold. The whole template tree (plus the bundled `config.guess`/`config.sub`) is embedded at compile time with `include_str!` in the new `miniextendr-cli/src/scaffold.rs`, so template edits land in the CLI on the next build with zero new dependencies.
- Rendering mirrors the R scaffolder's substitution contract (`minirextendr/R/utils.R`): `use_template()`'s mustache pass (`{{{key}}}` then `{{key}}`, variables from `template_data()`: `package`, `package_rs`, `Package`, `features_var`, `year`, `crate_name{,_rs}`, `rpkg_name`), `copy_template()`'s literal-triple pass for `tools/bump-version.R`, `mx_ignore_patterns()`'s comment filter for the ignore files, and byte-copies for `stub.c`/`r_shim.h`/`tools/lock-shape-check.R`. The `DESCRIPTION`/`LICENSE`/`NAMESPACE` literals mirror `MX_CONFIG_BUILD_FIELDS`, `mx_license_content()`, `mx_minimal_namespace()`, and `create_rpkg_subdirectory()`'s DESCRIPTION. One deliberate hardening: an unresolved `{{placeholder}}` is a batched error rather than whisker's silent empty string, so a template that grows a new variable fails loudly.
- Result on the acceptance criteria: scaffolded packages get the two-mode install latch keyed only on `inst/vendor.tar.xz` (no `PREPARE_CRAN`/`NOT_CRAN`/`BUILD_CONTEXT`), configure-written `.cargo/config.toml` per mode (the `cargo-config.toml.in` + `AC_CONFIG_FILES` indirection is gone), the wrapper + wasm-registry generation pipeline in `Makevars`, source mode following the declared git dependency (monorepo scaffolds declare the workspace-sibling path dep the templates prescribe), and no `just` anywhere. Verified end to end by hand: `init package` then `bash ./configure` in the scaffold runs the canonical configure to completion in source mode.
- `init use` now honors `--template-type auto|rpkg|monorepo` like `use_miniextendr()`: auto-detection via `Cargo.toml` vs `DESCRIPTION`, monorepo embedding with the package name derived from the crate name, DESCRIPTION field **merge** (Config/build fields, License placeholder replacement, `SystemRequirements` Rust append), NAMESPACE seeded only when missing, ignore files appended with dedupe instead of clobbered.
- Fixes a latent clap bug the new smoke test caught: the global `--path` and `init package`/`init monorepo`'s positional shared the arg id `path`, so the positional value also populated the global and `ProjectContext::discover` failed on the not-yet-created destination. `miniextendr init package <new-dir>` could never have worked; the positional is now `dest`.
- README: `init` section documents the canonical-template consumption; removed the stale `workflow configure --cran` example (configure has been flag-free/auto-detected for a while).

## Test plan
- [x] `cargo test -p miniextendr-cli` (27 tests) and inside `just test` — all green, default features, no `dev` gating (avoids the #1336 silently-not-run failure mode)
- [x] Regression test (issue criterion 5): `package_scaffold_matches_canonical_templates` / `monorepo_scaffold_matches_canonical_templates` scaffold into a tempdir and compare every plan file against the templates **on disk** rendered by an independent naive substituter, so both the embedded copies and the renderer are checked against the source of truth
- [x] `embedded_covers_disk`: bidirectional manifest check (template added/renamed/removed on disk without an `EMBEDDED` update fails)
- [x] `no_obsolete_build_system_markers`: no `PREPARE_CRAN`/`NOT_CRAN`/`BUILD_CONTEXT`/`cargo-config.toml.in`, latch present, git dep present, no unresolved placeholders; exec-bit test for the R build hooks
- [x] Binary smoke floor (`tests/smoke.rs`, per the CLI audit plan): `--help` for every default-features subcommand exits 0, missing-path is a clean diagnostic, `init package` end to end through the real binary
- [x] Gates: `just check`, `cargo fmt --all --check`, all three CI clippy legs (`clippy_default`, `clippy_all`, `clippy_all_s7`) with `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p miniextendr-cli`, `just templates-check`, full `just test`
- [x] Manual e2e: scaffolded package's `bash ./configure` succeeds in source mode (Makevars + `.cargo/config.toml` written, lock-shape check runs)

## Notes
- rpkg/ and `minirextendr/inst/templates/` are untouched: the CLI is now a pure consumer, so `just templates-check` semantics are unaffected.
- Follow-ups filed: #1359 (CI-level configure+install smoke for CLI scaffolds, deferred per the issue's "heavy e2e" clause), #1360 (`feature detect init` still writes a non-canonical `detect-features.R`, the same bug class on a different surface), #1361 (neither scaffolder writes `src/Makevars.win`; the CLI deliberately mirrors the R gap for now so the two stay in lockstep).
- Intentional small divergences from the R scaffolder, all noted inline: strict unresolved-placeholder errors (above); monorepo `rpkg_name` falls back to `rpkg` when it would collide with the crate directory instead of erroring (R aborts for every dot-less package name); `init` does not run `git init`/hooks/Claude-skills installation (R-only extras, see #1360's audit item).

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
