### PR TITLE
ci(webr): assert the use_local_miniextendr [patch] block landed in each scaffold leg (#1309)

### DIFF
--- a/.github/workflows/webr.yml
+++ b/.github/workflows/webr.yml
@@ -223,6 +223,17 @@ jobs:
         run: |
           set -euo pipefail
           ( cd /tmp/mono-check/monorepo/mxmono && bash ./configure )
+          # use_local_miniextendr() guard (#1309): configure must have emitted
+          # the local-checkout [patch] block into the generated cargo config.
+          # If a marker regression made use_local_miniextendr() silently
+          # no-op, this leg would build the *published* git sources instead
+          # of this checkout — and stay green while validating the wrong code.
+          cfg=/tmp/mono-check/monorepo/mxmono/src/rust/.cargo/config.toml
+          if ! grep -qF '[patch."https://github.com/A2-ai/miniextendr"]' "$cfg"; then
+            echo "::error::use_local_miniextendr() [patch] block missing from $cfg — the scaffold would build the published miniextendr git sources, not this checkout."
+            cat "$cfg" || true
+            exit 1
+          fi
           mkdir -p /tmp/mono-check-native-lib
           R CMD INSTALL --no-test-load --library=/tmp/mono-check-native-lib \
               /tmp/mono-check/monorepo/mxmono
@@ -486,6 +497,17 @@ jobs:
           # UTF-8 locale. noble ships C.UTF-8 without locale-gen.
           export LANG=C.UTF-8 LC_ALL=C.UTF-8
           ( cd /tmp/scaffold/mxsmoke && bash ./configure )
+          # use_local_miniextendr() guard (#1309): configure must have emitted
+          # the local-checkout [patch] block into the generated cargo config.
+          # If a marker regression made use_local_miniextendr() silently
+          # no-op, this leg would build the *published* git sources instead
+          # of this checkout — and stay green while validating the wrong code.
+          cfg=/tmp/scaffold/mxsmoke/src/rust/.cargo/config.toml
+          if ! grep -qF '[patch."https://github.com/A2-ai/miniextendr"]' "$cfg"; then
+            echo "::error::use_local_miniextendr() [patch] block missing from $cfg — the scaffold would build the published miniextendr git sources, not this checkout."
+            cat "$cfg" || true
+            exit 1
+          fi
           mkdir -p /tmp/scaffold-native-lib
           # Install #1: the Makevars wrapper-gen pass writes
           # R/mxsmoke-wrappers.R and src/rust/wasm_registry.rs (the wasm build
@@ -585,6 +607,17 @@ jobs:
           set -euo pipefail
           export LANG=C.UTF-8 LC_ALL=C.UTF-8
           ( cd /tmp/scaffold-mono/monorepo/mxmono && bash ./configure )
+          # use_local_miniextendr() guard (#1309): configure must have emitted
+          # the local-checkout [patch] block into the generated cargo config.
+          # If a marker regression made use_local_miniextendr() silently
+          # no-op, this leg would build the *published* git sources instead
+          # of this checkout — and stay green while validating the wrong code.
+          cfg=/tmp/scaffold-mono/monorepo/mxmono/src/rust/.cargo/config.toml
+          if ! grep -qF '[patch."https://github.com/A2-ai/miniextendr"]' "$cfg"; then
+            echo "::error::use_local_miniextendr() [patch] block missing from $cfg — the scaffold would build the published miniextendr git sources, not this checkout."
+            cat "$cfg" || true
+            exit 1
+          fi
           mkdir -p /tmp/scaffold-mono-native-lib
           /opt/R/current/bin/R CMD INSTALL --no-test-load --library=/tmp/scaffold-mono-native-lib /tmp/scaffold-mono/monorepo/mxmono
           ch=$(grep 'content-hash:' /tmp/scaffold-mono/monorepo/mxmono/src/rust/wasm_registry.rs | awk '{print $NF}')

--- a/tests/webr-smoke.sh
+++ b/tests/webr-smoke.sh
@@ -416,6 +416,18 @@ RSCRIPT
         # otherwise; the container default locale is C.
         export LANG=C.UTF-8 LC_ALL=C.UTF-8
         ( cd "$SCAFFOLD_PKG_DIR" && bash ./configure )
+        # use_local_miniextendr guard (#1309, parity with the CI legs):
+        # configure must have emitted the local-checkout [patch] block into
+        # the generated cargo config. If a marker regression made
+        # use_local_miniextendr silently no-op, this leg would build the
+        # *published* git sources instead of /work — and stay green while
+        # validating the wrong code.
+        cfg="$SCAFFOLD_PKG_DIR/src/rust/.cargo/config.toml"
+        if ! grep -qF "[patch.\"https://github.com/A2-ai/miniextendr\"]" "$cfg"; then
+            echo "FAIL: use_local_miniextendr [patch] block missing from $cfg — the scaffold would build the published miniextendr git sources, not /work." >&2
+            cat "$cfg" >&2 || true
+            exit 1
+        fi
         mkdir -p "$SCAFFOLD_NATIVE_LIB"
         "$R_NATIVE_EXE" CMD INSTALL --no-test-load --library="$SCAFFOLD_NATIVE_LIB" "$SCAFFOLD_PKG_DIR"
         ch="$(grep "content-hash:" "$SCAFFOLD_PKG_DIR/src/rust/wasm_registry.rs")"
@@ -496,6 +508,14 @@ RSCRIPT
         # wasm_registry.rs, NAMESPACE). LANG/LC_ALL=C.UTF-8 are still
         # exported from the mxsmoke leg above.
         ( cd "$MONO_PKG_DIR" && bash ./configure )
+        # use_local_miniextendr guard (#1309): same assert as the mxsmoke
+        # leg above, for the monorepo template configure.
+        cfg="$MONO_PKG_DIR/src/rust/.cargo/config.toml"
+        if ! grep -qF "[patch.\"https://github.com/A2-ai/miniextendr\"]" "$cfg"; then
+            echo "FAIL: use_local_miniextendr [patch] block missing from $cfg — the scaffold would build the published miniextendr git sources, not /work." >&2
+            cat "$cfg" >&2 || true
+            exit 1
+        fi
         mkdir -p "$MONO_NATIVE_LIB"
         "$R_NATIVE_EXE" CMD INSTALL --no-test-load --library="$MONO_NATIVE_LIB" "$MONO_PKG_DIR"
         ch="$(grep "content-hash:" "$MONO_PKG_DIR/src/rust/wasm_registry.rs")"


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

None of the three scaffold legs in `.github/workflows/webr.yml` asserted that `minirextendr::use_local_miniextendr()` actually produced the `[patch."https://github.com/A2-ai/miniextendr"]` block in the scaffold's generated `src/rust/.cargo/config.toml`. If a marker regression ever made `use_local_miniextendr()` silently no-op, the legs would flip to building the *published* git sources instead of the checkout under test — and stay green while validating the wrong code.

## Changes

One assert per leg, immediately after that leg's `bash ./configure`:

- `.github/workflows/webr.yml`
  - `monorepo-wasm-check` job, "Native R CMD INSTALL" step (`/tmp/mono-check/monorepo/mxmono/src/rust/.cargo/config.toml`)
  - mxsmoke full leg, "Scaffold leg — native install + roxygen pass" step (`/tmp/scaffold/mxsmoke/src/rust/.cargo/config.toml`)
  - monorepo full leg, "Monorepo scaffold leg — native install + roxygen pass" step (`/tmp/scaffold-mono/monorepo/mxmono/src/rust/.cargo/config.toml`)
- `tests/webr-smoke.sh` — the same assert in both `--scaffold` sections (mxsmoke + mxmono), for CI parity.

Each assert is `grep -qF '[patch."https://github.com/A2-ai/miniextendr"]'` (fixed-string, so the dots/quotes need no regex escaping) against the generated config, with a loud `::error::` (CI) / `FAIL:` (smoke script) message and a `cat` of the offending config on failure. The literal matches what both templates' `configure.ac` emit in from-source monorepo mode (the `@<:@`/`@:>@` quadrigraphs render as `[`/`]`), and the generated path is `src/rust/.cargo/config.toml` in both the standalone and monorepo templates (`RPKG_CFG` in each `configure.ac`).

The assert is a genuine guard on the marker mechanism: all three CI scaffolds live under `/tmp` while the checkout is elsewhere (`$GITHUB_WORKSPACE` / `/work`), so configure's ancestor probe can never set `MONOREPO_ROOT` on its own — the `.miniextendr-local` marker written by `use_local_miniextendr()` is the only way the patch block appears.

## Validation

- `bash -n tests/webr-smoke.sh` — OK
- `shellcheck tests/webr-smoke.sh` — identical (pre-existing, info-level) finding set before and after; no new findings
- `actionlint .github/workflows/webr.yml` — OK
- Both grep variants (the YAML single-quoted form and the smoke script's escaped-double-quote form, which lives inside `phase_scaffold`'s single-quoted `docker_run` body) exercised against a synthetic monorepo-mode config (match) and a no-monorepo config (fail) — all four cases behave correctly
- Not run: `just docker-webr-smoke` (documented-infeasible on this host — 28G VM vs ~10G free disk)

## Residual

This PR's own webR CI run exercises two of the three new asserts live: `monorepo-wasm-check` and the mxsmoke full leg both run per-PR (this PR touches `.github/workflows/webr.yml`, a trigger path). The monorepo full leg's assert sits in steps gated `if: github.event_name != 'pull_request'` and gets its first real execution on the main-push after merge.

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
