### PR TITLE
chore: const _ audit residuals — doc-lint escalation note, anonymous fixture consts

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -83,6 +83,12 @@ Only `default` features are enabled automatically.
 Enables the build-time lint that checks `#[miniextendr]` source-level attributes
 for consistency. Warns on missing or mismatched annotations.
 
+The advisories are delivered through rustc's `deprecated` lint (the macro emits a
+`#[deprecated]` const that the generated code reads), so a crate that sets
+`#![deny(deprecated)]` — or builds with `-D warnings` / `RUSTFLAGS=-Dwarnings` —
+escalates them to hard errors. That is a reasonable strict mode, but be aware the
+escalation is controlled by your lint configuration, not by this feature.
+
 Forwarded to `miniextendr-macros/doc-lint`. Disable with `default-features = false` if
 the lint causes issues during development.
 

--- a/miniextendr-macros/tests/ui/typed_list_invalid_spec.rs
+++ b/miniextendr-macros/tests/ui/typed_list_invalid_spec.rs
@@ -1,6 +1,6 @@
 use miniextendr_macros::typed_list;
 
-const _SPEC: () = {
+const _: () = {
     let _ = typed_list!(alpha => 42);
 };
 

--- a/miniextendr-macros/tests/ui/typed_list_too_many_args.rs
+++ b/miniextendr-macros/tests/ui/typed_list_too_many_args.rs
@@ -1,6 +1,6 @@
 use miniextendr_macros::typed_list;
 
-const _SPEC: () = {
+const _: () = {
     let _ = typed_list!(alpha => numeric(1, 2));
 };
 

--- a/miniextendr-macros/tests/ui/typed_list_unknown_mode.rs
+++ b/miniextendr-macros/tests/ui/typed_list_unknown_mode.rs
@@ -1,6 +1,6 @@
 use miniextendr_macros::typed_list;
 
-const _SPEC: () = {
+const _: () = {
     let _ = typed_list!(@strict; alpha);
 };
 

--- a/miniextendr-macros/tests/ui/typed_list_unknown_type.rs
+++ b/miniextendr-macros/tests/ui/typed_list_unknown_type.rs
@@ -1,6 +1,6 @@
 use miniextendr_macros::typed_list;
 
-const _SPEC: () = {
+const _: () = {
     let _ = typed_list!(alpha => bogus());
 };
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `docs/FEATURES.md` (`doc-lint` section): documents that the advisories are delivered through rustc's `deprecated` lint, so a user crate with `#![deny(deprecated)]` or `-D warnings` escalates them to hard errors. The escalation is controlled by the user's lint configuration, not by the feature itself.
- `tests/ui/typed_list_{invalid_spec,unknown_type,too_many_args,unknown_mode}.rs`: renames `const _SPEC: ()` to the anonymous `const _: ()` form used by every other compile-time assertion in the codebase. The diagnostics anchor on the `typed_list!` call lines, so all four `.stderr` snapshots are byte-identical.
- Both items are the remaining follow-ups from the 2026-07-17 repo-wide `const _: ()` audit; the substantive findings landed as #1384 and #1385.

## Test plan
- [x] `just test-ui` under the minimal-profile 1.97.1 toolchain (all four `typed_list_*` compile-fail tests pass with unchanged snapshots; `ui` and `ui_vctrs` suites green)

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>