### PR TITLE
fix(serde): per-field struct opt-out for the Option<Enum> tag-column heuristic (#1320)

### DIFF
--- a/docs/SERDE_R.md
+++ b/docs/SERDE_R.md
@@ -618,7 +618,7 @@ fn echo_reading(x: SEXP) -> Result<AsSerialize<satellite::Reading>, String> {
 | `enum` → tagged list / per-variant `data.frame` | `vec_to_dataframe_split`, `result_to_dataframe` |
 | nested `enum` field → `<field>_variant` tag + `<field>_<sub>` columns | `vec_to_dataframe_flatten_enums`, `…_with_tags` (custom tag name) |
 | `HashMap`/`BTreeMap` → named list / `data.frame` | `map_to_dataframe`, `hashmap_to_dataframe` |
-| `data.frame` → `Vec<struct>` | `dataframe_to_vec` / `SerdeRows` |
+| `data.frame` → `Vec<struct>` | `dataframe_to_vec` / `SerdeRows` (`dataframe_to_vec_with_struct_fields` for the #1320 tag-collision opt-out) |
 | collated / flattened enum `data.frame` → `Vec<enum>` (collated and flattened shapes) | `dataframe_to_vec_collated` (top-level), `dataframe_to_vec` / `dataframe_to_vec_with_enum_tags` (nested fields) |
 
 The **collated and flattened** enum shapes are bidirectional: nested enum
@@ -637,11 +637,38 @@ The other enum writer shapes remain **write-only**: `PerVariantList` /
 per-variant frame *lists* no reader consumes, and internally-tagged flattened
 fields (`<field>_<tagfield>`, no `_variant` column) are not covered by the
 reader path — see [#1321](https://github.com/A2-ai/miniextendr/issues/1321).
-One reader caveat: an `Option<nested struct>` field whose flattened columns
-include one matching the tag-column name (a sub-field literally named
-`variant`) reads back as `None` when that cell is NA — silent loss; see
-[#1320](https://github.com/A2-ai/miniextendr/issues/1320) for the mechanism
-and workarounds.
+
+### Reader caveat: the `_variant` tag-column collision (#1320)
+
+The reader has no type information when it meets an `Option<T>` field with no
+bare column — it cannot tell `Option<NestedStruct>` from `Option<Enum>`. To
+read `Option<Enum>` `None` rows back, it probes the would-be variant-tag
+column — `<field>_variant` by default, or the configured
+`dataframe_to_vec_with_enum_tags` override — and an NA character/factor cell
+there means `None`. The `_variant` suffix (or whatever tag name the reader is
+configured with) is therefore effectively **reserved** under
+`Option<nested struct>` fields.
+
+**Silent loss** occurs when all of these hold:
+
+1. the field is `Option<NestedStruct>` (flattened columns, no bare column);
+2. the nested struct has a sub-field whose flattened column name equals the
+   would-be tag column (a sub-field literally named `variant` under the
+   default, e.g. `meta.variant` → `meta_variant`);
+3. that column is character or factor, and NA at the row.
+
+The whole struct then reads back as `None` — the other sub-fields'
+values on that row are dropped without an error. Fixes:
+
+| Approach | How | Trade-off |
+|---|---|---|
+| Struct opt-out (**preferred**) | `dataframe_to_vec_with_struct_fields(sexp, &["meta"])` | The heuristic never fires for `meta`; it is always read as a struct. An actual `None` struct row errors (non-`Option` sub-field) or reads as all-`None` `Some` — the writer emits no presence signal to recover it. |
+| Rename the colliding sub-field | `#[serde(rename = "kind")] variant: Option<String>` on the inner struct field | Changes the emitted column name (`meta_kind`) on both write and read. |
+| Per-field tag override | `dataframe_to_vec_with_enum_tags(sexp, &[("meta", "<unused column>")])` | Points the tag probe at a non-existent column so it never fires — works today, but expresses the intent poorly; prefer the opt-out. |
+
+`Option<Enum>` fields are unaffected by the opt-out unless listed: fields not
+named in `dataframe_to_vec_with_struct_fields` keep the tag heuristic, so
+`None` enum rows still round-trip.
 
 ### What serde alone cannot give you
 

--- a/miniextendr-api/src/serde.rs
+++ b/miniextendr-api/src/serde.rs
@@ -249,7 +249,8 @@ pub use columnar::{
 pub use columnar::{par_iter_to_dataframe, par_iter_to_dataframe_growing};
 pub use dataframe_de::{
     BorrowedRows, SerdeRows, dataframe_to_vec, dataframe_to_vec_borrowed,
-    dataframe_to_vec_collated, dataframe_to_vec_with_enum_tags, with_dataframe_rows,
+    dataframe_to_vec_collated, dataframe_to_vec_with_enum_tags,
+    dataframe_to_vec_with_struct_fields, with_dataframe_rows,
 };
 pub use de::RDeserializer;
 pub use error::RSerdeError;

--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -1379,8 +1379,10 @@ enum SchemaMode {
 ///
 /// - **Compound-vs-Compound recursive union**: when two rows produce different Compound
 ///   shapes for the same key (e.g., enum variants with different nested structs), the
-///   first Compound wins and the second is silently discarded. Recursive union is tracked
-///   as a separate follow-up.
+///   first Compound wins and the second is silently discarded. Corollary: a nested
+///   sub-field probed as `None` on the first row stays `Generic` (list column) even
+///   when a later row types it. Recursive union is tracked as
+///   [#1370](https://github.com/A2-ai/miniextendr/issues/1370).
 struct SchemaAccumulator {
     candidates: HashMap<String, Vec<Candidate>>,
     key_order: Vec<String>,

--- a/miniextendr-api/src/serde/dataframe_de.rs
+++ b/miniextendr-api/src/serde/dataframe_de.rs
@@ -1,11 +1,18 @@
 //! Deserializer for converting an R `data.frame` SEXP into `Vec<T>`.
 //!
-//! Provides two public entry points:
+//! Public entry points:
 //!
 //! - [`dataframe_to_vec`] — owned; `T: DeserializeOwned`; always materialises
 //!   `String` for character cells.
 //! - [`with_dataframe_rows`] — scoped callback; `T: for<'a> Deserialize<'a>`;
 //!   supports zero-copy borrows (`name: &'a str`).
+//! - [`dataframe_to_vec_borrowed`] — RAII handle keeping the source SEXP
+//!   rooted while the caller holds the rows.
+//! - [`dataframe_to_vec_collated`] — top-level enum rows (Collated shape).
+//! - [`dataframe_to_vec_with_enum_tags`] — caller-chosen variant-tag column
+//!   names for nested enum fields.
+//! - [`dataframe_to_vec_with_struct_fields`] — per-field opt-out from the
+//!   `Option<Enum>` tag-column heuristic (#1320).
 //!
 //! # Design (unified row/cell deserializer)
 //!
@@ -105,9 +112,11 @@ use serde::de::{
 ///    `Option<NestedStruct>` field's flattened columns include one matching
 ///    that name — i.e. the struct has a sub-field literally named `variant` —
 ///    an NA in that cell makes the *whole struct* read back as `None`,
-///    silently dropping the other sub-fields. Rename the sub-field, or point
-///    the tag lookup at an unused column name via
-///    [`dataframe_to_vec_with_enum_tags`].
+///    silently dropping the other sub-fields. Fixes, in order of preference:
+///    list the field in [`dataframe_to_vec_with_struct_fields`] (the
+///    heuristic never fires for it), rename the sub-field with
+///    `#[serde(rename = "...")]`, or point the tag lookup at an unused column
+///    name via [`dataframe_to_vec_with_enum_tags`].
 pub fn dataframe_to_vec<T>(sexp: SEXP) -> Result<Vec<T>, RSerdeError>
 where
     T: for<'de> serde::Deserialize<'de>,
@@ -224,8 +233,9 @@ where
 /// Same as [`dataframe_to_vec`] — including the `Option<nested struct>`
 /// tag-column collision
 /// ([#1320](https://github.com/A2-ai/miniextendr/issues/1320)). The `tags`
-/// mapping here is also the workaround: point the affected field's tag at an
-/// unused column name so the `None` heuristic never fires for it.
+/// mapping can paper over it (point the affected field's tag at an unused
+/// column name so the `None` heuristic never fires for it), but the
+/// dedicated opt-out is [`dataframe_to_vec_with_struct_fields`].
 ///
 /// # Example
 ///
@@ -251,6 +261,83 @@ where
     let _input = unsafe { OwnedProtect::new(sexp) };
     let view = DataFrame::from_sexp(sexp).map_err(|e| RSerdeError::Message(e.to_string()))?;
     deserialize_rows(&view, EnumReadConfig::from_field_tags(tags))
+}
+
+/// Convert a data.frame into `Vec<T>`, declaring `fields` that must always be
+/// read as **nested structs** — the `Option<Enum>` tag-column heuristic never
+/// fires for them.
+///
+/// # Why this exists (the `_variant` collision, #1320)
+///
+/// An `Option<T>` field with no bare column is either an `Option<NestedStruct>`
+/// or an `Option<Enum>`, and serde gives the reader no type information to tell
+/// them apart at that point. To read `Option<Enum>` `None` rows back, the
+/// reader probes the would-be variant-tag column (`<field>_variant` by
+/// default, or the [`dataframe_to_vec_with_enum_tags`] override): a
+/// character/factor column that is NA at the row means `None`. If a nested
+/// *struct* has a sub-field literally named `variant`, its flattened column
+/// collides with that name — an NA cell there silently reads the **whole
+/// struct** as `None`, dropping the other sub-fields
+/// ([#1320](https://github.com/A2-ai/miniextendr/issues/1320)).
+///
+/// Listing the field here disables the probe: the field is always read as a
+/// nested struct from its prefixed columns. Fields *not* listed keep the
+/// heuristic, so `Option<Enum>` fields in the same row type continue to
+/// round-trip their `None` rows.
+///
+/// # Field naming
+///
+/// Entries use the **flattened field path** — the same key space as
+/// [`dataframe_to_vec_with_enum_tags`]: `"meta"` for a top-level field `meta`,
+/// `"outer_meta"` for a field `meta` inside a nested struct field `outer`.
+///
+/// # `None` structs stay unreadable
+///
+/// The writer emits no per-row presence signal for `Option<NestedStruct>`: a
+/// `None` struct and a `Some` struct whose fields are all `None` produce
+/// identical (all-NA) columns. Opting a field out therefore commits to reading
+/// it as `Some(...)` on every row — a row written from `None` yields an
+/// `UnexpectedNa` error if the struct has any non-`Option` field, or
+/// `Some(struct with all-`None` fields)` if every field is `Option`.
+///
+/// # Errors
+///
+/// Same as [`dataframe_to_vec`].
+///
+/// # Example
+///
+/// ```ignore
+/// use miniextendr_api::serde::{dataframe_to_vec_with_struct_fields, vec_to_dataframe};
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Meta {
+///     variant: Option<String>, // collides with the `meta_variant` tag name
+///     size: f64,
+/// }
+/// #[derive(Serialize, Deserialize)]
+/// struct Row {
+///     id: i32,
+///     meta: Option<Meta>,
+/// }
+///
+/// let df = vec_to_dataframe(&rows)?; // columns: id, meta_variant, meta_size
+/// let round: Vec<Row> = dataframe_to_vec_with_struct_fields(df.as_sexp(), &["meta"])?;
+/// // `Meta { variant: None, size: 4.0 }` rows survive — no tag-column probe.
+/// ```
+pub fn dataframe_to_vec_with_struct_fields<T>(
+    sexp: SEXP,
+    fields: &[&str],
+) -> Result<Vec<T>, RSerdeError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    if is_empty_dataframe(sexp) {
+        return Ok(Vec::new());
+    }
+    // Root the input across deserialisation — see [`dataframe_to_vec`].
+    let _input = unsafe { OwnedProtect::new(sexp) };
+    let view = DataFrame::from_sexp(sexp).map_err(|e| RSerdeError::Message(e.to_string()))?;
+    deserialize_rows(&view, EnumReadConfig::from_struct_fields(fields))
 }
 
 // endregion
@@ -405,10 +492,14 @@ fn is_empty_dataframe(sexp: SEXP) -> bool {
 ///   (`field → column`), set by [`dataframe_to_vec_with_enum_tags`]. Fields not
 ///   listed use the default `<field>_variant` (symmetric with the writer's
 ///   [`vec_to_dataframe_flatten_enums_with_tags`](crate::serde::vec_to_dataframe_flatten_enums_with_tags)).
+/// - `struct_fields` — per-field opt-out from the `Option<Enum>` tag-column
+///   heuristic (#1320), set by [`dataframe_to_vec_with_struct_fields`]. Listed
+///   fields are always read as nested structs in `deserialize_option`.
 #[derive(Clone, Default)]
 struct EnumReadConfig {
     top_level_tag: Option<std::rc::Rc<str>>,
     field_tags: std::rc::Rc<[(String, String)]>,
+    struct_fields: std::rc::Rc<[String]>,
 }
 
 impl EnumReadConfig {
@@ -420,21 +511,38 @@ impl EnumReadConfig {
             .map(|(_, t)| t.as_str())
     }
 
+    /// Did the caller declare `field` (flattened path) a nested struct, opting
+    /// it out of the `Option<Enum>` tag-column heuristic (#1320)?
+    fn is_struct_field(&self, field: &str) -> bool {
+        self.struct_fields.iter().any(|f| f == field)
+    }
+
     fn from_field_tags(tags: &[(&str, &str)]) -> Self {
         Self {
-            top_level_tag: None,
             field_tags: tags
                 .iter()
                 .map(|(f, t)| ((*f).to_owned(), (*t).to_owned()))
                 .collect::<Vec<_>>()
                 .into(),
+            ..Self::default()
         }
     }
 
     fn from_top_level_tag(column: &str) -> Self {
         Self {
             top_level_tag: Some(std::rc::Rc::from(column)),
-            field_tags: std::rc::Rc::from(Vec::<(String, String)>::new().into_boxed_slice()),
+            ..Self::default()
+        }
+    }
+
+    fn from_struct_fields(fields: &[&str]) -> Self {
+        Self {
+            struct_fields: fields
+                .iter()
+                .map(|f| (*f).to_owned())
+                .collect::<Vec<_>>()
+                .into(),
+            ..Self::default()
         }
     }
 }
@@ -808,6 +916,14 @@ impl<'de> Deserializer<'de> for MaybeNestedDeserializer<'de> {
         // a nested struct with a sub-field literally named `variant` collides
         // with the tag-column name and an NA cell there reads the whole struct
         // as `None` — serde exposes no inner-type info here to disambiguate.
+        // The per-field opt-out below is the caller-side fix.
+        //
+        // Per-field opt-out (#1320): the caller declared this field a nested
+        // struct via [`dataframe_to_vec_with_struct_fields`] — never consult
+        // the tag-column heuristic, always read the payload.
+        if self.cfg.is_struct_field(&self.bare_name) {
+            return visitor.visit_some(self);
+        }
         let tag_col_name = self.tag_column_name();
         if let Some(tag_col) = self.view.column_raw(&tag_col_name)
             && is_variant_tag_column(tag_col)

--- a/miniextendr-api/tests/serde_columnar.rs
+++ b/miniextendr-api/tests/serde_columnar.rs
@@ -12,8 +12,9 @@ use miniextendr_api::into_r::IntoR as _;
 use miniextendr_api::prelude::SexpExt as _;
 use miniextendr_api::serde::{
     DataFrameShape, RSerdeError, ResultShape, SplitResults, SplitShape, dataframe_to_vec,
-    dataframe_to_vec_collated, dataframe_to_vec_with_enum_tags, hashmap_to_dataframe,
-    map_to_dataframe, result_to_dataframe, vec_to_dataframe, vec_to_dataframe_flatten_enums,
+    dataframe_to_vec_collated, dataframe_to_vec_with_enum_tags,
+    dataframe_to_vec_with_struct_fields, hashmap_to_dataframe, map_to_dataframe,
+    result_to_dataframe, vec_to_dataframe, vec_to_dataframe_flatten_enums,
     vec_to_dataframe_flatten_enums_with_tags, vec_to_dataframe_split,
 };
 use serde::{Deserialize, Serialize};
@@ -945,6 +946,144 @@ fn flatten_enum_reader_option_enum_none_roundtrip() {
         ];
         let df = vec_to_dataframe_flatten_enums(&rows, &["action"]).unwrap();
         let round: Vec<Row> = dataframe_to_vec(df.as_sexp()).unwrap();
+        assert_eq!(round, rows);
+    });
+}
+
+/// #1320 repro, default behaviour pinned: an `Option<NestedStruct>` whose
+/// sub-field is literally named `variant` collides with the enum tag-column
+/// name (`meta_variant`) — an NA in that cell reads the *whole struct* back as
+/// `None`, dropping the other sub-fields. This is the documented lossy
+/// default; [`option_nested_struct_with_struct_fields_roundtrips`] is the fix.
+#[test]
+fn option_nested_struct_tag_collision_default_is_lossy() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Some(Meta {
+                    variant: Some("a".into()),
+                    size: 1.0,
+                }),
+            },
+            Row {
+                id: 2,
+                meta: Some(Meta {
+                    variant: None,
+                    size: 4.0,
+                }),
+            },
+        ];
+        // Columns: id, meta_variant, meta_size — `meta_variant` is NA at row 2.
+        let df = vec_to_dataframe(&rows).unwrap();
+        let round: Vec<Row> = dataframe_to_vec(df.as_sexp()).unwrap();
+        // Row 1 survives (tag cell not NA → nested-struct read).
+        assert_eq!(round[0], rows[0]);
+        // Row 2's struct is silently dropped by the heuristic. If this
+        // assertion starts failing, the lossy default documented in #1320
+        // changed — update the docs alongside.
+        assert_eq!(round[1], Row { id: 2, meta: None });
+    });
+}
+
+/// #1320 fix: listing the field in `dataframe_to_vec_with_struct_fields`
+/// disables the tag-column heuristic for it — the
+/// `Meta { variant: None, size: 4.0 }` row round-trips losslessly.
+#[test]
+fn option_nested_struct_with_struct_fields_roundtrips() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Some(Meta {
+                    variant: Some("a".into()),
+                    size: 1.0,
+                }),
+            },
+            Row {
+                id: 2,
+                meta: Some(Meta {
+                    variant: None,
+                    size: 4.0,
+                }),
+            },
+        ];
+        let df = vec_to_dataframe(&rows).unwrap();
+        let round: Vec<Row> = dataframe_to_vec_with_struct_fields(df.as_sexp(), &["meta"]).unwrap();
+        assert_eq!(round, rows);
+    });
+}
+
+/// The struct-field opt-out is per-field: `Option<Enum>` `None` rows keep
+/// round-tripping through `dataframe_to_vec_with_struct_fields` for fields
+/// *not* listed — the tag-column heuristic still fires for them.
+#[test]
+fn struct_fields_optout_keeps_option_enum_none_for_other_fields() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    enum Action {
+        Go { steps: f64 },
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+        action: Option<Action>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        // Row 1 keeps `meta.variant = Some(...)`: a nested sub-field probed as
+        // `None` on the *first* row locks its column to Generic (list) via the
+        // writer's Compound-vs-Compound first-seen lattice (#1370) — a separate
+        // writer limitation, not the #1320 heuristic under test here.
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Some(Meta {
+                    variant: Some("x".into()),
+                    size: 5.0,
+                }),
+                action: Some(Action::Go { steps: 3.0 }),
+            },
+            Row {
+                id: 2,
+                meta: Some(Meta {
+                    variant: None,
+                    size: 4.0,
+                }),
+                action: None,
+            },
+        ];
+        let df = vec_to_dataframe_flatten_enums(&rows, &["action"]).unwrap();
+        // `meta` is opted out (always a struct); `action` keeps the default
+        // `action_variant` tag heuristic, so its `None` row still reads back.
+        let round: Vec<Row> = dataframe_to_vec_with_struct_fields(df.as_sexp(), &["meta"]).unwrap();
         assert_eq!(round, rows);
     });
 }


### PR DESCRIPTION
**TODO(user): replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Adds `dataframe_to_vec_with_struct_fields(sexp, &[field])` to `miniextendr_api::serde`, the principled per-field opt-out named as option 3 in #1320: listed fields are always read as nested structs, so the `Option<Enum>` NA-tag `None` heuristic never fires for them. Fields not listed keep the heuristic, so `Option<Enum>` `None` rows still round-trip.
- The opt-out threads through the shared `EnumReadConfig` (a new `struct_fields` entry beside `field_tags` / `top_level_tag`), which every reader entry point already carries; the check sits in `MaybeNestedDeserializer::deserialize_option` right before the tag-column probe. Entries use the same flattened-path key space as `dataframe_to_vec_with_enum_tags` (`"meta"`, or `"outer_meta"` under nesting), and the new fn mirrors that sibling's surface: same signature style, same `miniextendr_api::serde` re-export (the `*_with_enum_tags` reader is not prelude-exported, so the new fn is not either).
- Documentation hardened per the issue's mitigation 1: the new fn's rustdoc explains the collision, the reserved-suffix effect, and the `None`-struct caveat (the writer emits no presence signal, so an opted-out field reads as `Some(...)` on every row); `dataframe_to_vec`'s Limitations and `dataframe_to_vec_with_enum_tags`'s docs now point at all three fixes (opt-out, `#[serde(rename)]`, unused-column tag override); `docs/SERDE_R.md` gains a dedicated caveat section with the silent-loss conditions and a workaround table.
- Tests (engine-based `with_r_thread`, `miniextendr-api/tests/serde_columnar.rs`, run with `--features serde`):
  - `option_nested_struct_tag_collision_default_is_lossy`: the issue's exact repro, pinning the documented lossy default (`Meta { variant: None, size: 4.0 }` reads back as `meta == None`).
  - `option_nested_struct_with_struct_fields_roundtrips`: the same repro round-trips losslessly through the opt-out.
  - `struct_fields_optout_keeps_option_enum_none_for_other_fields`: one frame with an opted-out struct field plus an `Option<Enum>` field whose `None` row still reads back (per-field scope guard); the pre-existing `flatten_enum_reader_option_enum_none_roundtrip` keeps guarding the default path.
- Filed #1370 while writing the tests: a nested sub-field probed as `None` on the first row locks its column to Generic (VECSXP list) via the writer's Compound first-seen lattice, so row order changes the emitted column type. That is a writer emission change and out of scope here per #1320's constraint; the `SchemaAccumulator` limitation note that previously claimed an untracked follow-up now references it, and the combined test orders its rows to sidestep it.

Closes #1320. Refs #1319, #1321 (internally-tagged flattened residuals stay untouched), #1370.

## Test plan
- [x] `just check` green (all four manifests)
- [x] `cargo fmt --all --check` clean
- [x] All three CI clippy legs green with `-D warnings` (default, `full-codegen` list, `full-codegen-s7` list from ci.yml)
- [x] `just test` legs green (root workspace, cross-package consumer/producer, rpkg/src/rust, `just test-ui`); new tests verified by name in `cargo test -p miniextendr-api --features serde --test serde_columnar` (35 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` green (default and `-p miniextendr-api --features serde,serde_json`)
- [x] Rebased onto current `origin/main` (9407b5ed) before push; gates re-run post-rebase

## Notes
- No rpkg changes: the sibling config variant `dataframe_to_vec_with_enum_tags` has engine-test coverage only (no rpkg fixture), and the reader stores no SEXPs across allocations, so no gc-stress fixture is needed.
- No writer emission changes, per the issue's direction; the presence-signal design question stays with #1320's analysis and #1370 covers the schema-lattice defect found en route.
- `rust-llm-docs/generated/*` digests intentionally not regenerated: `llm-docs-check` is not wired into CI and the freshest precedent (#1363, api rustdoc changed, zero digest hunks) refreshes the corpus in dedicated PRs instead.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)