### PR TITLE
ci(rpkg): gate full-feature clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,16 @@ jobs:
           -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_all_s7.log"
         shell: bash
 
+      # rpkg/src/rust is a standalone workspace, so none of the root
+      # `--workspace` invocations above reach its fixture crate. The dedicated
+      # recipe supplies local framework patches without requiring configure or
+      # a real R installation, and restores the tarball-shaped lockfile.
+      - name: Clippy (rpkg, full features)
+        id: clippy_rpkg
+        continue-on-error: true
+        run: just clippy-rpkg --features full -- -D warnings 2>&1 | tee "$RUNNER_TEMP/clippy_rpkg.log"
+        shell: bash
+
       # cargo-revendor is a standalone workspace excluded from the root
       # workspace, so the `--workspace` clippy steps above never reach it
       # (#778). It has no R linkage, so it lints without configure/R setup.
@@ -453,6 +463,7 @@ jobs:
           clippy_default="${{ steps.clippy_default.outcome }}"
           clippy_all="${{ steps.clippy_all.outcome }}"
           clippy_all_s7="${{ steps.clippy_all_s7.outcome }}"
+          clippy_rpkg="${{ steps.clippy_rpkg.outcome }}"
           clippy_revendor="${{ steps.clippy_revendor.outcome }}"
           doc_revendor="${{ steps.doc_revendor.outcome }}"
 
@@ -461,6 +472,7 @@ jobs:
           echo "clippy_default:   $clippy_default"
           echo "clippy_all:       $clippy_all"
           echo "clippy_all_s7:    $clippy_all_s7"
+          echo "clippy_rpkg:      $clippy_rpkg"
           echo "clippy_revendor:  $clippy_revendor"
           echo "doc_revendor:     $doc_revendor"
           echo
@@ -484,6 +496,7 @@ jobs:
           dump_failed clippy_default   "$clippy_default"
           dump_failed clippy_all       "$clippy_all"
           dump_failed clippy_all_s7    "$clippy_all_s7"
+          dump_failed clippy_rpkg      "$clippy_rpkg"
           dump_failed clippy_revendor  "$clippy_revendor"
           dump_failed doc_revendor     "$doc_revendor"
 

--- a/justfile
+++ b/justfile
@@ -235,9 +235,24 @@ clippy *cargo_flags:
     cargo clippy --benches --tests --examples --workspace {{cargo_flags}}
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/consumer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/consumer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
     root="$(pwd)" && tmp="$(mktemp -d)" && (cd "$tmp" && CARGO_TARGET_DIR="$root/tests/cross-package/producer.pkg/rust-target" cargo clippy --benches --tests --examples --workspace --manifest-path="$root/tests/cross-package/producer.pkg/src/rust/Cargo.toml" {{cargo_flags}})
-    root="$(pwd)" && (cd "$root/rpkg/src/rust" && CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo clippy --benches --tests --examples --workspace --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" {{cargo_flags}})
+    just clippy-rpkg {{cargo_flags}}
     cargo clippy --benches --tests --examples --manifest-path cargo-revendor/Cargo.toml {{cargo_flags}}
     @just cargo-lock-restore
+
+# Run clippy on rpkg's standalone Rust workspace. Explicit patch overrides keep
+# this independent of configure-generated .cargo/config.toml, while the trap
+# preserves the committed tarball-shaped lockfile even when clippy fails.
+[script("bash")]
+clippy-rpkg *cargo_flags:
+    set -euo pipefail
+    root="{{justfile_directory()}}"
+    trap 'git -C "$root" restore --worktree -- rpkg/src/rust/Cargo.lock' EXIT
+    cd "$root/rpkg/src/rust"
+    CARGO_TARGET_DIR="$root/rpkg/src/rust/target" cargo clippy --all-targets --workspace \
+        --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-api.path=\"$root/miniextendr-api\"" \
+        --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-macros.path=\"$root/miniextendr-macros\"" \
+        --config "patch.'https://github.com/A2-ai/miniextendr'.miniextendr-lint.path=\"$root/miniextendr-lint\"" \
+        {{cargo_flags}}
 
 # Run miniextendr-lint on rpkg (checks #[miniextendr] consistency)
 # The lint runs as a build script; this command triggers it via cargo check.

--- a/reviews/2026-08-12-rpkg-clippy-duplicate-imports.md
+++ b/reviews/2026-08-12-rpkg-clippy-duplicate-imports.md
@@ -1,0 +1,28 @@
+# rpkg clippy gate exposed duplicate imports
+
+## What was attempted
+
+Ran the proposed `rpkg/src/rust` CI gate locally with its full feature set and
+`-D warnings`:
+
+```text
+just clippy-rpkg --features full -- -D warnings
+```
+
+## What went wrong
+
+The fixture crate failed with E0252 and `unused_imports` because
+`ColumnarFrame` was imported twice in each of two test modules.
+
+## Root cause
+
+Commit `d557ac39` (#1380) intended to move the imports under `#[cfg(test)]`, but
+the target modules already contained the imports. The change added a second
+copy instead of relocating the top-level copy, leaving main unable to pass the
+exact command that #1380 was meant to make warning-clean.
+
+## Fix
+
+Removed the two duplicate imports and reran the full-feature clippy gate. The
+new CI step now prevents the standalone fixture workspace from regressing
+silently again.

--- a/rpkg/src/rust/dataframe_collections_test.rs
+++ b/rpkg/src/rust/dataframe_collections_test.rs
@@ -353,8 +353,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn test_vec_dataframe() {
         let rows = vec![

--- a/rpkg/src/rust/dataframe_enum_payload_matrix.rs
+++ b/rpkg/src/rust/dataframe_enum_payload_matrix.rs
@@ -982,8 +982,6 @@ mod tests {
     use super::*;
     use miniextendr_api::dataframe::ColumnarFrame;
 
-    use miniextendr_api::dataframe::ColumnarFrame;
-
     #[test]
     fn vec_width_align_pinned_columns() {
         let df = VecWidthEvent::to_dataframe(vec![


### PR DESCRIPTION
## Summary
- add a dedicated full-feature, -D warnings clippy step for the standalone rpkg Rust workspace
- extract a reusable clippy-rpkg maintainer recipe with explicit local patches and lockfile restoration
- remove the duplicate test imports the new gate exposed on main and document that failure in reviews/

Closes #1379

## Verification
- just fmt-check
- just check
- just test
- just clippy -- -D warnings
- just clippy-rpkg --features full -- -D warnings
- CI clippy_default, clippy_all, and clippy_all_s7 commands with -D warnings
- actionlint on ci.yml after suppressing the eight diagnostics already present on origin/main