### PR TITLE
docs(macros): mark PreferX conflict-marker const as deliberately named

### DIFF
--- a/miniextendr-macros/src/list_derive.rs
+++ b/miniextendr-macros/src/list_derive.rs
@@ -352,6 +352,11 @@ fn prefer_conflict_marker(input: &DeriveInput) -> TokenStream {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
+    // Deliberately a NAMED const, not `const _: () = ...`: two stacked `Prefer*`
+    // derives must emit the identical name so rustc's duplicate-definition
+    // check (E0592) fires. An anonymous `const _` block never collides with
+    // itself, which would silently remove this diagnostic — do not "clean up"
+    // this into the anonymous form.
     quote! {
         #[allow(non_upper_case_globals, dead_code)]
         impl #impl_generics #name #ty_generics #where_clause {


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Adds a load-bearing comment at `prefer_conflict_marker`'s emission site in `miniextendr-macros/src/list_derive.rs`: the named inherent const `__miniextendr_conflicting_Prefer_derives__keep_ONE_or_use_call_site_As_wrappers` is deliberate. Two stacked `Prefer*` derives must emit the identical name so rustc's duplicate-definition check (E0592) fires; an anonymous `const _: ()` block never collides and would silently remove the diagnostic.
- Comment-only, no codegen change. Guards against a future cleanup sweep converting this site along with the codebase's other `const _: ()` assertion blocks (repo-wide audit, 2026-07-17).
- No new test needed: `tests/ui/derive_prefer_conflict.rs` + `.stderr` (#870) already stack `PreferList` + `PreferRNativeType` and assert both E0119 and the E0592 collision on this exact const name.

## Test plan
- [x] `just test-ui` (minimal-profile toolchain; `derive_prefer_conflict` passes unchanged)
- [x] `cargo clippy -p miniextendr-macros --all-targets -- -D warnings`
- [x] `cargo fmt --all`

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>