### PR TITLE
fix(rpkg): make rpkg/src/rust clippy --all-targets -D warnings clean

### DIFF
--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -2,7 +2,6 @@
 
 #![allow(dead_code)]
 
-use miniextendr_api::dataframe::ColumnarFrame;
 use miniextendr_api::{DataFrameRow, IntoList};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -352,6 +351,8 @@ impl IntoList for WithOptMapAsList {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use miniextendr_api::dataframe::ColumnarFrame;
 
     #[test]
     fn test_vec_dataframe() {

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -20,7 +20,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use miniextendr_api::dataframe::ColumnarFrame;
 use miniextendr_api::{BuiltDataFrame, IntoDataFrame, IntoDataFrameSplit};
 use miniextendr_api::{DataFrameRow, IntoList, List, miniextendr};
 
@@ -981,6 +980,8 @@ pub fn btreemap_split_nvnr() -> List {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use miniextendr_api::dataframe::ColumnarFrame;
 
     #[test]
     fn vec_width_align_pinned_columns() {

--- a/rpkg/src/rust/serde_json_adapter_tests.rs
+++ b/rpkg/src/rust/serde_json_adapter_tests.rs
@@ -98,7 +98,7 @@ pub fn json_array_len(value: JsonValue) -> i32 {
 pub fn json_from_key_values(keys: Vec<String>, values: Vec<i32>) -> String {
     use miniextendr_api::serde_impl::serde_json;
     let mut map = serde_json::Map::new();
-    for (k, v) in keys.into_iter().zip(values.into_iter()) {
+    for (k, v) in keys.into_iter().zip(values) {
         map.insert(k, serde_json::Value::Number(v.into()));
     }
     serde_json::Value::Object(map).to_string()

--- a/rpkg/src/rust/vctrs_derive_example.rs
+++ b/rpkg/src/rust/vctrs_derive_example.rs
@@ -281,6 +281,10 @@ impl DerivedCurrency {
     /// @param symbol Character currency symbol (informational; not stored in the vector).
     /// @param amounts Numeric vector of currency amounts.
     /// @return A `DerivedCurrency` vctrs vector.
+    // Canonical vctrs constructor pattern: must be named `new` (constructor
+    // inference keys on the ident) and must return the vector payload, not
+    // `Self` — `vctrs::new_vctr(.data, ...)` rejects an ExternalPtr as `.data`.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(_symbol: String, amounts: Vec<f64>) -> Vec<f64> {
         amounts
     }


### PR DESCRIPTION
**TODO(user): replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Reproduced #1292's exact configuration (`cargo clippy --all-targets --features full -- -D warnings`, run from inside `rpkg/src/rust` so the `.cargo/config.toml` patches resolve) and made it clean. Four warnings total: the two from the issue, plus two `unused_imports` that accumulated after the issue was filed.
- `serde_json_adapter_tests.rs:101` (`clippy::useless_conversion`): `keys.into_iter().zip(values.into_iter())` → `keys.into_iter().zip(values)`. Mechanical.
- `vctrs_derive_example.rs:284` (`clippy::new_ret_no_self`): kept the name, added `#[allow(clippy::new_ret_no_self)]` with an explanatory comment. Rationale below.
- `dataframe_collections_test.rs` / `dataframe_enum_payload_matrix.rs` (`unused_imports`, post-#1292 accumulation): the top-level `ColumnarFrame` imports were orphaned on the lib target by #1355's migration to the trait verbs, but still needed by `#[cfg(test)]` code (via `use super::*`). Moved each import into the `tests` module that uses it. Included per the repo's "fix warnings you see" rule, and because the issue's verification command cannot go green without them.

## The new_ret_no_self decision: allow, not rename
- The ident `new` is load-bearing for codegen: `is_method_constructor` in `miniextendr-macros/src/miniextendr_impl.rs:2599` infers the vctrs constructor from a receiver-less method literally named `new`, and for `ClassSystem::Vctrs` deliberately drops the returns-`Self` requirement. Renaming would break constructor inference (or force a `#[miniextendr(constructor)]` attribute, defeating the point of an example that demonstrates the inferred canonical pattern).
- The non-`Self` return is equally intentional: the surrounding doc comment and the macro's own comment both state that `vctrs::new_vctr(.data, ...)` requires a plain vector payload, and returning `Self` (an ExternalPtr) fails at runtime with ".data must be a vector type".
- A rename would also ripple into R-facing surfaces: the generated `new_derivedcurrency()` wrapper (vctrs `new_<class>` convention), `rpkg/man/DerivedCurrency.Rd`, and `rpkg/tests/testthat/test-vctrs-derive.R`, requiring the full install/document loop for zero benefit.
- Downstream note: any end-user writing the canonical vctrs constructor pattern will hit this lint too, so the example now also demonstrates the expected suppression.

## Test plan
- [x] `cd rpkg/src/rust && cargo clippy --all-targets --features full -- -D warnings` — reproduced all four warnings before, exit 0 after
- [x] `cd rpkg/src/rust && cargo clippy --all-targets -- -D warnings` (default features) — clean
- [x] Three CI clippy legs from ci.yml (`clippy_default`, `clippy_all`, `clippy_all_s7`), all `-D warnings` — clean
- [x] `just check` — pass
- [x] `cargo fmt --all --check` (root workspace and rpkg/src/rust) — clean
- [x] `just test` — pass (75 suites ok)
- No R loop needed: only a plain `//` comment and an attribute were added; roxygen-visible doc text, wrapper names, and exports are unchanged.

## Notes
- Follow-up filed: #1379 — no CI leg runs clippy with `-D warnings` against `rpkg/src/rust` (a standalone workspace the root `--workspace` legs never reach), which is exactly how these warnings accumulated. Adding the leg is deliberately out of scope here.
- The `dataframe_*` fixture edits are one-line import moves; if another in-flight branch touches those files the conflict is trivial.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)