### PR TITLE
fix(serde): recursive Compound union in columnar schema discovery (#1370)

### DIFF
--- a/miniextendr-api/src/serde/columnar.rs
+++ b/miniextendr-api/src/serde/columnar.rs
@@ -96,6 +96,7 @@ macro_rules! reject_non_struct {
 /// | `Option<T>` | Same type with NA for `None` |
 /// | `Option<T>` (every row `None`) | `logical` NA column — R coerces to the surrounding type on first use (`c(NA, 1L)` → integer, `c(NA, "x")` → character) |
 /// | Nested struct | Recursively flattened with `parent_child` naming |
+/// | Nested struct's `Option<T>` sub-field | Column type is the union across **all** rows, independent of row order — a sub-field that is `None` on the first row (or first several rows) but typed on a later one still gets that atomic type (`character`, `integer`, …), not a `list` column. Only if the sub-field is `None` in *every* row does it fall back to the `logical` NA downgrade above (nothing to union from). |
 /// | Other | Falls back to per-element list column |
 pub fn vec_to_dataframe<T: Serialize>(rows: &[T]) -> Result<BuiltDataFrame, RSerdeError> {
     if rows.is_empty() {
@@ -1271,6 +1272,7 @@ impl<T: Serialize> SerdeRowBuilder<T> {
 // region: Field mapping (recursive name → column routing)
 
 /// Maps a field name to its column location in the flat column array.
+#[derive(Clone)]
 enum FieldMapping {
     /// Scalar field: writes directly to one column.
     Scalar { col_idx: usize },
@@ -1283,6 +1285,7 @@ enum FieldMapping {
 }
 
 /// Name-to-column mapping for one level of struct fields.
+#[derive(Clone)]
 struct FieldMap {
     map: HashMap<String, FieldMapping>,
     col_start: usize,
@@ -1302,6 +1305,7 @@ enum ColumnType {
     Generic,
 }
 
+#[derive(Clone)]
 struct FieldInfo {
     name: String,
     col_type: ColumnType,
@@ -1329,28 +1333,217 @@ enum Candidate {
 /// - `Scalar(Generic)` is the bottom (None-only probes land here).
 ///
 /// Two `Scalar(non-Generic)` of different types: keep the first seen (no widening).
-/// Two `Compound` of different shapes: keep the first seen (recursive union is out of scope).
+/// Two `Compound` of different shapes: **recursively unioned** key-by-key
+/// (#1370) — see [`merge_compound_shapes`]. This is what lets a nested
+/// sub-field whose first-row probe is `None` (`Scalar(Generic)`) still
+/// upgrade to an atomic type when a later row types it, instead of locking
+/// the whole nested column to `Generic` (list).
 fn resolve_candidates(candidates: &mut Vec<Candidate>) -> Candidate {
-    // Walk candidates and pick the best.
-    // We need to own the winner, so find its index then swap-remove.
-    let mut best_idx = 0;
-    for (i, c) in candidates.iter().enumerate() {
-        match (&candidates[best_idx], c) {
-            // Compound is always at least as good as what we have.
-            (_, Candidate::Compound { .. }) => {
-                best_idx = i;
-                break; // Compound is the top of the lattice — no need to look further.
-            }
-            // Scalar(non-Generic) beats Scalar(Generic).
-            (Candidate::Scalar(ColumnType::Generic), Candidate::Scalar(t))
-                if *t != ColumnType::Generic =>
-            {
-                best_idx = i;
-            }
-            _ => {}
+    let mut drained = candidates.drain(..);
+    let mut acc = drained
+        .next()
+        .expect("resolve_candidates: called with an empty candidate list");
+    for next in drained {
+        acc = combine_two_candidates(acc, next);
+    }
+    acc
+}
+
+/// Fold two candidates (in row order — `a` seen no later than `b`) into one,
+/// per the lattice documented on [`resolve_candidates`].
+fn combine_two_candidates(a: Candidate, b: Candidate) -> Candidate {
+    match (a, b) {
+        (
+            Candidate::Compound {
+                fields: af,
+                sub_map: am,
+            },
+            Candidate::Compound {
+                fields: bf,
+                sub_map: bm,
+            },
+        ) => {
+            let (fields, sub_map) = merge_compound_shapes(af, am, bf, bm);
+            Candidate::Compound { fields, sub_map }
+        }
+        // Compound beats Scalar regardless of which side it's on.
+        (Candidate::Compound { fields, sub_map }, Candidate::Scalar(_))
+        | (Candidate::Scalar(_), Candidate::Compound { fields, sub_map }) => {
+            Candidate::Compound { fields, sub_map }
+        }
+        // Scalar(non-Generic) beats Scalar(Generic).
+        (Candidate::Scalar(ColumnType::Generic), Candidate::Scalar(t))
+            if t != ColumnType::Generic =>
+        {
+            Candidate::Scalar(t)
+        }
+        // Otherwise keep the first-seen scalar (no widening between two non-Generic
+        // types; both-Generic stays Generic).
+        (Candidate::Scalar(t), Candidate::Scalar(_)) => Candidate::Scalar(t),
+    }
+}
+
+/// A resolved slot for one key inside a nested-`Compound` shape, keeping its
+/// already fully-qualified column name(s) (`process_field` prefixes names
+/// with `{parent_key}_` as it flattens, so a leaf's [`FieldInfo::name`] is
+/// already e.g. `"meta_variant"` by the time it reaches here). Mirrors
+/// [`Candidate`] — the only difference is that the scalar leaf carries its
+/// `FieldInfo` (name + type) rather than just a bare [`ColumnType`], since
+/// [`Candidate::Scalar`] normally gets its name for free from the enclosing
+/// per-key `HashMap` key, which nested recursion doesn't have.
+enum SubShape {
+    Scalar(FieldInfo),
+    Compound(Vec<FieldInfo>, FieldMap),
+}
+
+/// Pull the (bare-key) child `key`'s shape out of a `Compound` candidate's
+/// `(fields, field_map)` pair. `fields` holds every leaf under this Compound in
+/// flat, already-prefixed-name order; `field_map.col_start` is the absolute
+/// column index of `fields[0]`, so `col_idx - field_map.col_start` recovers the
+/// local index into `fields` for any mapping found in `field_map`.
+fn extract_sub_shape(fields: &[FieldInfo], field_map: &FieldMap, key: &str) -> Option<SubShape> {
+    match field_map.map.get(key)? {
+        FieldMapping::Scalar { col_idx } => {
+            let local = col_idx - field_map.col_start;
+            Some(SubShape::Scalar(fields[local].clone()))
+        }
+        FieldMapping::Compound {
+            col_start,
+            col_count,
+            sub_fields,
+        } => {
+            let local_start = col_start - field_map.col_start;
+            let child_fields = fields[local_start..local_start + col_count].to_vec();
+            Some(SubShape::Compound(child_fields, sub_fields.clone()))
         }
     }
-    candidates.swap_remove(best_idx)
+}
+
+/// The first-seen key order of one level of a [`FieldMap`], recovered from
+/// each mapping's column position (field declaration order is stable across
+/// probes of the same Rust type, so sorting by position reconstructs it;
+/// `FieldMap.map` itself is a `HashMap` with no ordering of its own).
+fn field_map_key_order(field_map: &FieldMap) -> Vec<String> {
+    let mut entries: Vec<(usize, &String)> = field_map
+        .map
+        .iter()
+        .map(|(k, v)| {
+            let pos = match v {
+                FieldMapping::Scalar { col_idx } => *col_idx,
+                FieldMapping::Compound { col_start, .. } => *col_start,
+            };
+            (pos, k)
+        })
+        .collect();
+    entries.sort_by_key(|(pos, _)| *pos);
+    entries.into_iter().map(|(_, k)| k.clone()).collect()
+}
+
+/// Fold two shapes for the *same* key into one, applying the same lattice as
+/// [`combine_two_candidates`] (recursing into [`merge_compound_shapes`] for
+/// Compound-vs-Compound instead of keeping the first seen).
+fn combine_sub_shapes(a: SubShape, b: SubShape) -> SubShape {
+    match (a, b) {
+        (SubShape::Compound(af, am), SubShape::Compound(bf, bm)) => {
+            let (fields, sub_map) = merge_compound_shapes(af, am, bf, bm);
+            SubShape::Compound(fields, sub_map)
+        }
+        (SubShape::Compound(fields, sub_map), SubShape::Scalar(_))
+        | (SubShape::Scalar(_), SubShape::Compound(fields, sub_map)) => {
+            SubShape::Compound(fields, sub_map)
+        }
+        (SubShape::Scalar(a_info), SubShape::Scalar(b_info)) => {
+            if a_info.col_type == ColumnType::Generic && b_info.col_type != ColumnType::Generic {
+                SubShape::Scalar(b_info)
+            } else {
+                SubShape::Scalar(a_info)
+            }
+        }
+    }
+}
+
+/// Append a resolved key's shape into a fresh flat `(fields, field_map)` pair
+/// under construction, assigning it the next contiguous column slot(s).
+fn place_sub_shape(
+    key: String,
+    shape: SubShape,
+    merged_fields: &mut Vec<FieldInfo>,
+    merged_map: &mut HashMap<String, FieldMapping>,
+) {
+    match shape {
+        SubShape::Scalar(info) => {
+            let col_idx = merged_fields.len();
+            merged_fields.push(info);
+            merged_map.insert(key, FieldMapping::Scalar { col_idx });
+        }
+        SubShape::Compound(fields, sub_fields) => {
+            let col_start = merged_fields.len();
+            let col_count = fields.len();
+            let old_base = sub_fields.col_start;
+            let remapped = remap_field_map(sub_fields, old_base, col_start);
+            merged_fields.extend(fields);
+            merged_map.insert(
+                key,
+                FieldMapping::Compound {
+                    col_start,
+                    col_count,
+                    sub_fields: remapped,
+                },
+            );
+        }
+    }
+}
+
+/// Recursively union two `Compound` candidates' shapes key-by-key (#1370).
+///
+/// Instead of discarding `b` wholesale (the pre-#1370 "keep first seen"
+/// behaviour), each key present in either side is resolved through the same
+/// lattice as [`resolve_candidates`] — recursing for nested `Compound`
+/// sub-fields — so a sub-field that probed as `Generic` in `a` (e.g. a `None`
+/// row) can still pick up a concrete type from `b`, and a key present only in
+/// `b` (a genuinely different shape, e.g. a `#[serde(skip_serializing_if)]`
+/// field omitted in `a`'s row but present in `b`'s) is no longer dropped.
+///
+/// Key order is first-seen union: `a`'s keys in `a`'s own order, then any of
+/// `b`'s keys not already in `a`, in `b`'s own order — mirroring the
+/// top-level `SchemaAccumulator` union order.
+fn merge_compound_shapes(
+    a_fields: Vec<FieldInfo>,
+    a_map: FieldMap,
+    b_fields: Vec<FieldInfo>,
+    b_map: FieldMap,
+) -> (Vec<FieldInfo>, FieldMap) {
+    let a_order = field_map_key_order(&a_map);
+    let b_order = field_map_key_order(&b_map);
+
+    let mut merged_fields: Vec<FieldInfo> = Vec::new();
+    let mut merged_map: HashMap<String, FieldMapping> = HashMap::new();
+
+    for key in a_order {
+        let a_shape = extract_sub_shape(&a_fields, &a_map, &key)
+            .expect("key drawn from a_map's own key order");
+        let shape = match extract_sub_shape(&b_fields, &b_map, &key) {
+            Some(b_shape) => combine_sub_shapes(a_shape, b_shape),
+            None => a_shape,
+        };
+        place_sub_shape(key, shape, &mut merged_fields, &mut merged_map);
+    }
+    for key in b_order {
+        if a_map.map.contains_key(&key) {
+            continue; // already resolved above (both sides had it)
+        }
+        let b_shape = extract_sub_shape(&b_fields, &b_map, &key)
+            .expect("key drawn from b_map's own key order");
+        place_sub_shape(key, b_shape, &mut merged_fields, &mut merged_map);
+    }
+
+    let total_cols = merged_fields.len();
+    let field_map = FieldMap {
+        map: merged_map,
+        col_start: 0,
+        total_cols,
+    };
+    (merged_fields, field_map)
 }
 
 /// Mode controls accumulation strictness and the final empty-schema error wording.
@@ -1368,8 +1561,8 @@ enum SchemaMode {
 /// Accumulates per-row probes into per-key candidate lists, then resolves them
 /// into a unified [`Schema`].
 ///
-/// Two limitations vs. a fully-typed schema (apply to Union mode; SingleRow sees ≤1
-/// candidate per key so the lattice degenerates):
+/// One limitation vs. a fully-typed schema (applies to Union mode; SingleRow sees
+/// ≤1 candidate per key so the lattice degenerates):
 ///
 /// - **Truly-all-None nested `Option<Struct>`**: when every row has `None` for an
 ///   `Option<UserStruct>`, the probe never sees the inner struct's fields. The key lands
@@ -1377,12 +1570,14 @@ enum SchemaMode {
 ///   downgrade converts to a single logical-NA column. Structurally unfixable without a
 ///   type-level hint on stable Rust.
 ///
-/// - **Compound-vs-Compound recursive union**: when two rows produce different Compound
-///   shapes for the same key (e.g., enum variants with different nested structs), the
-///   first Compound wins and the second is silently discarded. Corollary: a nested
-///   sub-field probed as `None` on the first row stays `Generic` (list column) even
-///   when a later row types it. Recursive union is tracked as
-///   [#1370](https://github.com/A2-ai/miniextendr/issues/1370).
+/// Two rows producing different `Compound` shapes for the same key (e.g., a nested
+/// sub-field probed as `None` — `Scalar(Generic)` — on the first row and typed on a
+/// later one, or a `#[serde(skip_serializing_if)]` sub-field present in some rows'
+/// shape but not others') are no longer resolved by keeping the first seen: they are
+/// **recursively unioned** key-by-key through the same lattice, so the merged shape
+/// carries every sub-field each side saw, each at its best-seen type. See
+/// [`resolve_candidates`] / [`merge_compound_shapes`]
+/// ([#1370](https://github.com/A2-ai/miniextendr/issues/1370), fixed).
 struct SchemaAccumulator {
     candidates: HashMap<String, Vec<Candidate>>,
     key_order: Vec<String>,
@@ -3917,8 +4112,10 @@ impl<M: ser::SerializeMap> ser::SerializeTupleVariant for ForwardingMapEmitter<'
 /// - **Compound-vs-compound payload divergence.** Payload subfields are emitted
 ///   *flat* into the parent map, so each leaf key goes through scalar Union
 ///   resolution independently — variants whose payloads differ in shape merge
-///   per-leaf-key, sidestepping the first-seen-Compound limitation of nested
-///   struct discovery.
+///   per-leaf-key. (Plain [`vec_to_dataframe`]'s nested-struct `Compound`
+///   candidates recursively union the same way as of
+///   [#1370](https://github.com/A2-ai/miniextendr/issues/1370); this bullet
+///   just documents that this function's flat-leaf-key path always did.)
 ///
 /// # Errors
 ///

--- a/miniextendr-api/tests/serde_columnar.rs
+++ b/miniextendr-api/tests/serde_columnar.rs
@@ -1058,10 +1058,15 @@ fn struct_fields_optout_keeps_option_enum_none_for_other_fields() {
     }
 
     r_test_utils::with_r_thread(|| {
-        // Row 1 keeps `meta.variant = Some(...)`: a nested sub-field probed as
-        // `None` on the *first* row locks its column to Generic (list) via the
-        // writer's Compound-vs-Compound first-seen lattice (#1370) — a separate
-        // writer limitation, not the #1320 heuristic under test here.
+        // Row 1 keeps `meta.variant = Some(...)`; row 2 has `meta.variant =
+        // None`. Prior to #1370's recursive Compound union this row order
+        // avoided a *separate* writer limitation (a nested sub-field probed
+        // as `None` on the first row locked its column to Generic/list) that
+        // would otherwise be conflated with the #1320 heuristic under test
+        // here. #1370 is now fixed (see `option_nested_struct_tag_collision_...`-
+        // adjacent tests in this file for direct coverage), so this ordering
+        // is no longer load-bearing for the writer — kept as-is since it's
+        // still a valid, order-independent regression for the #1320 opt-out.
         let rows = vec![
             Row {
                 id: 1,
@@ -1297,6 +1302,318 @@ fn flatten_enum_reader_tuple_variant_roundtrip() {
         assert!(names.contains(&"m__1".to_string()), "{names:?}");
         let round: Vec<Row> = dataframe_to_vec(sexp).unwrap();
         assert_eq!(round, rows);
+    });
+}
+
+// endregion
+
+// region: recursive Compound union in schema discovery (#1370)
+
+/// #1370 repro, plain (non-`Option`) nested struct: a sub-field probed as
+/// `None` on the *first* row must still type as an atomic column (not a
+/// Generic/list column) once a later row types it.
+#[test]
+fn compound_none_first_nested_subfield_types_atomic() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Meta,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Meta {
+                    variant: None,
+                    size: 4.0,
+                },
+            },
+            Row {
+                id: 2,
+                meta: Meta {
+                    variant: Some("x".into()),
+                    size: 5.0,
+                },
+            },
+        ];
+        let df = vec_to_dataframe(&rows).unwrap();
+        let sexp = df.as_sexp();
+        let variant_col = col(&sexp, "meta_variant");
+        assert_eq!(
+            variant_col.type_of(),
+            miniextendr_api::SEXPTYPE::STRSXP,
+            "None-first nested sub-field must type as character, not a list column"
+        );
+        assert_eq!(variant_col.string_elt_str(0), None, "row 1 is NA");
+        assert_eq!(variant_col.string_elt_str(1), Some("x"));
+        let round: Vec<Row> = dataframe_to_vec(sexp).unwrap();
+        assert_eq!(round, rows);
+    });
+}
+
+/// Same repro through an `Option<Meta>` outer field (the issue notes "plain
+/// or `Option<Meta>` — same result"): the outer `Option` resolves to
+/// `Compound` (both rows are `Some`), so the same nested-sub-field-`None`-
+/// first bug applies to `meta_variant` underneath it.
+///
+/// Reads back via the `dataframe_to_vec_with_struct_fields` opt-out (not the
+/// default `dataframe_to_vec`) so this test isolates the *writer* fix (#1370)
+/// from the *reader*'s separate `variant`-name tag-column collision (#1320,
+/// covered by `option_nested_struct_tag_collision_default_is_lossy` and
+/// `compound_fix_resolves_1320_interaction_none_first_no_longer_errors`).
+#[test]
+fn compound_none_first_nested_subfield_types_atomic_through_option_outer() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Some(Meta {
+                    variant: None,
+                    size: 4.0,
+                }),
+            },
+            Row {
+                id: 2,
+                meta: Some(Meta {
+                    variant: Some("x".into()),
+                    size: 5.0,
+                }),
+            },
+        ];
+        let df = vec_to_dataframe(&rows).unwrap();
+        let sexp = df.as_sexp();
+        let variant_col = col(&sexp, "meta_variant");
+        assert_eq!(
+            variant_col.type_of(),
+            miniextendr_api::SEXPTYPE::STRSXP,
+            "None-first nested sub-field must type as character, not a list column"
+        );
+        let round: Vec<Row> = dataframe_to_vec_with_struct_fields(sexp, &["meta"]).unwrap();
+        assert_eq!(round, rows);
+    });
+}
+
+/// Row order must not change the emitted schema: the same two rows, reversed
+/// (`Some`-first instead of `None`-first), produce the identical column set
+/// and types for the nested sub-field.
+#[test]
+fn compound_schema_is_row_order_independent() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Meta,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let none_first = vec![
+            Row {
+                id: 1,
+                meta: Meta {
+                    variant: None,
+                    size: 4.0,
+                },
+            },
+            Row {
+                id: 2,
+                meta: Meta {
+                    variant: Some("x".into()),
+                    size: 5.0,
+                },
+            },
+        ];
+        let some_first = vec![none_first[1].clone(), none_first[0].clone()];
+
+        let df_none_first = vec_to_dataframe(&none_first).unwrap();
+        let df_some_first = vec_to_dataframe(&some_first).unwrap();
+
+        let names_a = col_names(&df_none_first.as_sexp());
+        let names_b = col_names(&df_some_first.as_sexp());
+        assert_eq!(
+            names_a, names_b,
+            "column set/order must match regardless of row order"
+        );
+
+        let type_a = col(&df_none_first.as_sexp(), "meta_variant").type_of();
+        let type_b = col(&df_some_first.as_sexp(), "meta_variant").type_of();
+        assert_eq!(
+            type_a, type_b,
+            "meta_variant's column type must not depend on row order"
+        );
+        assert_eq!(
+            type_a,
+            miniextendr_api::SEXPTYPE::STRSXP,
+            "both orderings must resolve to character"
+        );
+    });
+}
+
+/// Two `Compound` candidates of genuinely *different* shapes (a
+/// `#[serde(skip_serializing_if)]` sub-field entirely absent from one row's
+/// probe, present in another's) must union their keys rather than drop the
+/// side not seen first.
+#[test]
+fn compound_union_of_keys_when_shapes_differ() {
+    #[derive(Debug, Serialize)]
+    struct Meta {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        extra: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Serialize)]
+    struct Row {
+        id: i32,
+        meta: Meta,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![
+            Row {
+                id: 1,
+                meta: Meta {
+                    extra: None, // `extra` is omitted entirely from row 1's probe
+                    size: 1.0,
+                },
+            },
+            Row {
+                id: 2,
+                meta: Meta {
+                    extra: Some("x".into()),
+                    size: 2.0,
+                },
+            },
+        ];
+        let df = vec_to_dataframe(&rows).unwrap();
+        let sexp = df.as_sexp();
+        let names = col_names(&sexp);
+        assert!(
+            names.contains(&"meta_extra".to_string()),
+            "row 2's extra field must not be dropped just because row 1's Compound omitted it: {names:?}"
+        );
+        assert!(names.contains(&"meta_size".to_string()), "{names:?}");
+        let extra = col(&sexp, "meta_extra");
+        assert_eq!(extra.string_elt_str(0), None, "row 1 omitted extra -> NA");
+        assert_eq!(extra.string_elt_str(1), Some("x"));
+        let size = col(&sexp, "meta_size");
+        assert_eq!(size.real_elt(0), 1.0);
+        assert_eq!(size.real_elt(1), 2.0);
+    });
+}
+
+/// #1320 interaction (issue's point 3): with the writer bug present, a
+/// colliding `variant` sub-field would flip failure mode with row order —
+/// `Some`-first silently drops the struct (the #1320 default), `None`-first
+/// errored loudly with a type mismatch. Post-#1370, `None`-first no longer
+/// errors: it hits the *same* documented #1320 lossy default as `Some`-first
+/// (the opt-out in `option_nested_struct_with_struct_fields_roundtrips`
+/// still fixes it losslessly, order notwithstanding).
+#[test]
+fn compound_fix_resolves_1320_interaction_none_first_no_longer_errors() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        // None-first (reverse of `option_nested_struct_tag_collision_default_is_lossy`).
+        let rows = vec![
+            Row {
+                id: 2,
+                meta: Some(Meta {
+                    variant: None,
+                    size: 4.0,
+                }),
+            },
+            Row {
+                id: 1,
+                meta: Some(Meta {
+                    variant: Some("a".into()),
+                    size: 1.0,
+                }),
+            },
+        ];
+        let df = vec_to_dataframe(&rows).unwrap();
+        // Pre-#1370 this failed writing: `meta_variant` would only be
+        // discovered as Generic (list), and the type-mismatch reader error
+        // from the issue (`column "meta_variant": type mismatch: expected
+        // character, got list`) never even applied because the *writer*
+        // itself never produced a working frame here in the first place —
+        // confirm the default (non-opt-out) reader no longer errors at all.
+        let round: Vec<Row> = dataframe_to_vec(df.as_sexp()).unwrap();
+        // Row 0 (`variant: None`) collides with the tag-column heuristic and
+        // is read back as `meta: None` — the same #1320 lossy default as the
+        // `Some`-first ordering, just applied to whichever row has the NA.
+        assert_eq!(round[0], Row { id: 2, meta: None });
+        // Row 1 (`variant: Some`) is unaffected.
+        assert_eq!(round[1], rows[1]);
+
+        // The per-field opt-out still makes both rows round-trip losslessly,
+        // regardless of order.
+        let round_optout: Vec<Row> =
+            dataframe_to_vec_with_struct_fields(df.as_sexp(), &["meta"]).unwrap();
+        assert_eq!(round_optout, rows);
+    });
+}
+
+/// Out of scope (stays as documented): a nested `Option<Struct>` that is
+/// `None` in *every* row never sees a `Compound` probe at all — the key
+/// resolves to `Scalar(Generic)` and the assembly-time all-None downgrade
+/// still converts it to a single logical-NA column, not a per-sub-field
+/// atomic column. Recursive union cannot help here: there's nothing to union.
+#[test]
+fn compound_all_none_option_struct_downgrade_still_applies() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Meta {
+        variant: Option<String>,
+        size: f64,
+    }
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Row {
+        id: i32,
+        meta: Option<Meta>,
+    }
+
+    r_test_utils::with_r_thread(|| {
+        let rows = vec![Row { id: 1, meta: None }, Row { id: 2, meta: None }];
+        let df = vec_to_dataframe(&rows).unwrap();
+        let sexp = df.as_sexp();
+        let names = col_names(&sexp);
+        // No Compound ever discovered: `meta` stays a single (unflattened)
+        // column, not `meta_variant`/`meta_size`.
+        assert_eq!(names, vec!["id".to_string(), "meta".to_string()]);
+        let meta_col = col(&sexp, "meta");
+        assert_eq!(
+            meta_col.type_of(),
+            miniextendr_api::SEXPTYPE::LGLSXP,
+            "all-None Option<Struct> must downgrade to a logical-NA column, per docs"
+        );
     });
 }
 

--- a/rpkg/src/rust/columnar_option_none_tests.rs
+++ b/rpkg/src/rust/columnar_option_none_tests.rs
@@ -1,8 +1,12 @@
-//! Tests for `vec_to_dataframe` all-`None` column downgrade.
+//! Tests for `vec_to_dataframe` all-`None` column downgrade, schema-upgrade
+//! ordering, and recursive `Compound` union.
 //!
 //! When every row has `None` for an `Option<T>` field, the column lands as a
 //! logical NA vector (LGLSXP) rather than `list(NULL, NULL, …)`.  R coerces
-//! logical NA to the surrounding type on first use.
+//! logical NA to the surrounding type on first use. The final region covers
+//! #1370: a nested struct sub-field probed `None` on the first row (or a
+//! `Compound` shape missing a key present in another row's shape) must still
+//! resolve via the union across all rows, not just the first one seen.
 
 use crate::serde::Serialize;
 use miniextendr_api::dataframe::BuiltDataFrame;
@@ -413,10 +417,13 @@ pub fn test_columnar_schema_upgrade_multi_none_first() -> BuiltDataFrame {
 /// This fixture tests that the per-key candidate accumulation works correctly for
 /// an enum with fields that differ between variants.
 ///
-/// TODO (union recursion): when a single *key* maps to two different Compound
-/// shapes (e.g. two variant rows of an internally-tagged enum where the nested
-/// struct differs per variant), the first Compound wins silently.  Recursive
-/// Compound union is tracked as a separate follow-up issue.
+/// (Formerly a "TODO (union recursion)" placeholder here: when a single *key* maps
+/// to two different `Compound` shapes for the same row set, the first `Compound`
+/// silently won. Recursive `Compound` union is now implemented — see
+/// [#1370](https://github.com/A2-ai/miniextendr/issues/1370) — and the
+/// same-key case is covered directly by
+/// [`test_columnar_nested_subfield_none_first`] and
+/// [`test_columnar_nested_compound_union_of_keys`] below.)
 ///
 #[miniextendr(noexport)]
 pub fn test_columnar_compound_different_shapes() -> BuiltDataFrame {
@@ -425,6 +432,120 @@ pub fn test_columnar_compound_different_shapes() -> BuiltDataFrame {
         EventDifferentNested::B {
             value: 2.0,
             extra: 3.0,
+        },
+    ];
+    vec_to_dataframe(&rows).expect("from_rows")
+}
+
+// endregion
+
+// region: Recursive Compound union — same key, different shapes (#1370)
+
+/// Nested struct whose `variant` sub-field is `Option<String>` — used to
+/// reproduce #1370's exact repro shape (a sub-field literally named `variant`,
+/// as in the issue, probed `None` on the first row).
+#[derive(Serialize)]
+#[serde(crate = "crate::serde")]
+struct MetaWithOptVariant {
+    variant: Option<String>,
+    size: f64,
+}
+
+#[derive(Serialize)]
+#[serde(crate = "crate::serde")]
+struct WithNestedOptVariant {
+    id: i32,
+    meta: MetaWithOptVariant,
+}
+
+/// Nested struct with a `#[serde(skip_serializing_if)]` sub-field: some rows'
+/// probe of `meta` omits `extra` entirely (a genuinely different `Compound`
+/// shape — one fewer key — not just a differently-typed same key).
+#[derive(Serialize)]
+#[serde(crate = "crate::serde")]
+struct MetaMaybeExtra {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra: Option<f64>,
+    size: f64,
+}
+
+#[derive(Serialize)]
+#[serde(crate = "crate::serde")]
+struct WithNestedMaybeExtra {
+    id: i32,
+    meta: MetaMaybeExtra,
+}
+
+/// #1370 repro: nested sub-field `meta.variant` is `None` on the *first* row,
+/// typed (`Some`) on the second. Pre-fix this locked `meta_variant` to a
+/// Generic (list) column; post-fix it resolves to `character` with `NA` at
+/// row 1, matching what a `Some`-first ordering already produced.
+#[miniextendr(noexport)]
+pub fn test_columnar_nested_subfield_none_first() -> BuiltDataFrame {
+    let rows = vec![
+        WithNestedOptVariant {
+            id: 1,
+            meta: MetaWithOptVariant {
+                variant: None,
+                size: 4.0,
+            },
+        },
+        WithNestedOptVariant {
+            id: 2,
+            meta: MetaWithOptVariant {
+                variant: Some("x".into()),
+                size: 5.0,
+            },
+        },
+    ];
+    vec_to_dataframe(&rows).expect("from_rows")
+}
+
+/// Same rows as [`test_columnar_nested_subfield_none_first`], reversed
+/// (`Some`-first). The emitted schema must be identical regardless of row
+/// order — this is the order-independence half of the #1370 regression.
+#[miniextendr(noexport)]
+pub fn test_columnar_nested_subfield_some_first() -> BuiltDataFrame {
+    let rows = vec![
+        WithNestedOptVariant {
+            id: 2,
+            meta: MetaWithOptVariant {
+                variant: Some("x".into()),
+                size: 5.0,
+            },
+        },
+        WithNestedOptVariant {
+            id: 1,
+            meta: MetaWithOptVariant {
+                variant: None,
+                size: 4.0,
+            },
+        },
+    ];
+    vec_to_dataframe(&rows).expect("from_rows")
+}
+
+/// #1370 "union of keys" case: the *same* key (`meta`) maps to two genuinely
+/// different `Compound` shapes across rows — row 1's probe omits `extra`
+/// entirely (`skip_serializing_if` fires), row 2's includes it. Pre-fix, row
+/// 2's `extra` sub-field was silently dropped (first-Compound-wins); post-fix
+/// both `meta_extra` and `meta_size` are discovered.
+#[miniextendr(noexport)]
+pub fn test_columnar_nested_compound_union_of_keys() -> BuiltDataFrame {
+    let rows = vec![
+        WithNestedMaybeExtra {
+            id: 1,
+            meta: MetaMaybeExtra {
+                extra: None,
+                size: 1.0,
+            },
+        },
+        WithNestedMaybeExtra {
+            id: 2,
+            meta: MetaMaybeExtra {
+                extra: Some(3.0),
+                size: 2.0,
+            },
         },
     ];
     vec_to_dataframe(&rows).expect("from_rows")

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -353,8 +353,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn test_vec_dataframe() {
         let rows = vec![

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -982,8 +982,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn vec_width_align_pinned_columns() {
         let df = VecWidthEvent::to_dataframe(vec![

--- a/rpkg/tests/testthat/test-columnar-option-none.R
+++ b/rpkg/tests/testthat/test-columnar-option-none.R
@@ -1,4 +1,5 @@
-# Tests for ColumnarDataFrame all-None column downgrade (#307).
+# Tests for ColumnarDataFrame all-None column downgrade (#307), schema-upgrade
+# ordering, and recursive Compound union (#1370).
 #
 # When every row has None for an Option<T> field the column lands as a logical
 # NA vector (is.logical() && all(is.na())), not list(NULL, NULL, ...).
@@ -238,9 +239,9 @@ test_that("multiple leading None rows then Some(42): numeric column with NAs at 
 test_that("compound-vs-compound different shapes: both field sets discovered", {
   # Variant A has only 'value'; variant B has 'value' and 'extra'.
   # Both are distinct top-level keys in the struct (not nested under a single key),
-  # so both 'value' and 'extra' are found regardless of order.
-  # TODO: union recursion — when one key maps to two different Compound shapes, only
-  # the first Compound wins.  This test verifies existing-wins semantics remain stable.
+  # so both 'value' and 'extra' are found regardless of order. (The single-key
+  # Compound-vs-Compound case — recursive union — is covered in the "Recursive
+  # Compound union (#1370)" region below.)
   df <- miniextendr:::test_columnar_compound_different_shapes()
   expect_s3_class(df, "data.frame")
   expect_equal(nrow(df), 2L)
@@ -250,6 +251,43 @@ test_that("compound-vs-compound different shapes: both field sets discovered", {
   expect_true(is.na(df$extra[[1]]))
   # variant B (row 2) has extra=3.0
   expect_equal(df$extra[[2]], 3.0)
+})
+
+# endregion
+
+# region: Recursive Compound union (#1370)
+
+test_that("nested sub-field None-first types as character, not a list column", {
+  df <- miniextendr:::test_columnar_nested_subfield_none_first()
+  expect_s3_class(df, "data.frame")
+  expect_equal(nrow(df), 2L)
+  expect_true("meta_variant" %in% names(df))
+  expect_true("meta_size" %in% names(df))
+  expect_true(is.character(df$meta_variant))
+  expect_true(is.na(df$meta_variant[[1]]))
+  expect_equal(df$meta_variant[[2]], "x")
+  expect_equal(df$meta_size, c(4.0, 5.0))
+})
+
+test_that("nested sub-field schema is row-order independent", {
+  none_first <- miniextendr:::test_columnar_nested_subfield_none_first()
+  some_first <- miniextendr:::test_columnar_nested_subfield_some_first()
+  expect_equal(names(none_first), names(some_first))
+  expect_equal(class(none_first$meta_variant), class(some_first$meta_variant))
+  expect_true(is.character(some_first$meta_variant))
+})
+
+test_that("Compound union of keys: a key present only in one row's shape is not dropped", {
+  df <- miniextendr:::test_columnar_nested_compound_union_of_keys()
+  expect_s3_class(df, "data.frame")
+  expect_equal(nrow(df), 2L)
+  # Row 1's probe of `meta` omitted `extra` (skip_serializing_if); row 2's
+  # included it. Both `meta_extra` and `meta_size` must be discovered.
+  expect_true("meta_extra" %in% names(df))
+  expect_true("meta_size" %in% names(df))
+  expect_true(is.na(df$meta_extra[[1]]))
+  expect_equal(df$meta_extra[[2]], 3.0)
+  expect_equal(df$meta_size, c(1.0, 2.0))
 })
 
 # endregion


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Closes #1370. `vec_to_dataframe`'s union schema discovery resolved two `Compound` candidates for the same key by keeping the first seen, so a nested sub-field probed as `None` on the first row stayed `Generic` even when a later row typed it: the column materialised as a VECSXP list column instead of an atomic vector, row order changed the emitted schema, and round-tripping a `None`-first frame failed loudly (the row reader has no list-column support).
- `resolve_candidates` now folds candidates through the same lattice as before, but Compound-vs-Compound merges recursively key-by-key (`merge_compound_shapes`): each key present in either shape resolves through the lattice (`Compound` > `Scalar(non-Generic)` > `Scalar(Generic)`), recursing for nested Compounds. A sub-field picks up its best-seen type, and a key present in only one shape (e.g. behind `serde(skip_serializing_if)`) is no longer dropped. Key order is first-seen union, matching the top level.
- Merged shapes rebuild their `FieldMap` at base 0; `finalize()`'s existing `remap_field_map` pass shifts them into the unified layout unchanged, recursively.
- Doc updates in place: the `SchemaAccumulator` limitation note (which had tracked this as a follow-up), the `vec_to_dataframe` type table, and the enum-payload emitter's cross-reference.
- Drive-by: removed duplicated `ColumnarFrame` imports in two dataframe test modules.

## Test plan
- [x] Step-0 verification: the bug reproduced on fresh origin/main (833f4e21+) before the fix was applied
- [x] Six new `serde_columnar` integration tests: `None`-first typing through plain and `Option` outer structs, row-order independence, key union across differing shapes, the #1320 interaction case, and the all-`None` downgrade staying put — suite 41 pass / 0 fail after a fresh `cargo clean -p` rebuild
- [x] rpkg fixtures mirroring the issue's exact repro shape (a sub-field literally named `variant`, `None` on the first row) plus a `skip_serializing_if` fixture, with testthat coverage in `test-columnar-option-none.R`
- [x] Full `just devtools-test`: 7276 pass / 0 fail / 27 feature-gated skips
- [x] Fresh `cargo clippy -p miniextendr-api --features serde --all-targets --locked -- -D warnings` clean; `cargo fmt --all --check` clean

## Notes
- This is a deliberate writer emission change, which is why #1320 (PR #1371) kept it out of scope. Only shapes that previously produced `Generic`/list columns (or silently dropped a second variant's sub-fields) emit differently; already-atomic columns are unchanged.
- Out of scope, unchanged and still documented: a nested `Option<Struct>` that is `None` in every row still downgrades to a logical NA column (no `Compound` probe ever exists to union from; structurally unfixable without type-level hints).
- No new SEXP-storage paths: the change is pure schema-resolution logic ahead of column materialisation, so no new gc-stress fixture is required.

---
_Drafted by Claude (claude-fable-5). Review pending._

</details>