### PR TITLE
chore(llm-docs): refresh generated digests

### DIFF
--- a/rust-llm-docs/generated/conversion-impl-inventory.md
+++ b/rust-llm-docs/generated/conversion-impl-inventory.md
@@ -8,17 +8,17 @@ Traits with impls: 9
 
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
-| `TryFromSexp` | 453 | 453 |
-| `IntoR` | 337 | 337 |
+| `TryFromSexp` | 469 | 469 |
+| `IntoR` | 353 | 353 |
 | `IntoRAs` | 135 | 135 |
 | `TryCoerce` | 95 | 93 |
 | `Coerce` | 53 | 53 |
 | `AltrepSerialize` | 27 | 27 |
-| `RSerializeNative` | 6 | 1 |
+| `RSerializeNative` | 7 | 1 |
 | `IntoRAltrep` | 3 | 1 |
-| `RDeserializeNative` | 1 | 1 |
+| `RDeserializeNative` | 2 | 1 |
 
-## `TryFromSexp` — 453 impls
+## `TryFromSexp` — 469 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -317,90 +317,106 @@ Traits with impls: 9
 | `DVector<crate::coerce::Coerced<T, R>>` | `<T, R> +4wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:854 |
 | `DMatrix<crate::coerce::Coerced<T, R>>` | `<T, R> +4wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:885 |
 | `DMatrix<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:96 |
-| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:119 |
-| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:140 |
-| `Array2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:155 |
-| `Array3<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:176 |
-| `Array4<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:197 |
-| `Array5<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:230 |
-| `Array6<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:265 |
-| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2920 |
-| `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:300 |
-| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3065 |
-| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array4<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array4<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Vec<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
-| `Vec<Option<BigInt>>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:122 |
+| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:143 |
+| `Array2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:158 |
+| `Array3<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:179 |
+| `Array4<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:200 |
+| `Array5<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:233 |
+| `Array6<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:268 |
+| `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:303 |
+| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3205 |
+| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3350 |
+| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array4<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array4<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array0<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array3<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array6<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array2<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array5<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array1<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array4<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `ArrayD<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array5<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array1<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array4<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `ArrayD<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array0<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array3<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array6<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array2<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
 | `BigInt` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
 | `Option<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Vec<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Vec<Option<BigInt>>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
 | `BigUint` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
 | `Option<BigUint>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
 | `Vec<BigUint>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
@@ -483,32 +499,34 @@ Traits with impls: 9
 - **miniextendr-api/src/from_r/references.rs:323** (12 impls): `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`, `&'static mut u8`
 - **miniextendr-api/src/from_r/references.rs:324** (12 impls): `&'static mut crate::RLogical`, `&'static crate::RLogical`, `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `Option<&'static crate::RLogical>`
 - **miniextendr-api/src/from_r/references.rs:322** (12 impls): `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`, `Option<&'static f64>`, `&'static mut f64`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `Array4<i16>`, `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array2<u16>`, `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:676** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
-- **miniextendr-api/src/optionals/num_bigint_impl.rs:193** (4 impls): `Vec<BigInt>`, `Vec<Option<BigInt>>`, `BigInt`, `Option<BigInt>`
-- **miniextendr-api/src/from_r/cow_and_paths.rs:312** (4 impls): `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:867** (8 impls): `Array5<Option<String>>`, `Array1<Option<String>>`, `Array4<Option<String>>`, `ArrayD<Option<String>>`, `Array0<Option<String>>`, `Array3<Option<String>>`, `Array6<Option<String>>`, `Array2<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:866** (8 impls): `Array0<String>`, `Array3<String>`, `Array6<String>`, `Array2<String>`, `Array5<String>`, `Array1<String>`, `Array4<String>`, `ArrayD<String>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:683** (7 impls): `Array2<bool>`, `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array4<i16>`, `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array2<u16>`, `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:674** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:675** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:673** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:679** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
 - **miniextendr-api/src/optionals/num_bigint_impl.rs:194** (4 impls): `BigUint`, `Option<BigUint>`, `Vec<BigUint>`, `Vec<Option<BigUint>>`
 - **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<Option<OffsetDateTime>>`, `OffsetDateTime`, `Vec<OffsetDateTime>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:476** (4 impls): `SignedDuration`, `Vec<SignedDuration>`, `Option<SignedDuration>`, `Vec<Option<SignedDuration>>`
+- **miniextendr-api/src/from_r/cow_and_paths.rs:312** (4 impls): `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`
 - **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Date`, `Vec<Date>`, `Option<Date>`, `Vec<Option<Date>>`
 - **miniextendr-api/src/optionals/url_impl.rs:48** (4 impls): `Option<Url>`, `Vec<Url>`, `Vec<Option<Url>>`, `Url`
 - **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Option<Timestamp>>`, `Timestamp`, `Vec<Timestamp>`, `Option<Timestamp>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Option<Date>`, `Vec<Option<Date>>`, `Date`, `Vec<Date>`
+- **miniextendr-api/src/optionals/num_bigint_impl.rs:193** (4 impls): `BigInt`, `Option<BigInt>`, `Vec<BigInt>`, `Vec<Option<BigInt>>`
 - **miniextendr-api/src/from_r/cow_and_paths.rs:289** (4 impls): `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `Vec<std::path::PathBuf>`, `Option<std::path::PathBuf>`
 - **miniextendr-api/src/optionals/regex_impl.rs:67** (4 impls): `Option<Regex>`, `Vec<Regex>`, `Vec<Option<Regex>>`, `Regex`
 - **miniextendr-api/src/optionals/uuid_impl.rs:43** (4 impls): `Option<Uuid>`, `Vec<Uuid>`, `Vec<Option<Uuid>>`, `Uuid`
 - **miniextendr-api/src/optionals/jiff_impl.rs:915** (2 impls): `JiffZonedVecRef`, `JiffZonedVecMut`
 - **miniextendr-api/src/optionals/jiff_impl.rs:874** (2 impls): `JiffTimestampVecMut`, `JiffTimestampVecRef`
 
-## `IntoR` — 337 impls
+## `IntoR` — 353 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -745,16 +763,16 @@ Traits with impls: 9
 | `Vec<Option<SignedDuration>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
 | `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
 | `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
+| `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
 | `JiffZonedVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `log::LevelFilter` | `` | concrete | 4 | miniextendr-api/src/optionals/log_impl.rs:332 |
 | `RDVector<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1334 |
 | `RDMatrix<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1347 |
@@ -764,22 +782,38 @@ Traits with impls: 9
 | `Option<SMatrix<T, R, C>>` | `<T, R, C>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:335 |
 | `DVector<crate::coerce::Coerced<T, R>>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:924 |
 | `DMatrix<crate::coerce::Coerced<T, R>>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:946 |
-| `ArcArray2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1009 |
-| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1030 |
-| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1048 |
-| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1079 |
-| `ArrayViewD<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1122 |
-| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2932 |
-| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3077 |
-| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:325 |
-| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:342 |
-| `Array2<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:689 |
-| `Array3<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:731 |
-| `Array4<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:778 |
-| `Array5<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:823 |
-| `Array6<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
-| `ArrayD<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:910 |
-| `ArcArray1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:992 |
+| `Array5<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1010 |
+| `Array6<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1054 |
+| `ArrayD<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1097 |
+| `Array0<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1264 |
+| `Array0<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1264 |
+| `Array1<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1265 |
+| `Array1<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1265 |
+| `Array2<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1266 |
+| `Array2<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1266 |
+| `Array3<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1267 |
+| `Array3<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1267 |
+| `Array4<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1268 |
+| `Array4<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1268 |
+| `Array5<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1269 |
+| `Array5<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1269 |
+| `Array6<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1270 |
+| `Array6<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1270 |
+| `ArrayD<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1271 |
+| `ArrayD<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1271 |
+| `ArcArray1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1277 |
+| `ArcArray2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1294 |
+| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1315 |
+| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1333 |
+| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1364 |
+| `ArrayViewD<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1407 |
+| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3217 |
+| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:328 |
+| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3362 |
+| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:345 |
+| `Array2<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:876 |
+| `Array3<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:918 |
+| `Array4<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:965 |
 | `BigInt` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:196 |
 | `BigUint` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:197 |
 | `Option<BigInt>` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:198 |
@@ -809,10 +843,10 @@ Traits with impls: 9
 | `Vec<JsonValue>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:626 |
 | `Vec<Option<JsonValue>>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:653 |
 | `Table` | `` | concrete | 4 | miniextendr-api/src/optionals/tabled_impl.rs:197 |
-| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
-| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `OffsetDateTime` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
@@ -842,7 +876,7 @@ Traits with impls: 9
 | `RawSliceTagged<T>` | `<T>` | concrete | 2 | miniextendr-api/src/raw_conversions.rs:465 |
 | `RCow<'_, T>` | `<T>` | concrete | 5 | miniextendr-api/src/rcow.rs:193 |
 | `RValue` | `` | concrete | 4 | miniextendr-api/src/rvalue.rs:50 |
-| `DataFrameShape` | `` | concrete | 3 | miniextendr-api/src/serde/columnar.rs:3247 |
+| `DataFrameShape` | `` | concrete | 3 | miniextendr-api/src/serde/columnar.rs:3249 |
 | `AsJsonVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:131 |
 | `AsJson<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:34 |
 | `AsJsonPretty<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:58 |
@@ -854,11 +888,11 @@ Traits with impls: 9
 
 - **miniextendr-api/src/into_r.rs:985** (5 impls): `Option<std::ffi::OsString>`, `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`
 - **miniextendr-api/src/into_r.rs:969** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Option<Timestamp>>`, `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`
+- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`, `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:476** (4 impls): `SignedDuration`, `Vec<Option<SignedDuration>>`, `Option<SignedDuration>`, `Vec<SignedDuration>`
 - **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`, `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`
 - **miniextendr-api/src/into_r.rs:1038** (2 impls): `BTreeSet<i8>`, `HashSet<i8>`
 - **miniextendr-api/src/into_r.rs:1040** (2 impls): `HashSet<u16>`, `BTreeSet<u16>`
 - **miniextendr-api/src/into_r.rs:604** (2 impls): `Vec<i8>`, `&[i8]`
@@ -866,6 +900,14 @@ Traits with impls: 9
 - **miniextendr-api/src/into_r.rs:605** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r.rs:606** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r.rs:609** (2 impls): `Vec<f32>`, `&[f32]`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1264** (2 impls): `Array0<String>`, `Array0<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1265** (2 impls): `Array1<String>`, `Array1<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1266** (2 impls): `Array2<String>`, `Array2<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1267** (2 impls): `Array3<String>`, `Array3<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1268** (2 impls): `Array4<String>`, `Array4<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1269** (2 impls): `Array5<String>`, `Array5<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1270** (2 impls): `Array6<String>`, `Array6<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1271** (2 impls): `ArrayD<String>`, `ArrayD<Option<String>>`
 
 ## `IntoRAs` — 135 impls
 
@@ -929,16 +971,16 @@ Traits with impls: 9
 | `crate::RLogical` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:607 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:681 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:688 |
-| `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
 | `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
-| `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
+| `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
+| `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:697 |
 | `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:697 |
-| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
+| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:700 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:700 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:701 |
@@ -957,24 +999,24 @@ Traits with impls: 9
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:752 |
 | `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:779 |
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:808 |
-| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
+| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:857 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:857 |
-| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
-| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
+| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
+| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:860 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:860 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:865 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:894 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:925 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:925 |
-| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
+| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:927 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:927 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:930 |
@@ -993,22 +1035,35 @@ Traits with impls: 9
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:969 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:970 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:970 |
-| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
-| `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
+| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
+| `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:973 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:973 |
-| `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
 | `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
-| `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
+| `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
+| `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:980 |
 | `&[bool]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:987 |
 | `Vec<String>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:997 |
 
 ### `IntoRAs` — for-types sharing a source span (likely macro-expanded / co-located)
 
+- **miniextendr-api/src/into_r_as.rs:971** (2 impls): `Vec<u32>`, `&[u32]`
+- **miniextendr-api/src/into_r_as.rs:856** (2 impls): `&[i8]`, `Vec<i8>`
+- **miniextendr-api/src/into_r_as.rs:972** (2 impls): `&[u64]`, `Vec<u64>`
+- **miniextendr-api/src/into_r_as.rs:858** (2 impls): `Vec<u8>`, `&[u8]`
+- **miniextendr-api/src/into_r_as.rs:974** (2 impls): `Vec<f32>`, `&[f32]`
+- **miniextendr-api/src/into_r_as.rs:859** (2 impls): `&[u16]`, `Vec<u16>`
+- **miniextendr-api/src/into_r_as.rs:695** (2 impls): `Vec<i8>`, `&[i8]`
+- **miniextendr-api/src/into_r_as.rs:975** (2 impls): `&[f64]`, `Vec<f64>`
+- **miniextendr-api/src/into_r_as.rs:696** (2 impls): `&[i16]`, `Vec<i16>`
+- **miniextendr-api/src/into_r_as.rs:924** (2 impls): `&[i64]`, `Vec<i64>`
+- **miniextendr-api/src/into_r_as.rs:698** (2 impls): `Vec<u16>`, `&[u16]`
+- **miniextendr-api/src/into_r_as.rs:926** (2 impls): `Vec<isize>`, `&[isize]`
+- **miniextendr-api/src/into_r_as.rs:699** (2 impls): `&[i64]`, `Vec<i64>`
 - **miniextendr-api/src/into_r_as.rs:927** (2 impls): `&[usize]`, `Vec<usize>`
 - **miniextendr-api/src/into_r_as.rs:701** (2 impls): `Vec<u32>`, `&[u32]`
 - **miniextendr-api/src/into_r_as.rs:702** (2 impls): `&[u64]`, `Vec<u64>`
@@ -1018,28 +1073,15 @@ Traits with impls: 9
 - **miniextendr-api/src/into_r_as.rs:705** (2 impls): `&[f64]`, `Vec<f64>`
 - **miniextendr-api/src/into_r_as.rs:968** (2 impls): `&[i64]`, `Vec<i64>`
 - **miniextendr-api/src/into_r_as.rs:970** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:971** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:857** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:973** (2 impls): `Vec<usize>`, `&[usize]`
-- **miniextendr-api/src/into_r_as.rs:858** (2 impls): `&[u8]`, `Vec<u8>`
-- **miniextendr-api/src/into_r_as.rs:974** (2 impls): `&[f32]`, `Vec<f32>`
 - **miniextendr-api/src/into_r_as.rs:860** (2 impls): `Vec<u32>`, `&[u32]`
-- **miniextendr-api/src/into_r_as.rs:695** (2 impls): `&[i8]`, `Vec<i8>`
 - **miniextendr-api/src/into_r_as.rs:697** (2 impls): `Vec<u8>`, `&[u8]`
 - **miniextendr-api/src/into_r_as.rs:925** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:698** (2 impls): `&[u16]`, `Vec<u16>`
-- **miniextendr-api/src/into_r_as.rs:926** (2 impls): `&[isize]`, `Vec<isize>`
 - **miniextendr-api/src/into_r_as.rs:700** (2 impls): `Vec<isize>`, `&[isize]`
 - **miniextendr-api/src/into_r_as.rs:703** (2 impls): `Vec<usize>`, `&[usize]`
 - **miniextendr-api/src/into_r_as.rs:966** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:969** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:856** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r_as.rs:972** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:859** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:975** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:696** (2 impls): `Vec<i16>`, `&[i16]`
-- **miniextendr-api/src/into_r_as.rs:924** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:699** (2 impls): `Vec<i64>`, `&[i64]`
 
 ## `TryCoerce` — 93 impls
 
@@ -1207,8 +1249,8 @@ Traits with impls: 9
 
 ### `Coerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 - **miniextendr-api/src/coerce.rs:212** (5 impls): `u8`, `u8`, `u8`, `u8`, `u8`
+- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 
 ## `AltrepSerialize` — 27 impls
 

--- a/rust-llm-docs/generated/conversion-manual-vs-macro.md
+++ b/rust-llm-docs/generated/conversion-manual-vs-macro.md
@@ -303,26 +303,34 @@ Source: `target/doc/miniextendr_api.json`
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:499
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:527
     - `i32` (1 items) — miniextendr-api/src/into_r_as.rs:586
-- shape `i64`: **4 hand-rolled**, 0 macro-generated
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:370
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:472
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:500
-    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:593
 - shape `f32`: **4 hand-rolled**, 0 macro-generated
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:377
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:406
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:506
     - `f32` (1 items) — miniextendr-api/src/into_r_as.rs:579
-- shape `f64`: **4 hand-rolled**, 0 macro-generated
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:378
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:392
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:507
-    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:561
 - shape `bool`: **4 hand-rolled**, 0 macro-generated
     - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:381
     - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:478
     - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:512
     - `bool` (1 items) — miniextendr-api/src/into_r_as.rs:600
+- shape `i64`: **4 hand-rolled**, 0 macro-generated
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:370
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:472
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:500
+    - `i64` (1 items) — miniextendr-api/src/into_r_as.rs:593
+- shape `f64`: **4 hand-rolled**, 0 macro-generated
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:378
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:392
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:507
+    - `f64` (1 items) — miniextendr-api/src/into_r_as.rs:561
+- shape `u8`: **3 hand-rolled**, 0 macro-generated
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:366
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:450
+    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:489
+- shape `isize`: **3 hand-rolled**, 0 macro-generated
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:371
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:474
+    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:501
 - shape `usize`: **3 hand-rolled**, 0 macro-generated
     - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:374
     - `usize` (1 items) — miniextendr-api/src/into_r_as.rs:475
@@ -347,14 +355,6 @@ Source: `target/doc/miniextendr_api.json`
     - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:373
     - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:473
     - `u64` (1 items) — miniextendr-api/src/into_r_as.rs:504
-- shape `isize`: **3 hand-rolled**, 0 macro-generated
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:371
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:474
-    - `isize` (1 items) — miniextendr-api/src/into_r_as.rs:501
-- shape `u8`: **3 hand-rolled**, 0 macro-generated
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:366
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:450
-    - `u8` (1 items) — miniextendr-api/src/into_r_as.rs:489
 
 ## Coerce
 
@@ -423,6 +423,9 @@ Source: `target/doc/miniextendr_api.json`
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:104
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:119
     - `Decimal` (2 items) — miniextendr-api/src/optionals/rust_decimal_impl.rs:91
+- shape `usize`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
+    - `usize` (2 items) — miniextendr-api/src/coerce.rs:378
+    - `usize` (2 items) — miniextendr-api/src/coerce.rs:890
 - shape `u64`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `u64` (2 items) — miniextendr-api/src/coerce.rs:377
     - `u64` (2 items) — miniextendr-api/src/coerce.rs:869
@@ -432,9 +435,8 @@ Source: `target/doc/miniextendr_api.json`
 - shape `i64`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `i64` (2 items) — miniextendr-api/src/coerce.rs:372
     - `i64` (2 items) — miniextendr-api/src/coerce.rs:852
-- shape `usize`: **2 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
-    - `usize` (2 items) — miniextendr-api/src/coerce.rs:378
-    - `usize` (2 items) — miniextendr-api/src/coerce.rs:890
+- shape `u16`: **1 hand-rolled**, 3 macro-generated  <== macro already exists for this shape
+    - `u16` (2 items) — miniextendr-api/src/coerce.rs:375
 - shape `i8`: **1 hand-rolled**, 2 macro-generated  <== macro already exists for this shape
     - `i8` (2 items) — miniextendr-api/src/coerce.rs:369
 - shape `u8`: **1 hand-rolled**, 1 macro-generated  <== macro already exists for this shape
@@ -443,5 +445,3 @@ Source: `target/doc/miniextendr_api.json`
     - `i16` (2 items) — miniextendr-api/src/coerce.rs:370
 - shape `u32`: **1 hand-rolled**, 5 macro-generated  <== macro already exists for this shape
     - `u32` (2 items) — miniextendr-api/src/coerce.rs:376
-- shape `u16`: **1 hand-rolled**, 3 macro-generated  <== macro already exists for this shape
-    - `u16` (2 items) — miniextendr-api/src/coerce.rs:375

--- a/rust-llm-docs/generated/miniextendr-api-impl-inventory.md
+++ b/rust-llm-docs/generated/miniextendr-api-impl-inventory.md
@@ -2,38 +2,38 @@
 
 Source: `target/doc/miniextendr_api.json`
 
-Traits with impls: 216
+Traits with impls: 218
 
 ## Summary (impl count per trait)
 
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
-| `TryFromSexp` | 453 | 453 |
+| `TryFromSexp` | 469 | 469 |
 | `From` | 389 | 74 |
-| `IntoR` | 337 | 337 |
+| `IntoR` | 353 | 353 |
 | `TryFrom` | 320 | 11 |
-| `Borrow` | 310 | 1 |
 | `BorrowMut` | 310 | 1 |
-| `IntoEither` | 309 | 0 |
-| `Tap` | 309 | 0 |
-| `RefUnwindSafe` | 309 | 1 |
-| `Send` | 309 | 10 |
-| `Sync` | 309 | 13 |
-| `Conv` | 309 | 0 |
-| `TryInto` | 309 | 0 |
-| `Into` | 309 | 0 |
-| `Unpin` | 309 | 0 |
-| `Pipe` | 309 | 0 |
-| `UnwindSafe` | 309 | 0 |
-| `VZip` | 309 | 0 |
-| `Pointable` | 309 | 0 |
-| `Any` | 309 | 0 |
-| `FmtForward` | 309 | 0 |
+| `Borrow` | 310 | 1 |
 | `UnsafeUnpin` | 309 | 0 |
-| `Freeze` | 309 | 0 |
+| `Send` | 309 | 10 |
+| `Tap` | 309 | 0 |
 | `SupersetOf` | 309 | 0 |
-| `Same` | 309 | 0 |
+| `FmtForward` | 309 | 0 |
+| `Freeze` | 309 | 0 |
+| `Any` | 309 | 0 |
+| `Into` | 309 | 0 |
+| `VZip` | 309 | 0 |
+| `Unpin` | 309 | 0 |
+| `Pointable` | 309 | 0 |
+| `IntoEither` | 309 | 0 |
+| `TryInto` | 309 | 0 |
+| `Pipe` | 309 | 0 |
+| `Sync` | 309 | 13 |
+| `RefUnwindSafe` | 309 | 1 |
 | `TryConv` | 309 | 0 |
+| `Conv` | 309 | 0 |
+| `UnwindSafe` | 309 | 0 |
+| `Same` | 309 | 0 |
 | `Allocation` | 218 | 0 |
 | `TypedExternal` | 181 | 181 |
 | `Equivalent` | 160 | 0 |
@@ -41,9 +41,9 @@ Traits with impls: 216
 | `RDebug` | 109 | 1 |
 | `Debug` | 108 | 108 |
 | `RClone` | 101 | 1 |
-| `CloneToUninit` | 100 | 0 |
 | `ToOwned` | 100 | 0 |
 | `Clone` | 100 | 100 |
+| `CloneToUninit` | 100 | 0 |
 | `TryCoerce` | 95 | 93 |
 | `AltrepLen` | 64 | 64 |
 | `RCopy` | 59 | 1 |
@@ -55,8 +55,8 @@ Traits with impls: 216
 | `PartialEq` | 44 | 44 |
 | `Scalar` | 43 | 0 |
 | `StructuralPartialEq` | 43 | 43 |
-| `DynEq` | 40 | 0 |
 | `Eq` | 40 | 40 |
+| `DynEq` | 40 | 0 |
 | `RegisterAltrep` | 33 | 33 |
 | `AltrepDataptr` | 27 | 27 |
 | `AltrepSerialize` | 27 | 27 |
@@ -66,166 +66,168 @@ Traits with impls: 216
 | `RDisplay` | 23 | 1 |
 | `ToString` | 22 | 0 |
 | `Display` | 22 | 22 |
-| `Deref` | 21 | 21 |
 | `Receiver` | 21 | 0 |
+| `Deref` | 21 | 21 |
 | `Error` | 20 | 20 |
 | `RError` | 19 | 1 |
 | `AltIntegerData` | 16 | 16 |
-| `AltRealData` | 16 | 16 |
 | `RHash` | 16 | 1 |
+| `AltRealData` | 16 | 16 |
 | `DynHash` | 15 | 0 |
 | `Hash` | 15 | 15 |
 | `MultiUnzip` | 13 | 0 |
 | `TraitView` | 12 | 12 |
 | `AltReal` | 11 | 11 |
-| `Serializer` | 10 | 10 |
+| `IteratorRandom` | 10 | 0 |
 | `AltInteger` | 10 | 10 |
 | `AltStringData` | 10 | 10 |
-| `IteratorRandom` | 10 | 0 |
-| `AltString` | 9 | 9 |
+| `Serializer` | 10 | 10 |
 | `AtomicElement` | 9 | 9 |
+| `AltString` | 9 | 9 |
 | `AltRawData` | 8 | 8 |
 | `DerefMut` | 8 | 8 |
-| `SerializeStruct` | 7 | 7 |
-| `Rng` | 7 | 0 |
-| `IoCaps` | 7 | 7 |
-| `TryRngCore` | 7 | 0 |
-| `WidensToF64` | 7 | 7 |
 | `RConnectionImpl` | 7 | 7 |
-| `SerializeMap` | 7 | 7 |
-| `AltLogicalData` | 7 | 7 |
+| `RSerialize` | 7 | 1 |
+| `SerializeStruct` | 7 | 7 |
+| `WidensToF64` | 7 | 7 |
 | `IntoIterator` | 7 | 2 |
+| `IoCaps` | 7 | 7 |
+| `Rng` | 7 | 0 |
 | `RngCore` | 7 | 0 |
-| `Formattable` | 6 | 0 |
-| `RSerializeNative` | 6 | 1 |
-| `RSerialize` | 6 | 1 |
+| `SerializeMap` | 7 | 7 |
+| `TryRngCore` | 7 | 0 |
+| `AltLogicalData` | 7 | 7 |
+| `RSerializeNative` | 7 | 1 |
+| `Deserializer` | 6 | 6 |
 | `CryptoRng` | 6 | 0 |
-| `AsRef` | 6 | 6 |
-| `TryCryptoRng` | 6 | 0 |
 | `Parsable` | 6 | 0 |
+| `TryCryptoRng` | 6 | 0 |
+| `RNdArrayOps` | 6 | 6 |
+| `Serialize` | 6 | 6 |
+| `Formattable` | 6 | 0 |
 | `AltComplexData` | 6 | 6 |
 | `AltRaw` | 6 | 6 |
-| `Deserializer` | 6 | 6 |
-| `RNdArrayOps` | 6 | 6 |
+| `AsRef` | 6 | 6 |
 | `AltLogical` | 5 | 5 |
-| `Itertools` | 5 | 0 |
-| `ProgressIterator` | 5 | 0 |
-| `Iterator` | 5 | 5 |
-| `RPartialOrd` | 5 | 1 |
-| `ROrd` | 5 | 1 |
-| `Serialize` | 5 | 5 |
-| `RNativeType` | 5 | 5 |
-| `AltrepExtract` | 5 | 1 |
-| `TreeNodeIterator` | 5 | 0 |
-| `IntoList` | 5 | 5 |
-| `TryFromList` | 5 | 5 |
-| `ExactSizeIterator` | 5 | 5 |
 | `SeqAccess` | 5 | 5 |
+| `RPartialOrd` | 5 | 1 |
+| `ExactSizeIterator` | 5 | 5 |
+| `IntoList` | 5 | 5 |
+| `ROrd` | 5 | 1 |
+| `Iterator` | 5 | 5 |
+| `TreeNodeIterator` | 5 | 0 |
+| `ProgressIterator` | 5 | 0 |
+| `RNativeType` | 5 | 5 |
+| `Itertools` | 5 | 0 |
+| `AltrepExtract` | 5 | 1 |
+| `TryFromList` | 5 | 5 |
 | `AltComplex` | 4 | 4 |
-| `Ord` | 4 | 4 |
-| `SerializeTupleVariant` | 4 | 4 |
 | `WidensToI32` | 4 | 4 |
 | `PartialOrd` | 4 | 4 |
-| `SerializeStructVariant` | 4 | 4 |
 | `RngExt` | 4 | 0 |
-| `TryRng` | 4 | 1 |
 | `Comparable` | 4 | 0 |
-| `AsNamedListExt` | 3 | 3 |
-| `AsNamedVectorExt` | 3 | 3 |
+| `SerializeTupleVariant` | 4 | 4 |
+| `Ord` | 4 | 4 |
+| `TryRng` | 4 | 1 |
+| `SerializeStructVariant` | 4 | 4 |
 | `IntoRAltrep` | 3 | 1 |
 | `VariantAccess` | 3 | 3 |
+| `AsNamedListExt` | 3 | 3 |
+| `AsNamedVectorExt` | 3 | 3 |
 | `Write` | 3 | 3 |
-| `AsRNativeExt` | 3 | 1 |
 | `EnumAccess` | 3 | 3 |
-| `RSourced` | 2 | 2 |
-| `IntoDataFrame` | 2 | 2 |
-| `RNdIndex` | 2 | 2 |
-| `FromDataFrame` | 2 | 2 |
-| `RNdSlice` | 2 | 2 |
-| `NodeTrait` | 2 | 0 |
-| `Storage` | 2 | 2 |
-| `RNdSlice2D` | 2 | 2 |
-| `Protector` | 2 | 2 |
-| `AltrepClass` | 2 | 2 |
-| `RDateTimeFormat` | 2 | 2 |
+| `AsRNativeExt` | 3 | 1 |
 | `MapAccess` | 2 | 2 |
-| `AsDataFrameExt` | 2 | 1 |
+| `RDeserialize` | 2 | 1 |
+| `RDateTimeFormat` | 2 | 2 |
+| `RJsonBridge` | 2 | 1 |
+| `Storage` | 2 | 2 |
+| `IntoDataFrame` | 2 | 2 |
+| `FromDataFrame` | 2 | 2 |
+| `NodeTrait` | 2 | 0 |
+| `AltrepClass` | 2 | 2 |
+| `RNdIndex` | 2 | 2 |
+| `RSourced` | 2 | 2 |
+| `RNdSlice2D` | 2 | 2 |
 | `AsMut` | 2 | 2 |
+| `Protector` | 2 | 2 |
+| `RDeserializeNative` | 2 | 1 |
+| `RNdSlice` | 2 | 2 |
+| `AsDataFrameExt` | 2 | 1 |
+| `IntoRecords` | 1 | 0 |
+| `RDecimalOps` | 1 | 1 |
+| `Not` | 1 | 1 |
+| `StorageMut` | 1 | 0 |
+| `RDuration` | 1 | 1 |
+| `FusedIterator` | 1 | 1 |
+| `UnitEnumFactor` | 1 | 1 |
+| `RBigUintBitOps` | 1 | 1 |
+| `RJsonValueOps` | 1 | 1 |
+| `RSpan` | 1 | 1 |
+| `RFromStr` | 1 | 1 |
+| `SerializeSeq` | 1 | 1 |
+| `SexpExt` | 1 | 1 |
+| `RBigUintOps` | 1 | 1 |
+| `RMatrixOps` | 1 | 1 |
+| `SerializeTuple` | 1 | 1 |
+| `CheckedBitPattern` | 1 | 0 |
+| `RUuidOps` | 1 | 1 |
+| `PairListExt` | 1 | 1 |
+| `ParCollectR` | 1 | 1 |
+| `Pod` | 1 | 1 |
+| `Pointer` | 1 | 1 |
+| `RComplexOps` | 1 | 1 |
+| `IntoDataFrameSplit` | 1 | 1 |
+| `RBigIntBitOps` | 1 | 1 |
+| `RFromIter` | 1 | 1 |
+| `BitXor` | 1 | 1 |
+| `RNum` | 1 | 1 |
+| `DoubleEndedIterator` | 1 | 1 |
+| `RBigIntOps` | 1 | 1 |
+| `TermLike` | 1 | 1 |
+| `ROrderedFloatOps` | 1 | 1 |
+| `RawStorageMut` | 1 | 1 |
+| `RTomlOps` | 1 | 1 |
+| `RDate` | 1 | 1 |
+| `ElementIterator` | 1 | 0 |
+| `AltListData` | 1 | 1 |
+| `AnyBitPattern` | 1 | 0 |
+| `AsListExt` | 1 | 1 |
+| `Log` | 1 | 1 |
+| `IsContiguous` | 1 | 1 |
+| `AsExternalPtrExt` | 1 | 1 |
+| `NoUninit` | 1 | 0 |
+| `DeserializeOwned` | 1 | 0 |
+| `SerializeTupleStruct` | 1 | 1 |
+| `MatchArg` | 1 | 1 |
+| `BitOr` | 1 | 1 |
+| `RVectorOps` | 1 | 1 |
+| `RRegexOps` | 1 | 1 |
+| `RToVec` | 1 | 1 |
 | `RUrlOps` | 1 | 1 |
 | `RZoned` | 1 | 1 |
-| `RToVec` | 1 | 1 |
 | `RSigned` | 1 | 1 |
+| `GlobalAlloc` | 1 | 1 |
+| `AltrepSexpExt` | 1 | 1 |
+| `Deserialize` | 1 | 1 |
 | `RFloat` | 1 | 1 |
 | `RawStorage` | 1 | 1 |
-| `GlobalAlloc` | 1 | 1 |
-| `IntoDataFrameSplit` | 1 | 1 |
 | `RAhoCorasickOps` | 1 | 1 |
 | `RDateTime` | 1 | 1 |
 | `RCaptureGroups` | 1 | 1 |
 | `RIndexMapOps` | 1 | 1 |
-| `SexpExt` | 1 | 1 |
-| `RTime` | 1 | 1 |
-| `SerializeTupleStruct` | 1 | 1 |
-| `RSignedDuration` | 1 | 1 |
-| `RBorshOps` | 1 | 1 |
-| `ParCollectR` | 1 | 1 |
-| `RTimestamp` | 1 | 1 |
-| `PairListExt` | 1 | 1 |
-| `Read` | 1 | 1 |
-| `RDecimalOps` | 1 | 1 |
-| `BitAnd` | 1 | 1 |
-| `TermLike` | 1 | 1 |
-| `Zeroable` | 1 | 1 |
-| `Not` | 1 | 1 |
-| `StorageMut` | 1 | 0 |
-| `RDuration` | 1 | 1 |
-| `AsListExt` | 1 | 1 |
-| `IntoRecords` | 1 | 0 |
-| `AsExternalPtrExt` | 1 | 1 |
-| `RBigUintBitOps` | 1 | 1 |
-| `RSpan` | 1 | 1 |
-| `UnitEnumFactor` | 1 | 1 |
-| `RJsonValueOps` | 1 | 1 |
-| `RJsonBridge` | 1 | 1 |
-| `FusedIterator` | 1 | 1 |
-| `RFromStr` | 1 | 1 |
-| `RBigUintOps` | 1 | 1 |
-| `RMatrixOps` | 1 | 1 |
-| `AltListData` | 1 | 1 |
-| `RUuidOps` | 1 | 1 |
-| `CheckedBitPattern` | 1 | 0 |
-| `RComplexOps` | 1 | 1 |
-| `RBigIntBitOps` | 1 | 1 |
-| `Pod` | 1 | 1 |
-| `BitXor` | 1 | 1 |
-| `RNum` | 1 | 1 |
-| `RFromIter` | 1 | 1 |
-| `Pointer` | 1 | 1 |
-| `RBigIntOps` | 1 | 1 |
-| `AsVctrsExt` | 1 | 1 |
-| `IntoRVecElement` | 1 | 1 |
-| `DoubleEndedIterator` | 1 | 1 |
-| `AltrepSexpExt` | 1 | 1 |
-| `ROrderedFloatOps` | 1 | 1 |
-| `RawStorageMut` | 1 | 1 |
-| `RDate` | 1 | 1 |
-| `RTomlOps` | 1 | 1 |
-| `IsContiguous` | 1 | 1 |
-| `SerializeSeq` | 1 | 1 |
-| `RDeserialize` | 1 | 1 |
-| `AnyBitPattern` | 1 | 0 |
 | `RDistributions` | 1 | 1 |
-| `ElementIterator` | 1 | 0 |
-| `SerializeTuple` | 1 | 1 |
-| `RDeserializeNative` | 1 | 1 |
-| `Log` | 1 | 1 |
-| `NoUninit` | 1 | 0 |
-| `MatchArg` | 1 | 1 |
-| `RVectorOps` | 1 | 1 |
-| `BitOr` | 1 | 1 |
-| `RRegexOps` | 1 | 1 |
+| `RTime` | 1 | 1 |
+| `Read` | 1 | 1 |
+| `RBorshOps` | 1 | 1 |
+| `AsVctrsExt` | 1 | 1 |
+| `BitAnd` | 1 | 1 |
+| `RSignedDuration` | 1 | 1 |
+| `IntoRVecElement` | 1 | 1 |
+| `Zeroable` | 1 | 1 |
+| `RTimestamp` | 1 | 1 |
 
-## `TryFromSexp` — 453 impls
+## `TryFromSexp` — 469 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -524,90 +526,106 @@ Traits with impls: 216
 | `DVector<crate::coerce::Coerced<T, R>>` | `<T, R> +4wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:854 |
 | `DMatrix<crate::coerce::Coerced<T, R>>` | `<T, R> +4wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:885 |
 | `DMatrix<T>` | `<T> +1wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:96 |
-| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:119 |
-| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:140 |
-| `Array2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:155 |
-| `Array3<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:176 |
-| `Array4<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:197 |
-| `Array5<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:230 |
-| `Array6<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:265 |
-| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2920 |
-| `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:300 |
-| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3065 |
-| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:665 |
-| `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:666 |
-| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:667 |
-| `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array4<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
-| `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
-| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
-| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
-| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
-| `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array4<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:676 |
-| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:680 |
-| `Vec<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
-| `Vec<Option<BigInt>>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:122 |
+| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:143 |
+| `Array2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:158 |
+| `Array3<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:179 |
+| `Array4<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:200 |
+| `Array5<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:233 |
+| `Array6<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:268 |
+| `ArrayD<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:303 |
+| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3205 |
+| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3350 |
+| `Array1<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array4<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `ArrayD<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array3<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array6<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array2<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array5<i8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:668 |
+| `Array4<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `ArrayD<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array3<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array6<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array2<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array5<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array1<i16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:669 |
+| `Array3<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array6<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array2<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array5<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array1<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array4<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `ArrayD<i64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:670 |
+| `Array2<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array5<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array1<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array4<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `ArrayD<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array3<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array6<isize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:671 |
+| `Array2<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array5<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array1<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array4<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `ArrayD<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array3<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array6<u16>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:672 |
+| `Array1<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array4<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `ArrayD<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array3<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array6<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array2<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `Array5<u32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:673 |
+| `ArrayD<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array3<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array6<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array2<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array5<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array1<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array4<u64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:674 |
+| `Array3<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array6<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array2<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array5<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array1<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array4<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `ArrayD<usize>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:675 |
+| `Array2<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array5<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array1<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array4<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `ArrayD<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array3<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array6<f32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:679 |
+| `Array2<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array5<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array1<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array4<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `ArrayD<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array3<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array6<bool>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:683 |
+| `Array0<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array3<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array6<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array2<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array5<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array1<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array4<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `ArrayD<String>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:866 |
+| `Array5<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array1<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array4<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `ArrayD<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array0<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array3<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array6<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
+| `Array2<Option<String>>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
 | `BigInt` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
 | `Option<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Vec<BigInt>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
+| `Vec<Option<BigInt>>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:193 |
 | `BigUint` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
 | `Option<BigUint>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
 | `Vec<BigUint>` | `` | concrete | 2 | miniextendr-api/src/optionals/num_bigint_impl.rs:194 |
@@ -690,25 +708,27 @@ Traits with impls: 216
 - **miniextendr-api/src/from_r/references.rs:323** (12 impls): `&'static u8`, `Option<&'static mut u8>`, `Vec<&'static u8>`, `Vec<Option<&'static u8>>`, `Vec<&'static mut u8>`, `Vec<Option<&'static mut u8>>`, `Vec<&'static [u8]>`, `Vec<Option<&'static [u8]>>`, `Vec<&'static mut [u8]>`, `Vec<Option<&'static mut [u8]>>`, `Option<&'static u8>`, `&'static mut u8`
 - **miniextendr-api/src/from_r/references.rs:324** (12 impls): `&'static mut crate::RLogical`, `&'static crate::RLogical`, `Option<&'static mut crate::RLogical>`, `Vec<&'static crate::RLogical>`, `Vec<Option<&'static crate::RLogical>>`, `Vec<&'static mut crate::RLogical>`, `Vec<Option<&'static mut crate::RLogical>>`, `Vec<&'static [crate::RLogical]>`, `Vec<Option<&'static [crate::RLogical]>>`, `Vec<&'static mut [crate::RLogical]>`, `Vec<Option<&'static mut [crate::RLogical]>>`, `Option<&'static crate::RLogical>`
 - **miniextendr-api/src/from_r/references.rs:322** (12 impls): `&'static f64`, `Option<&'static mut f64>`, `Vec<&'static f64>`, `Vec<Option<&'static f64>>`, `Vec<&'static mut f64>`, `Vec<Option<&'static mut f64>>`, `Vec<&'static [f64]>`, `Vec<Option<&'static [f64]>>`, `Vec<&'static mut [f64]>`, `Vec<Option<&'static mut [f64]>>`, `Option<&'static f64>`, `&'static mut f64`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:666** (7 impls): `Array4<i16>`, `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array2<u16>`, `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:680** (7 impls): `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`, `Array2<bool>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:667** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:665** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:676** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
-- **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
-- **miniextendr-api/src/optionals/num_bigint_impl.rs:193** (4 impls): `Vec<BigInt>`, `Vec<Option<BigInt>>`, `BigInt`, `Option<BigInt>`
-- **miniextendr-api/src/from_r/cow_and_paths.rs:312** (4 impls): `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:867** (8 impls): `Array5<Option<String>>`, `Array1<Option<String>>`, `Array4<Option<String>>`, `ArrayD<Option<String>>`, `Array0<Option<String>>`, `Array3<Option<String>>`, `Array6<Option<String>>`, `Array2<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:866** (8 impls): `Array0<String>`, `Array3<String>`, `Array6<String>`, `Array2<String>`, `Array5<String>`, `Array1<String>`, `Array4<String>`, `ArrayD<String>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:683** (7 impls): `Array2<bool>`, `Array5<bool>`, `Array1<bool>`, `Array4<bool>`, `ArrayD<bool>`, `Array3<bool>`, `Array6<bool>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:669** (7 impls): `Array4<i16>`, `ArrayD<i16>`, `Array3<i16>`, `Array6<i16>`, `Array2<i16>`, `Array5<i16>`, `Array1<i16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:672** (7 impls): `Array2<u16>`, `Array5<u16>`, `Array1<u16>`, `Array4<u16>`, `ArrayD<u16>`, `Array3<u16>`, `Array6<u16>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:674** (7 impls): `ArrayD<u64>`, `Array3<u64>`, `Array6<u64>`, `Array2<u64>`, `Array5<u64>`, `Array1<u64>`, `Array4<u64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:675** (7 impls): `Array3<usize>`, `Array6<usize>`, `Array2<usize>`, `Array5<usize>`, `Array1<usize>`, `Array4<usize>`, `ArrayD<usize>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:670** (7 impls): `Array3<i64>`, `Array6<i64>`, `Array2<i64>`, `Array5<i64>`, `Array1<i64>`, `Array4<i64>`, `ArrayD<i64>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:673** (7 impls): `Array1<u32>`, `Array4<u32>`, `ArrayD<u32>`, `Array3<u32>`, `Array6<u32>`, `Array2<u32>`, `Array5<u32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:668** (7 impls): `Array1<i8>`, `Array4<i8>`, `ArrayD<i8>`, `Array3<i8>`, `Array6<i8>`, `Array2<i8>`, `Array5<i8>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:679** (7 impls): `Array2<f32>`, `Array5<f32>`, `Array1<f32>`, `Array4<f32>`, `ArrayD<f32>`, `Array3<f32>`, `Array6<f32>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:671** (7 impls): `Array2<isize>`, `Array5<isize>`, `Array1<isize>`, `Array4<isize>`, `ArrayD<isize>`, `Array3<isize>`, `Array6<isize>`
 - **miniextendr-api/src/optionals/num_bigint_impl.rs:194** (4 impls): `BigUint`, `Option<BigUint>`, `Vec<BigUint>`, `Vec<Option<BigUint>>`
 - **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<Option<OffsetDateTime>>`, `OffsetDateTime`, `Vec<OffsetDateTime>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:476** (4 impls): `SignedDuration`, `Vec<SignedDuration>`, `Option<SignedDuration>`, `Vec<Option<SignedDuration>>`
+- **miniextendr-api/src/from_r/cow_and_paths.rs:312** (4 impls): `std::ffi::OsString`, `Vec<std::ffi::OsString>`, `Option<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`
 - **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Date`, `Vec<Date>`, `Option<Date>`, `Vec<Option<Date>>`
 - **miniextendr-api/src/optionals/url_impl.rs:48** (4 impls): `Option<Url>`, `Vec<Url>`, `Vec<Option<Url>>`, `Url`
 - **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Option<Timestamp>>`, `Timestamp`, `Vec<Timestamp>`, `Option<Timestamp>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Option<Date>`, `Vec<Option<Date>>`, `Date`, `Vec<Date>`
+- **miniextendr-api/src/optionals/num_bigint_impl.rs:193** (4 impls): `BigInt`, `Option<BigInt>`, `Vec<BigInt>`, `Vec<Option<BigInt>>`
 - **miniextendr-api/src/from_r/cow_and_paths.rs:289** (4 impls): `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `Vec<std::path::PathBuf>`, `Option<std::path::PathBuf>`
 - **miniextendr-api/src/optionals/regex_impl.rs:67** (4 impls): `Option<Regex>`, `Vec<Regex>`, `Vec<Option<Regex>>`, `Regex`
 - **miniextendr-api/src/optionals/uuid_impl.rs:43** (4 impls): `Option<Uuid>`, `Vec<Uuid>`, `Vec<Option<Uuid>>`, `Uuid`
@@ -752,14 +772,14 @@ Traits with impls: 216
 | `Option<T>` | `<T>` | concrete | 1 | miniextendr-api/src/missing.rs:238 |
 | `NamedVector<M>` | `<M>` | concrete | 1 | miniextendr-api/src/named_vector.rs:201 |
 | `RFlags<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/bitflags_impl.rs:126 |
-| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1453 |
-| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1479 |
-| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1491 |
-| `ArrayViewD<'a, T>` | `<'a, T, NDIM>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1503 |
-| `Array1<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1533 |
-| `Array2<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1544 |
-| `Array3<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1556 |
-| `ArrayD<T>` | `<T, NDIM>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1569 |
+| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1738 |
+| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1764 |
+| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1776 |
+| `ArrayViewD<'a, T>` | `<'a, T, NDIM>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1788 |
+| `Array1<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1818 |
+| `Array2<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1829 |
+| `Array3<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1841 |
+| `ArrayD<T>` | `<T, NDIM>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:1854 |
 | `RCoerceError` | `` | concrete | 1 | miniextendr-api/src/r_coerce.rs:158 |
 | `RCoerceError` | `` | concrete | 1 | miniextendr-api/src/r_coerce.rs:164 |
 | `RCow<'_, T>` | `<T>` | concrete | 1 | miniextendr-api/src/rcow.rs:159 |
@@ -785,7 +805,7 @@ Traits with impls: 216
 | `RValue` | `` | concrete | 1 | miniextendr-api/src/rvalue.rs:292 |
 | `RValue` | `` | concrete | 1 | miniextendr-api/src/rvalue.rs:301 |
 | `RValue` | `` | concrete | 1 | miniextendr-api/src/rvalue.rs:311 |
-| `CollatedResultRow<'a, T, E>` | `<'a, T, E>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4596 |
+| `CollatedResultRow<'a, T, E>` | `<'a, T, E>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4598 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:255 |
 | `SEXP` | `` | concrete | 1 | miniextendr-api/src/sexp.rs:482 |
 | `*mut SEXPREC` | `` | concrete | 1 | miniextendr-api/src/sexp.rs:489 |
@@ -794,7 +814,7 @@ Traits with impls: 216
 | `bool` | `` | concrete | 1 | miniextendr-api/src/sexp_types.rs:339 |
 | `TypedListError` | `` | concrete | 1 | miniextendr-api/src/typed_list.rs:265 |
 
-## `IntoR` — 337 impls
+## `IntoR` — 353 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
@@ -1031,16 +1051,16 @@ Traits with impls: 216
 | `Vec<Option<SignedDuration>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
 | `Option<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
 | `Vec<SignedDuration>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:476 |
+| `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Option<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Vec<Timestamp>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `Timestamp` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
-| `Vec<Option<Timestamp>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:81 |
 | `JiffTimestampVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
 | `JiffZonedVec` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
+| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `Option<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
-| `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:98 |
 | `log::LevelFilter` | `` | concrete | 4 | miniextendr-api/src/optionals/log_impl.rs:332 |
 | `RDVector<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1334 |
 | `RDMatrix<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1347 |
@@ -1050,22 +1070,38 @@ Traits with impls: 216
 | `Option<SMatrix<T, R, C>>` | `<T, R, C>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:335 |
 | `DVector<crate::coerce::Coerced<T, R>>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:924 |
 | `DMatrix<crate::coerce::Coerced<T, R>>` | `<T, R> +3wc` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:946 |
-| `ArcArray2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1009 |
-| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1030 |
-| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1048 |
-| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1079 |
-| `ArrayViewD<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1122 |
-| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:2932 |
-| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3077 |
-| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:325 |
-| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:342 |
-| `Array2<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:689 |
-| `Array3<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:731 |
-| `Array4<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:778 |
-| `Array5<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:823 |
-| `Array6<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:867 |
-| `ArrayD<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:910 |
-| `ArcArray1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:992 |
+| `Array5<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1010 |
+| `Array6<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1054 |
+| `ArrayD<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1097 |
+| `Array0<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1264 |
+| `Array0<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1264 |
+| `Array1<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1265 |
+| `Array1<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1265 |
+| `Array2<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1266 |
+| `Array2<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1266 |
+| `Array3<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1267 |
+| `Array3<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1267 |
+| `Array4<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1268 |
+| `Array4<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1268 |
+| `Array5<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1269 |
+| `Array5<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1269 |
+| `Array6<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1270 |
+| `Array6<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1270 |
+| `ArrayD<String>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1271 |
+| `ArrayD<Option<String>>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1271 |
+| `ArcArray1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1277 |
+| `ArcArray2<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1294 |
+| `ArrayView1<'a, T>` | `<'a, T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1315 |
+| `ArrayView2<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1333 |
+| `ArrayView3<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1364 |
+| `ArrayViewD<'a, T>` | `<'a, T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:1407 |
+| `RndVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3217 |
+| `Array0<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:328 |
+| `RndMat<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3362 |
+| `Array1<T>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:345 |
+| `Array2<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:876 |
+| `Array3<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:918 |
+| `Array4<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:965 |
 | `BigInt` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:196 |
 | `BigUint` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:197 |
 | `Option<BigInt>` | `` | concrete | 4 | miniextendr-api/src/optionals/num_bigint_impl.rs:198 |
@@ -1095,10 +1131,10 @@ Traits with impls: 216
 | `Vec<JsonValue>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:626 |
 | `Vec<Option<JsonValue>>` | `` | concrete | 4 | miniextendr-api/src/optionals/serde_impl.rs:653 |
 | `Table` | `` | concrete | 4 | miniextendr-api/src/optionals/tabled_impl.rs:197 |
-| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
-| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `OffsetDateTime` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Option<OffsetDateTime>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Option<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
+| `Vec<OffsetDateTime>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:69 |
 | `Vec<Date>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Date` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
 | `Vec<Option<Date>>` | `` | concrete | 4 | miniextendr-api/src/optionals/time_impl.rs:97 |
@@ -1128,7 +1164,7 @@ Traits with impls: 216
 | `RawSliceTagged<T>` | `<T>` | concrete | 2 | miniextendr-api/src/raw_conversions.rs:465 |
 | `RCow<'_, T>` | `<T>` | concrete | 5 | miniextendr-api/src/rcow.rs:193 |
 | `RValue` | `` | concrete | 4 | miniextendr-api/src/rvalue.rs:50 |
-| `DataFrameShape` | `` | concrete | 3 | miniextendr-api/src/serde/columnar.rs:3247 |
+| `DataFrameShape` | `` | concrete | 3 | miniextendr-api/src/serde/columnar.rs:3249 |
 | `AsJsonVec<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:131 |
 | `AsJson<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:34 |
 | `AsJsonPretty<T>` | `<T>` | concrete | 3 | miniextendr-api/src/serde/json_string.rs:58 |
@@ -1140,11 +1176,11 @@ Traits with impls: 216
 
 - **miniextendr-api/src/into_r.rs:985** (5 impls): `Option<std::ffi::OsString>`, `Vec<std::ffi::OsString>`, `Vec<Option<std::ffi::OsString>>`, `std::ffi::OsString`, `&std::ffi::OsStr`
 - **miniextendr-api/src/into_r.rs:969** (5 impls): `Option<std::path::PathBuf>`, `Vec<std::path::PathBuf>`, `Vec<Option<std::path::PathBuf>>`, `std::path::PathBuf`, `&std::path::Path`
+- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Vec<Option<Timestamp>>`, `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`
+- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
+- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`, `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`
 - **miniextendr-api/src/optionals/jiff_impl.rs:476** (4 impls): `SignedDuration`, `Vec<Option<SignedDuration>>`, `Option<SignedDuration>`, `Vec<SignedDuration>`
 - **miniextendr-api/src/optionals/time_impl.rs:97** (4 impls): `Vec<Date>`, `Date`, `Vec<Option<Date>>`, `Option<Date>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:81** (4 impls): `Option<Timestamp>`, `Vec<Timestamp>`, `Timestamp`, `Vec<Option<Timestamp>>`
-- **miniextendr-api/src/optionals/jiff_impl.rs:98** (4 impls): `Date`, `Vec<Option<Date>>`, `Option<Date>`, `Vec<Date>`
-- **miniextendr-api/src/optionals/time_impl.rs:69** (4 impls): `Option<OffsetDateTime>`, `Vec<OffsetDateTime>`, `OffsetDateTime`, `Vec<Option<OffsetDateTime>>`
 - **miniextendr-api/src/into_r.rs:1038** (2 impls): `BTreeSet<i8>`, `HashSet<i8>`
 - **miniextendr-api/src/into_r.rs:1040** (2 impls): `HashSet<u16>`, `BTreeSet<u16>`
 - **miniextendr-api/src/into_r.rs:604** (2 impls): `Vec<i8>`, `&[i8]`
@@ -1152,6 +1188,14 @@ Traits with impls: 216
 - **miniextendr-api/src/into_r.rs:605** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r.rs:606** (2 impls): `Vec<u16>`, `&[u16]`
 - **miniextendr-api/src/into_r.rs:609** (2 impls): `Vec<f32>`, `&[f32]`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1264** (2 impls): `Array0<String>`, `Array0<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1265** (2 impls): `Array1<String>`, `Array1<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1266** (2 impls): `Array2<String>`, `Array2<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1267** (2 impls): `Array3<String>`, `Array3<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1268** (2 impls): `Array4<String>`, `Array4<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1269** (2 impls): `Array5<String>`, `Array5<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1270** (2 impls): `Array6<String>`, `Array6<Option<String>>`
+- **miniextendr-api/src/optionals/ndarray_impl.rs:1271** (2 impls): `ArrayD<String>`, `ArrayD<Option<String>>`
 
 ## `TryFrom` — 11 impls
 
@@ -1169,23 +1213,17 @@ Traits with impls: 216
 | `Vec<u8>` | `` | concrete | 2 | miniextendr-api/src/rvalue.rs:484 |
 | `Vec<(Option<String>, RValue)>` | `` | concrete | 2 | miniextendr-api/src/rvalue.rs:485 |
 
-## `Borrow` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1651 |
-
 ## `BorrowMut` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1658 |
 
-## `RefUnwindSafe` — 1 impls
+## `Borrow` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `RPreservedSexp` | `` | concrete | 0 | miniextendr-api/src/optionals/arrow_impl.rs:287 |
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1651 |
 
 ## `Send` — 10 impls
 
@@ -1219,6 +1257,12 @@ Traits with impls: 216
 | `SEXP` | `` | concrete | 0 | miniextendr-api/src/sexp.rs:72 |
 | `R_CallMethodDef` | `` | concrete | 0 | miniextendr-api/src/sys.rs:1156 |
 | `R_altrep_class_t` | `` | concrete | 0 | miniextendr-api/src/sys/altrep.rs:198 |
+
+## `RefUnwindSafe` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RPreservedSexp` | `` | concrete | 0 | miniextendr-api/src/optionals/arrow_impl.rs:287 |
 
 ## `TypedExternal` — 181 impls
 
@@ -1366,45 +1410,45 @@ Traits with impls: 216
 | `SMatrix<i32, 2, 2>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:408 |
 | `SMatrix<i32, 3, 3>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:409 |
 | `SMatrix<i32, 4, 4>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:410 |
-| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1610 |
-| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1611 |
-| `Array1<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1612 |
-| `Array1<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1613 |
-| `Array1<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1614 |
-| `Array2<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1617 |
-| `Array2<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1618 |
-| `Array2<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1619 |
-| `Array2<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1620 |
-| `Array2<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1621 |
-| `Array3<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1624 |
-| `Array3<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1625 |
-| `Array3<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1626 |
-| `Array3<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1627 |
-| `Array3<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1628 |
-| `Array4<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1631 |
-| `Array4<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1632 |
-| `Array4<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1633 |
-| `Array4<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1634 |
-| `Array4<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1635 |
-| `Array5<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1638 |
-| `Array5<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1639 |
-| `Array5<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1640 |
-| `Array5<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1641 |
-| `Array5<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1642 |
-| `Array6<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1645 |
-| `Array6<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1646 |
-| `Array6<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1647 |
-| `Array6<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1648 |
-| `Array6<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1649 |
-| `ArrayD<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1652 |
-| `ArrayD<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1653 |
-| `ArrayD<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1654 |
-| `ArrayD<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1655 |
-| `ArrayD<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1656 |
-| `ArcArray1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1659 |
-| `ArcArray1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1660 |
-| `ArcArray2<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1661 |
-| `ArcArray2<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1662 |
+| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1895 |
+| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1896 |
+| `Array1<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1897 |
+| `Array1<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1898 |
+| `Array1<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1899 |
+| `Array2<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1902 |
+| `Array2<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1903 |
+| `Array2<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1904 |
+| `Array2<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1905 |
+| `Array2<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1906 |
+| `Array3<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1909 |
+| `Array3<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1910 |
+| `Array3<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1911 |
+| `Array3<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1912 |
+| `Array3<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1913 |
+| `Array4<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1916 |
+| `Array4<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1917 |
+| `Array4<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1918 |
+| `Array4<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1919 |
+| `Array4<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1920 |
+| `Array5<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1923 |
+| `Array5<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1924 |
+| `Array5<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1925 |
+| `Array5<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1926 |
+| `Array5<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1927 |
+| `Array6<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1930 |
+| `Array6<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1931 |
+| `Array6<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1932 |
+| `Array6<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1933 |
+| `Array6<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1934 |
+| `ArrayD<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1937 |
+| `ArrayD<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1938 |
+| `ArrayD<u8>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1939 |
+| `ArrayD<crate::RLogical>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1940 |
+| `ArrayD<crate::Rcomplex>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1941 |
+| `ArcArray1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1944 |
+| `ArcArray1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1945 |
+| `ArcArray2<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1946 |
+| `ArcArray2<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:1947 |
 
 ## `IntoRAs` — 135 impls
 
@@ -1468,16 +1512,16 @@ Traits with impls: 216
 | `crate::RLogical` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:607 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:681 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:688 |
-| `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
 | `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
-| `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
+| `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:695 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
+| `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:696 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:697 |
 | `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:697 |
-| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
+| `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:698 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:699 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:700 |
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:700 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:701 |
@@ -1496,24 +1540,24 @@ Traits with impls: 216
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:752 |
 | `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:779 |
 | `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:808 |
-| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
 | `&[i8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
+| `Vec<i8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:856 |
 | `Vec<i16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:857 |
 | `&[i16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:857 |
-| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
 | `Vec<u8>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
-| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
+| `&[u8]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:858 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
+| `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:859 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:860 |
 | `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:860 |
 | `Vec<i32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:865 |
 | `&[i32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:894 |
-| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
 | `&[i64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
+| `Vec<i64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:924 |
 | `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:925 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:925 |
-| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
 | `Vec<isize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
+| `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:926 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:927 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:927 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:930 |
@@ -1532,22 +1576,35 @@ Traits with impls: 216
 | `&[isize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:969 |
 | `Vec<u16>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:970 |
 | `&[u16]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:970 |
-| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
 | `Vec<u32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
-| `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
+| `&[u32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:971 |
 | `&[u64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
+| `Vec<u64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:972 |
 | `Vec<usize>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:973 |
 | `&[usize]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:973 |
-| `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
 | `Vec<f32>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
-| `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
+| `&[f32]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:974 |
 | `&[f64]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
+| `Vec<f64>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:975 |
 | `Vec<bool>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:980 |
 | `&[bool]` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:987 |
 | `Vec<String>` | `` | concrete | 1 | miniextendr-api/src/into_r_as.rs:997 |
 
 ### `IntoRAs` — for-types sharing a source span (likely macro-expanded / co-located)
 
+- **miniextendr-api/src/into_r_as.rs:971** (2 impls): `Vec<u32>`, `&[u32]`
+- **miniextendr-api/src/into_r_as.rs:856** (2 impls): `&[i8]`, `Vec<i8>`
+- **miniextendr-api/src/into_r_as.rs:972** (2 impls): `&[u64]`, `Vec<u64>`
+- **miniextendr-api/src/into_r_as.rs:858** (2 impls): `Vec<u8>`, `&[u8]`
+- **miniextendr-api/src/into_r_as.rs:974** (2 impls): `Vec<f32>`, `&[f32]`
+- **miniextendr-api/src/into_r_as.rs:859** (2 impls): `&[u16]`, `Vec<u16>`
+- **miniextendr-api/src/into_r_as.rs:695** (2 impls): `Vec<i8>`, `&[i8]`
+- **miniextendr-api/src/into_r_as.rs:975** (2 impls): `&[f64]`, `Vec<f64>`
+- **miniextendr-api/src/into_r_as.rs:696** (2 impls): `&[i16]`, `Vec<i16>`
+- **miniextendr-api/src/into_r_as.rs:924** (2 impls): `&[i64]`, `Vec<i64>`
+- **miniextendr-api/src/into_r_as.rs:698** (2 impls): `Vec<u16>`, `&[u16]`
+- **miniextendr-api/src/into_r_as.rs:926** (2 impls): `Vec<isize>`, `&[isize]`
+- **miniextendr-api/src/into_r_as.rs:699** (2 impls): `&[i64]`, `Vec<i64>`
 - **miniextendr-api/src/into_r_as.rs:927** (2 impls): `&[usize]`, `Vec<usize>`
 - **miniextendr-api/src/into_r_as.rs:701** (2 impls): `Vec<u32>`, `&[u32]`
 - **miniextendr-api/src/into_r_as.rs:702** (2 impls): `&[u64]`, `Vec<u64>`
@@ -1557,28 +1614,15 @@ Traits with impls: 216
 - **miniextendr-api/src/into_r_as.rs:705** (2 impls): `&[f64]`, `Vec<f64>`
 - **miniextendr-api/src/into_r_as.rs:968** (2 impls): `&[i64]`, `Vec<i64>`
 - **miniextendr-api/src/into_r_as.rs:970** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:971** (2 impls): `&[u32]`, `Vec<u32>`
 - **miniextendr-api/src/into_r_as.rs:857** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:973** (2 impls): `Vec<usize>`, `&[usize]`
-- **miniextendr-api/src/into_r_as.rs:858** (2 impls): `&[u8]`, `Vec<u8>`
-- **miniextendr-api/src/into_r_as.rs:974** (2 impls): `&[f32]`, `Vec<f32>`
 - **miniextendr-api/src/into_r_as.rs:860** (2 impls): `Vec<u32>`, `&[u32]`
-- **miniextendr-api/src/into_r_as.rs:695** (2 impls): `&[i8]`, `Vec<i8>`
 - **miniextendr-api/src/into_r_as.rs:697** (2 impls): `Vec<u8>`, `&[u8]`
 - **miniextendr-api/src/into_r_as.rs:925** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:698** (2 impls): `&[u16]`, `Vec<u16>`
-- **miniextendr-api/src/into_r_as.rs:926** (2 impls): `&[isize]`, `Vec<isize>`
 - **miniextendr-api/src/into_r_as.rs:700** (2 impls): `Vec<isize>`, `&[isize]`
 - **miniextendr-api/src/into_r_as.rs:703** (2 impls): `Vec<usize>`, `&[usize]`
 - **miniextendr-api/src/into_r_as.rs:966** (2 impls): `Vec<i16>`, `&[i16]`
 - **miniextendr-api/src/into_r_as.rs:969** (2 impls): `Vec<isize>`, `&[isize]`
-- **miniextendr-api/src/into_r_as.rs:856** (2 impls): `Vec<i8>`, `&[i8]`
-- **miniextendr-api/src/into_r_as.rs:972** (2 impls): `Vec<u64>`, `&[u64]`
-- **miniextendr-api/src/into_r_as.rs:859** (2 impls): `Vec<u16>`, `&[u16]`
-- **miniextendr-api/src/into_r_as.rs:975** (2 impls): `Vec<f64>`, `&[f64]`
-- **miniextendr-api/src/into_r_as.rs:696** (2 impls): `Vec<i16>`, `&[i16]`
-- **miniextendr-api/src/into_r_as.rs:924** (2 impls): `Vec<i64>`, `&[i64]`
-- **miniextendr-api/src/into_r_as.rs:699** (2 impls): `Vec<i64>`, `&[i64]`
 
 ## `RDebug` — 1 impls
 
@@ -1785,7 +1829,7 @@ Traits with impls: 216
 | `SchemaMode` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:1362 |
 | `TypeSpec` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:818 |
 | `DispatchNames` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:937 |
-| `EnumReadConfig` | `` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:408 |
+| `EnumReadConfig` | `` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:498 |
 | `RSerdeError` | `` | concrete | 1 | miniextendr-api/src/serde/error.rs:12 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
 | `SEXP` | `` | concrete | 1 | miniextendr-api/src/sexp.rs:65 |
@@ -1982,8 +2026,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:953 |
 | `DVector<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/nalgebra_impl.rs:1613 |
 | `DVector<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/nalgebra_impl.rs:1619 |
-| `Array1<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3487 |
-| `Array1<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3493 |
+| `Array1<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3772 |
+| `Array1<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3778 |
 
 ## `RCopy` — 1 impls
 
@@ -2114,8 +2158,8 @@ Traits with impls: 216
 
 ### `Coerce` — for-types sharing a source span (likely macro-expanded / co-located)
 
-- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 - **miniextendr-api/src/coerce.rs:212** (5 impls): `u8`, `u8`, `u8`, `u8`, `u8`
+- **miniextendr-api/src/coerce.rs:546** (5 impls): `u8`, `u8`, `u8`, `i8`, `u16`
 
 ## `InferBase` — 45 impls
 
@@ -2164,8 +2208,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 3 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1673 |
 | `DVector<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1674 |
-| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3572 |
-| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3573 |
+| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3857 |
+| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3858 |
 
 ## `Altrep` — 45 impls
 
@@ -2214,8 +2258,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1673 |
 | `DVector<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1674 |
-| `Array1<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3572 |
-| `Array1<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3573 |
+| `Array1<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3857 |
+| `Array1<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3858 |
 
 ## `AltVec` — 45 impls
 
@@ -2264,8 +2308,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 4 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 4 | miniextendr-api/src/optionals/nalgebra_impl.rs:1673 |
 | `DVector<i32>` | `` | concrete | 4 | miniextendr-api/src/optionals/nalgebra_impl.rs:1674 |
-| `Array1<f64>` | `` | concrete | 4 | miniextendr-api/src/optionals/ndarray_impl.rs:3572 |
-| `Array1<i32>` | `` | concrete | 4 | miniextendr-api/src/optionals/ndarray_impl.rs:3573 |
+| `Array1<f64>` | `` | concrete | 4 | miniextendr-api/src/optionals/ndarray_impl.rs:3857 |
+| `Array1<i32>` | `` | concrete | 4 | miniextendr-api/src/optionals/ndarray_impl.rs:3858 |
 
 ## `PartialEq` — 44 impls
 
@@ -2444,8 +2488,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/nalgebra_impl.rs:1678 |
 | `DVector<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/nalgebra_impl.rs:1695 |
-| `Array1<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3577 |
-| `Array1<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3594 |
+| `Array1<f64>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3862 |
+| `Array1<i32>` | `` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3879 |
 
 ## `AltrepDataptr` — 27 impls
 
@@ -2476,8 +2520,8 @@ Traits with impls: 216
 | `JiffZonedVec` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1653 |
 | `DVector<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1663 |
-| `Array1<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3536 |
-| `Array1<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3554 |
+| `Array1<f64>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3821 |
+| `Array1<i32>` | `` | concrete | 2 | miniextendr-api/src/optionals/ndarray_impl.rs:3839 |
 
 ## `AltrepSerialize` — 27 impls
 
@@ -2536,11 +2580,11 @@ Traits with impls: 216
 | `NaHandling` | `` | concrete | 1 | miniextendr-api/src/optionals/serde_impl.rs:78 |
 | `SpecialFloatHandling` | `` | concrete | 1 | miniextendr-api/src/optionals/serde_impl.rs:90 |
 | `WorkerPump<T>` | `<T>` | concrete | 1 | miniextendr-api/src/pump.rs:181 |
-| `ValueExtractor` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2063 |
-| `ExtractedValue` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2068 |
-| `VariantNameExtractor` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2632 |
+| `ValueExtractor` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2065 |
+| `ExtractedValue` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2070 |
+| `VariantNameExtractor` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2634 |
 | `DispatchNames` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:943 |
-| `EnumReadConfig` | `` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:408 |
+| `EnumReadConfig` | `` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:498 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
 | `SEXP` | `` | concrete | 1 | miniextendr-api/src/sexp.rs:475 |
 | `RThreadBuilder` | `` | concrete | 1 | miniextendr-api/src/thread.rs:319 |
@@ -2562,15 +2606,15 @@ Traits with impls: 216
 | `TlsScopeGuard` | `` | concrete | 1 | miniextendr-api/src/gc_protect/tls.rs:64 |
 | `RPreservedSexp` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:292 |
 | `RVecStorage<T, R, C>` | `<T, R, C>` | concrete | 1 | miniextendr-api/src/optionals/nalgebra_impl.rs:1183 |
-| `RndVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:2914 |
-| `RndMat<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3059 |
+| `RndVec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3199 |
+| `RndMat<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/ndarray_impl.rs:3344 |
 | `RTerm` | `` | concrete | 1 | miniextendr-api/src/progress.rs:235 |
 | `ProtectPool` | `` | concrete | 1 | miniextendr-api/src/protect_pool.rs:301 |
 | `RefCountedArena` | `` | concrete | 1 | miniextendr-api/src/refcount_protect.rs:530 |
 | `ArenaGuard<'_>` | `` | concrete | 1 | miniextendr-api/src/refcount_protect.rs:569 |
 | `ThreadLocalState` | `` | concrete | 1 | miniextendr-api/src/refcount_protect.rs:632 |
 | `RngGuard` | `` | concrete | 1 | miniextendr-api/src/rng.rs:174 |
-| `RootedSentinel` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:3238 |
+| `RootedSentinel` | `` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:3240 |
 | `StackCheckGuard` | `` | concrete | 1 | miniextendr-api/src/thread.rs:155 |
 | `RTxtProgressBar` | `` | concrete | 1 | miniextendr-api/src/txt_progress_bar.rs:157 |
 
@@ -2688,7 +2732,13 @@ Traits with impls: 216
 | `StreamingIntData<F>` | `<F>` | concrete | 2 | miniextendr-api/src/altrep_data/stream.rs:187 |
 | `Int32Array` | `` | concrete | 3 | miniextendr-api/src/optionals/arrow_impl.rs:1652 |
 | `DVector<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1639 |
-| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3518 |
+| `Array1<i32>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3803 |
+
+## `RHash` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:148 |
 
 ## `AltRealData` — 16 impls
 
@@ -2709,13 +2759,7 @@ Traits with impls: 216
 | `JiffTimestampVec` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:896 |
 | `JiffZonedVec` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:959 |
 | `DVector<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1625 |
-| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3499 |
-
-## `RHash` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:148 |
+| `Array1<f64>` | `` | concrete | 3 | miniextendr-api/src/optionals/ndarray_impl.rs:3784 |
 
 ## `Hash` — 15 impls
 
@@ -2768,22 +2812,7 @@ Traits with impls: 216
 | `JiffTimestampVec` | `` | concrete | 14 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
 | `JiffZonedVec` | `` | concrete | 14 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 | `DVector<f64>` | `` | concrete | 14 | miniextendr-api/src/optionals/nalgebra_impl.rs:1673 |
-| `Array1<f64>` | `` | concrete | 14 | miniextendr-api/src/optionals/ndarray_impl.rs:3572 |
-
-## `Serializer` — 10 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `&'a mut SchemaDiscoverer` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:1645 |
-| `&mut TypeProbe` | `` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:1732 |
-| `&mut ValueExtractor` | `` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2078 |
-| `ColumnFiller<'a>` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2338 |
-| `&'a mut VariantNameExtractor` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2746 |
-| `VariantStrippingSerializer<S>` | `<S>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2938 |
-| `VariantStrippingMapForwarder<'m, M>` | `<'m, M>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:3594 |
-| `FieldSelectingForwarder<'m, M>` | `<'m, M>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:4033 |
-| `ParColumnFiller<'a>` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:723 |
-| `RSerializer` | `` | concrete | 37 | miniextendr-api/src/serde/ser.rs:51 |
+| `Array1<f64>` | `` | concrete | 14 | miniextendr-api/src/optionals/ndarray_impl.rs:3857 |
 
 ## `AltInteger` — 10 impls
 
@@ -2798,7 +2827,7 @@ Traits with impls: 216
 | `&'static [i32]` | `` | concrete | 12 | miniextendr-api/src/altrep_impl/static_slices.rs:54 |
 | `Int32Array` | `` | concrete | 14 | miniextendr-api/src/optionals/arrow_impl.rs:1865 |
 | `DVector<i32>` | `` | concrete | 14 | miniextendr-api/src/optionals/nalgebra_impl.rs:1674 |
-| `Array1<i32>` | `` | concrete | 14 | miniextendr-api/src/optionals/ndarray_impl.rs:3573 |
+| `Array1<i32>` | `` | concrete | 14 | miniextendr-api/src/optionals/ndarray_impl.rs:3858 |
 
 ## `AltStringData` — 10 impls
 
@@ -2815,19 +2844,20 @@ Traits with impls: 216
 | `IterStringData<I>` | `<I> +1wc` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:320 |
 | `StringArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:1955 |
 
-## `AltString` — 9 impls
+## `Serializer` — 10 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `[String; N]` | `<N>` | concrete | 1 | miniextendr-api/src/altrep_impl/arrays.rs:220 |
-| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:367 |
-| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:374 |
-| `Vec<std::borrow::Cow<'static, str>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:384 |
-| `Vec<Option<std::borrow::Cow<'static, str>>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:391 |
-| `Box<[String]>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:464 |
-| `&'static [String]` | `` | concrete | 3 | miniextendr-api/src/altrep_impl/static_slices.rs:363 |
-| `&'static [&'static str]` | `` | concrete | 3 | miniextendr-api/src/altrep_impl/static_slices.rs:403 |
-| `StringArray` | `` | concrete | 5 | miniextendr-api/src/optionals/arrow_impl.rs:1969 |
+| `&'a mut SchemaDiscoverer` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:1647 |
+| `&mut TypeProbe` | `` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:1734 |
+| `&mut ValueExtractor` | `` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2080 |
+| `ColumnFiller<'a>` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2340 |
+| `&'a mut VariantNameExtractor` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2748 |
+| `VariantStrippingSerializer<S>` | `<S>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:2940 |
+| `VariantStrippingMapForwarder<'m, M>` | `<'m, M>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:3596 |
+| `FieldSelectingForwarder<'m, M>` | `<'m, M>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:4035 |
+| `ParColumnFiller<'a>` | `<'a>` | concrete | 37 | miniextendr-api/src/serde/columnar.rs:723 |
+| `RSerializer` | `` | concrete | 37 | miniextendr-api/src/serde/ser.rs:51 |
 
 ## `AtomicElement` — 9 impls
 
@@ -2842,6 +2872,20 @@ Traits with impls: 216
 | `i32` | `` | concrete | 2 | miniextendr-api/src/named_vector.rs:47 |
 | `f64` | `` | concrete | 2 | miniextendr-api/src/named_vector.rs:66 |
 | `u8` | `` | concrete | 2 | miniextendr-api/src/named_vector.rs:85 |
+
+## `AltString` — 9 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `[String; N]` | `<N>` | concrete | 1 | miniextendr-api/src/altrep_impl/arrays.rs:220 |
+| `Vec<String>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:367 |
+| `Vec<Option<String>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:374 |
+| `Vec<std::borrow::Cow<'static, str>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:384 |
+| `Vec<Option<std::borrow::Cow<'static, str>>>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:391 |
+| `Box<[String]>` | `` | concrete | 5 | miniextendr-api/src/altrep_impl/builtins.rs:464 |
+| `&'static [String]` | `` | concrete | 3 | miniextendr-api/src/altrep_impl/static_slices.rs:363 |
+| `&'static [&'static str]` | `` | concrete | 3 | miniextendr-api/src/altrep_impl/static_slices.rs:403 |
+| `StringArray` | `` | concrete | 5 | miniextendr-api/src/optionals/arrow_impl.rs:1969 |
 
 ## `AltRawData` — 8 impls
 
@@ -2869,29 +2913,35 @@ Traits with impls: 216
 | `JiffTimestampVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
 | `JiffZonedVecMut` | `` | concrete | 1 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
 
-## `SerializeStruct` — 7 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `SchemaStructDiscoverer<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:1678 |
-| `ColumnFiller<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2381 |
-| `TagStructCapture<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2676 |
-| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3765 |
-| `SelectingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:4205 |
-| `ParColumnFiller<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:766 |
-| `StructSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:401 |
-
-## `IoCaps` — 7 impls
+## `RConnectionImpl` — 7 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `IoRead<T>` | `<T>` | concrete | 1 | miniextendr-api/src/connection/io_adapters.rs:102 |
-| `IoWrite<T>` | `<T>` | concrete | 1 | miniextendr-api/src/connection/io_adapters.rs:130 |
-| `IoReadWrite<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:162 |
+| `IoWrite<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:130 |
+| `IoReadWrite<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:162 |
 | `IoReadSeek<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:184 |
-| `IoWriteSeek<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:200 |
-| `IoReadWriteSeek<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:220 |
+| `IoWriteSeek<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:200 |
+| `IoReadWriteSeek<T>` | `<T>` | concrete | 4 | miniextendr-api/src/connection/io_adapters.rs:220 |
 | `IoBufRead<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:260 |
+
+## `RSerialize` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:228 |
+
+## `SerializeStruct` — 7 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `SchemaStructDiscoverer<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:1680 |
+| `ColumnFiller<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2383 |
+| `TagStructCapture<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2678 |
+| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3767 |
+| `SelectingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:4207 |
+| `ParColumnFiller<'_>` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:766 |
+| `StructSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:401 |
 
 ## `WidensToF64` — 7 impls
 
@@ -2905,27 +2955,34 @@ Traits with impls: 216
 | `u16` | `` | concrete | 0 | miniextendr-api/src/markers.rs:224 |
 | `u32` | `` | concrete | 0 | miniextendr-api/src/markers.rs:225 |
 
-## `RConnectionImpl` — 7 impls
+## `IntoIterator` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `StrVec<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:347 |
+| `&'a ProtectedStrVec` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:717 |
+
+## `IoCaps` — 7 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `IoRead<T>` | `<T>` | concrete | 1 | miniextendr-api/src/connection/io_adapters.rs:102 |
-| `IoWrite<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:130 |
-| `IoReadWrite<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:162 |
+| `IoWrite<T>` | `<T>` | concrete | 1 | miniextendr-api/src/connection/io_adapters.rs:130 |
+| `IoReadWrite<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:162 |
 | `IoReadSeek<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:184 |
-| `IoWriteSeek<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:200 |
-| `IoReadWriteSeek<T>` | `<T>` | concrete | 4 | miniextendr-api/src/connection/io_adapters.rs:220 |
+| `IoWriteSeek<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:200 |
+| `IoReadWriteSeek<T>` | `<T>` | concrete | 3 | miniextendr-api/src/connection/io_adapters.rs:220 |
 | `IoBufRead<T>` | `<T>` | concrete | 2 | miniextendr-api/src/connection/io_adapters.rs:260 |
 
 ## `SerializeMap` — 7 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `SchemaMapDiscoverer<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:1701 |
-| `ColumnFiller<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:2399 |
-| `TagMapCapture<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:2712 |
-| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 6 | miniextendr-api/src/serde/columnar.rs:3799 |
-| `SelectingMapEmitter<'_, M>` | `<M>` | concrete | 6 | miniextendr-api/src/serde/columnar.rs:4222 |
+| `SchemaMapDiscoverer<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:1703 |
+| `ColumnFiller<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:2401 |
+| `TagMapCapture<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:2714 |
+| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 6 | miniextendr-api/src/serde/columnar.rs:3801 |
+| `SelectingMapEmitter<'_, M>` | `<M>` | concrete | 6 | miniextendr-api/src/serde/columnar.rs:4224 |
 | `ParColumnFiller<'_>` | `` | concrete | 5 | miniextendr-api/src/serde/columnar.rs:785 |
 | `MapSerializer` | `` | concrete | 5 | miniextendr-api/src/serde/ser.rs:359 |
 
@@ -2941,35 +2998,44 @@ Traits with impls: 216
 | `IterLogicalData<I>` | `<I>` | concrete | 2 | miniextendr-api/src/altrep_data/iter/state.rs:364 |
 | `BooleanArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:1688 |
 
-## `IntoIterator` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `StrVec<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:347 |
-| `&'a ProtectedStrVec` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:717 |
-
 ## `RSerializeNative` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:73 |
 
-## `RSerialize` — 1 impls
+## `Deserializer` — 6 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:228 |
+| `CellDeserializer<'de, '_>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:1086 |
+| `RowDeserializer<'de>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:583 |
+| `MaybeNestedDeserializer<'de>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:829 |
+| `StrDeserializer<'a>` | `<'de, 'a>` | concrete | 30 | miniextendr-api/src/serde/de.rs:1046 |
+| `VectorElementDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:770 |
+| `RDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:89 |
 
-## `AsRef` — 6 impls
+## `RNdArrayOps` — 6 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1637 |
-| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:158 |
-| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:165 |
-| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:242 |
-| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:249 |
-| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:241 |
+| `Array1<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2013 |
+| `Array2<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2071 |
+| `ArrayD<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2129 |
+| `Array1<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2189 |
+| `Array2<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2254 |
+| `ArrayD<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2319 |
+
+## `Serialize` — 6 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `VariantPayload<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2900 |
+| `TaggedVariantRow<'_, T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:3519 |
+| `FlattenEnumFieldsRow<'_, T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4002 |
+| `MapEntry<'_, K, V>` | `<K, V>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4426 |
+| `CollatedResultRow<'_, T, E>` | `<T, E>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4613 |
+| `crate::externalptr::ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/externalptr.rs:36 |
 
 ## `AltComplexData` — 6 impls
 
@@ -2993,27 +3059,16 @@ Traits with impls: 216
 | `&'static [u8]` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/static_slices.rs:318 |
 | `UInt8Array` | `` | concrete | 4 | miniextendr-api/src/optionals/arrow_impl.rs:1866 |
 
-## `Deserializer` — 6 impls
+## `AsRef` — 6 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `RowDeserializer<'de>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:475 |
-| `MaybeNestedDeserializer<'de>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:721 |
-| `CellDeserializer<'de, '_>` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/dataframe_de.rs:970 |
-| `StrDeserializer<'a>` | `<'de, 'a>` | concrete | 30 | miniextendr-api/src/serde/de.rs:1046 |
-| `VectorElementDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:770 |
-| `RDeserializer` | `<'de>` | concrete | 30 | miniextendr-api/src/serde/de.rs:89 |
-
-## `RNdArrayOps` — 6 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Array1<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1728 |
-| `Array2<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1786 |
-| `ArrayD<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1844 |
-| `Array1<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1904 |
-| `Array2<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:1969 |
-| `ArrayD<i32>` | `` | concrete | 11 | miniextendr-api/src/optionals/ndarray_impl.rs:2034 |
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1637 |
+| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:158 |
+| `RPrimitive<T>` | `<T>` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:165 |
+| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:242 |
+| `RStringArray` | `` | concrete | 1 | miniextendr-api/src/optionals/arrow_impl.rs:249 |
+| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:241 |
 
 ## `AltLogical` — 5 impls
 
@@ -3025,6 +3080,48 @@ Traits with impls: 216
 | `&'static [bool]` | `` | concrete | 6 | miniextendr-api/src/altrep_impl/static_slices.rs:245 |
 | `BooleanArray` | `` | concrete | 10 | miniextendr-api/src/optionals/arrow_impl.rs:1867 |
 
+## `SeqAccess` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `EnumTupleSeqAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:1605 |
+| `EmptySeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:675 |
+| `VectorSeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:705 |
+| `VectorElementSeqAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:890 |
+| `ListSeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:960 |
+
+## `RPartialOrd` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:228 |
+
+## `ExactSizeIterator` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1765 |
+| `StrVecIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:310 |
+| `StrVecCowIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:345 |
+| `ProtectedStrVecIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:686 |
+| `ProtectedStrVecCowIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:715 |
+
+## `IntoList` — 5 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Vec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/list.rs:713 |
+| `std::collections::HashMap<K, V>` | `<K, V> +2wc` | concrete | 1 | miniextendr-api/src/list.rs:764 |
+| `std::collections::BTreeMap<K, V>` | `<K, V> +2wc` | concrete | 1 | miniextendr-api/src/list.rs:821 |
+| `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:878 |
+| `std::collections::BTreeSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:903 |
+
+## `ROrd` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:187 |
+
 ## `Iterator` — 5 impls
 
 | for-type | generics | kind | #items | span |
@@ -3034,28 +3131,6 @@ Traits with impls: 216
 | `StrVecCowIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:321 |
 | `ProtectedStrVecIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:664 |
 | `ProtectedStrVecCowIter<'a>` | `<'a>` | concrete | 3 | miniextendr-api/src/strvec.rs:695 |
-
-## `RPartialOrd` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:228 |
-
-## `ROrd` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:187 |
-
-## `Serialize` — 5 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `VariantPayload<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:2898 |
-| `TaggedVariantRow<'_, T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:3517 |
-| `FlattenEnumFieldsRow<'_, T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4000 |
-| `MapEntry<'_, K, V>` | `<K, V>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4424 |
-| `CollatedResultRow<'_, T, E>` | `<T, E>` | concrete | 1 | miniextendr-api/src/serde/columnar.rs:4611 |
 
 ## `RNativeType` — 5 impls
 
@@ -3073,16 +3148,6 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 2 | miniextendr-api/src/altrep_data/core.rs:336 |
 
-## `IntoList` — 5 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Vec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/list.rs:713 |
-| `std::collections::HashMap<K, V>` | `<K, V> +2wc` | concrete | 1 | miniextendr-api/src/list.rs:764 |
-| `std::collections::BTreeMap<K, V>` | `<K, V> +2wc` | concrete | 1 | miniextendr-api/src/list.rs:821 |
-| `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:878 |
-| `std::collections::BTreeSet<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/list.rs:903 |
-
 ## `TryFromList` — 5 impls
 
 | for-type | generics | kind | #items | span |
@@ -3093,26 +3158,6 @@ Traits with impls: 216
 | `std::collections::HashSet<T>` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/list.rs:888 |
 | `std::collections::BTreeSet<T>` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/list.rs:913 |
 
-## `ExactSizeIterator` — 5 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1765 |
-| `StrVecIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:310 |
-| `StrVecCowIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:345 |
-| `ProtectedStrVecIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:686 |
-| `ProtectedStrVecCowIter<'_>` | `` | concrete | 0 | miniextendr-api/src/strvec.rs:715 |
-
-## `SeqAccess` — 5 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `EnumTupleSeqAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:1489 |
-| `EmptySeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:675 |
-| `VectorSeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:705 |
-| `VectorElementSeqAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:890 |
-| `ListSeqAccess` | `<'de>` | concrete | 2 | miniextendr-api/src/serde/de.rs:960 |
-
 ## `AltComplex` — 4 impls
 
 | for-type | generics | kind | #items | span |
@@ -3121,24 +3166,6 @@ Traits with impls: 216
 | `Vec<crate::Rcomplex>` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/builtins.rs:398 |
 | `Box<[crate::Rcomplex]>` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/builtins.rs:471 |
 | `std::borrow::Cow<'static, [crate::Rcomplex]>` | `` | concrete | 4 | miniextendr-api/src/altrep_impl/builtins.rs:502 |
-
-## `Ord` — 4 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Coerced<T, R>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:919 |
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1723 |
-| `RWrapperPriority` | `` | concrete | 1 | miniextendr-api/src/registry.rs:209 |
-| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
-
-## `SerializeTupleVariant` — 4 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `NoopTupleVariant` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2660 |
-| `VariantAsTupleStruct<S>` | `<S>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2927 |
-| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3840 |
-| `TupleVariantSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:322 |
 
 ## `WidensToI32` — 4 impls
 
@@ -3158,20 +3185,52 @@ Traits with impls: 216
 | `RWrapperPriority` | `` | concrete | 1 | miniextendr-api/src/registry.rs:209 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
 
-## `SerializeStructVariant` — 4 impls
+## `SerializeTupleVariant` — 4 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `NoopStructVariant` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2644 |
-| `VariantAsStruct<S>` | `<S>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2910 |
-| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3782 |
-| `StructVariantSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:429 |
+| `NoopTupleVariant` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2662 |
+| `VariantAsTupleStruct<S>` | `<S>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2929 |
+| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3842 |
+| `TupleVariantSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:322 |
+
+## `Ord` — 4 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Coerced<T, R>` | `<T, R>` | concrete | 1 | miniextendr-api/src/coerce.rs:919 |
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1723 |
+| `RWrapperPriority` | `` | concrete | 1 | miniextendr-api/src/registry.rs:209 |
+| `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:224 |
 
 ## `TryRng` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `RRng` | `` | concrete | 4 | miniextendr-api/src/optionals/rand_impl.rs:129 |
+
+## `SerializeStructVariant` — 4 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `NoopStructVariant` | `` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2646 |
+| `VariantAsStruct<S>` | `<S>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:2912 |
+| `ForwardingMapEmitter<'_, M>` | `<M>` | concrete | 4 | miniextendr-api/src/serde/columnar.rs:3784 |
+| `StructVariantSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:429 |
+
+## `IntoRAltrep` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2016 |
+
+## `VariantAccess` — 3 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `DfVariantAccess<'de>` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/dataframe_de.rs:1534 |
+| `UnitVariantDeserializer` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/de.rs:1083 |
+| `DataVariantDeserializer` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/de.rs:1143 |
 
 ## `AsNamedListExt` — 3 impls
 
@@ -3189,20 +3248,6 @@ Traits with impls: 216
 | `[(K, V); N]` | `<K, V, N>` | concrete | 0 | miniextendr-api/src/convert.rs:939 |
 | `&[(K, V)]` | `<K, V>` | concrete | 0 | miniextendr-api/src/convert.rs:940 |
 
-## `IntoRAltrep` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T> +1wc` | concrete | 2 | miniextendr-api/src/into_r.rs:2016 |
-
-## `VariantAccess` — 3 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `DfVariantAccess<'de>` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/dataframe_de.rs:1418 |
-| `UnitVariantDeserializer` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/de.rs:1083 |
-| `DataVariantDeserializer` | `<'de>` | concrete | 5 | miniextendr-api/src/serde/de.rs:1143 |
-
 ## `Write` — 3 impls
 
 | for-type | generics | kind | #items | span |
@@ -3211,82 +3256,32 @@ Traits with impls: 216
 | `RStderr` | `` | concrete | 2 | miniextendr-api/src/connection.rs:1319 |
 | `RNullConnection` | `` | concrete | 2 | miniextendr-api/src/connection.rs:1460 |
 
+## `EnumAccess` — 3 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `DfEnumAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:1481 |
+| `UnitVariantAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1068 |
+| `DataVariantAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1126 |
+
 ## `AsRNativeExt` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:875 |
 
-## `EnumAccess` — 3 impls
+## `MapAccess` — 2 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `DfEnumAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:1365 |
-| `UnitVariantAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1068 |
-| `DataVariantAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1126 |
+| `RowMapAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:747 |
+| `NamedListMapAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1009 |
 
-## `RSourced` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RPrimitive<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:141 |
-| `RStringArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:223 |
-
-## `IntoDataFrame` — 2 impls
+## `RDeserialize` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `Vec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/dataframe.rs:1234 |
-| `SerdeRows<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:342 |
-
-## `RNdIndex` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ArrayD<f64>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2447 |
-| `ArrayD<i32>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2601 |
-
-## `FromDataFrame` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Vec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/dataframe.rs:1250 |
-| `SerdeRows<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:357 |
-
-## `RNdSlice` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Array1<f64>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2160 |
-| `Array1<i32>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2193 |
-
-## `Storage` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::Dyn>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1251 |
-| `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::U1>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1276 |
-
-## `RNdSlice2D` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Array2<f64>` | `` | concrete | 7 | miniextendr-api/src/optionals/ndarray_impl.rs:2273 |
-| `Array2<i32>` | `` | concrete | 7 | miniextendr-api/src/optionals/ndarray_impl.rs:2321 |
-
-## `Protector` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ProtectScope` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:219 |
-| `crate::protect_pool::ProtectPool` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:226 |
-
-## `AltrepClass` — 2 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `JiffTimestampVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
-| `JiffZonedVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
+| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:275 |
 
 ## `RDateTimeFormat` — 2 impls
 
@@ -3295,18 +3290,60 @@ Traits with impls: 216
 | `OffsetDateTime` | `` | concrete | 2 | miniextendr-api/src/optionals/time_impl.rs:287 |
 | `Date` | `` | concrete | 2 | miniextendr-api/src/optionals/time_impl.rs:299 |
 
-## `MapAccess` — 2 impls
+## `RJsonBridge` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `RowMapAccess<'de>` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/dataframe_de.rs:639 |
-| `NamedListMapAccess` | `<'de>` | concrete | 3 | miniextendr-api/src/serde/de.rs:1009 |
+| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:1049 |
 
-## `AsDataFrameExt` — 1 impls
+## `Storage` — 2 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:888 |
+| `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::Dyn>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1251 |
+| `RVecStorage<T, nalgebra::base::dimension::Dyn, nalgebra::base::dimension::U1>` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/nalgebra_impl.rs:1276 |
+
+## `IntoDataFrame` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Vec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/dataframe.rs:1234 |
+| `SerdeRows<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:429 |
+
+## `FromDataFrame` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Vec<T>` | `<T>` | concrete | 2 | miniextendr-api/src/dataframe.rs:1250 |
+| `SerdeRows<T>` | `<T> +1wc` | concrete | 1 | miniextendr-api/src/serde/dataframe_de.rs:444 |
+
+## `AltrepClass` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `JiffTimestampVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:874 |
+| `JiffZonedVec` | `` | concrete | 2 | miniextendr-api/src/optionals/jiff_impl.rs:915 |
+
+## `RNdIndex` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ArrayD<f64>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2732 |
+| `ArrayD<i32>` | `` | concrete | 10 | miniextendr-api/src/optionals/ndarray_impl.rs:2886 |
+
+## `RSourced` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RPrimitive<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:141 |
+| `RStringArray` | `` | concrete | 2 | miniextendr-api/src/optionals/arrow_impl.rs:223 |
+
+## `RNdSlice2D` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Array2<f64>` | `` | concrete | 7 | miniextendr-api/src/optionals/ndarray_impl.rs:2558 |
+| `Array2<i32>` | `` | concrete | 7 | miniextendr-api/src/optionals/ndarray_impl.rs:2606 |
 
 ## `AsMut` — 2 impls
 
@@ -3314,6 +3351,290 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1644 |
 | `AsSerialize<T>` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:248 |
+
+## `Protector` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ProtectScope` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:219 |
+| `crate::protect_pool::ProtectPool` | `` | concrete | 1 | miniextendr-api/src/gc_protect.rs:226 |
+
+## `RDeserializeNative` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:146 |
+
+## `RNdSlice` — 2 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Array1<f64>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2445 |
+| `Array1<i32>` | `` | concrete | 5 | miniextendr-api/src/optionals/ndarray_impl.rs:2478 |
+
+## `AsDataFrameExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:888 |
+
+## `RDecimalOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Decimal` | `` | concrete | 22 | miniextendr-api/src/optionals/rust_decimal_impl.rs:400 |
+
+## `Not` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:166 |
+
+## `RDuration` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Duration` | `` | concrete | 10 | miniextendr-api/src/optionals/time_impl.rs:189 |
+
+## `FusedIterator` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:1773 |
+
+## `UnitEnumFactor` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 3 | miniextendr-api/src/factor.rs:560 |
+
+## `RBigUintBitOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `BigUint` | `` | concrete | 10 | miniextendr-api/src/optionals/num_bigint_impl.rs:691 |
+
+## `RJsonValueOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `JsonValue` | `` | concrete | 15 | miniextendr-api/src/optionals/serde_impl.rs:937 |
+
+## `RSpan` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Span` | `` | concrete | 14 | miniextendr-api/src/optionals/jiff_impl.rs:587 |
+
+## `RFromStr` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:349 |
+
+## `SerializeSeq` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:256 |
+
+## `SexpExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::SEXP` | `` | concrete | 85 | miniextendr-api/src/sexp_ext.rs:523 |
+
+## `RBigUintOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `BigUint` | `` | concrete | 13 | miniextendr-api/src/optionals/num_bigint_impl.rs:449 |
+
+## `RMatrixOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `DMatrix<f64>` | `` | concrete | 24 | miniextendr-api/src/optionals/nalgebra_impl.rs:687 |
+
+## `SerializeTuple` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:289 |
+
+## `RUuidOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Uuid` | `` | concrete | 8 | miniextendr-api/src/optionals/uuid_impl.rs:113 |
+
+## `PairListExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::SEXP` | `` | concrete | 14 | miniextendr-api/src/sexp_ext.rs:1122 |
+
+## `ParCollectR` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 0 | miniextendr-api/src/optionals/rayon_bridge.rs:1378 |
+
+## `Pod` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RawHeader` | `` | concrete | 0 | miniextendr-api/src/raw_conversions.rs:115 |
+
+## `Pointer` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1701 |
+
+## `RComplexOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Complex<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/num_complex_impl.rs:329 |
+
+## `IntoDataFrameSplit` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Vec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/dataframe.rs:1282 |
+
+## `RBigIntBitOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `BigInt` | `` | concrete | 11 | miniextendr-api/src/optionals/num_bigint_impl.rs:585 |
+
+## `RFromIter` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `C` | `<C, T> +1wc` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:751 |
+
+## `BitXor` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:159 |
+
+## `RNum` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/optionals/num_traits_impl.rs:78 |
+
+## `DoubleEndedIterator` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `ExternalPtr<T>` | `<T>` | concrete | 2 | miniextendr-api/src/externalptr.rs:1753 |
+
+## `RBigIntOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `BigInt` | `` | concrete | 17 | miniextendr-api/src/optionals/num_bigint_impl.rs:309 |
+
+## `TermLike` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RTerm` | `` | concrete | 9 | miniextendr-api/src/progress.rs:246 |
+
+## `ROrderedFloatOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `OrderedFloat<T>` | `<T> +1wc` | concrete | 16 | miniextendr-api/src/optionals/ordered_float_impl.rs:344 |
+
+## `RawStorageMut` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1230 |
+
+## `RTomlOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `TomlValue` | `` | concrete | 16 | miniextendr-api/src/optionals/toml_impl.rs:624 |
+
+## `RDate` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Date` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:828 |
+
+## `AltListData` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `IterListData<I>` | `<I> +1wc` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:401 |
+
+## `AsListExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:830 |
+
+## `Log` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RLogger` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:162 |
+
+## `IsContiguous` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 0 | miniextendr-api/src/optionals/nalgebra_impl.rs:1301 |
+
+## `AsExternalPtrExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:854 |
+
+## `SerializeTupleStruct` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:303 |
+
+## `MatchArg` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `log::LevelFilter` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:283 |
+
+## `BitOr` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:152 |
+
+## `RVectorOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `DVector<f64>` | `` | concrete | 18 | miniextendr-api/src/optionals/nalgebra_impl.rs:495 |
+
+## `RRegexOps` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `Regex` | `` | concrete | 7 | miniextendr-api/src/optionals/regex_impl.rs:150 |
+
+## `RToVec` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `C` | `<C, T> +3wc` | concrete | 2 | miniextendr-api/src/adapter_traits.rs:822 |
 
 ## `RUrlOps` — 1 impls
 
@@ -3327,17 +3648,29 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `Zoned` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:774 |
 
-## `RToVec` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `C` | `<C, T> +3wc` | concrete | 2 | miniextendr-api/src/adapter_traits.rs:822 |
-
 ## `RSigned` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `T` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/optionals/num_traits_impl.rs:139 |
+
+## `GlobalAlloc` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `RAllocator` | `` | concrete | 4 | miniextendr-api/src/allocator.rs:146 |
+
+## `AltrepSexpExt` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/altrep_ext.rs:54 |
+
+## `Deserialize` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `crate::externalptr::ExternalPtr<T>` | `<'de, T>` | concrete | 1 | miniextendr-api/src/serde/externalptr.rs:47 |
 
 ## `RFloat` — 1 impls
 
@@ -3350,18 +3683,6 @@ Traits with impls: 216
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 7 | miniextendr-api/src/optionals/nalgebra_impl.rs:1191 |
-
-## `GlobalAlloc` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RAllocator` | `` | concrete | 4 | miniextendr-api/src/allocator.rs:146 |
-
-## `IntoDataFrameSplit` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Vec<T>` | `<T>` | concrete | 1 | miniextendr-api/src/dataframe.rs:1282 |
 
 ## `RAhoCorasickOps` — 1 impls
 
@@ -3387,11 +3708,11 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `IndexMap<String, T>` | `<T>` | concrete | 9 | miniextendr-api/src/optionals/indexmap_impl.rs:208 |
 
-## `SexpExt` — 1 impls
+## `RDistributions` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `crate::SEXP` | `` | concrete | 85 | miniextendr-api/src/sexp_ext.rs:523 |
+| `RRng` | `` | concrete | 4 | miniextendr-api/src/optionals/rand_impl.rs:232 |
 
 ## `RTime` — 1 impls
 
@@ -3399,17 +3720,11 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `Time` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:703 |
 
-## `SerializeTupleStruct` — 1 impls
+## `Read` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:303 |
-
-## `RSignedDuration` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `SignedDuration` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:523 |
+| `RStdin` | `` | concrete | 1 | miniextendr-api/src/connection.rs:1252 |
 
 ## `RBorshOps` — 1 impls
 
@@ -3417,35 +3732,11 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 3 | miniextendr-api/src/optionals/borsh_impl.rs:91 |
 
-## `ParCollectR` — 1 impls
+## `AsVctrsExt` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `T` | `<T>` | concrete | 0 | miniextendr-api/src/optionals/rayon_bridge.rs:1378 |
-
-## `RTimestamp` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Timestamp` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:736 |
-
-## `PairListExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `crate::SEXP` | `` | concrete | 14 | miniextendr-api/src/sexp_ext.rs:1122 |
-
-## `Read` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RStdin` | `` | concrete | 1 | miniextendr-api/src/connection.rs:1252 |
-
-## `RDecimalOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Decimal` | `` | concrete | 22 | miniextendr-api/src/optionals/rust_decimal_impl.rs:400 |
+| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:902 |
 
 ## `BitAnd` — 1 impls
 
@@ -3453,161 +3744,11 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:145 |
 
-## `TermLike` — 1 impls
+## `RSignedDuration` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `RTerm` | `` | concrete | 9 | miniextendr-api/src/progress.rs:246 |
-
-## `Zeroable` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RawHeader` | `` | concrete | 0 | miniextendr-api/src/raw_conversions.rs:115 |
-
-## `Not` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:166 |
-
-## `RDuration` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Duration` | `` | concrete | 10 | miniextendr-api/src/optionals/time_impl.rs:189 |
-
-## `AsListExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:830 |
-
-## `AsExternalPtrExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:854 |
-
-## `RBigUintBitOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `BigUint` | `` | concrete | 10 | miniextendr-api/src/optionals/num_bigint_impl.rs:691 |
-
-## `RSpan` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Span` | `` | concrete | 14 | miniextendr-api/src/optionals/jiff_impl.rs:587 |
-
-## `UnitEnumFactor` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 3 | miniextendr-api/src/factor.rs:560 |
-
-## `RJsonValueOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `JsonValue` | `` | concrete | 15 | miniextendr-api/src/optionals/serde_impl.rs:937 |
-
-## `RJsonBridge` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:1049 |
-
-## `FusedIterator` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 0 | miniextendr-api/src/externalptr.rs:1773 |
-
-## `RFromStr` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:349 |
-
-## `RBigUintOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `BigUint` | `` | concrete | 13 | miniextendr-api/src/optionals/num_bigint_impl.rs:449 |
-
-## `RMatrixOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `DMatrix<f64>` | `` | concrete | 24 | miniextendr-api/src/optionals/nalgebra_impl.rs:687 |
-
-## `AltListData` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `IterListData<I>` | `<I> +1wc` | concrete | 1 | miniextendr-api/src/altrep_data/iter/coerce.rs:401 |
-
-## `RUuidOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Uuid` | `` | concrete | 8 | miniextendr-api/src/optionals/uuid_impl.rs:113 |
-
-## `RComplexOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Complex<f64>` | `` | concrete | 11 | miniextendr-api/src/optionals/num_complex_impl.rs:329 |
-
-## `RBigIntBitOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `BigInt` | `` | concrete | 11 | miniextendr-api/src/optionals/num_bigint_impl.rs:585 |
-
-## `Pod` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RawHeader` | `` | concrete | 0 | miniextendr-api/src/raw_conversions.rs:115 |
-
-## `BitXor` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:159 |
-
-## `RNum` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T> +1wc` | concrete | 4 | miniextendr-api/src/optionals/num_traits_impl.rs:78 |
-
-## `RFromIter` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `C` | `<C, T> +1wc` | concrete | 1 | miniextendr-api/src/adapter_traits.rs:751 |
-
-## `Pointer` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 1 | miniextendr-api/src/externalptr.rs:1701 |
-
-## `RBigIntOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `BigInt` | `` | concrete | 17 | miniextendr-api/src/optionals/num_bigint_impl.rs:309 |
-
-## `AsVctrsExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 0 | miniextendr-api/src/convert.rs:902 |
+| `SignedDuration` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:523 |
 
 ## `IntoRVecElement` — 1 impls
 
@@ -3615,104 +3756,14 @@ Traits with impls: 216
 |---|---|---|---|---|
 | `T` | `<T>` | concrete | 1 | miniextendr-api/src/match_arg.rs:281 |
 
-## `DoubleEndedIterator` — 1 impls
+## `Zeroable` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `ExternalPtr<T>` | `<T>` | concrete | 2 | miniextendr-api/src/externalptr.rs:1753 |
+| `RawHeader` | `` | concrete | 0 | miniextendr-api/src/raw_conversions.rs:115 |
 
-## `AltrepSexpExt` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `crate::SEXP` | `` | concrete | 4 | miniextendr-api/src/altrep_ext.rs:54 |
-
-## `ROrderedFloatOps` — 1 impls
+## `RTimestamp` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
-| `OrderedFloat<T>` | `<T> +1wc` | concrete | 16 | miniextendr-api/src/optionals/ordered_float_impl.rs:344 |
-
-## `RawStorageMut` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 2 | miniextendr-api/src/optionals/nalgebra_impl.rs:1230 |
-
-## `RDate` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Date` | `` | concrete | 10 | miniextendr-api/src/optionals/jiff_impl.rs:828 |
-
-## `RTomlOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `TomlValue` | `` | concrete | 16 | miniextendr-api/src/optionals/toml_impl.rs:624 |
-
-## `IsContiguous` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RVecStorage<T, nalgebra::base::dimension::Dyn, C>` | `<T, C>` | concrete | 0 | miniextendr-api/src/optionals/nalgebra_impl.rs:1301 |
-
-## `SerializeSeq` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:256 |
-
-## `RDeserialize` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/serde_impl.rs:275 |
-
-## `RDistributions` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RRng` | `` | concrete | 4 | miniextendr-api/src/optionals/rand_impl.rs:232 |
-
-## `SerializeTuple` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `SeqSerializer` | `` | concrete | 4 | miniextendr-api/src/serde/ser.rs:289 |
-
-## `RDeserializeNative` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `T` | `<T>` | concrete | 1 | miniextendr-api/src/serde/traits.rs:146 |
-
-## `Log` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RLogger` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:162 |
-
-## `MatchArg` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `log::LevelFilter` | `` | concrete | 3 | miniextendr-api/src/optionals/log_impl.rs:283 |
-
-## `RVectorOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `DVector<f64>` | `` | concrete | 18 | miniextendr-api/src/optionals/nalgebra_impl.rs:495 |
-
-## `BitOr` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `RFlags<T>` | `<T>` | concrete | 2 | miniextendr-api/src/optionals/bitflags_impl.rs:152 |
-
-## `RRegexOps` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `Regex` | `` | concrete | 7 | miniextendr-api/src/optionals/regex_impl.rs:150 |
+| `Timestamp` | `` | concrete | 5 | miniextendr-api/src/optionals/jiff_impl.rs:736 |

--- a/rust-llm-docs/generated/miniextendr-api.md
+++ b/rust-llm-docs/generated/miniextendr-api.md
@@ -5570,9 +5570,10 @@ miniextendr-api = { version = "0.1", features = ["serde"] }
 |-----------|--------|
 | `bool` | `logical(1)` |
 | `i8/i16/i32` | `integer(1)` |
-| `i64/u64/f32/f64` | `numeric(1)` |
+| `i64/u64` | `integer(1)` when the value fits i32, else `numeric(1)` (lossy above 2^53) |
+| `f32/f64` | `numeric(1)` |
 | `String/&str` | `character(1)` |
-| `Option<T>::None` | NA or NULL |
+| `Option<T>::None` | `NULL` (always — never a typed NA) |
 | `Vec<primitive>` | atomic vector (smart dispatch) |
 | `Vec<struct>` | list of lists |
 | `HashMap<String, T>` | named list |
@@ -5605,16 +5606,20 @@ When serializing `Vec<T>`, the serializer uses smart dispatch:
 - `Vec<String>` → `character` vector
 - `Vec<struct>` → list of lists
 
-#### NA Roundtrip
+#### NA and NULL Roundtrip
 
-NA values are preserved through `Option<T>`:
+The absence encoding is asymmetric (pinned by
+`rpkg/tests/testthat/test-serde-hostile-probes.R`): serialization always
+emits `NULL` for `None` (the macro scalar `IntoR` path is the one that
+emits typed NAs — don't conflate them); deserialization accepts both
+`NULL` and a typed scalar NA as `None`:
 
 ```rust,ignore
 // Serialization
 let v: Option<i32> = None;
-// → NA_integer_
+// → NULL (not NA_integer_)
 
-// Deserialization
+// Deserialization: NULL and NA_integer_ both come back as None
 let v: Option<i32> = from_r(na_integer_sexp)?;
 assert!(v.is_none());
 ```
@@ -5798,12 +5803,19 @@ are handled correctly.
 
 Deserializer for converting an R `data.frame` SEXP into `Vec<T>`.
 
-Provides two public entry points:
+Public entry points:
 
 - [`dataframe_to_vec`] — owned; `T: DeserializeOwned`; always materialises
   `String` for character cells.
 - [`with_dataframe_rows`] — scoped callback; `T: for<'a> Deserialize<'a>`;
   supports zero-copy borrows (`name: &'a str`).
+- [`dataframe_to_vec_borrowed`] — RAII handle keeping the source SEXP
+  rooted while the caller holds the rows.
+- [`dataframe_to_vec_collated`] — top-level enum rows (Collated shape).
+- [`dataframe_to_vec_with_enum_tags`] — caller-chosen variant-tag column
+  names for nested enum fields.
+- [`dataframe_to_vec_with_struct_fields`] — per-field opt-out from the
+  `Option<Enum>` tag-column heuristic (#1320).
 
 #### Design (unified row/cell deserializer)
 
@@ -6613,11 +6625,1539 @@ R FFI APIs. Typically done in `R_init_<pkgname>()`.
 
 ## Re-exports
 
+### `pub use convert::AsListExt;`
+
+### `pub use arrow_schema::Schema;`
+
+### `pub use vctrs::new_list_of;`
+
+### `pub use optionals::Ix4;`
+
+### `pub use jiff;`
+
+### `pub use dataframe_de::BorrowedRows;`
+
+### `pub use crate::IntoList;`
+
+### `pub use optionals::Borsh;`
+
+### `pub use ndarray_impl::Array3;`
+
+### `pub use crate::RBigUintOps;`
+
+### `pub use factor::RFactor;`
+
+### `pub use regex_impl::RRegexOps;`
+
+### `pub use crate::AhoCorasick;`
+
+### `pub use bytes_impl::RBufMut;`
+
+### `pub use worker::with_r_thread;`
+
+### `pub use ndarray::ArrayViewD;`
+
+### `pub use convert::AsNamedVector;`
+
+### `pub use abi::mx_base_vtable;`
+
+### `pub use optionals::Ix5;`
+
+### `pub use optionals::JiffDate;`
+
+### `pub use dataframe_de::dataframe_to_vec_borrowed;`
+
+### `pub use crate::Lazy;`
+
+### `pub use optionals::borsh_to_raw;`
+
+### `pub use ndarray_impl::Array6;`
+
+### `pub use crate::Decimal;`
+
+### `pub use rayon;`
+
+### `pub use factor::build_levels_sexp;`
+
+### `pub use url_impl::Url;`
+
+### `pub use sha2_impl::sha512_bytes;`
+
+### `pub use miniextendr_macros::PreferRNativeType;`
+
+### `pub use thread::DEFAULT_R_STACK_SIZE;`
+
+### `pub use ndarray::ArrayViewMut1;`
+
+### `pub use core::AltrepExtractSubset;`
+
+### `pub use convert::AsRNativeExt;`
+
+### `pub use abi::mx_tag;`
+
+### `pub use optionals::IxDyn;`
+
+### `pub use optionals::JiffTimestampVec;`
+
+### `pub use dataframe_de::dataframe_to_vec_with_struct_fields;`
+
+### `pub use crate::ListMut;`
+
+### `pub use optionals::Flags;`
+
+### `pub use ndarray_impl::ArrayView1;`
+
+### `pub use aho_corasick_impl::RAhoCorasickOps;`
+
+### `pub use blake3_impl::blake3_hex;`
+
+### `pub use miniextendr_macros::TryFromList;`
+
+### `pub use thread::scope_with_r;`
+
+### `pub use core::InferBase;`
+
+### `pub use convert::CollectNAInt;`
+
+### `pub use adapter_traits::RCopy;`
+
+### `pub use optionals::RNdIndex;`
+
+### `pub use group::group_rows;`
+
+### `pub use optionals::RDateTime;`
+
+### `pub use log;`
+
+### `pub use error::RSerdeError;`
+
+### `pub use crate::OwnedProtect;`
+
+### `pub use optionals::BitVec;`
+
+### `pub use ndarray_impl::ArrayView4;`
+
+### `pub use num_complex;`
+
+### `pub use aho_corasick_impl::aho_find_all;`
+
+### `pub use md5_impl::md5_hex;`
+
+### `pub use sexp::SEXP;`
+
+### `pub use ffi_guard::GuardMode;`
+
+### `pub use ndarray::ArrayViewMut4;`
+
+### `pub use core::materialize_altrep_data2;`
+
+### `pub use convert::AsVctrsExt;`
+
+### `pub use adapter_traits::RDisplay;`
+
+### `pub use optionals::ShapeBuilder;`
+
+### `pub use optionals::RTime;`
+
+### `pub use json_string::AsJsonVec;`
+
+### `pub use crate::ProtectedStrVec;`
+
+### `pub use optionals::RBitVec;`
+
+### `pub use ndarray_impl::ArrayViewD;`
+
+### `pub use crate::RNum;`
+
+### `pub use aho_corasick_impl::aho_is_match;`
+
+### `pub use borsh;`
+
+### `pub use zstd_impl::zstd_decompress;`
+
+### `pub use sexp_types::R_CFinalizer_t;`
+
+### `pub use dataframe::BuiltDataFrame;`
+
+### `pub use traits::*;`
+
+### `pub use list::List;`
+
+### `pub use adapter_traits::RFromIter;`
+
+### `pub use optionals::DVector;`
+
+### `pub use optionals::SignedDuration;`
+
+### `pub use aho_corasick::AhoCorasick;`
+
+### `pub use traits::AsSerialize;`
+
+### `pub use crate::StrVecBuilder;`
+
+### `pub use optionals::Table;`
+
+### `pub use ndarray_impl::ArrayViewMut2;`
+
+### `pub use crate::dataframe_builder::RDataFrameBuilder;`
+
+### `pub use globset_impl::GlobBuilder;`
+
+### `pub use crate::Pod;`
+
+### `pub use bitvec_impl::BitVec;`
+
+### `pub use sexp_types::RNativeType;`
+
+### `pub use dataframe::DataFrameError;`
+
+### `pub use ndarray::ArrayViewMutD;`
+
+### `pub use list::ListMut;`
+
+### `pub use adapter_traits::RIterator;`
+
+### `pub use serde_json::Value as JsonValue;`
+
+### `pub use optionals::SMatrix;`
+
+### `pub use optionals::Zoned;`
+
+### `pub use traits::from_r;`
+
+### `pub use crate::DataFrame;`
+
+### `pub use optionals::table_from_vecs;`
+
+### `pub use ndarray_impl::ArrayViewMut5;`
+
+### `pub use crate::Array3;`
+
+### `pub use globset_impl::GlobSetBuilder;`
+
+### `pub use crate::Zeroable;`
+
+### `pub use bitvec_impl::RBitVec;`
+
+### `pub use sexp_types::Rcomplex;`
+
+### `pub use dataframe::GroupedDataFrame;`
+
+### `pub use tabled::settings::Alignment;`
+
+### `pub use list::collect_list;`
+
+### `pub use adapter_traits::RPartialOrd;`
+
+### `pub use optionals::BigInt;`
+
+### `pub use optionals::FactorHandling;`
+
+### `pub use bytemuck::Pod;`
+
+### `pub use crate::FromDataFrame;`
+
+### `pub use optionals::table_to_string_styled;`
+
+### `pub use ndarray_impl::Ix0;`
+
+### `pub use crate::Array6;`
+
+### `pub use globset_impl::globset_matches;`
+
+### `pub use tabled_impl::Tabled;`
+
+### `pub use altrep_data::AltComplexData;`
+
+### `pub use dataframe::NamedDataFrameListBuilder;`
+
+### `pub use ndarray::Ix1;`
+
+### `pub use named_vector::AtomicElement;`
+
+### `pub use optionals::rayon_bridge;`
+
+### `pub use optionals::RBigIntOps;`
+
+### `pub use crate::AltrepInteger;`
+
+### `pub use optionals::NaHandling;`
+
+### `pub use crate::AsVctrsExt;`
+
+### `pub use optionals::ArrayVec;`
+
+### `pub use ndarray_impl::Ix1;`
+
+### `pub use crate::ArrayView2;`
+
+### `pub use time_impl::Date;`
+
+### `pub use crate::sha512_bytes;`
+
+### `pub use tabled_impl::table_to_string;`
+
+### `pub use altrep_data::AltLogicalData;`
+
+### `pub use error::r_warning;`
+
+### `pub use tabled::settings::Width;`
+
+### `pub use rcow::RCow;`
+
+### `pub use optionals::rand;`
+
+### `pub use optionals::rust_decimal_impl;`
+
+### `pub use optionals::RJsonValueOps;`
+
+### `pub use nalgebra::DMatrix;`
+
+### `pub use crate::AsListExt;`
+
+### `pub use optionals::ArrayRef;`
+
+### `pub use ndarray_impl::Ix3;`
+
+### `pub use crate::ArrayViewMut2;`
+
+### `pub use time_impl::RDateTimeFormat;`
+
+### `pub use tinyvec_impl::Array;`
+
+### `pub use altrep_data::AltStringData;`
+
+### `pub use from_r::SexpError;`
+
+### `pub use ndarray::Ix2;`
+
+### `pub use tabled::Tabled;`
+
+### `pub use strvec::ProtectedStrVecIter;`
+
+### `pub use optionals::RDistributionOps;`
+
+### `pub use optionals::ordered_float_impl;`
+
+### `pub use crate::AltrepRaw;`
+
+### `pub use optionals::json_from_sexp;`
+
+### `pub use nalgebra::SVector;`
+
+### `pub use crate::AsRNativeExt;`
+
+### `pub use optionals::DataType;`
+
+### `pub use ndarray_impl::Ix4;`
+
+### `pub use ndarray;`
+
+### `pub use jiff_impl::DateTime as JiffDateTime;`
+
+### `pub use crate::table_to_string;`
+
+### `pub use sha2::Sha512;`
+
+### `pub use arrow_impl::Array as ArrowArray;`
+
+### `pub use altrep_data::AltrepLen;`
+
+### `pub use conv::extract_arg;`
+
+### `pub use from_r::SexpTypeError;`
+
+### `pub use strvec::StrVecCowIter;`
+
+### `pub use optionals::RRngOps;`
+
+### `pub use optionals::num_complex_impl;`
+
+### `pub use optionals::json_from_sexp_with;`
+
+### `pub use optionals::Field;`
+
+### `pub use ndarray_impl::Ix6;`
+
+### `pub use crate::DVector;`
+
+### `pub use jiff::civil::Time;`
+
+### `pub use jiff_impl::RDate;`
+
+### `pub use crate::ArrayVec;`
+
+### `pub use arrow_impl::DataType;`
+
+### `pub use altrep_data::IterIntData;`
+
+### `pub use conv::rf_error;`
+
+### `pub use expression::REnv;`
+
+### `pub use ndarray::Ix4;`
+
+### `pub use typed_list::TypedEntry;`
+
+### `pub use optionals::Left;`
+
+### `pub use optionals::num_traits_impl;`
+
+### `pub use crate::ExternalPtr;`
+
+### `pub use optionals::TomlValue;`
+
+### `pub use crate::r_warning;`
+
+### `pub use optionals::RecordBatch;`
+
+### `pub use ndarray_impl::IxDyn;`
+
+### `pub use crate::SMatrix;`
+
+### `pub use jiff::Timestamp;`
+
+### `pub use jiff_impl::RSpan;`
+
+### `pub use arrow_impl::Field;`
+
+### `pub use altrep_data::IterLogicalData;`
+
+### `pub use crate::condition::repanic_if_rust_error;`
+
+### `pub use expression::r_eval_str_global;`
+
+### `pub use tinyvec::ArrayVec;`
+
+### `pub use typed_list::TypedListSpec;`
+
+### `pub use optionals::ArcArray1;`
+
+### `pub use uuid::Uuid;`
+
+### `pub use optionals::RSigned;`
+
+### `pub use crate::MatchArg;`
+
+### `pub use optionals::toml_to_string_pretty;`
+
+### `pub use crate::r_str;`
+
+### `pub use optionals::StringDictionaryArray;`
+
+### `pub use ndarray_impl::RNdSlice;`
+
+### `pub use bytes::Buf;`
+
+### `pub use jiff_impl::RZoned;`
+
+### `pub use arrow_impl::RecordBatch;`
+
+### `pub use altrep_data::IterRealData;`
+
+### `pub use coerce::Coerced;`
+
+### `pub use ndarray::Ix5;`
+
+### `pub use typed_list::validate_list;`
+
+### `pub use optionals::Array1;`
+
+### `pub use cetype_t::CE_UTF8;`
+
+### `pub use optionals::Uuid;`
+
+### `pub use crate::RFactor;`
+
+### `pub use optionals::BufMut;`
+
+### `pub use globset::Glob;`
+
+### `pub use crate::Either;`
+
+### `pub use optionals::RSessionContext;`
+
+### `pub use ndarray_impl::RndMat;`
+
+### `pub use indexmap;`
+
+### `pub use jiff_impl::Time as JiffTime;`
+
+### `pub use miniextendr_macros::ExternalPtr;`
+
+### `pub use blake3::Hash;`
+
+### `pub use arrow_impl::StringDictionaryArray;`
+
+### `pub use altrep_data::Logical;`
+
+### `pub use r_coerce::RCoerceComplex;`
+
+### `pub use arrow_array::Array;`
+
+### `pub use externalptr::ExternalSlice;`
+
+### `pub use optionals::Array4;`
+
+### `pub use optionals::CaptureGroups;`
+
+### `pub use crate::list;`
+
+### `pub use optionals::RBuf;`
+
+### `pub use either;`
+
+### `pub use rarray::RArray3D;`
+
+### `pub use nalgebra_impl::DVector;`
+
+### `pub use crate::RParallelIterator;`
+
+### `pub use serde_impl::FactorHandling;`
+
+### `pub use miniextendr_macros::impl_typed_external;`
+
+### `pub use datafusion_impl::RDataFrame;`
+
+### `pub use altrep_data::SparseIterIntData;`
+
+### `pub use r_coerce::RCoerceEnvironment;`
+
+### `pub use ndarray::IxDyn;`
+
+### `pub use arrow_array::BooleanArray;`
+
+### `pub use externalptr::altrep_data1_as;`
+
+### `pub use optionals::ArrayD;`
+
+### `pub use optionals::Regex;`
+
+### `pub use crate::miniextendr;`
+
+### `pub use optionals::sha256_bytes;`
+
+### `pub use crate::Uuid;`
+
+### `pub use ::serde as serde_crate;`
+
+Re-export the upstream `serde` crate (aliased to avoid conflict with [`mod serde`]).
+
+Downstream crates can use `miniextendr_api::serde_crate::{Serialize, Deserialize}`
+and `#[serde(crate = "miniextendr_api::serde_crate")]` to avoid a direct `serde` dep.
+
+### `pub use nalgebra_impl::RMatrixOps;`
+
+### `pub use crate::RDistributions;`
+
+### `pub use serde_impl::NaHandling;`
+
+### `pub use miniextendr_macros::miniextendr;`
+
+### `pub use altrep_data::SparseIterRealData;`
+
+### `pub use r_coerce::RCoerceFunction;`
+
+### `pub use externalptr::altrep_data1_mut_unchecked;`
+
+### `pub use optionals::ArrayView2;`
+
+### `pub use optionals::Url;`
+
+### `pub use ::serde::Deserialize;`
+
+### `pub use optionals::sha512_str;`
+
+### `pub use crate::CaptureGroups;`
+
+### `pub use raw_conversions::Raw;`
+
+### `pub use nalgebra_impl::SMatrix;`
+
+### `pub use rand;`
+
+### `pub use serde_impl::RJsonValueOps;`
+
+### `pub use miniextendr_macros::r_ffi_checked;`
+
+### `pub use md5::Digest;`
+
+### `pub use altrep_data::StreamingRealData;`
+
+### `pub use r_coerce::RCoerceLogical;`
+
+### `pub use arrow_array::RecordBatch;`
+
+### `pub use gc_protect::OwnedProtect;`
+
+### `pub use optionals::ArrayView5;`
+
+### `pub use optionals::AhoCorasick;`
+
+### `pub use columnar::DataFrameShape;`
+
+### `pub use crate::altrep::RegisterAltrep;`
+
+### `pub use optionals::blake3_hex;`
+
+### `pub use regex;`
+
+### `pub use raw_conversions::RawSlice;`
+
+### `pub use num_bigint_impl::BigUint;`
+
+### `pub use crate::serde::RDeserializeNative;`
+
+### `pub use num_bigint::BigUint;`
+
+### `pub use serde_impl::json_from_sexp;`
+
+### `pub use miniextendr_macros::PreferVctrs;`
+
+### `pub use altrep_data::WindowedIterState;`
+
+### `pub use ndarray::Array0;`
+
+### `pub use r_coerce::RCoercePOSIXct;`
+
+### `pub use arrow_array::UInt8Array;`
+
+### `pub use gc_protect::Protected;`
+
+### `pub use optionals::ArrayViewMut0;`
+
+### `pub use optionals::aho_count_matches;`
+
+### `pub use columnar::RootedSentinel;`
+
+### `pub use crate::AltListData;`
+
+### `pub use optionals::md5_bytes;`
+
+### `pub use state::*;`
+
+### `pub use rand_impl::RDistributionOps;`
+
+### `pub use crate::Url;`
+
+### `pub use raw_conversions::Zeroable;`
+
+### `pub use time::Date;`
+
+### `pub use num_bigint_impl::RBigUintBitOps;`
+
+### `pub use serde_impl::json_from_sexp_with;`
+
+### `pub use altrep_sexp::ensure_materialized;`
+
+### `pub use ndarray::Array3;`
+
+### `pub use r_coerce::SUPPORTED_AS_GENERICS;`
+
+### `pub use arrow_array::types::Float64Type;`
+
+### `pub use gc_protect::Root;`
+
+### `pub use optionals::ArrayViewMut3;`
+
+### `pub use optionals::aho_find_first;`
+
+### `pub use url::Url;`
+
+### `pub use columnar::SplitShape;`
+
+### `pub use crate::AltRealData;`
+
+### `pub use optionals::globset_impl;`
+
+### `pub use rand_impl::RRngOps;`
+
+### `pub use crate::Date;`
+
+### `pub use raw_conversions::raw_slice_from_bytes;`
+
+### `pub use rust_decimal_impl::RDecimalOps;`
+
+### `pub use crate::RDeserialize;`
+
+### `pub use borsh_impl::RBorshOps;`
+
+### `pub use miniextendr_macros::AltrepInteger;`
+
+### `pub use zstd::compression_level_range;`
+
+### `pub use ndarray::Array6;`
+
+### `pub use rvalue::RValue;`
+
+### `pub use refcount_protect::ArenaGuard;`
+
+### `pub use optionals::ArrayViewMut6;`
+
+### `pub use optionals::indexmap_impl;`
+
+### `pub use columnar::hashmap_to_dataframe;`
+
+### `pub use crate::AltrepLen;`
+
+### `pub use optionals::GlobOptions;`
+
+### `pub use rand_distr;`
+
+Re-export of `rand_distr` for probability distributions.
+
+Provides distributions like `Normal`, `Exp`, `Uniform`, etc. that work
+with [`RRng`]. Enable with `features = ["rand_distr"]`.
+
+### `pub use crate::RDuration;`
+
+### `pub use match_arg::MatchArg;`
+
+### `pub use num_complex_impl::Complex;`
+
+### `pub use crate::TomlValue;`
+
+### `pub use toml_impl::RTomlOps;`
+
+### `pub use miniextendr_macros::AltrepRaw;`
+
+### `pub use into_r::Altrep;`
+
+### `pub use convert::AsDisplay;`
+
+### `pub use allocator::RAllocator;`
+
+### `pub use optionals::Ix0;`
+
+### `pub use optionals::time_impl;`
+
+### `pub use columnar::result_to_dataframe;`
+
+### `pub use crate::IntoR;`
+
+### `pub use optionals::build_globset;`
+
+### `pub use either_impl::Left;`
+
+### `pub use crate::OrderedFloat;`
+
+### `pub use match_arg::match_arg_from_sexp;`
+
+### `pub use num_traits_impl::RNum;`
+
+### `pub use toml;`
+
+### `pub use toml_impl::toml_to_string;`
+
+### `pub use miniextendr_macros::DataFrameRow;`
+
+### `pub use into_r_error::IntoRError;`
+
+### `pub use ndarray::ArrayView3;`
+
+### `pub use convert::AsExternalPtrExt;`
+
+### `pub use arrow_schema::DataType;`
+
+### `pub use vctrs::VctrsClass;`
+
+### `pub use optionals::Ix2;`
+
+### `pub use optionals::OffsetDateTime;`
+
+### `pub use columnar::vec_to_dataframe_flatten_enums_with_tags;`
+
+### `pub use crate::TryCoerce;`
+
+### `pub use optionals::zstd_impl;`
+
+### `pub use ndarray_impl::ArcArray2;`
+
+### `pub use factor::Factor;`
+
+### `pub use uuid_impl::Uuid;`
+
+### `pub use crate::BytesMut;`
+
+### `pub use bytes_impl::BufMut;`
+
+### `pub use miniextendr_macros::MatchArg;`
+
+### `pub use newtype::IntoRVecElement;`
+
+### `pub use ndarray::ArrayView5;`
+
+### `pub use convert::AsList;`
+
+### `pub use vctrs::VctrsRecord;`
+
+### `pub use optionals::Ix3;`
+
+### `pub use datafusion;`
+
+### `pub use time;`
+
+### `pub use columnar::par_iter_to_dataframe_growing;`
+
+### `pub use optionals::borsh_impl;`
+
+### `pub use ndarray_impl::Array2;`
+
+### `pub use crate::RBigIntOps;`
+
+### `pub use factor::FactorVec;`
+
+### `pub use regex_impl::RCaptureGroups;`
+
+### `pub use bytes;`
+
+### `pub use bytes_impl::RBuf;`
+
+### `pub use miniextendr_macros::PreferExternalPtr;`
+
+### `pub use worker::is_r_main_thread;`
+
+### `pub use convert::AsNamedListExt;`
+
+### `pub use vctrs::new_vctr;`
+
+### `pub use optionals::Ix5;`
+
+### `pub use optionals::jiff_impl;`
+
+### `pub use dataframe_de::dataframe_to_vec;`
+
+### `pub use optionals::borsh_from_raw;`
+
+### `pub use ndarray_impl::Array5;`
+
+### `pub use factor::build_factor;`
+
+### `pub use url_impl::RUrlOps;`
+
+### `pub use aho_corasick;`
+
+### `pub use sha2_impl::sha256_str;`
+
+### `pub use indicatif;`
+
+### `pub use core::AltrepExtract;`
+
+### `pub use convert::AsRNative;`
+
+### `pub use abi::mx_meth;`
+
+### `pub use optionals::Ix6;`
+
+### `pub use optionals::JiffTime;`
+
+### `pub use dataframe_de::dataframe_to_vec_with_enum_tags;`
+
+### `pub use crate::ListBuilder;`
+
+### `pub use optionals::bitflags_impl;`
+
+### `pub use ndarray_impl::ArrayView0;`
+
+### `pub use rust_decimal;`
+
+### `pub use factor::factor_from_sexp;`
+
+### `pub use aho_corasick_impl::AhoCorasick;`
+
+### `pub use bitflags;`
+
+### `pub use blake3_impl::blake3_bytes;`
+
+### `pub use miniextendr_macros::RFactor;`
+
+### `pub use thread::StackCheckGuard;`
+
+### `pub use ndarray::ArrayViewMut2;`
+
+### `pub use bitvec::order::Lsb0;`
+
+### `pub use core::AltrepSerialize;`
+
+### `pub use convert::CollectNA;`
+
+### `pub use adapter_traits::RClone;`
+
+### `pub use optionals::RNdArrayOps;`
+
+### `pub use group::GroupedDataFrame;`
+
+### `pub use optionals::RDate;`
+
+### `pub use de::RDeserializer;`
+
+### `pub use crate::NamedVector;`
+
+### `pub use optionals::bitvec_impl;`
+
+### `pub use ndarray_impl::ArrayView3;`
+
+### `pub use crate::RComplexOps;`
+
+### `pub use result::*;`
+
+### `pub use aho_corasick_impl::aho_count_matches;`
+
+### `pub use bitvec;`
+
+### `pub use md5_impl::md5_bytes;`
+
+### `pub use miniextendr_macros::TryFromSexp;`
+
+### `pub use thread::with_stack_checking_disabled;`
+
+### `pub use bitvec::vec::BitVec;`
+
+### `pub use core::Sortedness;`
+
+### `pub use convert::AsVctrs;`
+
+### `pub use adapter_traits::RDefault;`
+
+### `pub use serde::Deserialize;`
+
+### `pub use optionals::RNdSlice2D;`
+
+### `pub use optionals::RSpan;`
+
+### `pub use json_string::AsJsonPretty;`
+
+### `pub use crate::Protected;`
+
+### `pub use optionals::Msb0;`
+
+### `pub use ndarray_impl::ArrayView6;`
+
+### `pub use crate::RFloat;`
+
+### `pub use aho_corasick_impl::aho_find_first;`
+
+### `pub use crate::RBorshOps;`
+
+### `pub use zstd_impl::zstd_compress;`
+
+### `pub use sexp_ext::SexpExt;`
+
+### `pub use ffi_guard::guarded_ffi_call_with_fallback;`
+
+### `pub use ndarray::ArrayViewMut5;`
+
+### `pub use stream::*;`
+
+### `pub use list::IntoList;`
+
+### `pub use adapter_traits::RExtend;`
+
+### `pub use serde::Serialize;`
+
+### `pub use optionals::DMatrix;`
+
+### `pub use optionals::RZoned;`
+
+### `pub use ser::RSerializer;`
+
+### `pub use crate::StrVec;`
+
+### `pub use optionals::Builder;`
+
+### `pub use ndarray_impl::ArrayViewMut1;`
+
+### `pub use num_traits;`
+
+### `pub use globset_impl::Glob;`
+
+### `pub use crate::Pod;`
+
+### `pub use bitflags_impl::RFlags;`
+
+### `pub use sexp_types::RLogical;`
+
+### `pub use dataframe::DataFrame;`
+
+### `pub use tabled::builder::Builder;`
+
+### `pub use list::ListBuilder;`
+
+### `pub use adapter_traits::RHash;`
+
+### `pub use optionals::RVectorOps;`
+
+### `pub use optionals::Timestamp;`
+
+### `pub use traits::RSerializeNative;`
+
+### `pub use crate::ColumnarFrame;`
+
+### `pub use optionals::builder_to_string;`
+
+### `pub use ndarray_impl::ArrayViewMut4;`
+
+### `pub use crate::Array2;`
+
+### `pub use globset_impl::GlobSet;`
+
+### `pub use crate::RawSlice;`
+
+### `pub use bitvec_impl::Msb0;`
+
+### `pub use sexp_types::Rbyte;`
+
+### `pub use dataframe::GroupKey;`
+
+### `pub use ndarray::Ix0;`
+
+### `pub use list::TryFromList;`
+
+### `pub use adapter_traits::ROrd;`
+
+### `pub use optionals::num_bigint_impl;`
+
+### `pub use crate::Altrep;`
+
+### `pub use optionals::toml_impl;`
+
+### `pub use bytemuck::Pod;`
+
+### `pub use crate::DataFrameRow;`
+
+### `pub use optionals::table_to_string_opts;`
+
+### `pub use ndarray_impl::ArrayViewMutD;`
+
+### `pub use crate::Array5;`
+
+### `pub use globset_impl::globset_is_match;`
+
+### `pub use bytemuck;`
+
+### `pub use tabled_impl::Table;`
+
+### `pub use sexp_types::cetype_t;`
+
+### `pub use rust_decimal::Decimal;`
+
+### `pub use dataframe::IntoDataFrameSplit;`
+
+### `pub use tabled::settings::Modify;`
+
+### `pub use missing::is_missing_arg;`
+
+### `pub use optionals::parallel;`
+
+### `pub use optionals::RBigIntBitOps;`
+
+### `pub use optionals::JsonValue;`
+
+### `pub use bytemuck::Zeroable;`
+
+### `pub use crate::IntoDataFrameSplit;`
+
+### `pub use optionals::Array;`
+
+### `pub use ndarray_impl::Ix1;`
+
+### `pub use crate::ArrayView1;`
+
+### `pub use indexmap_impl::RIndexMapOps;`
+
+### `pub use crate::sha256_str;`
+
+### `pub use tabled_impl::table_from_vecs;`
+
+### `pub use altrep_data::AltListData;`
+
+### `pub use dataframe_builder::RDataFrameBuilder;`
+
+### `pub use ndarray::Ix1;`
+
+### `pub use rcow::RBorrow;`
+
+### `pub use optionals::RParallelIterator;`
+
+### `pub use optionals::RBigUintOps;`
+
+### `pub use crate::AltrepList;`
+
+### `pub use optionals::RJsonBridge;`
+
+### `pub use crate::AsExternalPtrExt;`
+
+### `pub use optionals::arrow_impl;`
+
+### `pub use ndarray_impl::Ix2;`
+
+### `pub use crate::ArrayViewMut1;`
+
+### `pub use time_impl::OffsetDateTime;`
+
+### `pub use sha2;`
+
+### `pub use sha2::Digest;`
+
+### `pub use tabled_impl::table_to_string_styled;`
+
+### `pub use altrep_data::AltRealData;`
+
+### `pub use rng::with_rng;`
+
+### `pub use tabled::Table;`
+
+### `pub use strvec::ProtectedStrVecCowIter;`
+
+### `pub use optionals::rand_impl;`
+
+### `pub use optionals::RDecimalOps;`
+
+### `pub use optionals::SpecialFloatHandling;`
+
+### `pub use nalgebra::SMatrix;`
+
+### `pub use crate::AsNamedVectorExt;`
+
+### `pub use optionals::BooleanArray;`
+
+### `pub use ndarray_impl::Ix4;`
+
+### `pub use crate::RNdArrayOps;`
+
+### `pub use jiff_impl::Date as JiffDate;`
+
+### `pub use crate::Tabled;`
+
+### `pub use tinyvec_impl::TinyVec;`
+
+### `pub use altrep_data::AltrepExtract;`
+
+### `pub use conv::check_arity;`
+
+### `pub use from_r::SexpNaError;`
+
+### `pub use ndarray::Ix3;`
+
+### `pub use strvec::StrVecBuilder;`
+
+### `pub use optionals::RRng;`
+
+### `pub use optionals::ROrderedFloatOps;`
+
+### `pub use crate::AltrepReal;`
+
+### `pub use optionals::json_from_sexp_strict;`
+
+### `pub use crate::r_print;`
+
+### `pub use optionals::DictionaryArray;`
+
+### `pub use indexmap::IndexMap;`
+
+### `pub use ndarray_impl::Ix5;`
+
+### `pub use crate::DMatrix;`
+
+### `pub use jiff::civil::DateTime;`
+
+### `pub use jiff_impl::JiffZonedVec;`
+
+### `pub use arrow_impl::BooleanArray;`
+
+### `pub use altrep_data::IterIntCoerceData;`
+
+### `pub use conv::nil;`
+
+### `pub use expression::RCall;`
+
+### `pub use typed_list::TypeSpec;`
+
+### `pub use optionals::Either;`
+
+### `pub use optionals::RComplexOps;`
+
+### `pub use io_adapters::*;`
+
+### `pub use optionals::RTomlOps;`
+
+### `pub use optionals::Int32Array;`
+
+### `pub use ndarray_impl::IxDyn;`
+
+### `pub use crate::RVectorOps;`
+
+### `pub use jiff::Span;`
+
+### `pub use jiff_impl::RSignedDuration;`
+
+### `pub use tinyvec;`
+
+### `pub use arrow_impl::DictionaryArray;`
+
+### `pub use altrep_data::IterListData;`
+
+### `pub use conv::try_from_sexp;`
+
+### `pub use expression::r_eval_str;`
+
+### `pub use ndarray::Ix4;`
+
+### `pub use tinyvec::Array;`
+
+### `pub use typed_list::TypedListError;`
+
+### `pub use optionals::ndarray_impl;`
+
+### `pub use optionals::RNum;`
+
+### `pub use optionals::toml_to_string;`
+
+### `pub use crate::r;`
+
+### `pub use optionals::StringArray;`
+
+### `pub use ndarray_impl::RNdIndex;`
+
+### `pub use nalgebra;`
+
+### `pub use jiff_impl::RTimestamp;`
+
+### `pub use indicatif;`
+
+### `pub use arrow_impl::Int32Array;`
+
+### `pub use altrep_data::IterRealCoerceData;`
+
+### `pub use coerce::CoerceError;`
+
+### `pub use typed_list::sexptype_name;`
+
+### `pub use optionals::Array0;`
+
+### `pub use optionals::RUuidOps;`
+
+### `pub use optionals::Buf;`
+
+### `pub use crate::SexpExt;`
+
+### `pub use optionals::UInt8Array;`
+
+### `pub use ndarray_impl::ShapeBuilder;`
+
+### `pub use crate::RIndexMapOps;`
+
+### `pub use bytes::BufMut;`
+
+### `pub use jiff_impl::Span;`
+
+### `pub use crate::VctrsClass;`
+
+### `pub use arrow_impl::StringArray;`
+
+### `pub use altrep_data::IterStringData;`
+
+### `pub use r_coerce::RCoerceCharacter;`
+
+### `pub use ndarray::Ix6;`
+
+### `pub use externalptr::ExternalPtr;`
+
+### `pub use optionals::Array3;`
+
+### `pub use optionals::regex_impl;`
+
+### `pub use optionals::BytesMut;`
+
+### `pub use globset::GlobBuilder;`
+
+### `pub use crate::Right;`
+
+### `pub use rarray::RArray;`
+
+### `pub use nalgebra_impl::DMatrix;`
+
+### `pub use crate::RParallelExtend;`
+
+### `pub use bytes::BytesMut;`
+
+### `pub use jiff_impl::Zoned;`
+
+### `pub use blake3::Hasher;`
+
+### `pub use arrow_impl::UInt8Array;`
+
+### `pub use altrep_data::SparseIterComplexData;`
+
+### `pub use r_coerce::RCoerceDate;`
+
+### `pub use arrow_array::ArrayRef;`
+
+### `pub use externalptr::TypedExternal;`
+
+### `pub use optionals::Array6;`
+
+### `pub use optionals::RRegexOps;`
+
+### `pub use optionals::sha2_impl;`
+
+### `pub use globset::GlobSetBuilder;`
+
+### `pub use crate::RUuidOps;`
+
+### `pub use rarray::RVector;`
+
+### `pub use nalgebra_impl::RDVector;`
+
+### `pub use crate::RDistributionOps;`
+
+### `pub use serde_impl::JsonValue;`
+
+### `pub use miniextendr_macros::list;`
+
+### `pub use altrep_data::SparseIterRawData;`
+
+### `pub use either::Left;`
+
+### `pub use r_coerce::RCoerceFactor;`
+
+### `pub use ndarray::IxDyn;`
+
+### `pub use arrow_array::DictionaryArray;`
+
+### `pub use externalptr::altrep_data1_mut;`
+
+### `pub use optionals::ArrayView1;`
+
+### `pub use optionals::RUrlOps;`
+
+### `pub use ::serde::Deserialize;`
+
+### `pub use crate::typed_dataframe;`
+
+### `pub use optionals::sha512_bytes;`
+
+### `pub use raw_conversions::Pod;`
+
+### `pub use nalgebra_impl::RVectorOps;`
+
+### `pub use crate::RRngOps;`
+
+### `pub use serde_impl::RJsonBridge;`
+
+### `pub use altrep_data::StreamingIntData;`
+
+### `pub use r_coerce::RCoerceList;`
+
+### `pub use arrow_array::Int32Array;`
+
+### `pub use externalptr::altrep_data2_as_unchecked;`
+
+### `pub use optionals::ArrayView4;`
+
+### `pub use optionals::aho_corasick_impl;`
+
+### `pub use ::serde::Serialize;`
+
+### `pub use crate::typed_list;`
+
+### `pub use optionals::blake3_bytes;`
+
+### `pub use crate::Regex;`
+
+### `pub use raw_conversions::RawHeader;`
+
+### `pub use num_bigint_impl::BigInt;`
+
+### `pub use crate::serde::AsSerialize;`
+
+### `pub use num_bigint::BigInt;`
+
+### `pub use serde_impl::SpecialFloatHandling;`
+
+### `pub use miniextendr_macros::typed_list;`
+
+### `pub use altrep_data::WindowedIterRealData;`
+
+### `pub use ndarray::ArcArray2;`
+
+### `pub use named::*;`
+
+### `pub use r_coerce::RCoerceNumeric;`
+
+### `pub use arrow_array::TimestampSecondArray;`
+
+### `pub use gc_protect::ProtectScope;`
+
+### `pub use optionals::ArrayViewD;`
+
+### `pub use optionals::aho_compile;`
+
+### `pub use columnar::ResultShape;`
+
+### `pub use crate::AltIntegerData;`
+
+### `pub use optionals::md5_impl;`
+
+### `pub use sparse::*;`
+
+### `pub use rayon_bridge::RParallelIterator;`
+
+### `pub use crate::RUrlOps;`
+
+### `pub use raw_conversions::RawTagged;`
+
+### `pub use num_bigint_impl::RBigIntOps;`
+
+### `pub use serde;`
+
+### `pub use serde_impl::json_from_sexp_strict;`
+
+### `pub use miniextendr_macros::Vctrs;`
+
+### `pub use altrep_sexp::AltrepSexp;`
+
+### `pub use ndarray::Array2;`
+
+### `pub use r_coerce::RCoerceVector;`
+
+### `pub use gc_protect::ReprotectSlot;`
+
+### `pub use optionals::ArrayViewMut2;`
+
+### `pub use regex::Regex;`
+
+### `pub use optionals::aho_find_all_flat;`
+
+### `pub use columnar::SplitResults;`
+
+### `pub use crate::AltRawData;`
+
+### `pub use optionals::md5_str;`
+
+### `pub use rand_impl::RRng;`
+
+### `pub use raw_conversions::raw_from_bytes;`
+
+### `pub use rust_decimal_impl::Decimal;`
+
+### `pub use crate::JsonValue;`
+
+### `pub use borsh_impl::Borsh;`
+
+### `pub use miniextendr_macros::AltrepComplex;`
+
+### `pub use ndarray::Array5;`
+
+### `pub use condition::AsRError;`
+
+### `pub use arrow_array::types::TimestampSecondType;`
+
+### `pub use protect_pool::ProtectPool;`
+
+### `pub use optionals::ArrayViewMut5;`
+
+### `pub use optionals::aho_replace_all;`
+
+### `pub use columnar::dispatch_to_dataframes;`
+
+### `pub use crate::AltrepExtract;`
+
+### `pub use optionals::GlobBuilder;`
+
+### `pub use crate::OffsetDateTime;`
+
+### `pub use raw_conversions::raw_to_bytes;`
+
+### `pub use time::Duration;`
+
+### `pub use toml::Value as TomlValue;`
+
+### `pub use ordered_float_impl::ROrderedFloatOps;`
+
+### `pub use serde_json;`
+
+### `pub use borsh_impl::borsh_to_raw;`
+
+### `pub use miniextendr_macros::AltrepLogical;`
+
+### `pub use ndarray::ArrayView0;`
+
+### `pub use convert::AsDataFrameExt;`
+
+### `pub use arrow_buffer;`
+
+### `pub use refcount_protect::ThreadLocalArena;`
+
+### `pub use optionals::Ix0;`
+
+### `pub use optionals::RIndexMapOps;`
+
+### `pub use columnar::map_to_dataframe;`
+
+### `pub use crate::IntoR;`
+
+### `pub use optionals::GlobSetBuilder;`
+
+### `pub use either_impl::Either;`
+
+### `pub use match_arg::choices_sexp;`
+
+### `pub use num_traits_impl::RFloat;`
+
+### `pub use crate::toml_to_string;`
+
+### `pub use toml_impl::toml_from_str;`
+
+### `pub use miniextendr_macros::AltrepString;`
+
+### `pub use bitflags::Flags;`
+
+### `pub use into_r::IntoRAltrep;`
+
+### `pub use ndarray::ArrayView2;`
+
+### `pub use convert::AsExternalPtr;`
+
+### `pub use vctrs::VctrsBuildError;`
+
+### `pub use optionals::Ix1;`
+
+### `pub use optionals::Duration;`
+
+### `pub use columnar::vec_to_dataframe_flatten_enums;`
+
+### `pub use crate::IntoRAltrep;`
+
+### `pub use optionals::globset_matches;`
+
+### `pub use ndarray_impl::ArcArray1;`
+
+### `pub use ordered_float;`
+
+### `pub use match_arg::match_arg_vec_into_sexp;`
+
+### `pub use uuid_impl::RUuidOps;`
+
+### `pub use crate::Bytes;`
+
+### `pub use bytes_impl::Buf;`
+
+### `pub use miniextendr_macros::IntoR;`
+
+### `pub use newtype::IntoRNewtype;`
+
+### `pub use convert::AsFromStrVec;`
+
+### `pub use arrow_schema::Field;`
+
+### `pub use vctrs::VctrsListOf;`
+
 ### `pub use optionals::Ix3;`
 
 ### `pub use optionals::RDuration;`
 
-### `pub use columnar::vec_to_dataframe_split;`
+### `pub use columnar::par_iter_to_dataframe;`
 
 ### `pub use crate::TryFromSexp;`
 
@@ -6626,8 +8166,6 @@ R FFI APIs. Typically done in `R_init_<pkgname>()`.
 ### `pub use ndarray_impl::Array1;`
 
 ### `pub use crate::BigUint;`
-
-### `pub use rayon;`
 
 ### `pub use factor::FactorOptionVec;`
 
@@ -6639,17 +8177,19 @@ R FFI APIs. Typically done in `R_init_<pkgname>()`.
 
 ### `pub use into_r_as::StorageCoerceError;`
 
-### `pub use ndarray::ArrayViewMut1;`
+### `pub use ndarray::ArrayView6;`
+
+### `pub use ordered_float::OrderedFloat;`
 
 ### `pub use convert::AsNamedList;`
 
 ### `pub use vctrs::new_rcrd;`
 
-### `pub use serde::Deserialize;`
-
 ### `pub use optionals::Ix4;`
 
-### `pub use dataframe_de::BorrowedRows;`
+### `pub use altrep_helpers::*;`
+
+### `pub use dataframe_de::SerdeRows;`
 
 ### `pub use crate::IntoList;`
 
@@ -6738,21 +8278,19 @@ let rows = r!(getFromNamespace(".theoph_rows", "dataframeflows")())?;
 let in_env = r!(env: my_env; x + 1)?;
 ```
 
+### `pub use ndarray::ArrayViewMut0;`
+
+### `pub use core::AltrepDataptr;`
+
 ### `pub use convert::AsNamedVectorExt;`
 
 ### `pub use abi::mx_erased;`
 
-### `pub use serde::Serialize;`
-
-### `pub use core::AltrepExtractSubset;`
-
 ### `pub use optionals::Ix6;`
-
-### `pub use altrep_helpers::*;`
 
 ### `pub use optionals::JiffDateTime;`
 
-### `pub use dataframe_de::dataframe_to_vec_borrowed;`
+### `pub use dataframe_de::dataframe_to_vec_collated;`
 
 ### `pub use crate::List;`
 
@@ -6772,21 +8310,17 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use thread::RThreadBuilder;`
 
-### `pub use ndarray::ArrayViewMut4;`
+### `pub use core::AltrepLen;`
 
 ### `pub use convert::Collect;`
 
 ### `pub use trait_abi::TraitView;`
 
-### `pub use serde_json;`
-
-### `pub use core::InferBase;`
-
 ### `pub use optionals::IxDyn;`
 
-### `pub use optionals::JiffZonedVec;`
+### `pub use group::GroupKey;`
 
-### `pub use aho_corasick::MatchKind;`
+### `pub use optionals::JiffZonedVec;`
 
 ### `pub use dataframe_de::with_dataframe_rows;`
 
@@ -6798,6 +8332,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::Complex;`
 
+### `pub use altrep::*;`
+
 ### `pub use aho_corasick_impl::aho_compile;`
 
 ### `pub use crate::RBitVec;`
@@ -6806,13 +8342,17 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use thread::spawn_with_r;`
 
+### `pub use ndarray::ArrayViewMut3;`
+
 ### `pub use bitvec::order::Msb0;`
+
+### `pub use core::Logical;`
 
 ### `pub use convert::CollectStrings;`
 
 ### `pub use adapter_traits::RDebug;`
 
-### `pub use core::materialize_altrep_data2;`
+### `pub use serde::Deserialize;`
 
 ### `pub use optionals::RNdSlice;`
 
@@ -6826,8 +8366,6 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use ndarray_impl::ArrayView5;`
 
-### `pub use crate::dataframe_builder::RDataFrameBuilder;`
-
 ### `pub use aho_corasick_impl::aho_find_all_flat;`
 
 ### `pub use crate::Borsh;`
@@ -6838,13 +8376,13 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use ffi_guard::guarded_ffi_call;`
 
-### `pub use ndarray::ArrayViewMutD;`
+### `pub use iter::*;`
 
 ### `pub use into_r::Lazy;`
 
 ### `pub use adapter_traits::RError;`
 
-### `pub use traits::*;`
+### `pub use serde::Serialize;`
 
 ### `pub use optionals::nalgebra_impl;`
 
@@ -6868,13 +8406,19 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use dataframe::ColumnarFrame;`
 
+### `pub use ndarray::ArrayViewMut6;`
+
 ### `pub use list::ListAccumulator;`
 
 ### `pub use adapter_traits::RFromStr;`
 
+### `pub use serde_json;`
+
 ### `pub use optionals::RMatrixOps;`
 
 ### `pub use optionals::Span;`
+
+### `pub use aho_corasick::MatchKind;`
 
 ### `pub use traits::RDeserializeNative;`
 
@@ -6896,8 +8440,6 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use dataframe::FromDataFrame;`
 
-### `pub use ndarray::Ix1;`
-
 ### `pub use tabled::settings::object::Columns;`
 
 ### `pub use list::NamedList;`
@@ -6909,8 +8451,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use crate::Altrep;`
 
 ### `pub use optionals::serde_impl;`
-
-### `pub use nalgebra::DVector;`
 
 ### `pub use traits::to_r;`
 
@@ -6932,6 +8472,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use dataframe::IntoDataFrame;`
 
+### `pub use ndarray::Ix0;`
+
 ### `pub use missing::Missing;`
 
 ### `pub use adapter_traits::RToVec;`
@@ -6950,8 +8492,6 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::ArrayD;`
 
-### `pub use jiff::civil::Date;`
-
 ### `pub use indexmap_impl::IndexMap;`
 
 ### `pub use crate::sha256_bytes;`
@@ -6961,8 +8501,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use altrep_data::AltIntegerData;`
 
 ### `pub use dataframe::group_rows;`
-
-### `pub use ndarray::Ix2;`
 
 ### `pub use tabled::settings::Style;`
 
@@ -6984,8 +8522,6 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::ArrayViewD;`
 
-### `pub use jiff::SignedDuration;`
-
 ### `pub use time_impl::Duration;`
 
 ### `pub use crate::sha512_str;`
@@ -6995,6 +8531,8 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use altrep_data::AltRawData;`
 
 ### `pub use rng::RngGuard;`
+
+### `pub use ndarray::Ix2;`
 
 ### `pub use strvec::ProtectedStrVec;`
 
@@ -7006,6 +8544,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use optionals::RSerialize;`
 
+### `pub use nalgebra::DVector;`
+
 ### `pub use crate::AsNamedListExt;`
 
 ### `pub use optionals::ArrowArray;`
@@ -7013,8 +8553,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use ndarray_impl::Ix3;`
 
 ### `pub use crate::ArrayViewMutD;`
-
-### `pub use jiff::Zoned;`
 
 ### `pub use time_impl::RDuration;`
 
@@ -7027,10 +8565,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use altrep_data::AltrepDataptr;`
 
 ### `pub use from_r::SexpLengthError;`
-
-### `pub use ndarray::Ix4;`
-
-### `pub use num_complex::Complex;`
 
 ### `pub use strvec::StrVec;`
 
@@ -7046,6 +8580,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use ndarray_impl::Ix5;`
 
+### `pub use jiff::civil::Date;`
+
 ### `pub use jiff_impl::JiffTimestampVec;`
 
 ### `pub use tabled;`
@@ -7054,7 +8590,11 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_data::IterComplexData;`
 
+### `pub use conv::from_sexp;`
+
 ### `pub use from_r::TryFromSexp;`
+
+### `pub use ndarray::Ix3;`
 
 ### `pub use strvec::StrVecIter;`
 
@@ -7074,6 +8614,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::RMatrixOps;`
 
+### `pub use jiff::SignedDuration;`
+
 ### `pub use jiff_impl::RDateTime;`
 
 ### `pub use crate::TinyVec;`
@@ -7082,11 +8624,9 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_data::IterIntFromBoolData;`
 
-### `pub use conv::from_sexp;`
+### `pub use conv::to_sexp;`
 
 ### `pub use expression::RSymbol;`
-
-### `pub use ndarray::Ix5;`
 
 ### `pub use typed_list::TypedList;`
 
@@ -7096,11 +8636,7 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::ExternalPtr;`
 
-### `pub use group::GroupedDataFrame;`
-
 ### `pub use optionals::toml_from_str;`
-
-### `pub use globset::GlobSet;`
 
 ### `pub use crate::expression::r_eval_str;`
 
@@ -7110,7 +8646,7 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::SVector;`
 
-### `pub use result::*;`
+### `pub use jiff::Zoned;`
 
 ### `pub use jiff_impl::RTime;`
 
@@ -7120,9 +8656,11 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_data::IterRawData;`
 
-### `pub use conv::to_sexp;`
-
 ### `pub use coerce::Coerce;`
+
+### `pub use ndarray::Ix5;`
+
+### `pub use num_complex::Complex;`
 
 ### `pub use tinyvec::TinyVec;`
 
@@ -7137,8 +8675,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use optionals::bytes_impl;`
 
 ### `pub use crate::SEXP;`
-
-### `pub use cetype_t::CE_UTF8;`
 
 ### `pub use optionals::TimestampSecondArray;`
 
@@ -7155,8 +8691,6 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use altrep_data::IterState;`
 
 ### `pub use coerce::TryCoerce;`
-
-### `pub use ndarray::IxDyn;`
 
 ### `pub use arrow_array;`
 
@@ -7188,6 +8722,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use r_coerce::RCoerceDataFrame;`
 
+### `pub use ndarray::Ix6;`
+
 ### `pub use externalptr::IntoExternalPtr;`
 
 ### `pub use optionals::Array5;`
@@ -7197,6 +8733,8 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use crate::list;`
 
 ### `pub use optionals::RBufMut;`
+
+### `pub use globset::GlobSet;`
 
 ### `pub use rarray::RMatrix;`
 
@@ -7209,6 +8747,8 @@ let in_env = r!(env: my_env; x + 1)?;
 ### `pub use datafusion_impl::RSessionContext;`
 
 ### `pub use altrep_data::SparseIterLogicalData;`
+
+### `pub use either::Either;`
 
 ### `pub use r_coerce::RCoerceError;`
 
@@ -7226,8 +8766,6 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use raw_conversions::Pod;`
 
-### `pub use time::OffsetDateTime;`
-
 ### `pub use nalgebra_impl::RVecStorage;`
 
 ### `pub use crate::RRng;`
@@ -7238,9 +8776,11 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_data::SparseIterState;`
 
-### `pub use ndarray::Array0;`
+### `pub use either::Right;`
 
 ### `pub use r_coerce::RCoerceInteger;`
+
+### `pub use ndarray::ShapeBuilder;`
 
 ### `pub use arrow_array::Float64Array;`
 
@@ -7250,7 +8790,7 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use optionals::url_helpers;`
 
-### `pub use ::serde::Deserialize;`
+### `pub use ::serde::Serialize;`
 
 ### `pub use crate::typed_list;`
 
@@ -7270,7 +8810,9 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_data::WindowedIterIntData;`
 
-### `pub use ndarray::Array3;`
+### `pub use ndarray::ArcArray1;`
+
+### `pub use accumulator::*;`
 
 ### `pub use r_coerce::RCoerceMatrix;`
 
@@ -7282,11 +8824,13 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use optionals::RAhoCorasickOps;`
 
-### `pub use columnar::DataFrameShape;`
+### `pub use columnar::DispatchNames;`
 
 ### `pub use crate::AltComplexData;`
 
 ### `pub use optionals::blake3_str;`
+
+### `pub use coerce::*;`
 
 ### `pub use rayon_bridge::RParallelExtend;`
 
@@ -7296,13 +8840,11 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use crate::serde::RSerializeNative;`
 
-### `pub use state::*;`
-
 ### `pub use serde_impl::json_from_sexp_permissive;`
 
 ### `pub use altrep::RBase;`
 
-### `pub use ndarray::Array6;`
+### `pub use ndarray::Array1;`
 
 ### `pub use r_coerce::RCoerceRaw;`
 
@@ -7314,17 +8856,21 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use optionals::aho_find_all;`
 
-### `pub use columnar::RootedSentinel;`
+### `pub use columnar::SerdeRowBuilder;`
 
 ### `pub use crate::AltLogicalData;`
 
 ### `pub use optionals::md5_hex;`
+
+### `pub use windowed::*;`
 
 ### `pub use rand_impl::RDistributions;`
 
 ### `pub use url;`
 
 ### `pub use raw_conversions::Zeroable;`
+
+### `pub use time::OffsetDateTime;`
 
 ### `pub use num_bigint_impl::RBigUintOps;`
 
@@ -7338,6 +8884,8 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use altrep_traits::AltrepGuard;`
 
+### `pub use ndarray::Array4;`
+
 ### `pub use r_coerce::is_supported_as_generic;`
 
 ### `pub use arrow_array::types::Int32Type;`
@@ -7348,7 +8896,7 @@ let in_env = r!(env: my_env; x + 1)?;
 
 ### `pub use optionals::aho_is_match;`
 
-### `pub use columnar::SplitShape;`
+### `pub use columnar::TypeSpec;`
 
 ### `pub use crate::AltStringData;`
 
@@ -7373,7 +8921,7 @@ Enable with `features = ["rand"]`.
 
 ### `pub use miniextendr_macros::AltrepList;`
 
-### `pub use ndarray::ArrayView3;`
+### `pub use ndarray::ArrayD;`
 
 ### `pub use convert::AsDataFrame;`
 
@@ -7385,7 +8933,7 @@ Enable with `features = ["rand"]`.
 
 ### `pub use optionals::IndexMap;`
 
-### `pub use columnar::hashmap_to_dataframe;`
+### `pub use columnar::iter_to_dataframe;`
 
 ### `pub use crate::Coerce;`
 
@@ -7405,7 +8953,7 @@ Enable with `features = ["rand"]`.
 
 ### `pub use into_r::IntoR;`
 
-### `pub use ndarray::ArrayView5;`
+### `pub use ndarray::ArrayView1;`
 
 ### `pub use convert::AsDisplayVec;`
 
@@ -7417,7 +8965,7 @@ Enable with `features = ["rand"]`.
 
 ### `pub use optionals::Date;`
 
-### `pub use columnar::result_to_dataframe;`
+### `pub use columnar::vec_to_dataframe;`
 
 ### `pub use optionals::globset_is_match;`
 
@@ -7435,6 +8983,8 @@ Enable with `features = ["rand"]`.
 
 ### `pub use newtype::FromRNewtype;`
 
+### `pub use ndarray::ArrayView4;`
+
 ### `pub use convert::AsFromStr;`
 
 ### `pub use vctrs::VctrsKind;`
@@ -7443,7 +8993,7 @@ Enable with `features = ["rand"]`.
 
 ### `pub use optionals::RDateTimeFormat;`
 
-### `pub use columnar::vec_to_dataframe_flatten_enums_with_tags;`
+### `pub use columnar::vec_to_dataframe_split;`
 
 ### `pub use crate::TryFromSexp;`
 
@@ -7464,1542 +9014,6 @@ Enable with `features = ["rand"]`.
 ### `pub use miniextendr_macros::PreferDataFrame;`
 
 ### `pub use into_r_as::IntoRAs;`
-
-### `pub use convert::AsListExt;`
-
-### `pub use arrow_schema::Schema;`
-
-### `pub use vctrs::new_list_of;`
-
-### `pub use optionals::Ix4;`
-
-### `pub use jiff;`
-
-### `pub use columnar::par_iter_to_dataframe_growing;`
-
-### `pub use crate::IntoList;`
-
-### `pub use optionals::Borsh;`
-
-### `pub use ndarray_impl::Array3;`
-
-### `pub use crate::RBigUintOps;`
-
-### `pub use factor::RFactor;`
-
-### `pub use regex_impl::RRegexOps;`
-
-### `pub use crate::AhoCorasick;`
-
-### `pub use bytes_impl::RBufMut;`
-
-### `pub use worker::with_r_thread;`
-
-### `pub use ndarray::ArrayViewMut2;`
-
-### `pub use convert::AsNamedVector;`
-
-### `pub use abi::mx_base_vtable;`
-
-### `pub use core::AltrepExtract;`
-
-### `pub use optionals::Ix5;`
-
-### `pub use optionals::JiffDate;`
-
-### `pub use dataframe_de::dataframe_to_vec;`
-
-### `pub use crate::Lazy;`
-
-### `pub use optionals::borsh_to_raw;`
-
-### `pub use ndarray_impl::Array6;`
-
-### `pub use crate::Decimal;`
-
-### `pub use factor::build_levels_sexp;`
-
-### `pub use url_impl::Url;`
-
-### `pub use sha2_impl::sha512_bytes;`
-
-### `pub use miniextendr_macros::PreferRNativeType;`
-
-### `pub use thread::DEFAULT_R_STACK_SIZE;`
-
-### `pub use convert::AsRNativeExt;`
-
-### `pub use abi::mx_tag;`
-
-### `pub use core::AltrepSerialize;`
-
-### `pub use optionals::IxDyn;`
-
-### `pub use optionals::JiffTimestampVec;`
-
-### `pub use aho_corasick::AhoCorasick;`
-
-### `pub use dataframe_de::dataframe_to_vec_with_enum_tags;`
-
-### `pub use crate::ListMut;`
-
-### `pub use optionals::Flags;`
-
-### `pub use ndarray_impl::ArrayView1;`
-
-### `pub use aho_corasick_impl::RAhoCorasickOps;`
-
-### `pub use blake3_impl::blake3_hex;`
-
-### `pub use miniextendr_macros::TryFromList;`
-
-### `pub use thread::scope_with_r;`
-
-### `pub use ndarray::ArrayViewMut5;`
-
-### `pub use convert::CollectNAInt;`
-
-### `pub use adapter_traits::RCopy;`
-
-### `pub use serde_json::Value as JsonValue;`
-
-### `pub use core::Sortedness;`
-
-### `pub use optionals::RNdIndex;`
-
-### `pub use optionals::RDateTime;`
-
-### `pub use log;`
-
-### `pub use error::RSerdeError;`
-
-### `pub use crate::OwnedProtect;`
-
-### `pub use optionals::BitVec;`
-
-### `pub use ndarray_impl::ArrayView4;`
-
-### `pub use num_complex;`
-
-### `pub use aho_corasick_impl::aho_find_all;`
-
-### `pub use md5_impl::md5_hex;`
-
-### `pub use sexp::SEXP;`
-
-### `pub use ffi_guard::GuardMode;`
-
-### `pub use named::*;`
-
-### `pub use convert::AsVctrsExt;`
-
-### `pub use adapter_traits::RDisplay;`
-
-### `pub use stream::*;`
-
-### `pub use optionals::ShapeBuilder;`
-
-### `pub use optionals::RTime;`
-
-### `pub use json_string::AsJsonVec;`
-
-### `pub use crate::ProtectedStrVec;`
-
-### `pub use optionals::RBitVec;`
-
-### `pub use ndarray_impl::ArrayViewD;`
-
-### `pub use crate::RNum;`
-
-### `pub use aho_corasick_impl::aho_is_match;`
-
-### `pub use borsh;`
-
-### `pub use zstd_impl::zstd_decompress;`
-
-### `pub use sexp_types::R_CFinalizer_t;`
-
-### `pub use dataframe::BuiltDataFrame;`
-
-### `pub use ndarray::Ix0;`
-
-### `pub use list::List;`
-
-### `pub use adapter_traits::RFromIter;`
-
-### `pub use optionals::DVector;`
-
-### `pub use optionals::SignedDuration;`
-
-### `pub use traits::AsSerialize;`
-
-### `pub use crate::StrVecBuilder;`
-
-### `pub use optionals::Table;`
-
-### `pub use ndarray_impl::ArrayViewMut2;`
-
-### `pub use globset_impl::GlobBuilder;`
-
-### `pub use crate::Pod;`
-
-### `pub use bitvec_impl::BitVec;`
-
-### `pub use sexp_types::RNativeType;`
-
-### `pub use dataframe::DataFrameError;`
-
-### `pub use list::ListMut;`
-
-### `pub use adapter_traits::RIterator;`
-
-### `pub use optionals::SMatrix;`
-
-### `pub use optionals::Zoned;`
-
-### `pub use nalgebra::DMatrix;`
-
-### `pub use traits::from_r;`
-
-### `pub use crate::DataFrame;`
-
-### `pub use optionals::table_from_vecs;`
-
-### `pub use ndarray_impl::ArrayViewMut5;`
-
-### `pub use crate::Array3;`
-
-### `pub use globset_impl::GlobSetBuilder;`
-
-### `pub use crate::Zeroable;`
-
-### `pub use bitvec_impl::RBitVec;`
-
-### `pub use sexp_types::Rcomplex;`
-
-### `pub use dataframe::GroupedDataFrame;`
-
-### `pub use ndarray::Ix1;`
-
-### `pub use tabled::settings::Alignment;`
-
-### `pub use list::collect_list;`
-
-### `pub use adapter_traits::RPartialOrd;`
-
-### `pub use optionals::BigInt;`
-
-### `pub use optionals::FactorHandling;`
-
-### `pub use nalgebra::SVector;`
-
-### `pub use bytemuck::Pod;`
-
-### `pub use crate::FromDataFrame;`
-
-### `pub use optionals::table_to_string_styled;`
-
-### `pub use ndarray_impl::Ix0;`
-
-### `pub use crate::Array6;`
-
-### `pub use globset_impl::globset_matches;`
-
-### `pub use tabled_impl::Tabled;`
-
-### `pub use altrep_data::AltComplexData;`
-
-### `pub use dataframe::NamedDataFrameListBuilder;`
-
-### `pub use named_vector::AtomicElement;`
-
-### `pub use optionals::rayon_bridge;`
-
-### `pub use optionals::RBigIntOps;`
-
-### `pub use crate::AltrepInteger;`
-
-### `pub use optionals::NaHandling;`
-
-### `pub use crate::AsVctrsExt;`
-
-### `pub use optionals::ArrayVec;`
-
-### `pub use ndarray_impl::Ix1;`
-
-### `pub use crate::ArrayView2;`
-
-### `pub use jiff::civil::Time;`
-
-### `pub use time_impl::Date;`
-
-### `pub use crate::sha512_bytes;`
-
-### `pub use tabled_impl::table_to_string;`
-
-### `pub use altrep_data::AltLogicalData;`
-
-### `pub use error::r_warning;`
-
-### `pub use ndarray::Ix3;`
-
-### `pub use tabled::settings::Width;`
-
-### `pub use rcow::RCow;`
-
-### `pub use optionals::rand;`
-
-### `pub use optionals::rust_decimal_impl;`
-
-### `pub use optionals::RJsonValueOps;`
-
-### `pub use crate::AsListExt;`
-
-### `pub use optionals::ArrayRef;`
-
-### `pub use ndarray_impl::Ix3;`
-
-### `pub use crate::ArrayViewMut2;`
-
-### `pub use jiff::Timestamp;`
-
-### `pub use time_impl::RDateTimeFormat;`
-
-### `pub use tinyvec_impl::Array;`
-
-### `pub use altrep_data::AltStringData;`
-
-### `pub use from_r::SexpError;`
-
-### `pub use tabled::Tabled;`
-
-### `pub use strvec::ProtectedStrVecIter;`
-
-### `pub use optionals::RDistributionOps;`
-
-### `pub use uuid::Uuid;`
-
-### `pub use optionals::ordered_float_impl;`
-
-### `pub use crate::AltrepRaw;`
-
-### `pub use optionals::json_from_sexp;`
-
-### `pub use crate::AsRNativeExt;`
-
-### `pub use optionals::DataType;`
-
-### `pub use ndarray_impl::Ix4;`
-
-### `pub use ndarray;`
-
-### `pub use jiff_impl::DateTime as JiffDateTime;`
-
-### `pub use crate::table_to_string;`
-
-### `pub use sha2::Sha512;`
-
-### `pub use arrow_impl::Array as ArrowArray;`
-
-### `pub use altrep_data::AltrepLen;`
-
-### `pub use from_r::SexpTypeError;`
-
-### `pub use ndarray::Ix4;`
-
-### `pub use strvec::StrVecCowIter;`
-
-### `pub use optionals::RRngOps;`
-
-### `pub use optionals::num_complex_impl;`
-
-### `pub use optionals::json_from_sexp_with;`
-
-### `pub use globset::Glob;`
-
-### `pub use optionals::Field;`
-
-### `pub use ndarray_impl::Ix6;`
-
-### `pub use crate::DVector;`
-
-### `pub use jiff_impl::RDate;`
-
-### `pub use crate::ArrayVec;`
-
-### `pub use arrow_impl::DataType;`
-
-### `pub use altrep_data::IterIntData;`
-
-### `pub use conv::extract_arg;`
-
-### `pub use expression::REnv;`
-
-### `pub use typed_list::TypedEntry;`
-
-### `pub use optionals::Left;`
-
-### `pub use optionals::num_traits_impl;`
-
-### `pub use crate::ExternalPtr;`
-
-### `pub use group::GroupKey;`
-
-### `pub use optionals::TomlValue;`
-
-### `pub use crate::r_warning;`
-
-### `pub use optionals::RecordBatch;`
-
-### `pub use ndarray_impl::IxDyn;`
-
-### `pub use crate::SMatrix;`
-
-### `pub use altrep::*;`
-
-### `pub use jiff_impl::RSpan;`
-
-### `pub use arrow_impl::Field;`
-
-### `pub use altrep_data::IterLogicalData;`
-
-### `pub use conv::rf_error;`
-
-### `pub use expression::r_eval_str_global;`
-
-### `pub use ndarray::Ix6;`
-
-### `pub use tinyvec::ArrayVec;`
-
-### `pub use typed_list::TypedListSpec;`
-
-### `pub use optionals::ArcArray1;`
-
-### `pub use optionals::RSigned;`
-
-### `pub use crate::MatchArg;`
-
-### `pub use optionals::toml_to_string_pretty;`
-
-### `pub use crate::r_str;`
-
-### `pub use optionals::StringDictionaryArray;`
-
-### `pub use ndarray_impl::RNdSlice;`
-
-### `pub use bytes::Buf;`
-
-### `pub use jiff_impl::RZoned;`
-
-### `pub use arrow_impl::RecordBatch;`
-
-### `pub use altrep_data::IterRealData;`
-
-### `pub use crate::condition::repanic_if_rust_error;`
-
-### `pub use coerce::Coerced;`
-
-### `pub use typed_list::validate_list;`
-
-### `pub use optionals::Array1;`
-
-### `pub use optionals::Uuid;`
-
-### `pub use crate::RFactor;`
-
-### `pub use optionals::BufMut;`
-
-### `pub use crate::Either;`
-
-### `pub use optionals::RSessionContext;`
-
-### `pub use ndarray_impl::RndMat;`
-
-### `pub use indexmap;`
-
-### `pub use jiff_impl::Time as JiffTime;`
-
-### `pub use miniextendr_macros::ExternalPtr;`
-
-### `pub use blake3::Hash;`
-
-### `pub use arrow_impl::StringDictionaryArray;`
-
-### `pub use altrep_data::Logical;`
-
-### `pub use either::Left;`
-
-### `pub use r_coerce::RCoerceComplex;`
-
-### `pub use ndarray::IxDyn;`
-
-### `pub use arrow_array::Array;`
-
-### `pub use externalptr::ExternalSlice;`
-
-### `pub use optionals::Array4;`
-
-### `pub use optionals::CaptureGroups;`
-
-### `pub use crate::list;`
-
-### `pub use optionals::RBuf;`
-
-### `pub use either;`
-
-### `pub use rarray::RArray3D;`
-
-### `pub use nalgebra_impl::DVector;`
-
-### `pub use crate::RParallelIterator;`
-
-### `pub use num_bigint::BigUint;`
-
-### `pub use serde_impl::FactorHandling;`
-
-### `pub use miniextendr_macros::impl_typed_external;`
-
-### `pub use datafusion_impl::RDataFrame;`
-
-### `pub use altrep_data::SparseIterIntData;`
-
-### `pub use r_coerce::RCoerceEnvironment;`
-
-### `pub use arrow_array::BooleanArray;`
-
-### `pub use externalptr::altrep_data1_as;`
-
-### `pub use optionals::ArrayD;`
-
-### `pub use optionals::Regex;`
-
-### `pub use crate::miniextendr;`
-
-### `pub use optionals::sha256_bytes;`
-
-### `pub use crate::Uuid;`
-
-### `pub use ::serde as serde_crate;`
-
-Re-export the upstream `serde` crate (aliased to avoid conflict with [`mod serde`]).
-
-Downstream crates can use `miniextendr_api::serde_crate::{Serialize, Deserialize}`
-and `#[serde(crate = "miniextendr_api::serde_crate")]` to avoid a direct `serde` dep.
-
-### `pub use time::Date;`
-
-### `pub use nalgebra_impl::RMatrixOps;`
-
-### `pub use crate::RDistributions;`
-
-### `pub use serde_impl::NaHandling;`
-
-### `pub use miniextendr_macros::miniextendr;`
-
-### `pub use altrep_data::SparseIterRealData;`
-
-### `pub use ndarray::ArcArray2;`
-
-### `pub use r_coerce::RCoerceFunction;`
-
-### `pub use externalptr::altrep_data1_mut_unchecked;`
-
-### `pub use optionals::ArrayView2;`
-
-### `pub use optionals::Url;`
-
-### `pub use url::Url;`
-
-### `pub use ::serde::Deserialize;`
-
-### `pub use optionals::sha512_str;`
-
-### `pub use crate::CaptureGroups;`
-
-### `pub use raw_conversions::Raw;`
-
-### `pub use nalgebra_impl::SMatrix;`
-
-### `pub use rand;`
-
-### `pub use serde_impl::RJsonValueOps;`
-
-### `pub use miniextendr_macros::r_ffi_checked;`
-
-### `pub use md5::Digest;`
-
-### `pub use altrep_data::StreamingRealData;`
-
-### `pub use ndarray::Array2;`
-
-### `pub use r_coerce::RCoerceLogical;`
-
-### `pub use arrow_array::RecordBatch;`
-
-### `pub use gc_protect::OwnedProtect;`
-
-### `pub use optionals::ArrayView5;`
-
-### `pub use optionals::AhoCorasick;`
-
-### `pub use ::serde::Serialize;`
-
-### `pub use crate::altrep::RegisterAltrep;`
-
-### `pub use optionals::blake3_hex;`
-
-### `pub use regex;`
-
-### `pub use raw_conversions::RawSlice;`
-
-### `pub use num_bigint_impl::BigUint;`
-
-### `pub use crate::serde::RDeserializeNative;`
-
-### `pub use sparse::*;`
-
-### `pub use serde_impl::json_from_sexp;`
-
-### `pub use miniextendr_macros::PreferVctrs;`
-
-### `pub use altrep_data::WindowedIterState;`
-
-### `pub use ndarray::Array5;`
-
-### `pub use r_coerce::RCoercePOSIXct;`
-
-### `pub use arrow_array::UInt8Array;`
-
-### `pub use gc_protect::Protected;`
-
-### `pub use optionals::ArrayViewMut0;`
-
-### `pub use optionals::aho_count_matches;`
-
-### `pub use columnar::ResultShape;`
-
-### `pub use crate::AltListData;`
-
-### `pub use optionals::md5_bytes;`
-
-### `pub use rand_impl::RDistributionOps;`
-
-### `pub use crate::Url;`
-
-### `pub use raw_conversions::Zeroable;`
-
-### `pub use num_bigint_impl::RBigUintBitOps;`
-
-### `pub use serde_impl::json_from_sexp_with;`
-
-### `pub use altrep_sexp::ensure_materialized;`
-
-### `pub use ndarray::ArrayView0;`
-
-### `pub use r_coerce::SUPPORTED_AS_GENERICS;`
-
-### `pub use arrow_array::types::Float64Type;`
-
-### `pub use gc_protect::Root;`
-
-### `pub use optionals::ArrayViewMut3;`
-
-### `pub use optionals::aho_find_first;`
-
-### `pub use columnar::SplitResults;`
-
-### `pub use crate::AltRealData;`
-
-### `pub use optionals::globset_impl;`
-
-### `pub use rand_impl::RRngOps;`
-
-### `pub use crate::Date;`
-
-### `pub use raw_conversions::raw_slice_from_bytes;`
-
-### `pub use rust_decimal_impl::RDecimalOps;`
-
-### `pub use crate::RDeserialize;`
-
-### `pub use borsh_impl::RBorshOps;`
-
-### `pub use miniextendr_macros::AltrepInteger;`
-
-### `pub use zstd::compression_level_range;`
-
-### `pub use ndarray::ArrayView2;`
-
-### `pub use rvalue::RValue;`
-
-### `pub use refcount_protect::ArenaGuard;`
-
-### `pub use optionals::ArrayViewMut6;`
-
-### `pub use optionals::indexmap_impl;`
-
-### `pub use columnar::dispatch_to_dataframes;`
-
-### `pub use crate::AltrepLen;`
-
-### `pub use optionals::GlobOptions;`
-
-### `pub use rand_distr;`
-
-Re-export of `rand_distr` for probability distributions.
-
-Provides distributions like `Normal`, `Exp`, `Uniform`, etc. that work
-with [`RRng`]. Enable with `features = ["rand_distr"]`.
-
-### `pub use crate::RDuration;`
-
-### `pub use match_arg::MatchArg;`
-
-### `pub use num_complex_impl::Complex;`
-
-### `pub use crate::TomlValue;`
-
-### `pub use toml_impl::RTomlOps;`
-
-### `pub use miniextendr_macros::AltrepRaw;`
-
-### `pub use into_r::Altrep;`
-
-### `pub use convert::AsDisplay;`
-
-### `pub use allocator::RAllocator;`
-
-### `pub use optionals::Ix0;`
-
-### `pub use optionals::time_impl;`
-
-### `pub use columnar::map_to_dataframe;`
-
-### `pub use crate::IntoR;`
-
-### `pub use optionals::build_globset;`
-
-### `pub use either_impl::Left;`
-
-### `pub use crate::OrderedFloat;`
-
-### `pub use match_arg::match_arg_from_sexp;`
-
-### `pub use num_traits_impl::RNum;`
-
-### `pub use toml;`
-
-### `pub use toml_impl::toml_to_string;`
-
-### `pub use miniextendr_macros::DataFrameRow;`
-
-### `pub use into_r_error::IntoRError;`
-
-### `pub use ndarray::ArrayView6;`
-
-### `pub use convert::AsExternalPtrExt;`
-
-### `pub use arrow_schema::DataType;`
-
-### `pub use vctrs::VctrsClass;`
-
-### `pub use optionals::Ix2;`
-
-### `pub use optionals::OffsetDateTime;`
-
-### `pub use columnar::vec_to_dataframe_flatten_enums;`
-
-### `pub use crate::TryCoerce;`
-
-### `pub use optionals::zstd_impl;`
-
-### `pub use ndarray_impl::ArcArray2;`
-
-### `pub use factor::Factor;`
-
-### `pub use uuid_impl::Uuid;`
-
-### `pub use crate::BytesMut;`
-
-### `pub use bytes_impl::BufMut;`
-
-### `pub use miniextendr_macros::MatchArg;`
-
-### `pub use newtype::IntoRVecElement;`
-
-### `pub use ndarray::ArrayViewMut0;`
-
-### `pub use convert::AsList;`
-
-### `pub use vctrs::VctrsRecord;`
-
-### `pub use optionals::Ix3;`
-
-### `pub use datafusion;`
-
-### `pub use time;`
-
-### `pub use columnar::par_iter_to_dataframe;`
-
-### `pub use optionals::borsh_impl;`
-
-### `pub use ndarray_impl::Array2;`
-
-### `pub use crate::RBigIntOps;`
-
-### `pub use factor::FactorVec;`
-
-### `pub use regex_impl::RCaptureGroups;`
-
-### `pub use bytes;`
-
-### `pub use bytes_impl::RBuf;`
-
-### `pub use miniextendr_macros::PreferExternalPtr;`
-
-### `pub use worker::is_r_main_thread;`
-
-### `pub use convert::AsNamedListExt;`
-
-### `pub use vctrs::new_vctr;`
-
-### `pub use serde::Deserialize;`
-
-### `pub use core::AltrepDataptr;`
-
-### `pub use optionals::Ix5;`
-
-### `pub use optionals::jiff_impl;`
-
-### `pub use dataframe_de::SerdeRows;`
-
-### `pub use optionals::borsh_from_raw;`
-
-### `pub use ndarray_impl::Array5;`
-
-### `pub use factor::build_factor;`
-
-### `pub use url_impl::RUrlOps;`
-
-### `pub use aho_corasick;`
-
-### `pub use sha2_impl::sha256_str;`
-
-### `pub use indicatif;`
-
-### `pub use ndarray::ArrayViewMut3;`
-
-### `pub use convert::AsRNative;`
-
-### `pub use abi::mx_meth;`
-
-### `pub use serde::Serialize;`
-
-### `pub use core::AltrepLen;`
-
-### `pub use optionals::Ix6;`
-
-### `pub use optionals::JiffTime;`
-
-### `pub use dataframe_de::dataframe_to_vec_collated;`
-
-### `pub use crate::ListBuilder;`
-
-### `pub use optionals::bitflags_impl;`
-
-### `pub use ndarray_impl::ArrayView0;`
-
-### `pub use rust_decimal;`
-
-### `pub use factor::factor_from_sexp;`
-
-### `pub use aho_corasick_impl::AhoCorasick;`
-
-### `pub use bitflags;`
-
-### `pub use blake3_impl::blake3_bytes;`
-
-### `pub use miniextendr_macros::RFactor;`
-
-### `pub use thread::StackCheckGuard;`
-
-### `pub use bitvec::order::Lsb0;`
-
-### `pub use convert::CollectNA;`
-
-### `pub use adapter_traits::RClone;`
-
-### `pub use core::Logical;`
-
-### `pub use optionals::RNdArrayOps;`
-
-### `pub use optionals::RDate;`
-
-### `pub use de::RDeserializer;`
-
-### `pub use crate::NamedVector;`
-
-### `pub use optionals::bitvec_impl;`
-
-### `pub use ndarray_impl::ArrayView3;`
-
-### `pub use crate::RComplexOps;`
-
-### `pub use aho_corasick_impl::aho_count_matches;`
-
-### `pub use bitvec;`
-
-### `pub use md5_impl::md5_bytes;`
-
-### `pub use miniextendr_macros::TryFromSexp;`
-
-### `pub use thread::with_stack_checking_disabled;`
-
-### `pub use ndarray::ArrayViewMut6;`
-
-### `pub use bitvec::vec::BitVec;`
-
-### `pub use accumulator::*;`
-
-### `pub use convert::AsVctrs;`
-
-### `pub use adapter_traits::RDefault;`
-
-### `pub use iter::*;`
-
-### `pub use optionals::RNdSlice2D;`
-
-### `pub use optionals::RSpan;`
-
-### `pub use json_string::AsJsonPretty;`
-
-### `pub use crate::Protected;`
-
-### `pub use optionals::Msb0;`
-
-### `pub use ndarray_impl::ArrayView6;`
-
-### `pub use crate::RFloat;`
-
-### `pub use aho_corasick_impl::aho_find_first;`
-
-### `pub use crate::RBorshOps;`
-
-### `pub use zstd_impl::zstd_compress;`
-
-### `pub use sexp_ext::SexpExt;`
-
-### `pub use rust_decimal::Decimal;`
-
-### `pub use ffi_guard::guarded_ffi_call_with_fallback;`
-
-### `pub use list::IntoList;`
-
-### `pub use adapter_traits::RExtend;`
-
-### `pub use optionals::DMatrix;`
-
-### `pub use optionals::RZoned;`
-
-### `pub use ser::RSerializer;`
-
-### `pub use crate::StrVec;`
-
-### `pub use optionals::Builder;`
-
-### `pub use ndarray_impl::ArrayViewMut1;`
-
-### `pub use num_traits;`
-
-### `pub use globset_impl::Glob;`
-
-### `pub use crate::Pod;`
-
-### `pub use bitflags_impl::RFlags;`
-
-### `pub use sexp_types::RLogical;`
-
-### `pub use dataframe::DataFrame;`
-
-### `pub use ndarray::Ix0;`
-
-### `pub use tabled::builder::Builder;`
-
-### `pub use list::ListBuilder;`
-
-### `pub use adapter_traits::RHash;`
-
-### `pub use optionals::RVectorOps;`
-
-### `pub use optionals::Timestamp;`
-
-### `pub use traits::RSerializeNative;`
-
-### `pub use crate::ColumnarFrame;`
-
-### `pub use optionals::builder_to_string;`
-
-### `pub use ndarray_impl::ArrayViewMut4;`
-
-### `pub use crate::Array2;`
-
-### `pub use globset_impl::GlobSet;`
-
-### `pub use crate::RawSlice;`
-
-### `pub use bitvec_impl::Msb0;`
-
-### `pub use sexp_types::Rbyte;`
-
-### `pub use dataframe::GroupKey;`
-
-### `pub use list::TryFromList;`
-
-### `pub use adapter_traits::ROrd;`
-
-### `pub use optionals::num_bigint_impl;`
-
-### `pub use crate::Altrep;`
-
-### `pub use optionals::toml_impl;`
-
-### `pub use nalgebra::SMatrix;`
-
-### `pub use bytemuck::Pod;`
-
-### `pub use crate::DataFrameRow;`
-
-### `pub use optionals::table_to_string_opts;`
-
-### `pub use ndarray_impl::ArrayViewMutD;`
-
-### `pub use crate::Array5;`
-
-### `pub use globset_impl::globset_is_match;`
-
-### `pub use bytemuck;`
-
-### `pub use tabled_impl::Table;`
-
-### `pub use sexp_types::cetype_t;`
-
-### `pub use dataframe::IntoDataFrameSplit;`
-
-### `pub use ndarray::Ix2;`
-
-### `pub use tabled::settings::Modify;`
-
-### `pub use missing::is_missing_arg;`
-
-### `pub use optionals::parallel;`
-
-### `pub use optionals::RBigIntBitOps;`
-
-### `pub use optionals::JsonValue;`
-
-### `pub use bytemuck::Zeroable;`
-
-### `pub use crate::IntoDataFrameSplit;`
-
-### `pub use optionals::Array;`
-
-### `pub use indexmap::IndexMap;`
-
-### `pub use ndarray_impl::Ix1;`
-
-### `pub use crate::ArrayView1;`
-
-### `pub use jiff::civil::DateTime;`
-
-### `pub use indexmap_impl::RIndexMapOps;`
-
-### `pub use crate::sha256_str;`
-
-### `pub use tabled_impl::table_from_vecs;`
-
-### `pub use altrep_data::AltListData;`
-
-### `pub use dataframe_builder::RDataFrameBuilder;`
-
-### `pub use rcow::RBorrow;`
-
-### `pub use optionals::RParallelIterator;`
-
-### `pub use optionals::RBigUintOps;`
-
-### `pub use crate::AltrepList;`
-
-### `pub use optionals::RJsonBridge;`
-
-### `pub use crate::AsExternalPtrExt;`
-
-### `pub use optionals::arrow_impl;`
-
-### `pub use ndarray_impl::Ix2;`
-
-### `pub use crate::ArrayViewMut1;`
-
-### `pub use jiff::Span;`
-
-### `pub use time_impl::OffsetDateTime;`
-
-### `pub use sha2;`
-
-### `pub use sha2::Digest;`
-
-### `pub use tabled_impl::table_to_string_styled;`
-
-### `pub use altrep_data::AltRealData;`
-
-### `pub use rng::with_rng;`
-
-### `pub use ndarray::Ix3;`
-
-### `pub use tabled::Table;`
-
-### `pub use strvec::ProtectedStrVecCowIter;`
-
-### `pub use optionals::rand_impl;`
-
-### `pub use optionals::RDecimalOps;`
-
-### `pub use optionals::SpecialFloatHandling;`
-
-### `pub use crate::AsNamedVectorExt;`
-
-### `pub use optionals::BooleanArray;`
-
-### `pub use ndarray_impl::Ix4;`
-
-### `pub use crate::RNdArrayOps;`
-
-### `pub use jiff_impl::Date as JiffDate;`
-
-### `pub use crate::Tabled;`
-
-### `pub use tinyvec_impl::TinyVec;`
-
-### `pub use altrep_data::AltrepExtract;`
-
-### `pub use from_r::SexpNaError;`
-
-### `pub use strvec::StrVecBuilder;`
-
-### `pub use optionals::RRng;`
-
-### `pub use optionals::ROrderedFloatOps;`
-
-### `pub use crate::AltrepReal;`
-
-### `pub use optionals::json_from_sexp_strict;`
-
-### `pub use crate::r_print;`
-
-### `pub use optionals::DictionaryArray;`
-
-### `pub use ndarray_impl::Ix5;`
-
-### `pub use crate::DMatrix;`
-
-### `pub use jiff_impl::JiffZonedVec;`
-
-### `pub use arrow_impl::BooleanArray;`
-
-### `pub use altrep_data::IterIntCoerceData;`
-
-### `pub use conv::check_arity;`
-
-### `pub use expression::RCall;`
-
-### `pub use ndarray::Ix5;`
-
-### `pub use typed_list::TypeSpec;`
-
-### `pub use optionals::Either;`
-
-### `pub use optionals::RComplexOps;`
-
-### `pub use optionals::RTomlOps;`
-
-### `pub use globset::GlobBuilder;`
-
-### `pub use optionals::Int32Array;`
-
-### `pub use ndarray_impl::IxDyn;`
-
-### `pub use crate::RVectorOps;`
-
-### `pub use jiff_impl::RSignedDuration;`
-
-### `pub use tinyvec;`
-
-### `pub use arrow_impl::DictionaryArray;`
-
-### `pub use altrep_data::IterListData;`
-
-### `pub use conv::nil;`
-
-### `pub use expression::r_eval_str;`
-
-### `pub use tinyvec::Array;`
-
-### `pub use typed_list::TypedListError;`
-
-### `pub use optionals::ndarray_impl;`
-
-### `pub use optionals::RNum;`
-
-### `pub use io_adapters::*;`
-
-### `pub use group::group_rows;`
-
-### `pub use optionals::toml_to_string;`
-
-### `pub use globset::GlobSetBuilder;`
-
-### `pub use crate::r;`
-
-### `pub use optionals::StringArray;`
-
-### `pub use ndarray_impl::RNdIndex;`
-
-### `pub use nalgebra;`
-
-### `pub use jiff_impl::RTimestamp;`
-
-### `pub use indicatif;`
-
-### `pub use arrow_impl::Int32Array;`
-
-### `pub use altrep_data::IterRealCoerceData;`
-
-### `pub use conv::try_from_sexp;`
-
-### `pub use coerce::CoerceError;`
-
-### `pub use ndarray::Ix6;`
-
-### `pub use typed_list::sexptype_name;`
-
-### `pub use optionals::Array0;`
-
-### `pub use optionals::RUuidOps;`
-
-### `pub use optionals::Buf;`
-
-### `pub use crate::SexpExt;`
-
-### `pub use optionals::UInt8Array;`
-
-### `pub use ndarray_impl::ShapeBuilder;`
-
-### `pub use crate::RIndexMapOps;`
-
-### `pub use bytes::BufMut;`
-
-### `pub use jiff_impl::Span;`
-
-### `pub use crate::VctrsClass;`
-
-### `pub use arrow_impl::StringArray;`
-
-### `pub use altrep_data::IterStringData;`
-
-### `pub use either::Either;`
-
-### `pub use r_coerce::RCoerceCharacter;`
-
-### `pub use externalptr::ExternalPtr;`
-
-### `pub use optionals::Array3;`
-
-### `pub use optionals::regex_impl;`
-
-### `pub use optionals::BytesMut;`
-
-### `pub use crate::Right;`
-
-### `pub use rarray::RArray;`
-
-### `pub use nalgebra_impl::DMatrix;`
-
-### `pub use crate::RParallelExtend;`
-
-### `pub use num_bigint::BigInt;`
-
-### `pub use bytes::BytesMut;`
-
-### `pub use jiff_impl::Zoned;`
-
-### `pub use blake3::Hasher;`
-
-### `pub use arrow_impl::UInt8Array;`
-
-### `pub use altrep_data::SparseIterComplexData;`
-
-### `pub use either::Right;`
-
-### `pub use r_coerce::RCoerceDate;`
-
-### `pub use ndarray::ShapeBuilder;`
-
-### `pub use arrow_array::ArrayRef;`
-
-### `pub use externalptr::TypedExternal;`
-
-### `pub use optionals::Array6;`
-
-### `pub use optionals::RRegexOps;`
-
-### `pub use optionals::sha2_impl;`
-
-### `pub use crate::RUuidOps;`
-
-### `pub use rarray::RVector;`
-
-### `pub use nalgebra_impl::RDVector;`
-
-### `pub use crate::RDistributionOps;`
-
-### `pub use serde_impl::JsonValue;`
-
-### `pub use miniextendr_macros::list;`
-
-### `pub use altrep_data::SparseIterRawData;`
-
-### `pub use ndarray::ArcArray1;`
-
-### `pub use r_coerce::RCoerceFactor;`
-
-### `pub use arrow_array::DictionaryArray;`
-
-### `pub use externalptr::altrep_data1_mut;`
-
-### `pub use optionals::ArrayView1;`
-
-### `pub use regex::Regex;`
-
-### `pub use optionals::RUrlOps;`
-
-### `pub use crate::typed_dataframe;`
-
-### `pub use optionals::sha512_bytes;`
-
-### `pub use raw_conversions::Pod;`
-
-### `pub use nalgebra_impl::RVectorOps;`
-
-### `pub use crate::RRngOps;`
-
-### `pub use serde_impl::RJsonBridge;`
-
-### `pub use altrep_data::StreamingIntData;`
-
-### `pub use ndarray::Array1;`
-
-### `pub use r_coerce::RCoerceList;`
-
-### `pub use arrow_array::Int32Array;`
-
-### `pub use externalptr::altrep_data2_as_unchecked;`
-
-### `pub use optionals::ArrayView4;`
-
-### `pub use optionals::aho_corasick_impl;`
-
-### `pub use ::serde::Serialize;`
-
-### `pub use crate::typed_list;`
-
-### `pub use optionals::blake3_bytes;`
-
-### `pub use crate::Regex;`
-
-### `pub use raw_conversions::RawHeader;`
-
-### `pub use time::Duration;`
-
-### `pub use num_bigint_impl::BigInt;`
-
-### `pub use crate::serde::AsSerialize;`
-
-### `pub use coerce::*;`
-
-### `pub use serde_impl::SpecialFloatHandling;`
-
-### `pub use miniextendr_macros::typed_list;`
-
-### `pub use altrep_data::WindowedIterRealData;`
-
-### `pub use ndarray::Array4;`
-
-### `pub use r_coerce::RCoerceNumeric;`
-
-### `pub use arrow_array::TimestampSecondArray;`
-
-### `pub use gc_protect::ProtectScope;`
-
-### `pub use optionals::ArrayViewD;`
-
-### `pub use optionals::aho_compile;`
-
-### `pub use columnar::DispatchNames;`
-
-### `pub use crate::AltIntegerData;`
-
-### `pub use optionals::md5_impl;`
-
-### `pub use rayon_bridge::RParallelIterator;`
-
-### `pub use crate::RUrlOps;`
-
-### `pub use raw_conversions::RawTagged;`
-
-### `pub use num_bigint_impl::RBigIntOps;`
-
-### `pub use serde;`
-
-### `pub use windowed::*;`
-
-### `pub use serde_impl::json_from_sexp_strict;`
-
-### `pub use miniextendr_macros::Vctrs;`
-
-### `pub use altrep_sexp::AltrepSexp;`
-
-### `pub use ndarray::ArrayD;`
-
-### `pub use r_coerce::RCoerceVector;`
-
-### `pub use gc_protect::ReprotectSlot;`
-
-### `pub use optionals::ArrayViewMut2;`
-
-### `pub use optionals::aho_find_all_flat;`
-
-### `pub use columnar::SerdeRowBuilder;`
-
-### `pub use crate::AltRawData;`
-
-### `pub use optionals::md5_str;`
-
-### `pub use rand_impl::RRng;`
-
-### `pub use raw_conversions::raw_from_bytes;`
-
-### `pub use rust_decimal_impl::Decimal;`
-
-### `pub use crate::JsonValue;`
-
-### `pub use borsh_impl::Borsh;`
-
-### `pub use miniextendr_macros::AltrepComplex;`
-
-### `pub use ndarray::ArrayView1;`
-
-### `pub use condition::AsRError;`
-
-### `pub use arrow_array::types::TimestampSecondType;`
-
-### `pub use protect_pool::ProtectPool;`
-
-### `pub use optionals::ArrayViewMut5;`
-
-### `pub use optionals::aho_replace_all;`
-
-### `pub use columnar::TypeSpec;`
-
-### `pub use crate::AltrepExtract;`
-
-### `pub use optionals::GlobBuilder;`
-
-### `pub use crate::OffsetDateTime;`
-
-### `pub use raw_conversions::raw_to_bytes;`
-
-### `pub use toml::Value as TomlValue;`
-
-### `pub use ordered_float_impl::ROrderedFloatOps;`
-
-### `pub use serde_json;`
-
-### `pub use borsh_impl::borsh_to_raw;`
-
-### `pub use miniextendr_macros::AltrepLogical;`
-
-### `pub use ndarray::ArrayView4;`
-
-### `pub use ordered_float::OrderedFloat;`
-
-### `pub use convert::AsDataFrameExt;`
-
-### `pub use arrow_buffer;`
-
-### `pub use refcount_protect::ThreadLocalArena;`
-
-### `pub use optionals::Ix0;`
-
-### `pub use optionals::RIndexMapOps;`
-
-### `pub use columnar::iter_to_dataframe;`
-
-### `pub use crate::IntoR;`
-
-### `pub use optionals::GlobSetBuilder;`
-
-### `pub use either_impl::Either;`
-
-### `pub use match_arg::choices_sexp;`
-
-### `pub use num_traits_impl::RFloat;`
-
-### `pub use crate::toml_to_string;`
-
-### `pub use toml_impl::toml_from_str;`
-
-### `pub use miniextendr_macros::AltrepString;`
-
-### `pub use bitflags::Flags;`
-
-### `pub use into_r::IntoRAltrep;`
-
-### `pub use convert::AsExternalPtr;`
-
-### `pub use vctrs::VctrsBuildError;`
-
-### `pub use optionals::Ix1;`
-
-### `pub use optionals::Duration;`
-
-### `pub use columnar::vec_to_dataframe;`
-
-### `pub use crate::IntoRAltrep;`
-
-### `pub use optionals::globset_matches;`
-
-### `pub use ndarray_impl::ArcArray1;`
-
-### `pub use ordered_float;`
-
-### `pub use match_arg::match_arg_vec_into_sexp;`
-
-### `pub use uuid_impl::RUuidOps;`
-
-### `pub use crate::Bytes;`
-
-### `pub use bytes_impl::Buf;`
-
-### `pub use miniextendr_macros::IntoR;`
-
-### `pub use newtype::IntoRNewtype;`
-
-### `pub use ndarray::ArrayViewD;`
-
-### `pub use convert::AsFromStrVec;`
-
-### `pub use arrow_schema::Field;`
-
-### `pub use vctrs::VctrsListOf;`
 
 ---
 
@@ -29749,7 +29763,7 @@ without going through an intermediate format like JSON.
 | `i32` | `integer(1)` |
 | `f64` | `numeric(1)` |
 | `String` | `character(1)` |
-| `Option<T>::None` | NA or NULL |
+| `Option<T>::None` | `NULL` (always — never a typed NA) |
 | `Vec<primitive>` | atomic vector |
 | `Vec<struct>` | list of lists |
 | `HashMap<String, T>` | named list |
@@ -31280,7 +31294,7 @@ Return the cached encoding info (if `miniextendr_encoding_init()` has run).
 ### `encoding::miniextendr_assert_utf8_locale`
 
 ```rust
-extern "C" fn miniextendr_assert_utf8_locale()
+extern "C-unwind" fn miniextendr_assert_utf8_locale()
 ```
 
 Assert that R's locale is UTF-8.
@@ -31290,6 +31304,16 @@ does not use UTF-8, since `charsxp_to_str` assumes all CHARSXP bytes
 are valid UTF-8.
 
 Uses `l10n_info()[["UTF-8"]]` which is public R API.
+
+ABI: must be `extern "C-unwind"`, not `extern "C"` — the failure branch
+raises via `Rf_error`, and under webR (Emscripten builds R with
+`-sSUPPORT_LONGJMP=wasm`) that longjmp is a real wasm exception that
+unwinds through this frame. A non-unwind `extern "C"` ABI makes rustc
+insert an abort guard at the boundary, which turns the load-gate error
+into an `unreachable` trap that kills the whole wasm runtime (observed
+in the tier-3 testthat pass via `assert_utf8_locale_now()`). On native
+targets `longjmp` never touches landing pads, which is why this only
+bit on wasm32.
 
 ### `encoding::miniextendr_encoding_init`
 
@@ -34526,9 +34550,11 @@ struct (no nested `#[derive(Deserialize)]` structs as fields — see
    `Option<NestedStruct>` field's flattened columns include one matching
    that name — i.e. the struct has a sub-field literally named `variant` —
    an NA in that cell makes the *whole struct* read back as `None`,
-   silently dropping the other sub-fields. Rename the sub-field, or point
-   the tag lookup at an unused column name via
-   [`dataframe_to_vec_with_enum_tags`].
+   silently dropping the other sub-fields. Fixes, in order of preference:
+   list the field in [`dataframe_to_vec_with_struct_fields`] (the
+   heuristic never fires for it), rename the sub-field with
+   `#[serde(rename = "...")]`, or point the tag lookup at an unused column
+   name via [`dataframe_to_vec_with_enum_tags`].
 
 ### `serde::dataframe_de::dataframe_to_vec_borrowed`
 
@@ -34622,8 +34648,9 @@ Same as [`dataframe_to_vec`], plus the enum-tag errors described on
 Same as [`dataframe_to_vec`] — including the `Option<nested struct>`
 tag-column collision
 ([#1320](https://github.com/A2-ai/miniextendr/issues/1320)). The `tags`
-mapping here is also the workaround: point the affected field's tag at an
-unused column name so the `None` heuristic never fires for it.
+mapping can paper over it (point the affected field's tag at an unused
+column name so the `None` heuristic never fires for it), but the
+dedicated opt-out is [`dataframe_to_vec_with_struct_fields`].
 
 #### Example
 
@@ -34634,6 +34661,74 @@ use miniextendr_api::serde::{
 
 let df = vec_to_dataframe_flatten_enums_with_tags(&rows, &["state"], &[("state", "state_tag")])?;
 let round: Vec<Row> = dataframe_to_vec_with_enum_tags(df.as_sexp(), &[("state", "state_tag")])?;
+```
+
+### `serde::dataframe_de::dataframe_to_vec_with_struct_fields`
+
+```rust
+fn dataframe_to_vec_with_struct_fields<T>(sexp: crate::SEXP, fields: &[&str]) -> Result<Vec<T>, super::error::RSerdeError> where T: for<'de> serde::Deserialize<'de>
+```
+
+Convert a data.frame into `Vec<T>`, declaring `fields` that must always be
+read as **nested structs** — the `Option<Enum>` tag-column heuristic never
+fires for them.
+
+#### Why this exists (the `_variant` collision, #1320)
+
+An `Option<T>` field with no bare column is either an `Option<NestedStruct>`
+or an `Option<Enum>`, and serde gives the reader no type information to tell
+them apart at that point. To read `Option<Enum>` `None` rows back, the
+reader probes the would-be variant-tag column (`<field>_variant` by
+default, or the [`dataframe_to_vec_with_enum_tags`] override): a
+character/factor column that is NA at the row means `None`. If a nested
+*struct* has a sub-field literally named `variant`, its flattened column
+collides with that name — an NA cell there silently reads the **whole
+struct** as `None`, dropping the other sub-fields
+([#1320](https://github.com/A2-ai/miniextendr/issues/1320)).
+
+Listing the field here disables the probe: the field is always read as a
+nested struct from its prefixed columns. Fields *not* listed keep the
+heuristic, so `Option<Enum>` fields in the same row type continue to
+round-trip their `None` rows.
+
+#### Field naming
+
+Entries use the **flattened field path** — the same key space as
+[`dataframe_to_vec_with_enum_tags`]: `"meta"` for a top-level field `meta`,
+`"outer_meta"` for a field `meta` inside a nested struct field `outer`.
+
+#### `None` structs stay unreadable
+
+The writer emits no per-row presence signal for `Option<NestedStruct>`: a
+`None` struct and a `Some` struct whose fields are all `None` produce
+identical (all-NA) columns. Opting a field out therefore commits to reading
+it as `Some(...)` on every row — a row written from `None` yields an
+`UnexpectedNa` error if the struct has any non-`Option` field, or
+`Some(struct with all-`None` fields)` if every field is `Option`.
+
+#### Errors
+
+Same as [`dataframe_to_vec`].
+
+#### Example
+
+```ignore
+use miniextendr_api::serde::{dataframe_to_vec_with_struct_fields, vec_to_dataframe};
+
+#[derive(Serialize, Deserialize)]
+struct Meta {
+    variant: Option<String>, // collides with the `meta_variant` tag name
+    size: f64,
+}
+#[derive(Serialize, Deserialize)]
+struct Row {
+    id: i32,
+    meta: Option<Meta>,
+}
+
+let df = vec_to_dataframe(&rows)?; // columns: id, meta_variant, meta_size
+let round: Vec<Row> = dataframe_to_vec_with_struct_fields(df.as_sexp(), &["meta"])?;
+// `Meta { variant: None, size: 4.0 }` rows survive — no tag-column probe.
 ```
 
 ### `serde::dataframe_de::with_dataframe_rows`

--- a/rust-llm-docs/generated/miniextendr-cli.md
+++ b/rust-llm-docs/generated/miniextendr-cli.md
@@ -730,6 +730,20 @@ are appended with dedupe, mirroring `usethis::use_build_ignore()` /
 `use_git_ignore()`. Every other file is overwritten — the template is the
 source of truth, matching `use_template()`'s delete-first behavior.
 
+### `scaffold::desc_ensure_r_floor`
+
+```rust
+fn desc_ensure_r_floor(content: &str) -> String
+```
+
+Ensure `Depends` declares at least the [`R_VERSION_FLOOR`] R version
+floor (~ `mx_desc_ensure_r_floor()` in `minirextendr/R/utils.R`). Merges
+rather than overwrites: no `Depends` field adds one carrying the floor;
+an existing `Depends` without an `R` entry gains the floor (prepended,
+other entries untouched); an `R` entry with a provably lower `>=`/`>`
+floor — or no version constraint at all — is raised; a floor already at
+or above ours, or a constraint using another operator, is left untouched.
+
 ### `scaffold::desc_set_field`
 
 ```rust
@@ -794,6 +808,14 @@ fn minimal_namespace(package: &str) -> String
 Minimal roxygen2-managed NAMESPACE (~ `mx_minimal_namespace()`): carries
 the roxygen2 header so a later `devtools::document()` overwrites it
 cleanly, plus `useDynLib()` so the fresh shared library loads.
+
+### `scaffold::r_depends_entry`
+
+```rust
+fn r_depends_entry() -> String
+```
+
+`Depends` entry carrying [`R_VERSION_FLOOR`] (~ `mx_r_depends_entry()`).
 
 ### `scaffold::render`
 
@@ -901,3 +923,16 @@ pub const RUST_SYSTEM_REQUIREMENT: &str = "Rust (>= 1.85)";
 
 `SystemRequirements` entry for the Rust toolchain (shared between the
 fresh DESCRIPTION and the `init use` merge path).
+
+### `scaffold::R_VERSION_FLOOR`
+
+```rust
+pub const R_VERSION_FLOOR: &str = "4.5";
+```
+
+Minimum R version required by miniextendr-backed packages — the runtime
+calls `R_getVarEx` (the `Rf_findVarInFrame` replacement), which only
+exists on R >= 4.5.0 (#1300), so any package linking miniextendr-api
+inherits this floor (~ `MX_R_FLOOR` in `minirextendr/R/utils.R`; the
+`r_floor_matches_minirextendr_and_rpkg` test asserts both mirrors and
+`rpkg/DESCRIPTION` agree).

--- a/rust-llm-docs/generated/miniextendr-macros-impl-inventory.md
+++ b/rust-llm-docs/generated/miniextendr-macros-impl-inventory.md
@@ -9,19 +9,19 @@ Traits with impls: 28
 | Trait | # impls | # non-blanket non-synthetic |
 |---|---|---|
 | `Freeze` | 94 | 0 |
-| `TryInto` | 94 | 0 |
 | `RefUnwindSafe` | 94 | 0 |
+| `TryInto` | 94 | 0 |
+| `TryFrom` | 94 | 0 |
 | `Any` | 94 | 0 |
 | `Send` | 94 | 0 |
-| `Sync` | 94 | 0 |
-| `UnsafeUnpin` | 94 | 0 |
-| `TryFrom` | 94 | 0 |
-| `Borrow` | 94 | 0 |
-| `BorrowMut` | 94 | 0 |
 | `Into` | 94 | 0 |
 | `Unpin` | 94 | 0 |
-| `UnwindSafe` | 94 | 0 |
+| `BorrowMut` | 94 | 0 |
+| `Borrow` | 94 | 0 |
+| `Sync` | 94 | 0 |
 | `From` | 94 | 0 |
+| `UnsafeUnpin` | 94 | 0 |
+| `UnwindSafe` | 94 | 0 |
 | `Debug` | 28 | 28 |
 | `CloneToUninit` | 19 | 0 |
 | `ToOwned` | 19 | 0 |
@@ -33,9 +33,9 @@ Traits with impls: 28
 | `StructuralPartialEq` | 9 | 9 |
 | `PartialEq` | 9 | 9 |
 | `FromStr` | 2 | 2 |
-| `Display` | 1 | 1 |
 | `ToString` | 1 | 0 |
 | `ParsedImplExt` | 1 | 1 |
+| `Display` | 1 | 1 |
 
 ## `Debug` — 28 impls
 
@@ -197,14 +197,14 @@ Traits with impls: 28
 | `ClassSystem` | `` | concrete | 2 | miniextendr-macros/src/miniextendr_impl.rs:310 |
 | `VctrsKind` | `` | concrete | 2 | miniextendr-macros/src/miniextendr_impl.rs:341 |
 
-## `Display` — 1 impls
-
-| for-type | generics | kind | #items | span |
-|---|---|---|---|---|
-| `LifecycleStage` | `` | concrete | 1 | miniextendr-macros/src/lifecycle.rs:126 |
-
 ## `ParsedImplExt` — 1 impls
 
 | for-type | generics | kind | #items | span |
 |---|---|---|---|---|
 | `crate::miniextendr_impl::ParsedImpl` | `` | concrete | 6 | miniextendr-macros/src/r_class_formatter.rs:1024 |
+
+## `Display` — 1 impls
+
+| for-type | generics | kind | #items | span |
+|---|---|---|---|---|
+| `LifecycleStage` | `` | concrete | 1 | miniextendr-macros/src/lifecycle.rs:126 |

--- a/rust-llm-docs/generated/miniextendr-macros.md
+++ b/rust-llm-docs/generated/miniextendr-macros.md
@@ -711,7 +711,8 @@ fn with_return_class_from_method(self: Self, method: &ParsedMethod) -> Self
 ```
 
 Attach the method's cross-class return name when this builder uses
-[`ReturnStrategy::ReturnOtherClass`].
+[`ReturnStrategy::ReturnOtherClass`] or
+[`ReturnStrategy::ReturnOtherClassList`].
 
 #### `with_strategy`
 
@@ -1201,8 +1202,51 @@ Three shapes are recognized:
 ident is `Self`) — `ReturnStrategy::for_method` checks
 `returns_result_self()` / `returns_option_self()` before this method,
 so those already take the `ReturnSelf` path regardless.
-Nested containers (`Vec<T>`, `Option<Vec<T>>`, …) are not recognized:
-the inner type must be a bare path with no path arguments of its own.
+List-shaped returns (`Vec<Class>` and its `Option`/`Result` wrappers)
+are handled separately by
+[`returns_other_class_list`](Self::returns_other_class_list); any other
+nested container is not recognized: the inner type must be a bare path
+with no path arguments of its own.
+
+#### `returns_other_class_list`
+
+```rust
+fn returns_other_class_list(self: &Self) -> Option<syn::Ident>
+```
+
+Returns the bare element type name when this method returns a *list* of
+values that may be a different registered ExternalPtr-backed class.
+
+The list-shaped sibling of
+[`returns_other_class`](Self::returns_other_class) (#1284). Like the
+scalar detector it is deliberately syntactic: the write-time resolver
+checks the complete class registry, and an unregistered element type
+falls back to the bare list of external pointers.
+
+Three shapes are recognized (the element type must pass the same bare
+capitalized-path filter as the scalar case):
+- `Vec<Class>` — the C wrapper converts via `IntoR` into a `VECSXP` of
+  external pointers (the `IntoRVecElement` impl emitted by
+  `#[derive(ExternalPtr)]`), so `.val` is a bare list.
+- `Option<Vec<Class>>` — the C wrapper already unwraps and raises on
+  `None` (`ReturnHandling::OptionIntoRUnwrap`), so the successful
+  `.val` is the same bare list.
+- `Result<Vec<Class>, E>` where `E` is not `()` — the C wrapper raises
+  on `Err` (`ReturnHandling::ResultIntoR`); same bare list on `Ok`.
+  `Result<Vec<Class>, ()>` is excluded: the unit-error sentinel maps to
+  `ReturnHandling::ResultNullOnErr`, where `.val` can be `NULL`, and
+  `lapply(NULL, ...)` would silently turn that `NULL` into `list()`.
+
+Not recognized (deliberately):
+- `Vec<Self>` — the receiver type ident is not visible here; spell the
+  concrete type name (`-> Vec<Board>` inside `impl Board`) to get the
+  wrapped list.
+- `Vec<Option<Class>>` — has no `IntoR` impl (the `Vec<Option<T>>`
+  blanket slot is occupied by the newtype funnel) and would need a
+  NULL-tolerant per-element wrap; tracked as a follow-up.
+- `Vec<ExternalPtr<Class>>` — kept unwrapped for symmetry with the
+  scalar `ExternalPtr<Class>` return, which `returns_other_class` also
+  leaves unwrapped.
 
 #### `returns_result_self`
 
@@ -2493,6 +2537,8 @@ Each class system generator uses this to produce idiomatic R return code.
   - The method returns `Self`. The wrapper wraps the raw pointer result with
 - `ReturnOtherClass`
   - The method returns a bare type name that may be another registered
+- `ReturnOtherClassList`
+  - The method returns a *list* of values (`Vec<Class>`, plus the
 - `ChainableMutation`
   - The method is a `&mut self` method returning `()`. The wrapper calls the
 - `Direct`
@@ -2524,6 +2570,10 @@ Determine the return strategy for a parsed method.
 - Bare capitalized return types that are not known primitives/containers
   use `ReturnOtherClass`; write-time registry lookup wraps registered
   classes and leaves false positives unchanged.
+- `Vec<Class>` (and the `Option`/`Result` wrappers of it the C wrapper
+  unwraps) use `ReturnOtherClassList`; write-time registry lookup wraps
+  registered element classes via `lapply` and leaves false positives
+  unchanged (#1284).
 - All other methods use `Direct`.
 
 ### `miniextendr_impl::ClassSystem`
@@ -2904,11 +2954,13 @@ Orchestrates the full derive expansion:
 1. Parses `#[externalptr(...)]` attributes for class system selection.
 2. Analyzes struct fields for `#[r_data]` sidecar slots.
 3. Generates `TypedExternal` impl (type identity for `ExternalPtr<T>`).
-4. Generates `IntoExternalPtr` marker impl (enables `IntoR` blanket impl) —
-   suppressed when `emit_into_r_marker` is `false`, which the struct-level
-   `#[miniextendr(prefer = "native")]` path uses so its concrete `AsRNative`
-   `IntoR` does not collide with the blanket `IntoExternalPtr` `IntoR`
-   (E0119, #1283).
+4. Generates `IntoExternalPtr` marker impl (enables `IntoR` blanket impl)
+   and a concrete `IntoRVecElement` impl (enables the `IntoR for Vec<T>`
+   blanket, so `-> Vec<MyType>` returns a `VECSXP` of external pointers —
+   #1284). Both are suppressed when `emit_into_r_marker` is `false`, which
+   the struct-level `#[miniextendr(prefer = "native")]` path uses so its
+   concrete `AsRNative` `IntoR` does not collide with the blanket
+   `IntoExternalPtr` `IntoR` (E0119, #1283).
 5. Generates sidecar accessor FFI functions, registration constants, and R wrappers.
 
 Returns the combined token stream of all generated items.


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary

Stacked on #1420 (split out of #1416). Pure regeneration of `rust-llm-docs/generated/` via `just llm-docs`:

- Embeds the corrected serde rustdoc from #1420 (the None → NULL contract and the new `ExternalPtr` pass-through module).
- Catches up staleness from recently merged PRs — e.g. the #1372 R-floor scaffold helpers were missing from the cli digest. `llm-docs-check` is not CI-gated, so this drift had accumulated silently.

## Notes
- Regeneration required `CARGO_TARGET_DIR=target just llm-docs`: the generator hard-codes `target/doc` paths and breaks under a global cargo `target-dir` override — that is open issue #1413 (the relative override resolves correctly for both the root and cargo-revendor workspaces).

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)