### PR TITLE
fix(api): drop dispatch-only imports from generated wasm_registry.rs (#1307)

### DIFF
--- a/miniextendr-api/src/wasm_registry_writer.rs
+++ b/miniextendr-api/src/wasm_registry_writer.rs
@@ -24,9 +24,12 @@ use crate::registry::{
 use std::ffi::CStr;
 use std::fmt::Write as _;
 
-// Bumped whenever the generated-file shape changes (struct fields, import
-// paths, macro names). The receiving `build.rs` (step 5) refuses to compile
-// a `wasm_registry.rs` whose header doesn't match.
+// Bumped whenever the generated-file shape changes in a way the receiving
+// `build.rs` version check must reject (e.g. registry struct fields renamed
+// so an old file no longer compiles). Cosmetic changes — import lines,
+// qualified paths, formatting — are NOT part of the checked contract and
+// don't warrant a bump (#1307). The receiving `build.rs` (step 5) refuses
+// to compile a `wasm_registry.rs` whose header doesn't match.
 const GENERATOR_VERSION: u32 = 1;
 
 /// Pre-extracted, cdylib-side view of one `R_CallMethodDef`.
@@ -103,7 +106,10 @@ fn format_body(
 ) -> String {
     let mut out = String::new();
 
-    writeln!(&mut out, "use ::miniextendr_api::abi::mx_tag;").unwrap();
+    // `mx_tag` and `c_void` are referenced only by trait-dispatch entries and
+    // deliberately NOT imported here: a minimal package with an empty dispatch
+    // table would get `unused_imports` warnings on wasm32 (#1307). The
+    // dispatch entries spell both fully qualified instead.
     writeln!(&mut out, "use ::miniextendr_api::SEXP;").unwrap();
     writeln!(&mut out, "use ::miniextendr_api::sys::R_CallMethodDef;").unwrap();
     writeln!(
@@ -111,7 +117,6 @@ fn format_body(
         "use ::miniextendr_api::registry::{{AltrepRegistration, TraitDispatchEntry}};"
     )
     .unwrap();
-    writeln!(&mut out, "use ::core::ffi::c_void;").unwrap();
     writeln!(&mut out).unwrap();
 
     format_extern_unwind_block(&mut out, call_defs);
@@ -204,21 +209,23 @@ fn format_trait_dispatch_slice(out: &mut String, trait_dispatches: &[TraitDispat
     .unwrap();
     for row in trait_dispatches {
         writeln!(out, "    TraitDispatchEntry {{").unwrap();
+        // `mx_tag` / `c_void` are fully qualified (no header import) so
+        // dispatch-free files carry no unused imports — see format_body.
         writeln!(
             out,
-            "        concrete_tag: mx_tag::new(0x{:016x}, 0x{:016x}),",
+            "        concrete_tag: ::miniextendr_api::abi::mx_tag::new(0x{:016x}, 0x{:016x}),",
             row.concrete_tag.lo, row.concrete_tag.hi
         )
         .unwrap();
         writeln!(
             out,
-            "        trait_tag: mx_tag::new(0x{:016x}, 0x{:016x}),",
+            "        trait_tag: ::miniextendr_api::abi::mx_tag::new(0x{:016x}, 0x{:016x}),",
             row.trait_tag.lo, row.trait_tag.hi
         )
         .unwrap();
         writeln!(
             out,
-            "        vtable: unsafe {{ ::core::ptr::from_ref(&{}).cast::<c_void>() }},",
+            "        vtable: unsafe {{ ::core::ptr::from_ref(&{}).cast::<::core::ffi::c_void>() }},",
             row.vtable_symbol
         )
         .unwrap();
@@ -426,12 +433,90 @@ mod tests {
         let (a, b, c) = sample_inputs();
         let out = format_wasm_registry(&a, &b, &c);
         assert!(
-            out.contains("mx_tag::new(0xdeadbeefdeadbeef, 0x1234567812345678)"),
-            "expected concrete_tag literal; got:\n{out}"
+            out.contains(
+                "::miniextendr_api::abi::mx_tag::new(0xdeadbeefdeadbeef, 0x1234567812345678)"
+            ),
+            "expected fully-qualified concrete_tag literal; got:\n{out}"
         );
         assert!(
-            out.contains("mx_tag::new(0xcafebabecafebabe, 0xfeedfacefeedface)"),
-            "expected trait_tag literal; got:\n{out}"
+            out.contains(
+                "::miniextendr_api::abi::mx_tag::new(0xcafebabecafebabe, 0xfeedfacefeedface)"
+            ),
+            "expected fully-qualified trait_tag literal; got:\n{out}"
+        );
+    }
+
+    /// #1307: a minimal package (call defs only — no trait impls, no ALTREP)
+    /// produces an empty dispatch table; the generated file must not carry
+    /// imports that only dispatch entries would use, or wasm32 `cargo check`
+    /// reports `unused_imports` on every build.
+    #[test]
+    fn dispatch_free_output_has_no_dispatch_only_imports() {
+        let (call_defs, _, _) = sample_inputs();
+        let out = format_wasm_registry(&call_defs, &[], &[]);
+        assert!(
+            !out.contains("mx_tag"),
+            "dispatch-free output must not mention mx_tag; got:\n{out}"
+        );
+        assert!(
+            !out.contains("c_void"),
+            "dispatch-free output must not mention c_void; got:\n{out}"
+        );
+    }
+
+    /// Every emitted `use` line must be referenced in the body that follows —
+    /// the generalized no-unused-imports property for the minimal-package
+    /// shape (#1307). Imports are single-segment or `{A, B}` groups; each
+    /// imported ident must reappear after the import block.
+    #[test]
+    fn every_import_is_used_in_dispatch_free_output() {
+        let (call_defs, _, _) = sample_inputs();
+        let out = format_wasm_registry(&call_defs, &[], &[]);
+        let (imports, rest): (Vec<&str>, Vec<&str>) =
+            out.lines().partition(|l| l.starts_with("use "));
+        assert!(!imports.is_empty(), "output has imports; got:\n{out}");
+        let body = rest.join("\n");
+        for line in imports {
+            let idents = line
+                .trim_start_matches("use ")
+                .trim_end_matches(';')
+                .rsplit("::")
+                .next()
+                .unwrap()
+                .trim_matches(['{', '}'])
+                .split(',')
+                .map(str::trim);
+            for ident in idents {
+                assert!(
+                    body.contains(ident),
+                    "import `{ident}` from `{line}` is unused; got:\n{out}"
+                );
+            }
+        }
+    }
+
+    /// With dispatch entries present, the emitted entries must reference
+    /// `mx_tag` / `c_void` fully qualified (no header import exists to
+    /// resolve bare names — #1307 dropped them).
+    #[test]
+    fn dispatch_entries_reference_items_fully_qualified() {
+        let (a, b, c) = sample_inputs();
+        let out = format_wasm_registry(&a, &b, &c);
+        assert!(
+            !out.contains("use ::miniextendr_api::abi::mx_tag;"),
+            "mx_tag header import must not be emitted; got:\n{out}"
+        );
+        assert!(
+            !out.contains("use ::core::ffi::c_void;"),
+            "c_void header import must not be emitted; got:\n{out}"
+        );
+        assert!(
+            out.contains("::miniextendr_api::abi::mx_tag::new("),
+            "dispatch tags must be fully qualified; got:\n{out}"
+        );
+        assert!(
+            out.contains(".cast::<::core::ffi::c_void>()"),
+            "vtable cast must be fully qualified; got:\n{out}"
         );
     }
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `miniextendr_write_wasm_registry` unconditionally emitted `use ::miniextendr_api::abi::mx_tag;` and `use ::core::ffi::c_void;` into generated `wasm_registry.rs`, but both are referenced only by trait-dispatch entries. Minimal scaffolded packages (no trait impls, empty dispatch table) got two `unused_imports` warnings on every wasm32 `cargo check`, recurring log noise in the #1271 `monorepo-wasm-check` job. rpkg never surfaced it because its dispatch table is never empty.
- Fix (option 2 from the issue): the emitted dispatch entries now spell both items fully qualified (`::miniextendr_api::abi::mx_tag::new(...)`, `.cast::<::core::ffi::c_void>()`) and the two header imports are gone entirely. No conditional-emission logic to get wrong; dispatch-free output carries no mention of either item.
- `GENERATOR_VERSION` stays at 1. The receiving `build.rs` (rpkg + both templates) only parses and compares the `// generator-version: N` header integer; imports and entry formatting are not part of the checked contract, and files of both shapes compile against the same registry structs, so there is no compatibility break in either direction. The version comment now states that bump criterion explicitly so cosmetic changes do not get spurious bumps.
- `tests/cross-package/*/src/rust/wasm_registry.rs` need no update: they are hand-written stubs (#493) with empty slices that already omit these imports, not generator output.

Closes #1307

## Test plan
- [x] New unit test `dispatch_free_output_has_no_dispatch_only_imports`: minimal-package shape (call defs only) produces output with no `mx_tag`/`c_void` token anywhere.
- [x] New unit test `every_import_is_used_in_dispatch_free_output`: generalized sweep asserting every emitted `use` line's idents reappear in the body (guards the remaining `SEXP` / `R_CallMethodDef` / registry-type imports too).
- [x] New unit test `dispatch_entries_reference_items_fully_qualified` + updated `renders_mx_tag_with_const_constructor`: with-dispatch output references both items fully qualified and emits neither header import.
- [x] Compile-proof beyond string asserts: both generated shapes (with-dispatch and dispatch-free) were `include!`d into a scratch crate depending on `miniextendr-api` and pass `cargo check` under `#![deny(unused_imports)]` with zero unused-import diagnostics. The `extern` declarations only resolve at link time, so this exercises the same rustc front-end path wasm32 uses.
- [x] `just check`, `cargo fmt --all --check`, `just test` (all writer tests green by name), and all three CI clippy legs (`clippy_default`, `clippy_all`, `clippy_all_s7`) locally with `-D warnings`.
- [ ] Final wasm32 confirmation is CI: the #1271 `monorepo-wasm-check` job logs must show the two `unused import` warnings gone. That job does not `-D warnings`, so check the log text, not the job status.

## Notes
- Host builds never compile `wasm_registry.rs` (it is wasm32-gated), so `just rcmdinstall` cannot exercise this change; the scratch compile-proof above plus the wasm CI log is the verification layering. `just check`/`just test` cover the rpkg/src/rust manifest against the changed API.
- rpkg's gitignored `rpkg/src/rust/wasm_registry.rs` regenerates on the next host install (the writer's content comparison sees the new shape and rewrites); nothing to commit there.
- No llm-docs digests committed; the corpus refreshes in dedicated PRs per current working convention.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>