### PR TITLE
refactor(macros): drop the impl-tag warning-const block-id counter

### DIFF
--- a/miniextendr-macros/src/miniextendr_impl.rs
+++ b/miniextendr-macros/src/miniextendr_impl.rs
@@ -2593,23 +2593,20 @@ impl ParsedImpl {
             .cloned()
             .collect();
         let raw_doc_tags = crate::roxygen::roxygen_tags_from_attrs(&item_impl.attrs);
-        // Per-block disambiguator so two inherent impl blocks on the same type
-        // don't emit colliding warning consts (#1118).
-        let tag_block_id = crate::roxygen::next_impl_tag_block_id();
         // For R6: keep class-level @param tags (roxygen2 8.0.0 inherits them into
-        // all methods); for other class systems use the stricter filter.
+        // all methods); for other class systems use the stricter filter. Each
+        // stripped tag's warning lives in its own anonymous `const _: () = { .. };`
+        // scope (#1118), so no per-block disambiguator is needed here.
         let (doc_tags, param_warnings) = if attrs.class_system == ClassSystem::R6 {
             crate::roxygen::strip_method_tags_r6(
                 &raw_doc_tags,
                 &type_ident.to_string(),
-                tag_block_id,
                 item_impl.impl_token.span,
             )
         } else {
             crate::roxygen::strip_method_tags(
                 &raw_doc_tags,
                 &type_ident.to_string(),
-                tag_block_id,
                 item_impl.impl_token.span,
             )
         };

--- a/miniextendr-macros/src/miniextendr_impl_trait.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait.rs
@@ -363,7 +363,6 @@ pub fn expand_miniextendr_impl_trait(
         let (doc_tags, param_warnings) = crate::roxygen::strip_method_tags(
             &raw_tags,
             &concrete_type.to_token_stream().to_string(),
-            crate::roxygen::next_impl_tag_block_id(),
             impl_item.impl_token.span,
         );
         let no_rd = crate::roxygen::has_roxygen_tag(&doc_tags, "noRd");

--- a/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
+++ b/miniextendr-macros/src/miniextendr_impl_trait/vtable.rs
@@ -149,7 +149,6 @@ pub(super) fn generate_vtable_static(
     let (impl_doc_tags, param_warnings) = crate::roxygen::strip_method_tags(
         &raw_impl_tags,
         &type_ident.to_string(),
-        crate::roxygen::next_impl_tag_block_id(),
         impl_item.impl_token.span,
     );
     let class_has_no_rd = crate::roxygen::has_roxygen_tag(&impl_doc_tags, "noRd");

--- a/miniextendr-macros/src/roxygen.rs
+++ b/miniextendr-macros/src/roxygen.rs
@@ -661,23 +661,6 @@ fn roxygen_tag_name(tag: &str) -> Option<&str> {
     Some(&rest[..end])
 }
 
-/// Monotonic per-crate counter used to disambiguate the compile-warning const
-/// names emitted by [`strip_method_tags`] / [`strip_method_tags_r6`].
-///
-/// The const name is keyed on the type name, but two `#[miniextendr] impl Foo`
-/// blocks on the *same* type (e.g. an inherent impl plus a trait impl, or two
-/// inherent impls) each restart their per-block `warning_id` at 0, so without a
-/// per-block disambiguator they emit identically-named consts and collide with
-/// `error[E0428]: the name ... is defined multiple times` (#1118). Every call
-/// site draws a fresh block id from this counter so the names stay unique
-/// within a crate compilation — the exact scope const names must be unique in,
-/// since the statics reset per rustc process (one process per crate).
-pub(crate) fn next_impl_tag_block_id() -> usize {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    static IMPL_TAG_WARN_BLOCK: AtomicUsize = AtomicUsize::new(0);
-    IMPL_TAG_WARN_BLOCK.fetch_add(1, Ordering::Relaxed)
-}
-
 /// Filter out method-specific roxygen tags from impl-block-level docs and emit
 /// compile warnings for each stripped tag.
 ///
@@ -687,9 +670,13 @@ pub(crate) fn next_impl_tag_block_id() -> usize {
 /// put them on impl blocks, the tags leak into the class-level Rd file where
 /// R CMD check warns about "documented arguments not in \\usage" and similar.
 ///
-/// `block_id` is a per-impl-block disambiguator (see [`next_impl_tag_block_id`])
-/// that keeps the emitted warning-const names unique across multiple impl
-/// blocks on the same type (#1118).
+/// Each stripped tag's warning is wrapped in its own anonymous
+/// `const _: () = { ... };` block (same pattern as [`doc_conflict_warnings`]),
+/// so the inner const names can stay fixed — an anonymous const block is a
+/// fresh item scope every expansion, so two `#[miniextendr] impl Foo` blocks
+/// on the *same* type (e.g. an inherent impl plus a trait impl) never collide
+/// with `error[E0428]: the name ... is defined multiple times`, without any
+/// per-block disambiguator (#1118).
 ///
 /// Returns the filtered tags and a TokenStream of deprecation warnings for
 /// each stripped tag. The caller should append the warnings to its output so
@@ -697,14 +684,12 @@ pub(crate) fn next_impl_tag_block_id() -> usize {
 pub(crate) fn strip_method_tags(
     tags: &[String],
     type_name: &str,
-    block_id: usize,
     span: proc_macro2::Span,
 ) -> (Vec<String>, proc_macro2::TokenStream) {
     use quote::quote_spanned;
 
     let mut filtered = Vec::new();
     let mut warnings = proc_macro2::TokenStream::new();
-    let mut warning_id: usize = 0;
 
     for tag in tags {
         let Some(name) = roxygen_tag_name(tag) else {
@@ -721,23 +706,16 @@ pub(crate) fn strip_method_tags(
             type_name,
             tag.trim()
         );
-        let suffix = format!(
-            "{}_{}_{}",
-            type_name.replace(|c: char| !c.is_alphanumeric(), "_"),
-            block_id,
-            warning_id
-        );
-        let ident = quote::format_ident!("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_{}", suffix);
-        let use_ident = quote::format_ident!("_MINIEXTENDR_IMPL_METHOD_TAG_USE_{}", suffix);
-        warning_id += 1;
         warnings.extend(quote_spanned! { span =>
-            #[deprecated(note = #msg)]
-            #[doc(hidden)]
-            #[allow(dead_code, non_upper_case_globals)]
-            const #ident: () = ();
-            #[doc(hidden)]
-            #[allow(dead_code, non_upper_case_globals)]
-            const #use_ident: () = #ident;
+            const _: () = {
+                #[deprecated(note = #msg)]
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                const _MINIEXTENDR_IMPL_METHOD_TAG_WARN: () = ();
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                const _MINIEXTENDR_IMPL_METHOD_TAG_USE: () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN;
+            };
         });
     }
 
@@ -868,19 +846,19 @@ pub(crate) fn formal_name(formal: &str) -> &str {
 /// stripped with a compile-time warning. No warning is generated for `@param`.
 ///
 /// Returns `(filtered_tags, warnings)` — same shape as [`strip_method_tags`].
-/// `block_id` is the per-impl-block disambiguator (see
-/// [`next_impl_tag_block_id`]) that keeps warning-const names unique (#1118).
+/// Each stripped tag's warning is wrapped in its own anonymous
+/// `const _: () = { ... };` block, so no per-impl-block disambiguator is
+/// needed to keep warning-const names unique (#1118) — see
+/// [`strip_method_tags`] for the full rationale.
 pub(crate) fn strip_method_tags_r6(
     tags: &[String],
     type_name: &str,
-    block_id: usize,
     span: proc_macro2::Span,
 ) -> (Vec<String>, proc_macro2::TokenStream) {
     use quote::quote_spanned;
 
     let mut filtered = Vec::new();
     let mut warnings = proc_macro2::TokenStream::new();
-    let mut warning_id: usize = 0;
 
     for tag in tags {
         let Some(name) = roxygen_tag_name(tag) else {
@@ -898,23 +876,16 @@ pub(crate) fn strip_method_tags_r6(
             type_name,
             tag.trim()
         );
-        let suffix = format!(
-            "{}_{}_{}",
-            type_name.replace(|c: char| !c.is_alphanumeric(), "_"),
-            block_id,
-            warning_id
-        );
-        let ident = quote::format_ident!("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_{}", suffix);
-        let use_ident = quote::format_ident!("_MINIEXTENDR_IMPL_METHOD_TAG_USE_{}", suffix);
-        warning_id += 1;
         warnings.extend(quote_spanned! { span =>
-            #[deprecated(note = #msg)]
-            #[doc(hidden)]
-            #[allow(dead_code, non_upper_case_globals)]
-            const #ident: () = ();
-            #[doc(hidden)]
-            #[allow(dead_code, non_upper_case_globals)]
-            const #use_ident: () = #ident;
+            const _: () = {
+                #[deprecated(note = #msg)]
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                const _MINIEXTENDR_IMPL_METHOD_TAG_WARN: () = ();
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                const _MINIEXTENDR_IMPL_METHOD_TAG_USE: () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN;
+            };
         });
     }
 

--- a/miniextendr-macros/src/roxygen/tests.rs
+++ b/miniextendr-macros/src/roxygen/tests.rs
@@ -676,7 +676,7 @@ fn strip_method_tags_drops_param_return_examples_export() {
     .collect();
 
     let span = proc_macro2::Span::call_site();
-    let (kept, _warnings) = strip_method_tags(&tags, "MyType", 0, span);
+    let (kept, _warnings) = strip_method_tags(&tags, "MyType", span);
     assert_eq!(
         kept,
         vec![
@@ -701,7 +701,7 @@ fn strip_method_tags_preserves_export_variants() {
     .map(|s| (*s).to_string())
     .collect();
 
-    let (kept, _warnings) = strip_method_tags(&tags, "MyType", 0, proc_macro2::Span::call_site());
+    let (kept, _warnings) = strip_method_tags(&tags, "MyType", proc_macro2::Span::call_site());
     assert_eq!(
         kept,
         vec![
@@ -719,39 +719,39 @@ fn strip_method_tags_leaves_prose_untouched() {
         .map(|s| (*s).to_string())
         .collect();
 
-    let (kept, _warnings) = strip_method_tags(&tags, "MyType", 0, proc_macro2::Span::call_site());
+    let (kept, _warnings) = strip_method_tags(&tags, "MyType", proc_macro2::Span::call_site());
     assert_eq!(kept, tags);
 }
 
 #[test]
-fn strip_method_tags_disambiguates_warning_consts_per_block() {
+fn strip_method_tags_wraps_each_warning_in_its_own_anonymous_const_scope() {
     // #1118: two impl blocks on the same type each strip a method-only tag.
-    // With a per-block `block_id` the emitted warning-const names must differ,
-    // otherwise the two consts collide with E0428 when spliced side-by-side.
+    // Previously this needed a per-block `block_id` disambiguator baked into
+    // the const names, or the two emissions collided with E0428 once spliced
+    // side by side. Wrapping each warning in its own `const _: () = { .. };`
+    // block gives every emission a fresh, anonymous item scope instead — so
+    // two calls produce textually *identical* tokens and still never collide.
     let tags: Vec<String> = vec!["@param x an input".to_string()];
     let span = proc_macro2::Span::call_site();
 
-    let (_, warn_block0) = strip_method_tags(&tags, "MyType", 0, span);
-    let (_, warn_block1) = strip_method_tags(&tags, "MyType", 1, span);
+    let (_, warnings_a) = strip_method_tags(&tags, "MyType", span);
+    let (_, warnings_b) = strip_method_tags(&tags, "MyType", span);
 
-    let s0 = warn_block0.to_string();
-    let s1 = warn_block1.to_string();
+    let sa = warnings_a.to_string();
+    let sb = warnings_b.to_string();
 
-    // Each block emits exactly one nudge const, and the names carry the block id.
-    assert!(
-        s0.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyType_0_0"),
-        "block 0 const name unexpected: {s0}"
+    assert_eq!(
+        sa, sb,
+        "no per-block disambiguator needed — anonymous scoping does the work"
     );
     assert!(
-        s1.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyType_1_0"),
-        "block 1 const name unexpected: {s1}"
+        sa.contains("const _"),
+        "warning must be wrapped in an anonymous const scope: {sa}"
     );
-    assert_ne!(s0, s1, "warning consts from different blocks must differ");
-
-    // next_impl_tag_block_id() must hand out distinct ids so callers never reuse.
-    let a = crate::roxygen::next_impl_tag_block_id();
-    let b = crate::roxygen::next_impl_tag_block_id();
-    assert_ne!(a, b);
+    assert!(
+        sa.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN"),
+        "WARN const missing: {sa}"
+    );
 }
 
 #[test]
@@ -764,30 +764,24 @@ fn strip_method_tags_activates_use_const_referencing_warn_ident() {
     let tags: Vec<String> = vec!["@param x an input".to_string()];
     let span = proc_macro2::Span::call_site();
 
-    let (_, warnings) = strip_method_tags(&tags, "MyType", 0, span);
+    let (_, warnings) = strip_method_tags(&tags, "MyType", span);
     let s = warnings.to_string();
 
     assert!(
-        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyType_0_0"),
+        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN"),
         "WARN const missing: {s}"
     );
     assert!(
-        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_USE_MyType_0_0"),
+        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_USE"),
         "USE const missing: {s}"
     );
     // The USE const's initializer must read the WARN const by name, so
     // referencing it trips rustc's `deprecated` lint on the WARN const.
     assert!(
         s.contains(
-            "const _MINIEXTENDR_IMPL_METHOD_TAG_USE_MyType_0_0 : () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyType_0_0"
+            "const _MINIEXTENDR_IMPL_METHOD_TAG_USE : () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN"
         ),
         "USE const must initialize from the WARN const's value: {s}"
-    );
-    // Both consts carry `non_upper_case_globals` (names embed mixed-case type
-    // names) alongside `dead_code`.
-    assert!(
-        s.matches("non_upper_case_globals").count() >= 2,
-        "expected non_upper_case_globals on both consts: {s}"
     );
 }
 
@@ -798,21 +792,21 @@ fn strip_method_tags_r6_activates_use_const_for_stripped_tags() {
     let tags: Vec<String> = vec!["@return something".to_string()];
     let span = proc_macro2::Span::call_site();
 
-    let (kept, warnings) = strip_method_tags_r6(&tags, "MyR6Type", 0, span);
+    let (kept, warnings) = strip_method_tags_r6(&tags, "MyR6Type", span);
     assert!(kept.is_empty(), "@return must still be stripped for R6");
 
     let s = warnings.to_string();
     assert!(
-        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyR6Type_0_0"),
+        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_WARN"),
         "WARN const missing: {s}"
     );
     assert!(
-        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_USE_MyR6Type_0_0"),
+        s.contains("_MINIEXTENDR_IMPL_METHOD_TAG_USE"),
         "USE const missing: {s}"
     );
     assert!(
         s.contains(
-            "const _MINIEXTENDR_IMPL_METHOD_TAG_USE_MyR6Type_0_0 : () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyR6Type_0_0"
+            "const _MINIEXTENDR_IMPL_METHOD_TAG_USE : () = _MINIEXTENDR_IMPL_METHOD_TAG_WARN"
         ),
         "USE const must initialize from the WARN const's value: {s}"
     );

--- a/miniextendr-macros/tests/ui/impl_method_tag_deprecated_deny.stderr
+++ b/miniextendr-macros/tests/ui/impl_method_tag_deprecated_deny.stderr
@@ -1,12 +1,11 @@
-error: use of deprecated constant `_MINIEXTENDR_IMPL_METHOD_TAG_WARN_MyType_0_0`: miniextendr: @param on impl block `MyType` has no effect — move it to the method. Tag: @param x nope
-  --> tests/ui/impl_method_tag_deprecated_deny.rs:19:1
+error: use of deprecated constant `_::_MINIEXTENDR_IMPL_METHOD_TAG_WARN`: miniextendr: @param on impl block `MyType` has no effect — move it to the method. Tag: @param x nope
+  --> tests/ui/impl_method_tag_deprecated_deny.rs:20:1
    |
-19 | #[miniextendr]
-   | ^^^^^^^^^^^^^^
+20 | impl MyType {
+   | ^^^^
    |
 note: the lint level is defined here
   --> tests/ui/impl_method_tag_deprecated_deny.rs:11:9
    |
 11 | #![deny(deprecated)]
    |         ^^^^^^^^^^
-   = note: this error originates in the attribute macro `miniextendr` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/miniextendr-macros/tests/ui/pass/impl_method_tag_const_no_collision.rs
+++ b/miniextendr-macros/tests/ui/pass/impl_method_tag_const_no_collision.rs
@@ -6,8 +6,10 @@
 //! Each block strips its tag and emits a `#[deprecated]` nudge const; before
 //! the fix both consts were named `_MINIEXTENDR_IMPL_METHOD_TAG_WARN_<Type>_0`
 //! and collided with `error[E0428]: the name ... is defined multiple times`.
-//! The per-block disambiguator (`next_impl_tag_block_id`) makes the names
-//! unique, so this compiles.
+//! Each nudge is now wrapped in its own anonymous `const _: () = { .. };`
+//! scope, so the inner const names can stay fixed — an anonymous const block
+//! is a fresh item namespace every expansion — and this compiles without any
+//! per-block disambiguator.
 //!
 //! (Two *unlabeled* inherent impl blocks on one type is not a valid
 //! reproduction: they also collide on `R_WRAPPERS_IMPL_<TYPE>`, which is

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -353,8 +353,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn test_vec_dataframe() {
         let rows = vec![

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -982,8 +982,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn vec_width_align_pinned_columns() {
         let df = VecWidthEvent::to_dataframe(vec![


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `strip_method_tags` / `strip_method_tags_r6` emitted their misplaced-roxygen-tag nudge as named module-scope consts (`_MINIEXTENDR_IMPL_METHOD_TAG_{WARN,USE}_<type>_<block>_<n>`), which required the crate-wide `next_impl_tag_block_id()` `AtomicUsize` counter (#1118) purely to keep the names from colliding with E0428 across multiple impl blocks on one type.
- `doc_conflict_warnings` in the same file already solves the identical problem by wrapping its `#[deprecated]` dummy const in an anonymous `const _: () = { ... };` block (a fresh item scope per expansion). This PR converts both strip functions to that pattern with fixed inner names, drops the `block_id` parameter, deletes the counter and all suffix-formatting machinery, and updates the three call sites (`miniextendr_impl.rs`, `miniextendr_impl_trait.rs`, `miniextendr_impl_trait/vtable.rs`). All three splice at module scope, where anonymous consts are legal.
- Net -43 lines. The fixed const names are uppercase-conforming, so the `non_upper_case_globals` allow is gone too.
- `tests/ui/impl_method_tag_deprecated_deny.stderr` regenerated (via `just test-ui`, auto-isolated minimal-profile toolchain per the repo's rust-src rule): message text is byte-identical; the diagnostic now resolves as `_::_MINIEXTENDR_IMPL_METHOD_TAG_WARN` and points at the `impl MyType {` line instead of the `#[miniextendr]` attribute line, and the "originates in attribute macro" note is dropped. That is a diagnostic improvement (it points at the block carrying the misplaced tag).
- Also fixes duplicated `use miniextendr_api::dataframe::ColumnarFrame;` imports in `rpkg/src/rust/dataframe_collections_test.rs` and `dataframe_enum_payload_matrix.rs` (E0252, pre-existing on main via #1380). Unrelated to the refactor, but it made `just check` red on main and blocked verification, so it is fixed here per the fix-warnings-you-see rule.

## Test plan
- [x] `cargo test -p miniextendr-macros --locked` (480 unit tests + doctests)
- [x] `just test-ui` (both trybuild suites, minimal-profile toolchain; includes the #1118 regression test `tests/ui/pass/impl_method_tag_const_no_collision.rs`: inherent + trait impl on one type, two warnings, no E0428)
- [x] `cargo clippy -p miniextendr-macros --all-targets --locked -- -D warnings`
- [x] `just check`, `cargo fmt --all -- --check`
- [ ] CI `clippy_all` / `clippy_all_s7` legs (not run locally; touched paths carry no feature gates)

## Notes
- The deny-snapshot span shift is user-visible but cosmetic, and arguably better placed. No message text changed.
- Motivated by a repo-wide audit of `const _: ()` usage (2026-07-17), which found this was the only site implementing the deprecated-const trick without anonymous-block scoping.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>