### PR TITLE
fix(macros): route !Send framework returns to the main thread under worker-default

### DIFF
--- a/docs/MINIEXTENDR_ATTRIBUTE.md
+++ b/docs/MINIEXTENDR_ATTRIBUTE.md
@@ -62,9 +62,14 @@ pub fn set_option(key: String, value: i32) { /* ... */ }
 | `worker` | Run on worker thread (default if `worker-default` feature) |
 | `no_worker` | Run on main R thread |
 
-Functions taking `SEXP` parameters automatically run on the main thread — they
-are `!Send`, so the generated wrapper can only execute there. No attribute is
-needed.
+Functions taking or returning `!Send` framework types automatically run on the
+main thread — the generated wrapper can only execute there. No attribute is
+needed. This covers `SEXP` (parameters and returns), the R-backed views
+(`AltrepSexp`, `RDVector`, `RDMatrix`, `RndVec`, `RndMat`, `ProtectedStrVec`),
+and the GC-rooted owned handles (`BuiltDataFrame`, `DataFrameShape`) anywhere
+in the return type, including nested inside `Result`, `Option`, or containers.
+Arbitrary user `!Send` types can't be detected syntactically — mark those
+functions `no_worker` explicitly.
 
 ```rust
 #[miniextendr(no_worker)]

--- a/miniextendr-macros/src/lib.rs
+++ b/miniextendr-macros/src/lib.rs
@@ -221,7 +221,7 @@ compile_error!(
 
 pub(crate) use type_inspect::{
     SeveralOkContainer, classify_several_ok_container, first_type_argument,
-    is_main_thread_bound_input, is_sexp_type, second_type_argument,
+    is_main_thread_bound_input, is_main_thread_bound_return, is_sexp_type, second_type_argument,
 };
 pub(crate) use util::{extract_cfg_attrs, r_wrapper_raw_literal, source_location_doc};
 
@@ -902,6 +902,16 @@ pub fn miniextendr(
         }
     });
 
+    // Check if the return type is main-thread-bound (BuiltDataFrame /
+    // DataFrameShape / an R-backed view — all hold R memory and are !Send, so
+    // they cannot cross back from the worker thread; `run_on_worker` requires
+    // `T: Send`). Walks nested positions: Result<BuiltDataFrame, E>,
+    // Option<DataFrameShape>, Vec<...>, tuples.
+    let has_main_thread_bound_return = match output {
+        syn::ReturnType::Default => false,
+        syn::ReturnType::Type(_, ty) => is_main_thread_bound_return(ty),
+    };
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Thread Strategy Selection
     // ═══════════════════════════════════════════════════════════════════════════
@@ -934,8 +944,13 @@ pub fn miniextendr(
     // Thread strategy:
     // - Main thread is always used unless force_worker is set
     // - force_worker cannot override hard requirements for main thread
-    // - Hard requirements: returns_sexp, has_sexp_inputs, has_dots, check_interrupt
-    let requires_main_thread = returns_sexp || has_sexp_inputs || has_dots || check_interrupt;
+    // - Hard requirements: returns_sexp, has_sexp_inputs,
+    //   has_main_thread_bound_return, has_dots, check_interrupt
+    let requires_main_thread = returns_sexp
+        || has_sexp_inputs
+        || has_main_thread_bound_return
+        || has_dots
+        || check_interrupt;
     let use_main_thread = !force_worker || requires_main_thread;
 
     // Extract cfg attributes to apply to generated items (needed by CWrapperContext)

--- a/miniextendr-macros/src/type_inspect.rs
+++ b/miniextendr-macros/src/type_inspect.rs
@@ -37,33 +37,111 @@ pub(crate) fn is_sexp_type(ty: &syn::Type) -> bool {
         .unwrap_or(false))
 }
 
+/// Framework type names that hold R memory and are `!Send` by design.
+///
+/// Used only for thread-strategy selection: values of these types can neither
+/// move into the worker closure nor cross back out of it (`run_on_worker`
+/// requires `Send`), so any function touching one stays on the main thread
+/// even under `worker-default`. Covers the raw `SEXP`, `AltrepSexp`, the
+/// zero-copy R-backed views (`RDVector`, `RDMatrix`, `RndVec`, `RndMat`,
+/// `ProtectedStrVec`), and the owned GC-rooted handles (`BuiltDataFrame`,
+/// `DataFrameShape`). Arbitrary user `!Send` types can't be detected
+/// syntactically — those need an explicit `no_worker`.
+const MAIN_THREAD_BOUND: &[&str] = &[
+    "SEXP",
+    "AltrepSexp",
+    "RDVector",
+    "RDMatrix",
+    "RndVec",
+    "RndMat",
+    "ProtectedStrVec",
+    "BuiltDataFrame",
+    "DataFrameShape",
+];
+
 /// Returns `true` if `ty` is an input type bound to the R main thread.
 ///
-/// Used only for thread-strategy selection: parameters of these types cannot
-/// move into the worker closure (`run_on_worker` requires `Send`), so the
-/// function stays on the main thread even under `worker-default`. Covers the
-/// raw `SEXP` and framework wrapper types that hold R memory and are `!Send`
-/// by design: `AltrepSexp` and the zero-copy R-backed views (`RDVector`,
-/// `RDMatrix`, `RndVec`, `RndMat`). Arbitrary user `!Send` types can't be
-/// detected syntactically — those need an explicit `no_worker`.
-/// Return-type analysis keeps the narrower [`is_sexp_type`].
+/// Checks only the outermost path segment: main-thread-bound inputs arrive
+/// bare (`x: SEXP`, `v: RDVector<f64>`), never nested inside containers.
+/// Return-type analysis keeps the narrower [`is_sexp_type`] and uses the
+/// recursive [`is_main_thread_bound_return`] for thread selection.
 #[inline]
 pub(crate) fn is_main_thread_bound_input(ty: &syn::Type) -> bool {
-    const MAIN_THREAD_BOUND: &[&str] = &[
-        "SEXP",
-        "AltrepSexp",
-        "RDVector",
-        "RDMatrix",
-        "RndVec",
-        "RndMat",
-        "ProtectedStrVec",
-    ];
     matches!(ty, syn::Type::Path(p) if p
         .path
         .segments
         .last()
         .map(|s| MAIN_THREAD_BOUND.contains(&s.ident.to_string().as_str()))
         .unwrap_or(false))
+}
+
+/// Returns `true` if `ty` is (or contains) a main-thread-bound type anywhere
+/// in a return position — e.g. `BuiltDataFrame`, `Result<BuiltDataFrame,
+/// String>`, `Option<DataFrameShape>`, `Vec<BuiltDataFrame>`.
+///
+/// Unlike inputs, main-thread-bound returns routinely nest inside `Result` /
+/// `Option` / containers, so this walks the whole type tree. Under
+/// `worker-default` a function whose return type matches is forced onto the
+/// main thread: the value owns R memory (`!Send`) and cannot cross back from
+/// the worker (`run_on_worker` requires `T: Send`).
+pub(crate) fn is_main_thread_bound_return(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(p) => p.path.segments.last().is_some_and(|seg| {
+            if MAIN_THREAD_BOUND.contains(&seg.ident.to_string().as_str()) {
+                return true;
+            }
+            if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+                return ab.args.iter().any(|arg| {
+                    matches!(arg, syn::GenericArgument::Type(t) if is_main_thread_bound_return(t))
+                });
+            }
+            false
+        }),
+        syn::Type::Reference(r) => is_main_thread_bound_return(&r.elem),
+        syn::Type::Paren(p) => is_main_thread_bound_return(&p.elem),
+        syn::Type::Group(g) => is_main_thread_bound_return(&g.elem),
+        syn::Type::Tuple(t) => t.elems.iter().any(is_main_thread_bound_return),
+        syn::Type::Array(a) => is_main_thread_bound_return(&a.elem),
+        syn::Type::Slice(s) => is_main_thread_bound_return(&s.elem),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_main_thread_bound_return;
+
+    fn ty(s: &str) -> syn::Type {
+        syn::parse_str(s).unwrap()
+    }
+
+    #[test]
+    fn main_thread_bound_return_detects_nested_positions() {
+        // Bare and fully-qualified paths
+        assert!(is_main_thread_bound_return(&ty("BuiltDataFrame")));
+        assert!(is_main_thread_bound_return(&ty(
+            "miniextendr_api::dataframe::BuiltDataFrame"
+        )));
+        assert!(is_main_thread_bound_return(&ty("DataFrameShape")));
+        assert!(is_main_thread_bound_return(&ty("SEXP")));
+        // Nested inside Result / Option / containers / tuples
+        assert!(is_main_thread_bound_return(&ty(
+            "Result<BuiltDataFrame, String>"
+        )));
+        assert!(is_main_thread_bound_return(&ty(
+            "Result<DataFrameShape, std::string::String>"
+        )));
+        assert!(is_main_thread_bound_return(&ty("Option<BuiltDataFrame>")));
+        assert!(is_main_thread_bound_return(&ty("Vec<BuiltDataFrame>")));
+        assert!(is_main_thread_bound_return(&ty("(i32, BuiltDataFrame)")));
+        // Send-safe returns stay worker-eligible
+        assert!(!is_main_thread_bound_return(&ty("i32")));
+        assert!(!is_main_thread_bound_return(&ty(
+            "Result<Vec<f64>, String>"
+        )));
+        assert!(!is_main_thread_bound_return(&ty("ExternalPtr<MyType>")));
+        assert!(!is_main_thread_bound_return(&ty("DataFrame")));
+    }
 }
 
 /// Container family for a `several_ok` parameter, returned by


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

Closes #1303.

## Summary
- Fixes the scheduled CI "Feature runtime leg / worker-default" job, which fails to compile rpkg with 117 `E0277: *mut () cannot be sent between threads safely` errors (run 31868601478).
- Root cause: `#[miniextendr]` fns returning `BuiltDataFrame` / `DataFrameShape` (bare or nested in `Result`/`Option`) were routed through `run_on_worker` under `worker-default`, whose `T: Send` bound rejects them. Both types hold GC-rooted R memory and are `!Send` by design (#1128), so worker execution was never sound for them, the bound just catches it at compile time.
- Fix is in thread-strategy selection (`miniextendr-macros/src/lib.rs`): a new recursive `is_main_thread_bound_return` check (in `type_inspect.rs`) walks the return type tree (Result, Option, containers, tuples, references) for the framework's `!Send` type names and forces the main-thread strategy, mirroring the existing rule for `SEXP`-typed inputs and returns. No per-site `no_worker` annotations needed, and end-user packages get the same protection.
- The shared `MAIN_THREAD_BOUND` name list now also covers `BuiltDataFrame` / `DataFrameShape` for inputs (harmless, they are not convertible inputs today).
- Docs: `docs/MINIEXTENDR_ATTRIBUTE.md` threading section updated to state the full automatic main-thread rule.
- Default (non-`worker-default`) builds are unaffected: without `force_worker` the main-thread strategy was already chosen, so no generated-wrapper drift (NAMESPACE/man untouched).

## Test plan
- [x] `cargo check --features <detected base>,worker-default` on rpkg/src/rust (the failing leg's compile) now finishes clean; previously 117 errors.
- [x] New unit test `type_inspect::tests::main_thread_bound_return_detects_nested_positions` covering bare, qualified, nested, and negative cases.
- [x] `cargo test -p miniextendr-macros --lib` (481 passed).
- [x] All three CI clippy legs reproduced locally with `-D warnings`: default, `full-codegen` + integration list, `full-codegen-s7` + integration list.
- [x] `cargo fmt --all` clean.
- [x] Dispatched CI run on this branch (run 31907092822): the worker-default leg now **compiles** (was 117 errors) and runs the suite. The remaining failures are a distinct pre-existing runtime defect — RCondition panic payloads are stringified at the worker boundary — tracked in #1425 (related: #989). The leg goes fully green once #1425 is fixed.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>


