### PR TITLE
fix(cross-package): bump fixture R floor to 4.5 for R_getVarEx (#1300)

### DIFF
--- a/tests/cross-package/consumer.pkg/DESCRIPTION
+++ b/tests/cross-package/consumer.pkg/DESCRIPTION
@@ -2,7 +2,7 @@ Package: consumer.pkg
 Type: Package
 Title: Cross-Package Trait Dispatch Consumer Example
 Version: 0.1.0
-Depends: R (>= 4.4)
+Depends: R (>= 4.5)
 Authors@R: c(
     person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", role = c("aut", "cre")),
     person("A2-AI", role = c("cph", "fnd"))

--- a/tests/cross-package/producer.pkg/DESCRIPTION
+++ b/tests/cross-package/producer.pkg/DESCRIPTION
@@ -2,7 +2,7 @@ Package: producer.pkg
 Type: Package
 Title: Cross-Package Trait Dispatch Producer Example
 Version: 0.1.0
-Depends: R (>= 4.4)
+Depends: R (>= 4.5)
 Authors@R: c(
     person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", role = c("aut", "cre")),
     person("A2-AI", role = c("cph", "fnd"))


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Bump `tests/cross-package/producer.pkg/DESCRIPTION` and `tests/cross-package/consumer.pkg/DESCRIPTION` from `Depends: R (>= 4.4)` to `Depends: R (>= 4.5)`. Both fixtures path-depend on miniextendr-api, whose `Rf_findVarInFrame` replacement (`R_getVarEx`) exists only on R >= 4.5.0, so their compiled `.so` references the symbol transitively while the declared floor claimed 4.4 sufficed.
- Repo-wide sweep for other stale `R (>= 4.4)` floors (DESCRIPTIONs, docs, templates, CI configs, and the `R >= 4.x` prose variants) found none tied to packages linking miniextendr-api. Remaining 4.x mentions (UTF-8 locale >= 4.2, connections >= 4.3, a base-R feature probe in minirextendr) describe unrelated version gates and were left alone.
- The issue's "should the scaffold write an explicit floor" question is investigated and deferred to #1366 (see also the finding comment on #1300): no DESCRIPTION template file exists, all three scaffold paths generate DESCRIPTION in R-code literals (`minirextendr/R/create.R:217`, `minirextendr/R/use-r.R:82`, `minirextendr/R/rust-source.R:289`), and open PR #1362 mirrors exactly those literals into miniextendr-cli's Rust scaffolder. Touching them now would make the two scaffolders drift the moment #1362 merges.

Closes #1300. Refs #1362, #1366.

## Test plan
- [x] `just check` green
- [x] `cargo fmt --all --check` clean (no Rust touched)
- [x] `just cross-install` green (both fixtures rebuild and install)
- [x] `just cross-test` green: producer.pkg 52 PASS, consumer.pkg 335 PASS, 0 FAIL / 0 WARN / 0 SKIP

## Notes
- CI pins R 4.6, so nothing was failing today; the change corrects the declared floor for R 4.4 hosts.
- The fixtures' old 4.4 floor was itself deliberate (declared for `%||%`), now superseded by the 4.5 requirement.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)