### PR TITLE
feat(minirextendr): doctor check for stale NAMESPACE exports

### DIFF
--- a/minirextendr/R/doctor.R
+++ b/minirextendr/R/doctor.R
@@ -21,6 +21,20 @@
 #' enclosing git repository (e.g. an extracted source tarball or CRAN's
 #' build farm).
 #'
+#' The NAMESPACE section also flags stale-export drift: explicit `export()`
+#' directives with no backing definition in the union of top-level objects
+#' defined in `R/` sources (including the generated `R/<pkg>-wrappers.R`)
+#' and `importFrom()` names (re-exports). After a `#[miniextendr]` function
+#' is removed or renamed, `pkgload::load_all()` and `testthat` merely warn
+#' on the superset NAMESPACE and proceed, so the drift stays invisible in
+#' the dev loop until `R CMD check` or `library()` fails far from the cause;
+#' [miniextendr_build()] reconciles it. The comparison is fully static (no
+#' package code is loaded or executed). `exportPattern()` name-sets are not
+#' expanded, `S3method()` / `exportMethods()` / `exportClasses()` directives
+#' are out of scope, and the check skips when the wrappers file has not been
+#' generated yet or when a whole-package `import()` directive makes exports
+#' statically unattributable.
+#'
 #' For more targeted checks, see [miniextendr_status()] (file presence)
 #' and [miniextendr_validate()] (configuration correctness).
 #'
@@ -301,6 +315,78 @@ tarball-mode cleanup in Makevars. Fix: \\
     } else {
       cli::cli_alert_danger("NAMESPACE missing useDynLib directive")
       results$fail <- c(results$fail, "NAMESPACE missing useDynLib")
+    }
+
+    # -- Stale-export drift (#1304/#1305) --
+    # miniextendr_build() self-heals a NAMESPACE that still lists an export
+    # whose backing #[miniextendr] function was removed or renamed (#1288),
+    # but pkgload::load_all() / testthat only *warn* on a superset NAMESPACE
+    # ("Objects listed as exports, but not present in namespace") and
+    # proceed -- a dev loop that never runs a full build carries the drift
+    # green all the way to R CMD check / library(), which hard-fail far from
+    # the cause. Compare explicit export() directives against the union of
+    # top-level definitions in R/ (which includes the generated
+    # R/<pkg>-wrappers.R) and importFrom() names (re-exports). Fully static:
+    # doctor never loads or executes package code. Warn, not fail: dynamic
+    # definitions (computed assign() names, makeActiveBinding()) are
+    # invisible to a static scan.
+    drift <- stale_namespace_exports(usethis::proj_get())
+    if (identical(drift$status, "skip")) {
+      if (identical(drift$reason, "no-wrappers-file")) {
+        cli::cli_alert_info(
+          "Stale-export check skipped: no generated {.path R/<pkg>-wrappers.R} \\
+on disk yet (fresh clone or scaffold). Run {.code miniextendr_build()} to \\
+generate the wrappers."
+        )
+      } else if (identical(drift$reason, "whole-package-import")) {
+        cli::cli_alert_info(
+          "Stale-export check skipped: {.code import({drift$detail})} imports a \\
+whole namespace, so exports cannot be attributed statically."
+        )
+      } else if (identical(drift$reason, "parse-error")) {
+        cli::cli_alert_info(
+          "Stale-export check skipped: {.path {drift$detail}} could not be parsed."
+        )
+      }
+    } else {
+      if (isTRUE(drift$has_export_patterns)) {
+        cli::cli_alert_info(
+          "{.code exportPattern()} directives present: pattern-derived exports \\
+are not validated (only explicit {.code export()} names are checked)."
+        )
+      }
+      if (length(drift$stale) == 0L) {
+        cli::cli_alert_success(
+          "All {.code export()} directives have a backing definition"
+        )
+        results$pass <- c(results$pass, "no stale NAMESPACE exports")
+      } else {
+        cli::cli_alert_warning(
+          "{length(drift$stale)} NAMESPACE export{?s} {?has/have} no backing \\
+definition in {.path R/} or the generated wrappers (stale-export drift):"
+        )
+        for (stale_export in drift$stale) {
+          cli::cli_bullets(c("x" = "{.code export({stale_export})}"))
+        }
+        cli::cli_bullets(c(
+          "i" = paste0(
+            "This typically means a {.code #[miniextendr]} function was ",
+            "removed or renamed after the last {.code devtools::document()}: ",
+            "{.code pkgload::load_all()} / {.code testthat} only warn on the ",
+            "superset NAMESPACE and proceed, but {.code R CMD check} and ",
+            "{.code library()} fail."
+          ),
+          "i" = paste0(
+            "Fix: run {.code miniextendr_build()} (reconciles NAMESPACE and ",
+            "reinstalls), or {.code devtools::document()} followed by a ",
+            "reinstall."
+          )
+        ))
+        results$warn <- c(
+          results$warn,
+          paste0("stale NAMESPACE export: ", drift$stale)
+        )
+      }
     }
   }
 
@@ -595,4 +681,170 @@ tracked_generated_files <- function(proj_dir = usethis::proj_get()) {
     return(NULL)
   }
   tracked[nzchar(tracked)]
+}
+
+#' Stale NAMESPACE exports (#1304/#1305)
+#'
+#' Compares the package's explicit `export()` directives against the union of
+#' (a) top-level objects defined in `R/` sources -- which includes the
+#' generated `R/<pkg>-wrappers.R`, since it lives in `R/` -- and (b) names
+#' brought in by `importFrom()` directives (roxygen re-exports are
+#' `importFrom()` + `export()` pairs, so imported names are legitimate
+#' backing). Everything is derived statically (`parse()` +
+#' `parseNamespaceFile()`); the package is never loaded or executed, so the
+#' check is side-effect-free and safe to run on a broken tree.
+#'
+#' Directive semantics (deliberate):
+#' - Only plain `export()` names are checked. Each must resolve to an object
+#'   in the namespace at `loadNamespace()` time, so a name with no backing
+#'   definition is a guaranteed `library()` / `R CMD check` failure.
+#' - `exportPattern()` patterns are not expanded: they only *add* exports
+#'   (whatever happens to match at load time), so they cannot rescue a
+#'   missing explicit export, and expanding them statically would guess.
+#'   Their presence is surfaced via `has_export_patterns` so the doctor can
+#'   note that pattern-derived exports go unvalidated.
+#' - `S3method()` registers methods rather than exporting objects, and
+#'   `exportMethods()` / `exportClasses()` (S4) are backed by `setMethod()` /
+#'   `setClass()` side effects, not top-level assignments -- a static
+#'   assignment scan would false-positive them, so they are out of scope.
+#' - A whole-package `import(pkg)` makes every export statically
+#'   unattributable (any name might come from `pkg`), so the check skips
+#'   rather than enumerate a dependency's exports (which would require
+#'   loading its namespace).
+#'
+#' The generated wrappers file is gitignored in the scaffold: a fresh clone
+#' legitimately has NAMESPACE exports for every Rust wrapper but no
+#' `R/<pkg>-wrappers.R` on disk until the first build regenerates it. Running
+#' the comparison there would flag every Rust-backed export, so the check
+#' skips until the wrappers file exists.
+#'
+#' @param pkg_dir Package directory to inspect.
+#' @return `list(status = "ok", stale = <chr>, has_export_patterns = <flag>)`
+#'   when the check ran (`stale` empty = clean). `list(status = "skip",
+#'   reason = <chr>, detail = <chr or NULL>)` when it cannot run without
+#'   guessing; `reason` is one of `"no-namespace"`, `"no-wrappers-file"`,
+#'   `"whole-package-import"` (`detail` = the imported package), or
+#'   `"parse-error"` (`detail` = the unparseable file, relative to
+#'   `pkg_dir`).
+#' @noRd
+stale_namespace_exports <- function(pkg_dir = usethis::proj_get()) {
+  skip <- function(reason, detail = NULL) {
+    list(status = "skip", reason = reason, detail = detail)
+  }
+
+  if (!file.exists(file.path(pkg_dir, "NAMESPACE"))) {
+    return(skip("no-namespace"))
+  }
+  if (!wrappers_file_exists(pkg_dir)) {
+    return(skip("no-wrappers-file"))
+  }
+
+  ns <- tryCatch(
+    parseNamespaceFile(basename(pkg_dir), dirname(pkg_dir)),
+    error = function(e) NULL
+  )
+  if (is.null(ns)) {
+    return(skip("parse-error", detail = "NAMESPACE"))
+  }
+
+  has_export_patterns <- length(ns$exportPatterns) > 0L
+
+  imported <- character()
+  for (entry in ns$imports) {
+    # parseNamespaceFile() shapes (see also webr_import_findings()):
+    # bare character = import(pkg); list with an `except` element =
+    # import(pkg, except = ...); otherwise list(pkg, names) = importFrom().
+    if (is.character(entry) || "except" %in% names(entry)) {
+      return(skip("whole-package-import", detail = entry[[1L]]))
+    }
+    imported <- c(imported, as.character(entry[[2L]]))
+  }
+
+  r_dir <- file.path(pkg_dir, "R")
+  r_files <- if (dir.exists(r_dir)) {
+    # .R/.r/.S/.s/.q are the code extensions R CMD INSTALL collates (WRE 1.1.5).
+    list.files(r_dir, pattern = "\\.[RrSsq]$", full.names = TRUE)
+  } else {
+    character()
+  }
+  scan <- r_top_level_definitions(r_files)
+  if (length(scan$failed) > 0L) {
+    return(skip(
+      "parse-error",
+      detail = file.path("R", basename(scan$failed[[1L]]))
+    ))
+  }
+
+  list(
+    status = "ok",
+    stale = setdiff(unique(as.character(ns$exports)), c(scan$names, imported)),
+    has_export_patterns = has_export_patterns
+  )
+}
+
+#' Top-level object definitions in R source files
+#'
+#' Statically collects the names a set of R source files define at top level,
+#' without evaluating any code: `<-` / `=` / `<<-` assignments to a symbol or
+#' string literal (functions, operators, replacement functions, plain
+#' objects), literal-name `assign()` / `delayedAssign()` calls, and
+#' `setGeneric("name", ...)` (which creates an object of that name).
+#' Top-level `if` branches and `{` blocks are descended into --
+#' `loadNamespace()` evaluates whichever branch applies at load time, and
+#' taking the optimistic union of all branches avoids false positives.
+#' Dynamic definitions (computed names, `makeActiveBinding()`) are invisible
+#' to this scan -- one reason the doctor reports stale exports as warnings,
+#' not failures.
+#'
+#' @param r_files Character vector of file paths to parse.
+#' @return `list(names = <chr>, failed = <chr>)`: the unique defined names,
+#'   and any files that could not be parsed (syntax errors).
+#' @noRd
+r_top_level_definitions <- function(r_files) {
+  defined <- character()
+  failed <- character()
+
+  add_name <- function(x) {
+    if (is.name(x)) {
+      defined[[length(defined) + 1L]] <<- as.character(x)
+    } else if (is.character(x) && length(x) == 1L && !is.na(x)) {
+      defined[[length(defined) + 1L]] <<- x
+    }
+  }
+
+  walk <- function(e) {
+    if (!is.call(e) || !is.name(e[[1L]])) {
+      return(invisible(NULL))
+    }
+    op <- as.character(e[[1L]])
+    if (op %in% c("<-", "=", "<<-") && length(e) == 3L) {
+      # `x -> y` parses as `y <- x`, so right-assign is covered too.
+      add_name(e[[2L]])
+    } else if (op %in% c("assign", "delayedAssign", "setGeneric") &&
+      length(e) >= 2L) {
+      # Positional literal first argument only; a computed name is a dynamic
+      # definition this scan deliberately cannot see.
+      add_name(e[[2L]])
+    } else if (op == "if") {
+      if (length(e) >= 3L) walk(e[[3L]])
+      if (length(e) >= 4L) walk(e[[4L]])
+    } else if (op == "{") {
+      for (i in seq_len(length(e) - 1L)) walk(e[[i + 1L]])
+    }
+    invisible(NULL)
+  }
+
+  for (f in r_files) {
+    exprs <- tryCatch(
+      parse(f, keep.source = FALSE, encoding = "UTF-8"),
+      error = function(e) NULL
+    )
+    if (is.null(exprs)) {
+      failed <- c(failed, f)
+      next
+    }
+    for (e in exprs) walk(e)
+  }
+
+  list(names = unique(defined), failed = failed)
 }

--- a/minirextendr/man/miniextendr_doctor.Rd
+++ b/minirextendr/man/miniextendr_doctor.Rd
@@ -37,6 +37,20 @@ check is skipped silently when git is unavailable or there is no
 enclosing git repository (e.g. an extracted source tarball or CRAN's
 build farm).
 
+The NAMESPACE section also flags stale-export drift: explicit \code{export()}
+directives with no backing definition in the union of top-level objects
+defined in \verb{R/} sources (including the generated \verb{R/<pkg>-wrappers.R})
+and \code{importFrom()} names (re-exports). After a \verb{#[miniextendr]} function
+is removed or renamed, \code{pkgload::load_all()} and \code{testthat} merely warn
+on the superset NAMESPACE and proceed, so the drift stays invisible in
+the dev loop until \verb{R CMD check} or \code{library()} fails far from the cause;
+\code{\link[=miniextendr_build]{miniextendr_build()}} reconciles it. The comparison is fully static (no
+package code is loaded or executed). \code{exportPattern()} name-sets are not
+expanded, \code{S3method()} / \code{exportMethods()} / \code{exportClasses()} directives
+are out of scope, and the check skips when the wrappers file has not been
+generated yet or when a whole-package \code{import()} directive makes exports
+statically unattributable.
+
 For more targeted checks, see \code{\link[=miniextendr_status]{miniextendr_status()}} (file presence)
 and \code{\link[=miniextendr_validate]{miniextendr_validate()}} (configuration correctness).
 }

--- a/minirextendr/tests/testthat/test-doctor-stale-exports.R
+++ b/minirextendr/tests/testthat/test-doctor-stale-exports.R
@@ -1,0 +1,298 @@
+# Tests for the stale-export drift check in miniextendr_doctor() (#1304/#1305).
+#
+# miniextendr_build() self-heals a NAMESPACE that still lists an export whose
+# backing #[miniextendr] function was removed or renamed (#1288), but
+# pkgload::load_all() / testthat only WARN on a superset NAMESPACE and
+# proceed, so a load_all()-only dev loop carries the drift green all the way
+# to R CMD check / library(). doctor must flag explicit export() directives
+# with no backing definition in the union of (a) top-level objects defined in
+# R/ sources and (b) the generated R/<pkg>-wrappers.R -- statically, without
+# loading or executing any package code -- and advise miniextendr_build().
+
+# Build a minimal fake R-package directory suitable for doctor(). `r_files`
+# is a named list: name = file name under R/, value = character vector of
+# source lines. The generated-wrappers file is just another entry (e.g.
+# "testpkg-wrappers.R") -- the check keys off the *-wrappers.R name only for
+# its has-the-package-been-built-yet gate.
+make_stale_export_pkg <- function(ns_lines, r_files = list()) {
+  tmp <- tempfile("doctor-stale-exports-")
+  dir.create(tmp)
+  writeLines(
+    c("Package: testpkg", "Title: Test", "Version: 0.1.0", ""),
+    file.path(tmp, "DESCRIPTION")
+  )
+  writeLines(ns_lines, file.path(tmp, "NAMESPACE"))
+
+  rust_dir <- file.path(tmp, "src", "rust")
+  dir.create(rust_dir, recursive = TRUE)
+  writeLines(
+    c("[package]", 'name = "testpkg"', "", "[dependencies]", 'miniextendr-api = "*"'),
+    file.path(rust_dir, "Cargo.toml")
+  )
+
+  r_dir <- file.path(tmp, "R")
+  dir.create(r_dir)
+  for (name in names(r_files)) {
+    writeLines(r_files[[name]], file.path(r_dir, name))
+  }
+
+  tmp
+}
+
+ns_header <- "useDynLib(testpkg, .registration = TRUE)"
+
+test_that("doctor flags a NAMESPACE export with no backing definition and advises miniextendr_build()", {
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(ns_header, "export(real_fn)", "export(wrapper_fn)", "export(gone_fn)"),
+    r_files = list(
+      "code.R" = "real_fn <- function() 1",
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  msgs <- testthat::capture_messages(
+    result <- miniextendr_doctor(pkg)
+  )
+
+  # Exactly the removed function is flagged -- backed exports are not.
+  expect_identical(
+    grep("^stale NAMESPACE export: ", result$warn, value = TRUE),
+    "stale NAMESPACE export: gone_fn"
+  )
+  # Warn, not fail: a static scan cannot see dynamic definitions.
+  expect_false(any(grepl("gone_fn", result$fail, fixed = TRUE)))
+
+  # The console output names the offender and the remediation. cli wraps at
+  # the console width, so collapse and normalise whitespace before matching.
+  flat <- gsub("\\s+", " ", paste(msgs, collapse = " "))
+  expect_match(flat, "export(gone_fn)", fixed = TRUE)
+  expect_match(flat, "miniextendr_build()", fixed = TRUE)
+})
+
+test_that("doctor passes a clean package, whatever the top-level definition form", {
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(
+      ns_header,
+      "export(real_fn)",
+      'export("%+%")',
+      'export("foo<-")',
+      "export(obj)",
+      "export(cond_fn)",
+      "export(assigned_fn)",
+      "export(gen_fn)",
+      "export(wrapper_fn)"
+    ),
+    r_files = list(
+      "code.R" = c(
+        "real_fn = function() 1",
+        "`%+%` <- function(a, b) a + b",
+        "`foo<-` <- function(x, value) x",
+        "obj <- 1:10",
+        "if (getRversion() >= \"4.0.0\") {",
+        "  cond_fn <- function() 2",
+        "}",
+        'assign("assigned_fn", function() 3)',
+        'setGeneric("gen_fn", function(x) standardGeneric("gen_fn"))'
+      ),
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  result <- suppressMessages(miniextendr_doctor(pkg))
+
+  expect_true(any(grepl("no stale NAMESPACE exports", result$pass, fixed = TRUE)))
+  expect_false(any(grepl("stale NAMESPACE export", result$warn, fixed = TRUE)))
+})
+
+test_that("hand-written R/ exports beyond the wrappers are NOT flagged", {
+  # The available set is the UNION of R/ sources and the wrappers file: a
+  # package with hand-written exported helpers must come out clean.
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(ns_header, "export(hand_fn)", "export(wrapper_fn)"),
+    r_files = list(
+      "helpers.R" = "hand_fn <- function() 42",
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  result <- suppressMessages(miniextendr_doctor(pkg))
+
+  expect_true(any(grepl("no stale NAMESPACE exports", result$pass, fixed = TRUE)))
+  expect_false(any(grepl("stale NAMESPACE export", result$warn, fixed = TRUE)))
+})
+
+test_that("re-exports (importFrom + export) are NOT flagged", {
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(
+      ns_header,
+      "importFrom(utils, head)",
+      "export(head)",
+      "export(wrapper_fn)"
+    ),
+    r_files = list(
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  result <- suppressMessages(miniextendr_doctor(pkg))
+
+  expect_true(any(grepl("no stale NAMESPACE exports", result$pass, fixed = TRUE)))
+  expect_false(any(grepl("stale NAMESPACE export", result$warn, fixed = TRUE)))
+})
+
+test_that("a whole-package import() skips the check with a note instead of false-positives", {
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(ns_header, "import(stats)", "export(gone_fn)"),
+    r_files = list(
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  msgs <- testthat::capture_messages(
+    result <- miniextendr_doctor(pkg)
+  )
+
+  # Neither flagged nor passed: skipped, with a note naming the import.
+  expect_false(any(grepl("stale NAMESPACE export", result$warn, fixed = TRUE)))
+  expect_false(any(grepl("no stale NAMESPACE exports", result$pass, fixed = TRUE)))
+  flat <- gsub("\\s+", " ", paste(msgs, collapse = " "))
+  expect_match(flat, "Stale-export check skipped", fixed = TRUE)
+  expect_match(flat, "import(stats)", fixed = TRUE)
+})
+
+test_that("exportPattern() does not rescue a stale explicit export, and its presence is noted", {
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(
+      ns_header,
+      'exportPattern("^mx_")',
+      "export(gone_fn)",
+      "export(wrapper_fn)"
+    ),
+    r_files = list(
+      "testpkg-wrappers.R" = c(
+        'wrapper_fn <- function() .Call("C_wrapper_fn")',
+        "mx_pattern_fn <- function() 1"
+      )
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  msgs <- testthat::capture_messages(
+    result <- miniextendr_doctor(pkg)
+  )
+
+  # Explicit export() names must still resolve at loadNamespace() time, so
+  # the stale one is flagged even with a pattern present; pattern-derived
+  # exports themselves are not validated, and doctor says so.
+  expect_identical(
+    grep("^stale NAMESPACE export: ", result$warn, value = TRUE),
+    "stale NAMESPACE export: gone_fn"
+  )
+  flat <- gsub("\\s+", " ", paste(msgs, collapse = " "))
+  expect_match(flat, "pattern-derived exports", fixed = TRUE)
+})
+
+test_that("the check skips with a note when no generated wrappers file exists yet", {
+  # Fresh clone: the wrappers file is gitignored, so NAMESPACE legitimately
+  # lists exports whose wrappers are not on disk until the first build.
+  # Flagging them all would be a false-positive flood.
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(ns_header, "export(rust_backed_fn)"),
+    r_files = list(
+      "code.R" = "internal_helper <- function() 1"
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  msgs <- testthat::capture_messages(
+    result <- miniextendr_doctor(pkg)
+  )
+
+  expect_false(any(grepl("stale NAMESPACE export", result$warn, fixed = TRUE)))
+  expect_false(any(grepl("no stale NAMESPACE exports", result$pass, fixed = TRUE)))
+  flat <- gsub("\\s+", " ", paste(msgs, collapse = " "))
+  expect_match(flat, "Stale-export check skipped", fixed = TRUE)
+  expect_match(flat, "miniextendr_build()", fixed = TRUE)
+})
+
+test_that("stale_namespace_exports skips on unparseable sources rather than guessing", {
+  # A syntax error anywhere in R/ makes the definition union untrustworthy:
+  # skip (reason parse-error, detail = the file) instead of flagging exports
+  # whose definitions simply were not collectable.
+  pkg <- make_stale_export_pkg(
+    ns_lines = c(ns_header, "export(wrapper_fn)"),
+    r_files = list(
+      "broken.R" = "this is not valid R (((",
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  res <- stale_namespace_exports(pkg)
+  expect_identical(res$status, "skip")
+  expect_identical(res$reason, "parse-error")
+  expect_identical(res$detail, file.path("R", "broken.R"))
+
+  # An unparseable NAMESPACE is the same class of skip.
+  ns_pkg <- make_stale_export_pkg(
+    ns_lines = "export(unbalanced",
+    r_files = list(
+      "testpkg-wrappers.R" = 'wrapper_fn <- function() .Call("C_wrapper_fn")'
+    )
+  )
+  on.exit(unlink(ns_pkg, recursive = TRUE), add = TRUE)
+
+  ns_res <- stale_namespace_exports(ns_pkg)
+  expect_identical(ns_res$status, "skip")
+  expect_identical(ns_res$reason, "parse-error")
+  expect_identical(ns_res$detail, "NAMESPACE")
+})
+
+test_that("r_top_level_definitions collects every static definition form and reports parse failures", {
+  src <- withr::local_tempfile(fileext = ".R")
+  writeLines(
+    c(
+      "arrow_fn <- function() 1",
+      "eq_fn = function() 2",
+      "super_fn <<- function() 3",
+      # NB: `function() 4 -> right_fn` would parse as an anonymous function
+      # whose *body* is the assignment; assign a value to test `->` itself.
+      "4 -> right_fn",
+      "`%||%` <- function(a, b) if (is.null(a)) b else a",
+      "`val<-` <- function(x, value) x",
+      "plain_obj <- letters",
+      'assign("assigned_obj", 1)',
+      'delayedAssign("delayed_obj", 2)',
+      'setGeneric("generic_fn", function(x) standardGeneric("generic_fn"))',
+      "if (TRUE) then_fn <- function() 5 else else_fn <- function() 6",
+      "{",
+      "  braced_fn <- function() 7",
+      "}",
+      "# dynamic names are deliberately invisible to the scan:",
+      "assign(paste0('dyn', '_fn'), function() 8)"
+    ),
+    src
+  )
+
+  scan <- r_top_level_definitions(src)
+  expect_setequal(
+    scan$names,
+    c(
+      "arrow_fn", "eq_fn", "super_fn", "right_fn", "%||%", "val<-",
+      "plain_obj", "assigned_obj", "delayed_obj", "generic_fn",
+      "then_fn", "else_fn", "braced_fn"
+    )
+  )
+  expect_identical(scan$failed, character(0))
+
+  broken <- withr::local_tempfile(fileext = ".R")
+  writeLines("not R at all (((", broken)
+  broken_scan <- r_top_level_definitions(c(src, broken))
+  expect_identical(broken_scan$failed, broken)
+  expect_true("arrow_fn" %in% broken_scan$names)
+})


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

- Adds a stale-export drift check to `minirextendr_doctor()` (`minirextendr/R/doctor.R`): explicit `export()` directives are compared against the union of (a) top-level objects defined in `R/` sources, which includes the generated `R/<pkg>-wrappers.R`, and (b) `importFrom()` names (roxygen re-exports are `importFrom()` + `export()` pairs). Exports with no backing definition are reported as warnings with the fix hint: run `miniextendr_build()` (reconciles NAMESPACE and reinstalls) or `devtools::document()` followed by a reinstall.
- Motivation (#1305/#1304, follow-up to #1288/#1294): `miniextendr_build()` self-heals a NAMESPACE that still lists an export whose backing `#[miniextendr]` function was removed or renamed, but `pkgload::load_all()` / `testthat` only *warn* on a superset NAMESPACE and proceed, so a `load_all()`-only dev loop stays green while `R CMD check` and `library()` are broken far from the cause.
- The comparison is fully static (`parse()` + `parseNamespaceFile()`); no package code is loaded or executed, so doctor stays side-effect-free. The definition scan (`r_top_level_definitions()`) collects `<-` / `=` / `<<-` assignments to a symbol or string literal (functions, operators, replacement functions, plain objects), literal-name `assign()` / `delayedAssign()`, `setGeneric("name", ...)`, and descends into top-level `if` branches and `{` blocks.
- Deliberate directive handling, documented in the helper and the `miniextendr_doctor()` Rd:
  - Only plain `export()` names are checked; each must resolve at `loadNamespace()` time, so an unbacked one is a guaranteed `library()` failure.
  - `exportPattern()` name-sets are not expanded (patterns only *add* exports and cannot rescue a missing explicit one); their presence is surfaced with an info note that pattern-derived exports go unvalidated.
  - `S3method()` / `exportMethods()` / `exportClasses()` are out of scope: they are backed by `setMethod()` / `setClass()` side effects rather than top-level assignments, so a static assignment scan would false-positive them.
  - A whole-package `import(pkg)` makes every export statically unattributable, so the check skips with a note (follow-up to attribute these statically: #1368).
  - The check skips with a note when no generated `R/*-wrappers.R` exists on disk: the file is gitignored in the scaffold, so a fresh clone legitimately has NAMESPACE exports for every Rust wrapper with no wrappers file until the first build.
- Severity is warn, not fail: dynamic definitions (computed `assign()` names, `makeActiveBinding()`) are invisible to a static scan.
- Return-value and message conventions mirror the existing doctor checks (stale vendor latch, tracked generated files): one `results$warn` entry per stale export (`"stale NAMESPACE export: <name>"`), a `results$pass` entry (`"no stale NAMESPACE exports"`) when the check ran clean, and silent-vs-noted skip semantics matching `tracked_generated_files()`.

Closes #1305
Closes #1304

## Test plan

- [x] `just minirextendr-test` clean: 0 FAIL / 804 PASS (3 pre-existing skips for missing optional packages)
- [x] New `tests/testthat/test-doctor-stale-exports.R` (30 assertions): stale export flagged with `miniextendr_build()` advice; clean package passes across every static definition form (operators, replacement functions, `setGeneric`, `assign`, top-level `if`/`{`); hand-written `R/` exports beyond the wrappers not flagged; `importFrom` re-exports not flagged; whole-package `import()` skips with a note; `exportPattern()` does not rescue a stale explicit export; missing wrappers file skips with a note; unparseable `R/` source or NAMESPACE skips instead of guessing
- [x] `just minirextendr-check`: 0 errors, 0 warnings, 2 pre-existing NOTEs (top-level `AGENTS.md`, `miniextendr` Rd xref)
- [x] `just minirextendr-document` clean (no roxygen diagnostics); regenerated `man/miniextendr_doctor.Rd` committed
- [x] `just check` and `cargo fmt --all --check` pass (no Rust touched)

## Notes

- #1304 is an accidental duplicate of #1305 (filed 3 minutes apart, same ask); this PR closes both.
- The check detects drift only after the wrappers file has been regenerated (NAMESPACE stale relative to fresh wrappers). A wrappers file that is itself stale still masks the removal until the next rebuild regenerates it; that is inherent to static checking against the on-disk generated file, which is exactly the ground truth #1304 specifies.
- Follow-up filed: #1368 (attribute exports statically under whole-package `import()` via the installed dependency's `Meta/nsInfo.rds` instead of skipping).

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)