### PR TITLE
fix(api): stop webR wasm-runtime traps on the two unwinding boundaries (tier-3 unreachable)

### DIFF
--- a/miniextendr-api/src/encoding.rs
+++ b/miniextendr-api/src/encoding.rs
@@ -49,8 +49,18 @@ pub fn encoding_info() -> Option<&'static REncodingInfo> {
 /// are valid UTF-8.
 ///
 /// Uses `l10n_info()[["UTF-8"]]` which is public R API.
+///
+/// ABI: must be `extern "C-unwind"`, not `extern "C"` — the failure branch
+/// raises via `Rf_error`, and under webR (Emscripten builds R with
+/// `-sSUPPORT_LONGJMP=wasm`) that longjmp is a real wasm exception that
+/// unwinds through this frame. A non-unwind `extern "C"` ABI makes rustc
+/// insert an abort guard at the boundary, which turns the load-gate error
+/// into an `unreachable` trap that kills the whole wasm runtime (observed
+/// in the tier-3 testthat pass via `assert_utf8_locale_now()`). On native
+/// targets `longjmp` never touches landing pads, which is why this only
+/// bit on wasm32.
 #[unsafe(no_mangle)]
-pub extern "C" fn miniextendr_assert_utf8_locale() {
+pub extern "C-unwind" fn miniextendr_assert_utf8_locale() {
     debug_assert!(
         crate::worker::is_r_main_thread(),
         "must be called from R main thread"

--- a/miniextendr-api/src/worker.rs
+++ b/miniextendr-api/src/worker.rs
@@ -213,9 +213,33 @@ where
     // *enabled* on wasm so worker-gated routines still compile and the
     // pre-generated `wasm_registry.rs` (built with the feature) has no dangling
     // entries. See `worker_active` reasoning at the top of the worker functions.
+    //
+    // The inline path must uphold the same panic contract as the worker path:
+    // a panicking closure yields `Err(message)`, never an unwind out of
+    // `run_on_worker` (on the worker path the channel boundary guarantees
+    // this). Without the catch, a panic here unwinds out of raw
+    // `extern "C-unwind"` `.Call` entry points that rely on the Err contract —
+    // under webR's wasm-exception unwinding that escapes R entirely and
+    // reaches the JS host as an uncaught `WebAssembly.Exception`, killing the
+    // session (observed in tier-3 via `unsafe_C_test_worker_panic_simple`).
+    // The message rules mirror `worker_channel::fold_panic_message`:
+    // `RCondition` payloads stringify verbatim, generic panics fold in the
+    // recorded `(at file:line)` location — same thread, so the take-once
+    // location slot is valid here too.
     #[cfg(not(all(feature = "worker-thread", not(target_family = "wasm"))))]
     {
-        Ok(f())
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+            Ok(val) => Ok(val),
+            Err(payload) => {
+                let msg = if payload.is::<crate::condition::RCondition>() {
+                    crate::unwind_protect::panic_payload_to_string(payload.as_ref()).into_owned()
+                } else {
+                    crate::unwind_protect::panic_message_with_location(payload.as_ref())
+                };
+                crate::panic_telemetry::fire(&msg, crate::panic_telemetry::PanicSource::Worker);
+                Err(msg)
+            }
+        }
     }
 
     #[cfg(all(feature = "worker-thread", not(target_family = "wasm")))]

--- a/reviews/2026-07-17-webr-tier3-unreachable-trap.md
+++ b/reviews/2026-07-17-webr-tier3-unreachable-trap.md
@@ -1,0 +1,104 @@
+# webR tier-3 testthat pass: `unreachable` trap (main-push red since 2026-07-11)
+
+## What was attempted
+
+Every main-push run of `webr.yml`'s tier-3 informational testthat pass
+(#1255/#1258) died with:
+
+```
+[tier3][testthat] FAIL: harness error before counts: unreachable
+```
+
+`unreachable` is a WebAssembly trap: the R/wasm runtime aborted mid-`test_dir`,
+the R worker died, and the harness (correctly) turned the missing counts line
+into a red gate. The failure was first attributed to the most recent merge
+(#1363's streaming-ALTREP `get_region` forward), but the run history showed
+the step had **never** been green: the first failure is the merge commit of
+#1258 itself (2026-07-11T19:34Z, run 29165513537), the PR that added the
+testthat pass. `webr.yml`'s testthat leg only activates on main-push /
+workflow_dispatch, so the PR could not pre-verify it.
+
+## What went wrong
+
+Two independent framework bugs, both invisible on native targets, both fatal
+under webR because Emscripten implements `longjmp` and unwinding as **wasm
+exceptions** (webR builds R with `-fwasm-exceptions -s SUPPORT_LONGJMP=wasm`;
+Rust's `wasm32-unknown-emscripten` target defaults to `panic=unwind` over
+native wasm EH):
+
+1. **`miniextendr_assert_utf8_locale` was `extern "C"` (non-unwind) but
+   raises via `Rf_error`.** Under wasm the longjmp is an exception that
+   unwinds through the frame; rustc's abort guard on non-unwind ABIs turns it
+   into an `unreachable` trap. Natively, `longjmp` never touches landing
+   pads, so the bug was undetectable. First alphabetical hit:
+   `test-encoding.R`'s mid-session locale-flip tests calling
+   `assert_utf8_locale_now()` — this was the trap that killed every main-push
+   run. (`miniextendr_encoding_init`, its sibling, was already `"C-unwind"`.)
+
+2. **`run_on_worker`'s inline branch (wasm builds, or `worker-thread` off)
+   ran the closure bare** — `Ok(f())` with no catch — while the worker path
+   catches panics at the channel and returns `Err(msg)`. A panicking closure
+   therefore unwound out of raw `extern "C-unwind"` `.Call` fixtures that
+   rely on the `Err` contract, escaped R entirely (R has no handler for the
+   Rust exception tag), and reached Node as an uncaught
+   `WebAssembly.Exception` ("wasm exception"). Hit by `test-worker.R`
+   (`unsafe_C_test_worker_panic_simple`) and `test-errors-more.R`
+   (`unsafe_C_worker_drop_on_panic`).
+
+## How it was diagnosed
+
+Local Docker repro was infeasible (daemon down; Docker VM at 28 GB with 11 GB
+host disk free — the documented disk-exhaustion crash mode). Instead, a
+throwaway diagnostic branch instrumented `smoke.mjs` and was driven via
+`workflow_dispatch` (which enables `SMOKE_TESTTHAT=1`):
+
+- **Error-path probes in isolation**: plain R error, conversion error, pure
+  Rust panic, heap-drop panic, direct `Rf_error` longjmp through
+  `with_r_unwind_protect`. All five passed, proving the panic → tagged
+  condition transport and R-longjmp-through-Rust-frames both work under wasm
+  EH (the `__c_longjmp` tag passes through Rust's tag-filtered `catch_unwind`
+  pads without being caught, matching native bypass semantics).
+- **Per-file sweep with session reboot**: ran all 137 test files one at a
+  time via `test_dir(filter = ...)`, rebooting the webR session after each
+  trap. Result: 134/137 files clean; only `test-encoding.R` (trap:
+  `unreachable`), `test-errors-more.R` and `test-worker.R` (trap: `wasm
+  exception`). Diagnostic runs: 29535733978 (localization),
+  29540422832 (fix verification + per-call probes).
+
+## Root cause
+
+Non-unwind `extern "C"` ABI on a longjmp-ing export, and a panic-contract gap
+on `run_on_worker`'s inline path. Both are unwinding-boundary bugs that only
+materialize when longjmp/unwind is exception-based (wasm EH); native longjmp
+skips frames and native panics never cross those particular boundaries in
+tested configurations.
+
+## Fix
+
+`miniextendr-api/src/encoding.rs`: `miniextendr_assert_utf8_locale` →
+`extern "C-unwind"`. `miniextendr-api/src/worker.rs`: inline `run_on_worker`
+branch now `catch_unwind`s and returns `Err(message)` with the same
+stringification rules as `worker_channel::fold_panic_message` (RCondition
+verbatim, generic panics with `(at file:line)`), plus panic telemetry parity.
+
+Verified in dispatch run 29540422832 (same instrumented harness, rebuilt
+from the fix branch): all 16 error-path probes report `caught: ...` —
+including `encoding-locale-flip` (previously the `unreachable` trap, now
+"caught: miniextendr requires a UTF-8 locale") and every worker-panic
+probe (previously uncaught `WebAssembly.Exception`s) — and the per-file
+sweep reports **0/137 files trapped** (pre-fix: 3/137). Post-fix suite
+aggregate under wasm: passed=6846, failed=5, skipped=41, errors=100
+(ordinary informational failures: callr/subprocess-class
+incompatibilities, not traps).
+
+## Lessons
+
+- A wasm trap message tells you the failure class: `unreachable` = rustc
+  abort guard / `core::intrinsics::abort`; "wasm exception" = an uncaught
+  exception reaching the JS host. They are different bugs.
+- `extern "C"` vs `extern "C-unwind"` is load-bearing on wasm even for code
+  that "only longjmps" — audit non-unwind boundaries for `Rf_error`/panic
+  reachability when touching webR paths.
+- `workflow_dispatch` on a diagnostic branch is the cheap empirical loop for
+  main-push-only CI legs: per-call probes plus a per-file sweep with session
+  reboots localized three traps in one run.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Fixes the permanently-red main-push "webR / wasm32" job (failing run: https://github.com/A2-ai/miniextendr/actions/runs/29506574788/job/87657101644, `[tier3][testthat] FAIL: harness error before counts: unreachable`). Two fixes, both in miniextendr-api:

1. **`encoding.rs`: `miniextendr_assert_utf8_locale` flipped `extern "C"` to `extern "C-unwind"`.** Under webR, Emscripten builds R with `-fwasm-exceptions -sSUPPORT_LONGJMP=wasm`, so the `Rf_error` longjmp in the locale gate's failure branch is a real wasm exception that unwinds through the Rust frame. A non-unwind ABI makes rustc insert an abort guard at the boundary, which converts the ordinary R error into an `unreachable` trap that kills the whole wasm runtime. On native targets `longjmp` never touches landing pads, so this class is invisible off wasm32.
2. **`worker.rs`: the inline `run_on_worker` branch (wasm, or `worker-thread` off) now catches panics.** It previously ran closures bare (`Ok(f())`), so a panic unwound out of the raw `extern "C-unwind"` `.Call` fixtures and escaped R as an uncaught `WebAssembly.Exception` reaching Node. It now folds panic payloads to `Err(String)` with the same stringification (and panic telemetry) as the worker-channel path, restoring the documented `Result<T, String>` contract on every configuration.

## Diagnosis

- **Regression window**: the tier-3 testthat step never passed on main. Last green main-push webr.yml run was e504646c (2026-07-11); the first failure was the #1258 merge itself, i.e. the commit that *added* the tier-3 testthat pass. The initially suspected #1363 is exonerated. #1258's own PR CI could not catch this because the testthat leg only runs on main-push / workflow_dispatch.
- **Method**: local Docker repro was infeasible (daemon down; known disk-exhaustion mode for the webR container), so diagnosis ran as instrumented `workflow_dispatch` runs on throwaway diag branches, using isolated `evalR` probes plus a per-file `testthat::test_dir(filter=)` sweep with a webR session reboot after each trap.
- **Localization** (diag run [29535733978](https://github.com/A2-ai/miniextendr/actions/runs/29535733978)): every error-path probe passed; exactly 3/137 test files trapped. `test-encoding.R` died with `unreachable` (bug 1, via the mid-session locale-flip tests); `test-errors-more.R` and `test-worker.R` died with `wasm exception` (bug 2, via the raw worker fixtures). `test-encoding.R` is the first trap alphabetically, so the single locale-gate trap killed every main-push run before any counts printed.
- **Verification** (run [29540422832](https://github.com/A2-ai/miniextendr/actions/runs/29540422832), SUCCESS, built from this fix): 15/15 probes report `caught: ...` (including the locale flip: `caught: miniextendr requires a UTF-8 locale ...`); per-file sweep 0/137 trapped; the three files now produce real counts (encoding passed=10, errors-more passed=10, worker passed=33); aggregate passed=6846 failed=5 skipped=41 errors=100.
- Full post-mortem with the wasm-EH mechanics: `reviews/2026-07-17-webr-tier3-unreachable-trap.md` (in this PR).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `just check`, `just test` (exit 0)
- [x] All three CI clippy legs (`clippy_default`, `clippy_all`, `clippy_all_s7`) with `-D warnings`, feature lists read from ci.yml
- [x] `cargo check` with and without default features (the no-default build compiles the fixed inline `run_on_worker` branch natively)
- [x] Empirical wasm verification: workflow_dispatch run 29540422832 on an instrumented copy of this branch, 0/137 files trapped
- [ ] Final confirmation: the next main-push webr.yml run after merge (the tier-3 testthat leg does not run on PR CI)

## Notes

- Follow-up audit filed as #1377: inventory of the remaining non-unwind `extern "C"` boundaries in miniextendr-api (registration/wrapper-gen entry points) plus a proposed MXL lint to make this class a build-time diagnostic.
- Related but distinct: #1302 (worker-wrapper argument conversions outside `with_r_unwind_protect`) is about skipped destructors, a softer failure than the ABI abort guard.
- No harness changes: the tier-3 strict gate from #1255/#1258 is untouched, and the instrumented `smoke.mjs` lived only on the now-deleted diag branches.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)