### PR TITLE
fix(rpkg): regenerate NAMESPACE under roxygen2 8.1.0

### DIFF
--- a/rpkg/DESCRIPTION
+++ b/rpkg/DESCRIPTION
@@ -39,4 +39,4 @@ Config/build/bootstrap: TRUE
 Config/build/never-clean: true
 Config/build/extra-sources: src/rust/Cargo.lock
 Config/roxygen2/markdown: TRUE
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/rpkg/NAMESPACE
+++ b/rpkg/NAMESPACE
@@ -1704,49 +1704,57 @@ export(zstd_roundtrip)
 exportMethods(s4_mode_current)
 exportMethods(s4_mode_set)
 importFrom(R6,R6Class)
-importFrom(S7,S7_dispatch)
-importFrom(S7,S7_object)
-importFrom(S7,class_any)
-importFrom(S7,class_character)
-importFrom(S7,class_double)
-importFrom(S7,class_integer)
-importFrom(S7,convert)
-importFrom(S7,method)
-importFrom(S7,new_class)
-importFrom(S7,new_generic)
-importFrom(S7,new_object)
-importFrom(S7,new_property)
+importFrom(S7,
+  S7_dispatch,
+  S7_object,
+  class_any,
+  class_character,
+  class_double,
+  class_integer,
+  convert,
+  method,
+  new_class,
+  new_generic,
+  new_object,
+  new_property
+)
 importFrom(cli,cli_progress_bar)
-importFrom(lifecycle,badge)
-importFrom(lifecycle,deprecate_soft)
-importFrom(lifecycle,deprecate_stop)
-importFrom(lifecycle,deprecate_warn)
-importFrom(lifecycle,signal_stage)
-importFrom(methods,new)
-importFrom(methods,setClass)
-importFrom(methods,setGeneric)
-importFrom(methods,setMethod)
-importFrom(vctrs,field)
-importFrom(vctrs,new_data_frame)
-importFrom(vctrs,new_list_of)
-importFrom(vctrs,new_rcrd)
-importFrom(vctrs,new_vctr)
-importFrom(vctrs,stop_incompatible_op)
-importFrom(vctrs,vec_arith)
-importFrom(vctrs,vec_arith.numeric)
-importFrom(vctrs,vec_arith_base)
-importFrom(vctrs,vec_cast)
-importFrom(vctrs,vec_data)
-importFrom(vctrs,vec_math)
-importFrom(vctrs,vec_math_base)
-importFrom(vctrs,vec_proxy)
-importFrom(vctrs,vec_proxy_compare)
-importFrom(vctrs,vec_proxy_equal)
-importFrom(vctrs,vec_proxy_order)
-importFrom(vctrs,vec_ptype)
-importFrom(vctrs,vec_ptype2)
-importFrom(vctrs,vec_ptype_abbr)
-importFrom(vctrs,vec_ptype_common)
-importFrom(vctrs,vec_ptype_full)
-importFrom(vctrs,vec_restore)
+importFrom(lifecycle,
+  badge,
+  deprecate_soft,
+  deprecate_stop,
+  deprecate_warn,
+  signal_stage
+)
+importFrom(methods,
+  new,
+  setClass,
+  setGeneric,
+  setMethod
+)
+importFrom(vctrs,
+  field,
+  new_data_frame,
+  new_list_of,
+  new_rcrd,
+  new_vctr,
+  stop_incompatible_op,
+  vec_arith,
+  vec_arith.numeric,
+  vec_arith_base,
+  vec_cast,
+  vec_data,
+  vec_math,
+  vec_math_base,
+  vec_proxy,
+  vec_proxy_compare,
+  vec_proxy_equal,
+  vec_proxy_order,
+  vec_ptype,
+  vec_ptype2,
+  vec_ptype_abbr,
+  vec_ptype_common,
+  vec_ptype_full,
+  vec_restore
+)
 useDynLib(miniextendr, .registration = TRUE)

--- a/rproject.toml
+++ b/rproject.toml
@@ -38,7 +38,12 @@ dependencies = [
     "knitr",
     "rcmdcheck",
     "rmarkdown",
-    "roxygen2",
+    # CI's Sync Checks job installs roxygen2 from public RSPM "latest"; the
+    # stratus snapshot (2026-06-18) still has 8.0.0, whose NAMESPACE importFrom
+    # formatting differs from 8.1.0 — the committed NAMESPACE must be generated
+    # by the same major/minor roxygen2 CI regenerates with, or
+    # `just wrappers-sync-check` red-flags every PR. Pin to CRAN (latest).
+    {name = "roxygen2", repository = "CRAN"},
     "withr",
     "yaml",
     "jsonlite",

--- a/rv.lock
+++ b/rv.lock
@@ -835,6 +835,13 @@ dependencies = [
 ]
 
 [[packages]]
+name = "rdtools"
+version = "0.1.0"
+source = { repository = "https://cloud.r-project.org/" }
+force_source = false
+dependencies = []
+
+[[packages]]
 name = "rlang"
 version = "1.2.0"
 source = { repository = "https://cloud.r-project.org/" }
@@ -861,8 +868,8 @@ dependencies = [
 
 [[packages]]
 name = "roxygen2"
-version = "8.0.0"
-source = { repository = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2026-06-18" }
+version = "8.1.0"
+source = { repository = "https://cloud.r-project.org/" }
 force_source = false
 dependencies = [
     "brew",
@@ -873,6 +880,7 @@ dependencies = [
     "lifecycle",
     { name = "pkgload", requirement = "(>= 1.5.2)" },
     { name = "R6", requirement = "(>= 2.1.2)" },
+    { name = "rdtools", requirement = "(>= 0.1.0)" },
     { name = "rlang", requirement = "(>= 1.1.0)" },
     "withr",
     "xml2",


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Unblocks the PR queue: the Sync Checks job currently fails on **every** open PR because `wrappers-sync-check` regenerates `NAMESPACE` with roxygen2 8.1.0 (public RSPM latest), which groups multi-symbol `importFrom()` directives, while the committed NAMESPACE was generated by 8.0.0 (one symbol per line). The gate therefore red-flags every branch regardless of content.
- Fix follows "CI is authoritative": pin `roxygen2` to the CRAN repository in `rproject.toml` (the stratus snapshot 2026-06-18 still carries 8.0.0), `rv sync` to 8.1.0, regenerate, and commit the new `NAMESPACE` plus the `Config/roxygen2/version: 8.1.0` bump.
- The regenerated NAMESPACE blob matches the one CI's wrappers-sync-check produces byte-for-byte (`9f51147`, from the failing job's diff output). `man/` output is unchanged under 8.1.0.
- This PR should merge **before** the other two CI-fix PRs (#1422, #1423) and before rebasing the open PR queue; their Sync Checks legs fail until this lands.

## Test plan
- [x] `just configure && just rcmdinstall && just force-document` locally under roxygen2 8.1.0; only NAMESPACE and the version stamp changed.
- [x] Regenerated NAMESPACE blob hash equals CI's expected post-regen blob (9f51147).
- [ ] Sync Checks green on this PR's own CI run.

## Notes
- The 14 pre-existing roxygen2 warnings ("@field can't find matching R6 method", from generated R6 active-binding docs) are untouched here; open PR #1404 addresses that class of warning.
- rv users pick up roxygen2 8.1.0 (plus its new `rdtools` dependency) on their next `rv sync`.

---
_Drafted by Claude (claude-fable-5). Reviewed by the author._

</details>