### PR TITLE
docs: fix stale 'How the build works' (double-link is gone)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ Enable once per clone: `git config core.hooksPath .githooks`.
 2. Module must be reachable via `mod` from `lib.rs` (`#[cfg(feature = "foo")]` on `mod` declaration is sufficient for feature-gated modules)
 3. `just configure && just rcmdinstall && just force-document`
 
-Build sequence: `Makevars` → `cargo rustc --crate-type cdylib` → `dyn.load` + `miniextendr_write_wrappers` → `R/miniextendr-wrappers.R` → `cargo rustc --crate-type staticlib` → final `.so`.
+Build sequence: `Makevars` → `cargo build --lib` (staticlib, the only cargo invocation) → C-link `$(OBJECTS)` + staticlib → final `.so` (`$(SHLIB)`, via `stub.c`'s force-link) → `dyn.load($(SHLIB))` + registered `miniextendr_write_wrappers`/`miniextendr_write_wasm_registry` routines → `R/miniextendr-wrappers.R` + `src/rust/wasm_registry.rs`. No separate cdylib build — wrapper-gen loads the installed `.so` itself; tarball/wasm32 installs skip it and use the pre-shipped files.
 
 ### Reproducing CI clippy before PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,20 +80,26 @@ hand-maintained.
 
 ```
 Makevars
-  → cargo rustc --crate-type cdylib
-  → dyn.load + miniextendr_write_wrappers       (cdylib walks linkme #[distributed_slice] tables)
-  → R/miniextendr-wrappers.R                    (generated, do not hand-edit)
-  → cargo rustc --crate-type staticlib
-  → final .so
+  → cargo build --lib                           (staticlib — the only cargo invocation)
+  → C-link: $(OBJECTS) + staticlib → $(SHLIB)   (the final .so, via stub.c's force-link)
+  → dyn.load($(SHLIB)) + miniextendr_write_wrappers + miniextendr_write_wasm_registry
+                                                (walks the linkme #[distributed_slice]
+                                                 tables in the installed .so itself,
+                                                 under MINIEXTENDR_WRAPPER_GEN=1)
+  → R/miniextendr-wrappers.R + src/rust/wasm_registry.rs   (generated, do not hand-edit)
 ```
 
-`stub.c` declares `extern const char miniextendr_force_link`, which references a
+There is **no separate cdylib build**: the freshly linked `$(SHLIB)` is already a
+loadable shared object carrying every linkme entry, so wrapper generation loads
+it directly and calls the two *registered* writer routines via
+`getNativeSymbolInfo` (`rpkg/src/Makevars.in`, the `$(WRAPPERS_R)` recipe). In
+tarball/wasm32 installs the wrapper-gen step is skipped and the pre-shipped
+files are used (with the #1022 regenerate-if-absent fallback in tarball mode).
+
+`stub.c` declares `extern void miniextendr_force_link(void)`, referencing a
 symbol emitted by `miniextendr_init!()`. With `codegen-units = 1`, this pulls the
 entire user crate out of the staticlib archive, carrying all `#[distributed_slice]`
 entries — no `-force_load` / `--whole-archive` needed.
-The cdylib→staticlib double link is what makes wrapper generation possible:
-the cdylib boots far enough into R that we can call into Rust to emit the
-R wrappers, then we relink as staticlib for the final installed shared object.
 
 `miniextendr_init!(pkg)` (proc-macro) generates `R_init_<pkg>`; `package_init()`
 in `miniextendr-api/src/init.rs` consolidates the init steps.


### PR DESCRIPTION
## What

`CLAUDE.md`'s **How the build works** section (and the root `AGENTS.md` mirror line) still described the old build: a throwaway cdylib built first, `dyn.load`ed for wrapper generation, discarded, then a second staticlib build C-linked into the final `.so`.

`rpkg/src/Makevars.in` eliminated that flow: there is **one** cargo invocation (`cargo build --lib`, staticlib), the C-link produces `$(SHLIB)`, and wrapper generation `dyn.load`s that same freshly linked `.so` under `MINIEXTENDR_WRAPPER_GEN=1`, calling the two *registered* writer routines via `getNativeSymbolInfo` (the `$(WRAPPERS_R)` recipe — its own comments say "no separate cdylib build").

This PR rewrites the diagram and prose to match, notes the tarball/wasm32 skip paths (incl. the #1022 fallback), and fixes a second drift in the same section: `stub.c` declares `extern void miniextendr_force_link(void)`, not `extern const char`.

## Why it surfaced

A cross-repo design review of prebuilt-binary delivery (dynload-rpkg, `plans/cdylib-bundling-review.md`) took the CLAUDE.md description at face value and had to read `Makevars.in` to discover the docs had drifted — the double-link premise changed one of that review's design answers.

Docs-only; no code changes. Root `AGENTS.md` updated in the same pass per its hand-kept-mirror rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)